### PR TITLE
feat(db-rbac): CoachStudentAssignment foundation + secured coach ownership

### DIFF
--- a/__tests__/api/assistante-assignments.test.ts
+++ b/__tests__/api/assistante-assignments.test.ts
@@ -6,7 +6,13 @@
  * GET /api/assistante/coaches
  */
 
-jest.mock('@/auth', () => ({ auth: jest.fn() }));
+jest.mock('@/lib/guards', () => ({
+  requireRole: jest.fn(),
+  requireAnyRole: jest.fn(),
+  isErrorResponse: jest.fn((result): result is any => {
+    return result && typeof result === 'object' && 'json' in result && typeof result.json === 'function';
+  }),
+}));
 
 jest.mock('@/lib/prisma', () => ({
   prisma: {
@@ -21,11 +27,11 @@ import { GET as getAssignments, POST as postAssignments } from '@/app/api/assist
 import { GET as getAssignmentDetail, PATCH as patchAssignment } from '@/app/api/assistante/assignments/[id]/route';
 import { GET as getStudents } from '@/app/api/assistante/students/route';
 import { GET as getCoaches } from '@/app/api/assistante/coaches/route';
-import { auth } from '@/auth';
+import { requireAnyRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
 import { AssignmentStatus, AssignmentType, Subject } from '@prisma/client';
 
-const mockAuth = auth as jest.Mock;
+const mockRequireAnyRole = requireAnyRole as unknown as jest.Mock;
 
 function makeRequest(body?: any): Request {
   return new Request('http://localhost/', {
@@ -45,35 +51,39 @@ describe('API Assistante Assignments', () => {
 
   describe('Auth / RBAC', () => {
     it('1. Non connecté => 401', async () => {
-      mockAuth.mockResolvedValue(null);
+      const errorResponse = { json: () => ({ error: 'Unauthorized' }), status: 401 };
+      mockRequireAnyRole.mockResolvedValue(errorResponse);
 
       const res = await getStudents(new Request('http://localhost/'));
       expect(res.status).toBe(401);
     });
 
     it('2. Rôle ELEVE => 403', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'user-1', role: 'ELEVE' } });
+      const errorResponse = { json: () => ({ error: 'Forbidden' }), status: 403 };
+      mockRequireAnyRole.mockResolvedValue(errorResponse);
 
       const res = await getStudents(new Request('http://localhost/'));
       expect(res.status).toBe(403);
     });
 
     it('2. Rôle COACH => 403', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'user-1', role: 'COACH' } });
+      const errorResponse = { json: () => ({ error: 'Forbidden' }), status: 403 };
+      mockRequireAnyRole.mockResolvedValue(errorResponse);
 
       const res = await getStudents(new Request('http://localhost/'));
       expect(res.status).toBe(403);
     });
 
     it('2. Rôle PARENT => 403', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'user-1', role: 'PARENT' } });
+      const errorResponse = { json: () => ({ error: 'Forbidden' }), status: 403 };
+      mockRequireAnyRole.mockResolvedValue(errorResponse);
 
       const res = await getStudents(new Request('http://localhost/'));
       expect(res.status).toBe(403);
     });
 
     it('3. Rôle ASSISTANTE => autorisé', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
       (prisma.student.findMany as jest.Mock).mockResolvedValue([]);
       (prisma.student.count as jest.Mock).mockResolvedValue(0);
 
@@ -82,7 +92,7 @@ describe('API Assistante Assignments', () => {
     });
 
     it('4. Rôle ADMIN => autorisé', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } });
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } });
       (prisma.student.findMany as jest.Mock).mockResolvedValue([]);
       (prisma.student.count as jest.Mock).mockResolvedValue(0);
 
@@ -93,7 +103,7 @@ describe('API Assistante Assignments', () => {
 
   describe('POST /api/assistante/assignments', () => {
     it('5. POST assignment avec payload valide => crée CoachStudentAssignment', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
       (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1', user: { firstName: 'Coach', lastName: 'X' } } as any);
       (prisma.student.findMany as jest.Mock).mockResolvedValue([{ id: 'student-1', user: { firstName: 'Ahmed', lastName: 'B' } }] as any);
       (prisma.coachStudentAssignment.findMany as jest.Mock).mockResolvedValue([]);
@@ -121,7 +131,7 @@ describe('API Assistante Assignments', () => {
     });
 
     it('6. POST avec studentIds vide => 400', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
 
       const res = await postAssignments(makeRequest({
         coachId: 'coach-1',
@@ -132,7 +142,7 @@ describe('API Assistante Assignments', () => {
     });
 
     it('7. POST avec coachId invalide => 400', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
       (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue(null);
 
       const res = await postAssignments(makeRequest({
@@ -146,7 +156,7 @@ describe('API Assistante Assignments', () => {
     });
 
     it('8. POST avec studentId invalide => 400', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
       (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1' } as any);
       (prisma.student.findMany as jest.Mock).mockResolvedValue([]);
 
@@ -161,7 +171,7 @@ describe('API Assistante Assignments', () => {
     });
 
     it('9. POST doublon actif exact => erreur claire', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
       (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1', user: { firstName: 'Coach', lastName: 'X' } } as any);
       (prisma.student.findMany as jest.Mock).mockResolvedValue([{ id: 'student-1', user: { firstName: 'Ahmed', lastName: 'B' } }] as any);
       (prisma.coachStudentAssignment.findMany as jest.Mock).mockResolvedValue([{ id: 'existing-1', studentId: 'student-1' }] as any);
@@ -180,7 +190,7 @@ describe('API Assistante Assignments', () => {
 
   describe('PATCH /api/assistante/assignments/[id]', () => {
     it('10. PATCH status ENDED => termine l\'assignation sans hard delete', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
       (prisma.coachStudentAssignment.findUnique as jest.Mock).mockResolvedValue({ id: 'assignment-1' } as any);
       (prisma.coachStudentAssignment.update as jest.Mock).mockResolvedValue({
         id: 'assignment-1',
@@ -199,7 +209,7 @@ describe('API Assistante Assignments', () => {
     });
 
     it('11. PATCH status SUSPENDED => suspend l\'assignation sans hard delete', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
       (prisma.coachStudentAssignment.findUnique as jest.Mock).mockResolvedValue({ id: 'assignment-1' } as any);
       (prisma.coachStudentAssignment.update as jest.Mock).mockResolvedValue({
         id: 'assignment-1',
@@ -217,7 +227,7 @@ describe('API Assistante Assignments', () => {
     });
 
     it('returns 404 when assignment does not exist', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
       (prisma.coachStudentAssignment.findUnique as jest.Mock).mockResolvedValue(null);
 
       const res = await patchAssignment(
@@ -231,7 +241,7 @@ describe('API Assistante Assignments', () => {
 
   describe('GET /api/assistante/students', () => {
     it('returns paginated students list', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
       (prisma.student.findMany as jest.Mock).mockResolvedValue([]);
       (prisma.student.count as jest.Mock).mockResolvedValue(0);
 
@@ -244,7 +254,7 @@ describe('API Assistante Assignments', () => {
     });
 
     it('filters by hasCoach=true', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
       (prisma.student.findMany as jest.Mock).mockResolvedValue([]);
       (prisma.student.count as jest.Mock).mockResolvedValue(0);
 
@@ -256,7 +266,7 @@ describe('API Assistante Assignments', () => {
 
   describe('GET /api/assistante/coaches', () => {
     it('returns coaches list with stats', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
       (prisma.coachProfile.findMany as jest.Mock).mockResolvedValue([
         {
           id: 'coach-1',

--- a/__tests__/api/assistante-assignments.test.ts
+++ b/__tests__/api/assistante-assignments.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tests API Assistante Assignments
+ * POST /api/assistante/assignments
+ * PATCH /api/assistante/assignments/[id]
+ * GET /api/assistante/students
+ * GET /api/assistante/coaches
+ */
+
+jest.mock('@/auth', () => ({ auth: jest.fn() }));
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    coachProfile: { findUnique: jest.fn(), findMany: jest.fn(), count: jest.fn() },
+    student: { findMany: jest.fn(), findUnique: jest.fn(), count: jest.fn() },
+    coachStudentAssignment: { findMany: jest.fn(), findFirst: jest.fn(), findUnique: jest.fn(), create: jest.fn(), update: jest.fn() },
+    $transaction: jest.fn(),
+  },
+}));
+
+import { GET as getAssignments, POST as postAssignments } from '@/app/api/assistante/assignments/route';
+import { GET as getAssignmentDetail, PATCH as patchAssignment } from '@/app/api/assistante/assignments/[id]/route';
+import { GET as getStudents } from '@/app/api/assistante/students/route';
+import { GET as getCoaches } from '@/app/api/assistante/coaches/route';
+import { auth } from '@/auth';
+import { prisma } from '@/lib/prisma';
+import { AssignmentStatus, AssignmentType, Subject } from '@prisma/client';
+
+const mockAuth = auth as jest.Mock;
+
+function makeRequest(body?: any): Request {
+  return new Request('http://localhost/', {
+    method: body ? 'POST' : 'GET',
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+function makeDetailContext(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe('API Assistante Assignments', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Auth / RBAC', () => {
+    it('1. Non connecté => 401', async () => {
+      mockAuth.mockResolvedValue(null);
+
+      const res = await getStudents(new Request('http://localhost/'));
+      expect(res.status).toBe(401);
+    });
+
+    it('2. Rôle ELEVE => 403', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'user-1', role: 'ELEVE' } });
+
+      const res = await getStudents(new Request('http://localhost/'));
+      expect(res.status).toBe(403);
+    });
+
+    it('2. Rôle COACH => 403', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'user-1', role: 'COACH' } });
+
+      const res = await getStudents(new Request('http://localhost/'));
+      expect(res.status).toBe(403);
+    });
+
+    it('2. Rôle PARENT => 403', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'user-1', role: 'PARENT' } });
+
+      const res = await getStudents(new Request('http://localhost/'));
+      expect(res.status).toBe(403);
+    });
+
+    it('3. Rôle ASSISTANTE => autorisé', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      (prisma.student.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.student.count as jest.Mock).mockResolvedValue(0);
+
+      const res = await getStudents(new Request('http://localhost/'));
+      expect(res.status).toBe(200);
+    });
+
+    it('4. Rôle ADMIN => autorisé', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } });
+      (prisma.student.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.student.count as jest.Mock).mockResolvedValue(0);
+
+      const res = await getStudents(new Request('http://localhost/'));
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('POST /api/assistante/assignments', () => {
+    it('5. POST assignment avec payload valide => crée CoachStudentAssignment', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1', user: { firstName: 'Coach', lastName: 'X' } } as any);
+      (prisma.student.findMany as jest.Mock).mockResolvedValue([{ id: 'student-1', user: { firstName: 'Ahmed', lastName: 'B' } }] as any);
+      (prisma.coachStudentAssignment.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.$transaction as jest.Mock).mockImplementation(async (ops: any) => {
+        return ops.map((op: any) => op);
+      });
+      (prisma.coachStudentAssignment.create as jest.Mock).mockResolvedValue({
+        id: 'assignment-1',
+        coachId: 'coach-1',
+        studentId: 'student-1',
+        assignmentType: AssignmentType.PRIMARY,
+        status: AssignmentStatus.ACTIVE,
+      } as any);
+
+      const res = await postAssignments(makeRequest({
+        coachId: 'coach-1',
+        studentIds: ['student-1'],
+        assignmentType: AssignmentType.PRIMARY,
+      }));
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.success).toBe(true);
+      expect(body.assignments).toHaveLength(1);
+    });
+
+    it('6. POST avec studentIds vide => 400', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+
+      const res = await postAssignments(makeRequest({
+        coachId: 'coach-1',
+        studentIds: [],
+      }));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('7. POST avec coachId invalide => 400', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const res = await postAssignments(makeRequest({
+        coachId: 'invalid-coach',
+        studentIds: ['student-1'],
+      }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.message).toContain('Coach non trouvé');
+    });
+
+    it('8. POST avec studentId invalide => 400', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1' } as any);
+      (prisma.student.findMany as jest.Mock).mockResolvedValue([]);
+
+      const res = await postAssignments(makeRequest({
+        coachId: 'coach-1',
+        studentIds: ['invalid-student'],
+      }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.message).toContain('Élèves non trouvés');
+    });
+
+    it('9. POST doublon actif exact => erreur claire', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1', user: { firstName: 'Coach', lastName: 'X' } } as any);
+      (prisma.student.findMany as jest.Mock).mockResolvedValue([{ id: 'student-1', user: { firstName: 'Ahmed', lastName: 'B' } }] as any);
+      (prisma.coachStudentAssignment.findMany as jest.Mock).mockResolvedValue([{ id: 'existing-1', studentId: 'student-1' }] as any);
+
+      const res = await postAssignments(makeRequest({
+        coachId: 'coach-1',
+        studentIds: ['student-1'],
+        assignmentType: AssignmentType.PRIMARY,
+      }));
+      const body = await res.json();
+
+      expect(res.status).toBe(409);
+      expect(body.error).toBe('Conflict');
+    });
+  });
+
+  describe('PATCH /api/assistante/assignments/[id]', () => {
+    it('10. PATCH status ENDED => termine l\'assignation sans hard delete', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      (prisma.coachStudentAssignment.findUnique as jest.Mock).mockResolvedValue({ id: 'assignment-1' } as any);
+      (prisma.coachStudentAssignment.update as jest.Mock).mockResolvedValue({
+        id: 'assignment-1',
+        status: AssignmentStatus.ENDED,
+        endsAt: new Date(),
+      } as any);
+
+      const res = await patchAssignment(
+        makeRequest({ status: AssignmentStatus.ENDED }),
+        makeDetailContext('assignment-1')
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.assignment.status).toBe(AssignmentStatus.ENDED);
+    });
+
+    it('11. PATCH status SUSPENDED => suspend l\'assignation sans hard delete', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      (prisma.coachStudentAssignment.findUnique as jest.Mock).mockResolvedValue({ id: 'assignment-1' } as any);
+      (prisma.coachStudentAssignment.update as jest.Mock).mockResolvedValue({
+        id: 'assignment-1',
+        status: AssignmentStatus.SUSPENDED,
+      } as any);
+
+      const res = await patchAssignment(
+        makeRequest({ status: AssignmentStatus.SUSPENDED }),
+        makeDetailContext('assignment-1')
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.assignment.status).toBe(AssignmentStatus.SUSPENDED);
+    });
+
+    it('returns 404 when assignment does not exist', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      (prisma.coachStudentAssignment.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const res = await patchAssignment(
+        makeRequest({ status: AssignmentStatus.ENDED }),
+        makeDetailContext('ghost')
+      );
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /api/assistante/students', () => {
+    it('returns paginated students list', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      (prisma.student.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.student.count as jest.Mock).mockResolvedValue(0);
+
+      const res = await getStudents(new Request('http://localhost/'));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.pagination).toBeDefined();
+      expect(body.students).toEqual([]);
+    });
+
+    it('filters by hasCoach=true', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      (prisma.student.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.student.count as jest.Mock).mockResolvedValue(0);
+
+      const res = await getStudents(new Request('http://localhost/?hasCoach=true'));
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('GET /api/assistante/coaches', () => {
+    it('returns coaches list with stats', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      (prisma.coachProfile.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: 'coach-1',
+          userId: 'user-1',
+          user: { firstName: 'Coach', lastName: 'One', email: 'c@test.com' },
+          pseudonym: 'CoachX',
+          tag: 'Math',
+          title: 'Professeur',
+          subjects: [],
+          availableOnline: true,
+          availableInPerson: true,
+          studentAssignments: [],
+          _count: { studentAssignments: 2, sessions: 10 },
+          createdAt: new Date(),
+        },
+      ] as any);
+      (prisma.coachProfile.count as jest.Mock).mockResolvedValue(1);
+
+      const res = await getCoaches(new Request('http://localhost/'));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.coaches).toHaveLength(1);
+      expect(body.coaches[0].stats.activeStudents).toBe(2);
+    });
+  });
+});

--- a/__tests__/api/coach-students.test.ts
+++ b/__tests__/api/coach-students.test.ts
@@ -4,7 +4,13 @@
  * GET /api/coach/students/[studentId]
  */
 
-jest.mock('@/auth', () => ({ auth: jest.fn() }));
+jest.mock('@/lib/guards', () => ({
+  requireRole: jest.fn(),
+  requireAnyRole: jest.fn(),
+  isErrorResponse: jest.fn((result): result is any => {
+    return result && typeof result === 'object' && 'json' in result && typeof result.json === 'function';
+  }),
+}));
 
 jest.mock('@/lib/prisma', () => ({
   prisma: {
@@ -17,10 +23,11 @@ jest.mock('@/lib/prisma', () => ({
 
 import { GET as getStudents } from '@/app/api/coach/students/route';
 import { GET as getStudentDetail } from '@/app/api/coach/students/[studentId]/route';
-import { auth } from '@/auth';
+import { requireRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
 
-const mockAuth = auth as jest.Mock;
+const mockRequireRole = requireRole as unknown as jest.Mock;
+const mockIsErrorResponse = isErrorResponse as unknown as jest.Mock;
 
 function makeDetailContext(studentId: string) {
   return { params: Promise.resolve({ studentId }) };
@@ -33,21 +40,23 @@ describe('API Coach Students', () => {
 
   describe('GET /api/coach/students', () => {
     it('1. Non connecté => 401', async () => {
-      mockAuth.mockResolvedValue(null);
+      const errorResponse = { json: () => ({ error: 'Unauthorized' }), status: 401 };
+      mockRequireRole.mockResolvedValue(errorResponse);
 
       const res = await getStudents();
       expect(res.status).toBe(401);
     });
 
     it('2. Rôle non COACH => 403', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'user-1', role: 'PARENT' } });
+      const errorResponse = { json: () => ({ error: 'Forbidden' }), status: 403 };
+      mockRequireRole.mockResolvedValue(errorResponse);
 
       const res = await getStudents();
       expect(res.status).toBe(403);
     });
 
     it('3. Coach connecté avec assignations actives => retourne uniquement ses élèves', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+      mockRequireRole.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
       (prisma as any).coachProfile.findUnique.mockResolvedValue({ id: 'coach-1' });
       (prisma as any).coachStudentAssignment.findMany.mockResolvedValue([
         {
@@ -87,7 +96,7 @@ describe('API Coach Students', () => {
     });
 
     it('4. Coach connecté sans assignation => retourne liste vide', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+      mockRequireRole.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
       (prisma as any).coachProfile.findUnique.mockResolvedValue({ id: 'coach-1' });
       (prisma as any).coachStudentAssignment.findMany.mockResolvedValue([]);
 
@@ -102,10 +111,10 @@ describe('API Coach Students', () => {
 
   describe('GET /api/coach/students/[studentId]', () => {
     it('5. GET détail élève assigné => 200', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+      mockRequireRole.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
       (prisma as any).coachProfile.findUnique.mockResolvedValue({ id: 'coach-1' });
       (prisma as any).coachStudentAssignment.findFirst.mockResolvedValue({ id: 'assignment-1' });
-      (prisma.student.findUnique as jest.Mock).mockResolvedValue({
+      (prisma as any).student.findUnique.mockResolvedValue({
         id: 'student-1',
         userId: 'user-student-1',
         gradeLevel: 'PREMIERE',
@@ -122,7 +131,7 @@ describe('API Coach Students', () => {
         sessions: [],
         trajectories: [],
         _count: { sessions: 5, assessments: 2 },
-      } as any);
+      });
 
       const res = await getStudentDetail(new Request('http://localhost/'), makeDetailContext('student-1'));
       const body = await res.json();
@@ -133,7 +142,7 @@ describe('API Coach Students', () => {
     });
 
     it('6. GET détail élève non assigné => 403', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+      mockRequireRole.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
       (prisma as any).coachProfile.findUnique.mockResolvedValue({ id: 'coach-1' });
       (prisma as any).coachStudentAssignment.findFirst.mockResolvedValue(null);
 
@@ -145,7 +154,7 @@ describe('API Coach Students', () => {
     });
 
     it('7. Assignation ENDED => ne donne pas accès', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+      mockRequireRole.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
       (prisma as any).coachProfile.findUnique.mockResolvedValue({ id: 'coach-1' });
       (prisma as any).coachStudentAssignment.findFirst.mockResolvedValue(null);
 
@@ -154,7 +163,7 @@ describe('API Coach Students', () => {
     });
 
     it('7. Assignation SUSPENDED => ne donne pas accès', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+      mockRequireRole.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
       (prisma as any).coachProfile.findUnique.mockResolvedValue({ id: 'coach-1' });
       (prisma as any).coachStudentAssignment.findFirst.mockResolvedValue(null);
 
@@ -163,7 +172,7 @@ describe('API Coach Students', () => {
     });
 
     it('7. Assignation future => ne donne pas accès', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+      mockRequireRole.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
       (prisma as any).coachProfile.findUnique.mockResolvedValue({ id: 'coach-1' });
       (prisma as any).coachStudentAssignment.findFirst.mockResolvedValue(null);
 
@@ -172,7 +181,7 @@ describe('API Coach Students', () => {
     });
 
     it('7. Assignation expirée => ne donne pas accès', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+      mockRequireRole.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
       (prisma as any).coachProfile.findUnique.mockResolvedValue({ id: 'coach-1' });
       (prisma as any).coachStudentAssignment.findFirst.mockResolvedValue(null);
 
@@ -181,10 +190,10 @@ describe('API Coach Students', () => {
     });
 
     it('returns 404 when student does not exist', async () => {
-      mockAuth.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+      mockRequireRole.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
       (prisma as any).coachProfile.findUnique.mockResolvedValue({ id: 'coach-1' });
       (prisma as any).coachStudentAssignment.findFirst.mockResolvedValue({ id: 'assignment-1' });
-      (prisma.student.findUnique as jest.Mock).mockResolvedValue(null);
+      (prisma as any).student.findUnique.mockResolvedValue(null);
 
       const res = await getStudentDetail(new Request('http://localhost/'), makeDetailContext('ghost'));
       expect(res.status).toBe(404);

--- a/__tests__/api/coach-students.test.ts
+++ b/__tests__/api/coach-students.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests API Coach Students
+ * GET /api/coach/students
+ * GET /api/coach/students/[studentId]
+ */
+
+jest.mock('@/auth', () => ({ auth: jest.fn() }));
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    coachProfile: { findUnique: jest.fn() },
+    coachStudentAssignment: { findMany: jest.fn(), findFirst: jest.fn() },
+    student: { findUnique: jest.fn() },
+    sessionBooking: { findFirst: jest.fn() },
+  },
+}));
+
+import { GET as getStudents } from '@/app/api/coach/students/route';
+import { GET as getStudentDetail } from '@/app/api/coach/students/[studentId]/route';
+import { auth } from '@/auth';
+import { prisma } from '@/lib/prisma';
+
+const mockAuth = auth as jest.Mock;
+
+function makeDetailContext(studentId: string) {
+  return { params: Promise.resolve({ studentId }) };
+}
+
+describe('API Coach Students', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /api/coach/students', () => {
+    it('1. Non connecté => 401', async () => {
+      mockAuth.mockResolvedValue(null);
+
+      const res = await getStudents();
+      expect(res.status).toBe(401);
+    });
+
+    it('2. Rôle non COACH => 403', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'user-1', role: 'PARENT' } });
+
+      const res = await getStudents();
+      expect(res.status).toBe(403);
+    });
+
+    it('3. Coach connecté avec assignations actives => retourne uniquement ses élèves', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+      (prisma as any).coachProfile.findUnique.mockResolvedValue({ id: 'coach-1' });
+      (prisma as any).coachStudentAssignment.findMany.mockResolvedValue([
+        {
+          id: 'assignment-1',
+          assignmentType: 'PRIMARY',
+          subjects: [],
+          notes: null,
+          startsAt: new Date(),
+          endsAt: null,
+          student: {
+            id: 'student-1',
+            userId: 'user-student-1',
+            firstName: 'Ahmed',
+            lastName: 'B',
+            email: 'ahmed@test.com',
+            gradeLevel: 'PREMIERE',
+            academicTrack: 'EDS_GENERALE',
+            specialties: [],
+            stmgPathway: null,
+            survivalMode: false,
+            school: null,
+            credits: 10,
+            parent: null,
+            _count: { sessions: 5, assessments: 2 },
+          },
+        },
+      ]);
+
+      const res = await getStudents();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.count).toBe(1);
+      expect(body.students).toHaveLength(1);
+      expect(body.students[0].student.id).toBe('student-1');
+    });
+
+    it('4. Coach connecté sans assignation => retourne liste vide', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+      (prisma as any).coachProfile.findUnique.mockResolvedValue({ id: 'coach-1' });
+      (prisma as any).coachStudentAssignment.findMany.mockResolvedValue([]);
+
+      const res = await getStudents();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.count).toBe(0);
+      expect(body.students).toEqual([]);
+    });
+  });
+
+  describe('GET /api/coach/students/[studentId]', () => {
+    it('5. GET détail élève assigné => 200', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+      (prisma as any).coachProfile.findUnique.mockResolvedValue({ id: 'coach-1' });
+      (prisma as any).coachStudentAssignment.findFirst.mockResolvedValue({ id: 'assignment-1' });
+      (prisma.student.findUnique as jest.Mock).mockResolvedValue({
+        id: 'student-1',
+        userId: 'user-student-1',
+        gradeLevel: 'PREMIERE',
+        academicTrack: 'EDS_GENERALE',
+        specialties: [],
+        stmgPathway: null,
+        survivalMode: false,
+        school: null,
+        credits: 10,
+        user: { id: 'user-student-1', firstName: 'Ahmed', lastName: 'B', email: 'ahmed@test.com', phone: null },
+        parent: null,
+        coachAssignments: [],
+        assessments: [],
+        sessions: [],
+        trajectories: [],
+        _count: { sessions: 5, assessments: 2 },
+      } as any);
+
+      const res = await getStudentDetail(new Request('http://localhost/'), makeDetailContext('student-1'));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.student.id).toBe('student-1');
+    });
+
+    it('6. GET détail élève non assigné => 403', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+      (prisma as any).coachProfile.findUnique.mockResolvedValue({ id: 'coach-1' });
+      (prisma as any).coachStudentAssignment.findFirst.mockResolvedValue(null);
+
+      const res = await getStudentDetail(new Request('http://localhost/'), makeDetailContext('student-other'));
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Forbidden');
+    });
+
+    it('7. Assignation ENDED => ne donne pas accès', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+      (prisma as any).coachProfile.findUnique.mockResolvedValue({ id: 'coach-1' });
+      (prisma as any).coachStudentAssignment.findFirst.mockResolvedValue(null);
+
+      const res = await getStudentDetail(new Request('http://localhost/'), makeDetailContext('student-ended'));
+      expect(res.status).toBe(403);
+    });
+
+    it('7. Assignation SUSPENDED => ne donne pas accès', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+      (prisma as any).coachProfile.findUnique.mockResolvedValue({ id: 'coach-1' });
+      (prisma as any).coachStudentAssignment.findFirst.mockResolvedValue(null);
+
+      const res = await getStudentDetail(new Request('http://localhost/'), makeDetailContext('student-suspended'));
+      expect(res.status).toBe(403);
+    });
+
+    it('7. Assignation future => ne donne pas accès', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+      (prisma as any).coachProfile.findUnique.mockResolvedValue({ id: 'coach-1' });
+      (prisma as any).coachStudentAssignment.findFirst.mockResolvedValue(null);
+
+      const res = await getStudentDetail(new Request('http://localhost/'), makeDetailContext('student-future'));
+      expect(res.status).toBe(403);
+    });
+
+    it('7. Assignation expirée => ne donne pas accès', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+      (prisma as any).coachProfile.findUnique.mockResolvedValue({ id: 'coach-1' });
+      (prisma as any).coachStudentAssignment.findFirst.mockResolvedValue(null);
+
+      const res = await getStudentDetail(new Request('http://localhost/'), makeDetailContext('student-expired'));
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 404 when student does not exist', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+      (prisma as any).coachProfile.findUnique.mockResolvedValue({ id: 'coach-1' });
+      (prisma as any).coachStudentAssignment.findFirst.mockResolvedValue({ id: 'assignment-1' });
+      (prisma.student.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const res = await getStudentDetail(new Request('http://localhost/'), makeDetailContext('ghost'));
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/__tests__/rbac/coach-student-access.test.ts
+++ b/__tests__/rbac/coach-student-access.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests RBAC - Coach Student Access
+ * Vérifie les règles d'ownership coach ↔ élève via CoachStudentAssignment
+ */
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    coachProfile: { findUnique: jest.fn() },
+    coachStudentAssignment: { findFirst: jest.fn(), findMany: jest.fn() },
+    student: { findUnique: jest.fn() },
+    sessionBooking: { findFirst: jest.fn() },
+  },
+}));
+
+import {
+  isCoachAssignedToStudent,
+  assertCoachCanAccessStudent,
+  getAssignedStudentsForCoach,
+  getCoachProfileForUser,
+  isCoachRattachedToStudent,
+} from '@/lib/rbac/coach-student-access';
+import { prisma } from '@/lib/prisma';
+import { AssignmentStatus, AssignmentType } from '@prisma/client';
+
+
+describe('RBAC / CoachStudentAccess', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getCoachProfileForUser', () => {
+    it('returns null when userId is empty', async () => {
+      const result = await getCoachProfileForUser('');
+      expect(result).toBeNull();
+    });
+
+    it('returns coach profile when found', async () => {
+      const mockCoach = { id: 'coach-1', userId: 'user-1', pseudonym: 'CoachX' };
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue(mockCoach as any);
+
+      const result = await getCoachProfileForUser('user-1');
+      expect(result).toEqual(mockCoach);
+      expect(prisma.coachProfile.findUnique).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+      });
+    });
+  });
+
+  describe('isCoachAssignedToStudent - cas métier', () => {
+    const coachUserId = 'coach-user-1';
+    const studentId = 'student-1';
+    const now = new Date();
+
+    it('1. Coach assigné ACTIVE - accès autorisé', async () => {
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1' } as any);
+      (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue({ id: 'assignment-1' } as any);
+
+      const result = await isCoachAssignedToStudent({ coachUserId, studentId });
+      expect(result).toBe(true);
+      expect(prisma.coachStudentAssignment.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            coachId: 'coach-1',
+            studentId: 'student-1',
+            status: AssignmentStatus.ACTIVE,
+          }),
+        })
+      );
+    });
+
+    it('2. Coach non assigné - accès refusé', async () => {
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1' } as any);
+      (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue(null);
+
+      const result = await isCoachAssignedToStudent({ coachUserId, studentId });
+      expect(result).toBe(false);
+    });
+
+    it('3. Assignation ENDED - accès refusé', async () => {
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1' } as any);
+      (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue(null);
+
+      const result = await isCoachAssignedToStudent({ coachUserId, studentId });
+      expect(result).toBe(false);
+    });
+
+    it('4. Assignation SUSPENDED - accès refusé', async () => {
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1' } as any);
+      (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue(null);
+
+      const result = await isCoachAssignedToStudent({ coachUserId, studentId });
+      expect(result).toBe(false);
+    });
+
+    it('5. Assignation future (startsAt > now) - accès refusé', async () => {
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1' } as any);
+      (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue(null);
+
+      const result = await isCoachAssignedToStudent({ coachUserId, studentId });
+      expect(result).toBe(false);
+    });
+
+    it('6. Assignation expirée (endsAt < now) - accès refusé', async () => {
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1' } as any);
+      (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue(null);
+
+      const result = await isCoachAssignedToStudent({ coachUserId, studentId });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when coach profile does not exist', async () => {
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const result = await isCoachAssignedToStudent({ coachUserId, studentId });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when params are empty', async () => {
+      const result = await isCoachAssignedToStudent({ coachUserId: '', studentId: '' });
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('assertCoachCanAccessStudent', () => {
+    it('throws ACCESS_DENIED when not assigned', async () => {
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1' } as any);
+      (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        assertCoachCanAccessStudent({ coachUserId: 'user-1', studentId: 'student-1' })
+      ).rejects.toThrow('ACCESS_DENIED');
+    });
+
+    it('does not throw when assigned', async () => {
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1' } as any);
+      (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue({ id: 'assignment-1' } as any);
+
+      await expect(
+        assertCoachCanAccessStudent({ coachUserId: 'user-1', studentId: 'student-1' })
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('getAssignedStudentsForCoach', () => {
+    it('returns empty array when no coach profile', async () => {
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const result = await getAssignedStudentsForCoach({ coachUserId: 'user-1' });
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when coachUserId is empty', async () => {
+      const result = await getAssignedStudentsForCoach({ coachUserId: '' });
+      expect(result).toEqual([]);
+    });
+
+    it('7. Retourne seulement les élèves actifs', async () => {
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1' } as any);
+      (prisma.coachStudentAssignment.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: 'assignment-1',
+          assignmentType: AssignmentType.PRIMARY,
+          subjects: [],
+          notes: null,
+          startsAt: new Date(),
+          endsAt: null,
+          student: {
+            id: 'student-1',
+            userId: 'user-student-1',
+            gradeLevel: 'PREMIERE',
+            academicTrack: 'EDS_GENERALE',
+            specialties: [],
+            stmgPathway: null,
+            survivalMode: false,
+            school: null,
+            credits: 10,
+            user: { firstName: 'Ahmed', lastName: 'B', email: 'ahmed@test.com' },
+            parent: null,
+            mathsProgress: null,
+            survivalProgress: null,
+            _count: { sessions: 5, assessments: 2 },
+          },
+        },
+      ] as any);
+
+      const result = await getAssignedStudentsForCoach({ coachUserId: 'user-1' });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].student.id).toBe('student-1');
+      expect(result[0].assignmentType).toBe(AssignmentType.PRIMARY);
+      expect(prisma.coachStudentAssignment.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            coachId: 'coach-1',
+            status: AssignmentStatus.ACTIVE,
+          }),
+        })
+      );
+    });
+
+    it('n\'inclut pas les élèves sans assignation', async () => {
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1' } as any);
+      (prisma.coachStudentAssignment.findMany as jest.Mock).mockResolvedValue([]);
+
+      const result = await getAssignedStudentsForCoach({ coachUserId: 'user-1' });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('isCoachRattachedToStudent (legacy compatibility)', () => {
+    it('checks new CoachStudentAssignment first, then falls back to SessionBooking', async () => {
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1' } as any);
+      (prisma.student.findUnique as jest.Mock).mockResolvedValue({ id: 'student-1' } as any);
+      (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue(null);
+      (prisma.sessionBooking.findFirst as jest.Mock).mockResolvedValue({ id: 'sb-1' } as any);
+
+      const result = await isCoachRattachedToStudent('coach-user-1', 'student-user-1');
+
+      expect(result).toBe(true);
+      expect(prisma.sessionBooking.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { coachId: 'coach-user-1', studentId: 'student-user-1' },
+        })
+      );
+    });
+
+    it('returns false when no link exists', async () => {
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1' } as any);
+      (prisma.student.findUnique as jest.Mock).mockResolvedValue({ id: 'student-1' } as any);
+      (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue(null);
+      (prisma.sessionBooking.findFirst as jest.Mock).mockResolvedValue(null);
+
+      const result = await isCoachRattachedToStudent('coach-user-1', 'student-user-1');
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/app/api/assistante/assignments/[id]/route.ts
+++ b/app/api/assistante/assignments/[id]/route.ts
@@ -1,0 +1,192 @@
+import { NextResponse } from 'next/server';
+import { requireAnyRole, isErrorResponse } from '@/lib/guards';
+import { can } from '@/lib/rbac';
+import { prisma } from '@/lib/prisma';
+import { AssignmentStatus, Subject } from '@prisma/client';
+import { z } from 'zod';
+
+// Validation schema for updating assignments
+const updateAssignmentSchema = z.object({
+  status: z.nativeEnum(AssignmentStatus).optional(),
+  subjects: z.array(z.nativeEnum(Subject)).optional(),
+  notes: z.string().optional(),
+  endsAt: z.string().datetime().optional().nullable(),
+});
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * GET /api/assistante/assignments/[id]
+ *
+ * Returns details of a specific assignment.
+ * Requires: ASSISTANTE or ADMIN role
+ */
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const sessionOrError = await requireAnyRole(['ADMIN', 'ASSISTANTE']);
+    if (isErrorResponse(sessionOrError)) return sessionOrError;
+
+    const assignment = await prisma.coachStudentAssignment.findUnique({
+      where: { id },
+      include: {
+        coach: {
+          include: {
+            user: {
+              select: {
+                firstName: true,
+                lastName: true,
+                email: true,
+              },
+            },
+          },
+        },
+        student: {
+          include: {
+            user: {
+              select: {
+                firstName: true,
+                lastName: true,
+                email: true,
+              },
+            },
+          },
+        },
+        assignedBy: {
+          select: {
+            firstName: true,
+            lastName: true,
+          },
+        },
+      },
+    });
+
+    if (!assignment) {
+      return NextResponse.json(
+        { error: 'Not Found', message: 'Assignation non trouvée' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      assignment,
+    });
+  } catch (error) {
+    console.error('[API Assistante Assignment GET] Error:', error);
+    return NextResponse.json(
+      { error: 'Internal Server Error', message: 'Erreur lors de la récupération' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * PATCH /api/assistante/assignments/[id]
+ *
+ * Updates an assignment (suspend, end, or modify).
+ * Requires: ASSISTANTE or ADMIN role with ASSIGN/UNASSIGN permission
+ */
+export async function PATCH(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const sessionOrError = await requireAnyRole(['ADMIN', 'ASSISTANTE']);
+    if (isErrorResponse(sessionOrError)) return sessionOrError;
+
+    if (!can(sessionOrError.user.role, 'ASSIGN', 'COACH_ASSIGNMENT') &&
+        !can(sessionOrError.user.role, 'UNASSIGN', 'COACH_ASSIGNMENT')) {
+      return NextResponse.json(
+        { error: 'Forbidden', message: 'Permission insuffisante' },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json();
+    const validated = updateAssignmentSchema.parse(body);
+
+    // Check if assignment exists
+    const existingAssignment = await prisma.coachStudentAssignment.findUnique({
+      where: { id },
+    });
+
+    if (!existingAssignment) {
+      return NextResponse.json(
+        { error: 'Not Found', message: 'Assignation non trouvée' },
+        { status: 404 }
+      );
+    }
+
+    // Build update data
+    const updateData: any = {
+      updatedAt: new Date(),
+    };
+
+    if (validated.status !== undefined) {
+      updateData.status = validated.status;
+      // If ending the assignment, set endsAt to now
+      if (validated.status === AssignmentStatus.ENDED && !validated.endsAt) {
+        updateData.endsAt = new Date();
+      }
+    }
+
+    if (validated.subjects !== undefined) {
+      updateData.subjects = validated.subjects;
+    }
+
+    if (validated.notes !== undefined) {
+      updateData.notes = validated.notes;
+    }
+
+    if (validated.endsAt !== undefined) {
+      updateData.endsAt = validated.endsAt ? new Date(validated.endsAt) : null;
+    }
+
+    const updatedAssignment = await prisma.coachStudentAssignment.update({
+      where: { id },
+      data: updateData,
+      include: {
+        coach: {
+          include: {
+            user: {
+              select: {
+                firstName: true,
+                lastName: true,
+              },
+            },
+          },
+        },
+        student: {
+          include: {
+            user: {
+              select: {
+                firstName: true,
+                lastName: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: 'Assignation mise à jour',
+      assignment: updatedAssignment,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Validation Error', message: error.errors },
+        { status: 400 }
+      );
+    }
+
+    console.error('[API Assistante Assignment PATCH] Error:', error);
+    return NextResponse.json(
+      { error: 'Internal Server Error', message: 'Erreur lors de la mise à jour' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/assistante/assignments/route.ts
+++ b/app/api/assistante/assignments/route.ts
@@ -1,0 +1,241 @@
+import { NextResponse } from 'next/server';
+import { requireAnyRole, isErrorResponse } from '@/lib/guards';
+import { can } from '@/lib/rbac';
+import { prisma } from '@/lib/prisma';
+import { AssignmentType, AssignmentStatus, Subject } from '@prisma/client';
+import { z } from 'zod';
+
+// Validation schema for creating assignments
+const createAssignmentSchema = z.object({
+  coachId: z.string().min(1, 'Coach ID requis'),
+  studentIds: z.array(z.string().min(1)).min(1, 'Au moins un élève requis'),
+  assignmentType: z.nativeEnum(AssignmentType).default(AssignmentType.PRIMARY),
+  subjects: z.array(z.nativeEnum(Subject)).optional().default([]),
+  startsAt: z.string().datetime().optional(),
+  endsAt: z.string().datetime().optional(),
+  notes: z.string().optional(),
+});
+
+/**
+ * GET /api/assistante/assignments
+ *
+ * Returns a list of coach-student assignments.
+ * Requires: ASSISTANTE or ADMIN role
+ * Query params:
+ *   - coachId: string (filter by coach)
+ *   - studentId: string (filter by student)
+ *   - status: AssignmentStatus (default: ACTIVE)
+ *   - page: number (default: 1)
+ *   - limit: number (default: 20, max: 100)
+ */
+export async function GET(request: Request) {
+  try {
+    const sessionOrError = await requireAnyRole(['ADMIN', 'ASSISTANTE']);
+    if (isErrorResponse(sessionOrError)) return sessionOrError;
+
+    const session = sessionOrError;
+
+    const { searchParams } = new URL(request.url);
+    const coachId = searchParams.get('coachId');
+    const studentId = searchParams.get('studentId');
+    const status = (searchParams.get('status') as AssignmentStatus) || AssignmentStatus.ACTIVE;
+    const page = parseInt(searchParams.get('page') || '1', 10);
+    const limit = Math.min(parseInt(searchParams.get('limit') || '20', 10), 100);
+    const skip = (page - 1) * limit;
+
+    const where: any = {};
+    if (coachId) where.coachId = coachId;
+    if (studentId) where.studentId = studentId;
+    if (status) where.status = status;
+
+    const [assignments, total] = await Promise.all([
+      prisma.coachStudentAssignment.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+        include: {
+          coach: {
+            include: {
+              user: {
+                select: {
+                  firstName: true,
+                  lastName: true,
+                  email: true,
+                },
+              },
+            },
+          },
+          student: {
+            include: {
+              user: {
+                select: {
+                  firstName: true,
+                  lastName: true,
+                  email: true,
+                },
+              },
+            },
+          },
+          assignedBy: {
+            select: {
+              firstName: true,
+              lastName: true,
+            },
+          },
+        },
+      }),
+      prisma.coachStudentAssignment.count({ where }),
+    ]);
+
+    return NextResponse.json({
+      success: true,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+      assignments,
+    });
+  } catch (error) {
+    console.error('[API Assistante Assignments GET] Error:', error);
+    return NextResponse.json(
+      { error: 'Internal Server Error', message: 'Erreur lors de la récupération' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/assistante/assignments
+ *
+ * Creates one or multiple coach-student assignments.
+ * Requires: ASSISTANTE or ADMIN role with ASSIGN permission
+ */
+export async function POST(request: Request) {
+  try {
+    const sessionOrError = await requireAnyRole(['ADMIN', 'ASSISTANTE']);
+    if (isErrorResponse(sessionOrError)) return sessionOrError;
+
+    const session = sessionOrError;
+
+    if (!can(session.user.role, 'ASSIGN', 'COACH_ASSIGNMENT')) {
+      return NextResponse.json(
+        { error: 'Forbidden', message: 'Permission insuffisante pour créer des assignations' },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json();
+    const validated = createAssignmentSchema.parse(body);
+
+    // Verify coach exists
+    const coach = await prisma.coachProfile.findUnique({
+      where: { id: validated.coachId },
+      include: { user: { select: { firstName: true, lastName: true } } },
+    });
+
+    if (!coach) {
+      return NextResponse.json(
+        { error: 'Bad Request', message: 'Coach non trouvé' },
+        { status: 400 }
+      );
+    }
+
+    // Verify all students exist
+    const students = await prisma.student.findMany({
+      where: { id: { in: validated.studentIds } },
+      include: { user: { select: { firstName: true, lastName: true } } },
+    });
+
+    if (students.length !== validated.studentIds.length) {
+      const foundIds = students.map((s) => s.id);
+      const missingIds = validated.studentIds.filter((id) => !foundIds.includes(id));
+      return NextResponse.json(
+        { error: 'Bad Request', message: `Élèves non trouvés: ${missingIds.join(', ')}` },
+        { status: 400 }
+      );
+    }
+
+    // Check for existing active assignments (prevent duplicates)
+    const existingAssignments = await prisma.coachStudentAssignment.findMany({
+      where: {
+        coachId: validated.coachId,
+        studentId: { in: validated.studentIds },
+        status: AssignmentStatus.ACTIVE,
+      },
+    });
+
+    const existingStudentIds = existingAssignments.map((a) => a.studentId);
+
+    // If trying to create PRIMARY assignment where one already exists, reject
+    if (validated.assignmentType === AssignmentType.PRIMARY && existingStudentIds.length > 0) {
+      const existingStudents = students.filter((s) => existingStudentIds.includes(s.id));
+      return NextResponse.json(
+        {
+          error: 'Conflict',
+          message: `Ces élèves ont déjà une assignation active avec ce coach: ${existingStudents.map((s) => `${s.user.firstName} ${s.user.lastName}`).join(', ')}`,
+        },
+        { status: 409 }
+      );
+    }
+
+    // Create assignments in a transaction
+    const createdAssignments = await prisma.$transaction(
+      validated.studentIds.map((studentId) =>
+        prisma.coachStudentAssignment.create({
+          data: {
+            coachId: validated.coachId,
+            studentId,
+            assignedById: session.user.id,
+            assignmentType: validated.assignmentType,
+            subjects: validated.subjects,
+            notes: validated.notes,
+            startsAt: validated.startsAt ? new Date(validated.startsAt) : new Date(),
+            endsAt: validated.endsAt ? new Date(validated.endsAt) : null,
+            status: AssignmentStatus.ACTIVE,
+          },
+          include: {
+            coach: {
+              include: {
+                user: {
+                  select: { firstName: true, lastName: true },
+                },
+              },
+            },
+            student: {
+              include: {
+                user: {
+                  select: { firstName: true, lastName: true },
+                },
+              },
+            },
+          },
+        })
+      )
+    );
+
+    return NextResponse.json(
+      {
+        success: true,
+        message: `${createdAssignments.length} assignation(s) créée(s)`,
+        assignments: createdAssignments,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Validation Error', message: error.errors },
+        { status: 400 }
+      );
+    }
+
+    console.error('[API Assistante Assignments POST] Error:', error);
+    return NextResponse.json(
+      { error: 'Internal Server Error', message: 'Erreur lors de la création' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/assistante/coaches/route.ts
+++ b/app/api/assistante/coaches/route.ts
@@ -1,0 +1,141 @@
+import { NextResponse } from 'next/server';
+import { requireAnyRole, isErrorResponse } from '@/lib/guards';
+import { can } from '@/lib/rbac';
+import { prisma } from '@/lib/prisma';
+
+/**
+ * GET /api/assistante/coaches
+ *
+ * Returns a list of all coaches with their assignments count.
+ * Requires: ASSISTANTE or ADMIN role
+ * Query params:
+ *   - search: string (search by name, pseudonym, or email)
+ *   - subject: Subject enum (filter by specialty)
+ *   - availableOnline: 'true' | 'false'
+ *   - page: number (default: 1)
+ *   - limit: number (default: 20, max: 100)
+ */
+export async function GET(request: Request) {
+  try {
+    const sessionOrError = await requireAnyRole(['ADMIN', 'ASSISTANTE']);
+    if (isErrorResponse(sessionOrError)) return sessionOrError;
+
+    const session = sessionOrError;
+
+    if (!can(session.user.role, 'READ', 'USER')) {
+      return NextResponse.json(
+        { error: 'Forbidden', message: 'Permission insuffisante' },
+        { status: 403 }
+      );
+    }
+
+    // Parse query parameters
+    const { searchParams } = new URL(request.url);
+    const search = searchParams.get('search') || '';
+    const availableOnline = searchParams.get('availableOnline');
+    const page = parseInt(searchParams.get('page') || '1', 10);
+    const limit = Math.min(parseInt(searchParams.get('limit') || '20', 10), 100);
+    const skip = (page - 1) * limit;
+
+    // Build where clause
+    const where: any = {};
+
+    if (availableOnline === 'true') {
+      where.availableOnline = true;
+    } else if (availableOnline === 'false') {
+      where.availableOnline = false;
+    }
+
+    if (search) {
+      where.OR = [
+        { pseudonym: { contains: search, mode: 'insensitive' } },
+        { user: { firstName: { contains: search, mode: 'insensitive' } } },
+        { user: { lastName: { contains: search, mode: 'insensitive' } } },
+        { user: { email: { contains: search, mode: 'insensitive' } } },
+      ];
+    }
+
+    // Fetch coaches with pagination
+    const [coaches, total] = await Promise.all([
+      prisma.coachProfile.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+        include: {
+          user: {
+            select: {
+              id: true,
+              firstName: true,
+              lastName: true,
+              email: true,
+            },
+          },
+          studentAssignments: {
+            where: { status: 'ACTIVE' },
+            include: {
+              student: {
+                select: {
+                  id: true,
+                  gradeLevel: true,
+                  academicTrack: true,
+                },
+              },
+            },
+          },
+          _count: {
+            select: {
+              studentAssignments: true,
+              sessions: true,
+            },
+          },
+        },
+      }),
+      prisma.coachProfile.count({ where }),
+    ]);
+
+    // Transform data for response
+    const formattedCoaches = coaches.map((coach) => ({
+      id: coach.id,
+      userId: coach.userId,
+      firstName: coach.user.firstName,
+      lastName: coach.user.lastName,
+      email: coach.user.email,
+      pseudonym: coach.pseudonym,
+      title: coach.title,
+      tag: coach.tag,
+      subjects: coach.subjects,
+      availableOnline: coach.availableOnline,
+      availableInPerson: coach.availableInPerson,
+      stats: {
+        activeStudents: coach._count.studentAssignments,
+        totalSessions: coach._count.sessions,
+      },
+      activeAssignments: coach.studentAssignments.map((assignment) => ({
+        assignmentId: assignment.id,
+        studentId: assignment.student.id,
+        studentGrade: assignment.student.gradeLevel,
+        studentTrack: assignment.student.academicTrack,
+        subjects: assignment.subjects,
+      })),
+      createdAt: coach.createdAt,
+    }));
+
+    return NextResponse.json({
+      success: true,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+      coaches: formattedCoaches,
+    });
+  } catch (error) {
+    console.error('[API Assistante Coaches GET] Error:', error);
+    return NextResponse.json(
+      { error: 'Internal Server Error', message: 'Erreur lors de la récupération des coachs' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/assistante/students/route.ts
+++ b/app/api/assistante/students/route.ts
@@ -1,0 +1,155 @@
+import { NextResponse } from 'next/server';
+import { requireAnyRole, isErrorResponse } from '@/lib/guards';
+import { can } from '@/lib/rbac';
+import { prisma } from '@/lib/prisma';
+import { GradeLevel, AcademicTrack, StmgPathway } from '@prisma/client';
+
+/**
+ * GET /api/assistante/students
+ *
+ * Returns a paginated and filterable list of all students.
+ * Requires: ASSISTANTE or ADMIN role
+ * Query params:
+ *   - search: string (search by name or email)
+ *   - gradeLevel: GradeLevel
+ *   - academicTrack: AcademicTrack
+ *   - stmgPathway: StmgPathway
+ *   - hasCoach: 'true' | 'false' | 'all'
+ *   - page: number (default: 1)
+ *   - limit: number (default: 20, max: 100)
+ */
+export async function GET(request: Request) {
+  try {
+    const sessionOrError = await requireAnyRole(['ADMIN', 'ASSISTANTE']);
+    if (isErrorResponse(sessionOrError)) return sessionOrError;
+
+    const session = sessionOrError;
+
+    // RBAC check
+    if (!can(session.user.role, 'READ', 'STUDENT')) {
+      return NextResponse.json(
+        { error: 'Forbidden', message: 'Permission insuffisante' },
+        { status: 403 }
+      );
+    }
+
+    // Parse query parameters
+    const { searchParams } = new URL(request.url);
+    const search = searchParams.get('search') || '';
+    const gradeLevel = searchParams.get('gradeLevel') as GradeLevel | null;
+    const academicTrack = searchParams.get('academicTrack') as AcademicTrack | null;
+    const stmgPathway = searchParams.get('stmgPathway') as StmgPathway | null;
+    const hasCoach = searchParams.get('hasCoach') || 'all';
+    const page = parseInt(searchParams.get('page') || '1', 10);
+    const limit = Math.min(parseInt(searchParams.get('limit') || '20', 10), 100);
+    const skip = (page - 1) * limit;
+
+    // Build where clause
+    const where: any = {};
+
+    if (gradeLevel) {
+      where.gradeLevel = gradeLevel;
+    }
+
+    if (academicTrack) {
+      where.academicTrack = academicTrack;
+    }
+
+    if (stmgPathway) {
+      where.stmgPathway = stmgPathway;
+    }
+
+    if (hasCoach === 'true') {
+      where.coachAssignments = {
+        some: { status: 'ACTIVE' },
+      };
+    } else if (hasCoach === 'false') {
+      where.coachAssignments = {
+        none: { status: 'ACTIVE' },
+      };
+    }
+
+    if (search) {
+      where.OR = [
+        { user: { firstName: { contains: search, mode: 'insensitive' } } },
+        { user: { lastName: { contains: search, mode: 'insensitive' } } },
+        { user: { email: { contains: search, mode: 'insensitive' } } },
+      ];
+    }
+
+    // Fetch students with pagination
+    const [students, total] = await Promise.all([
+      prisma.student.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+        include: {
+          user: {
+            select: {
+              id: true,
+              firstName: true,
+              lastName: true,
+              email: true,
+              activatedAt: true,
+            },
+          },
+          parent: {
+            include: {
+              user: {
+                select: {
+                  firstName: true,
+                  lastName: true,
+                  email: true,
+                },
+              },
+            },
+          },
+          coachAssignments: {
+            where: { status: 'ACTIVE' },
+            include: {
+              coach: {
+                include: {
+                  user: {
+                    select: {
+                      firstName: true,
+                      lastName: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+          subscriptions: {
+            where: { status: 'ACTIVE' },
+            take: 1,
+          },
+          _count: {
+            select: {
+              coachAssignments: true,
+              sessions: true,
+            },
+          },
+        },
+      }),
+      prisma.student.count({ where }),
+    ]);
+
+    return NextResponse.json({
+      success: true,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+      students,
+    });
+  } catch (error) {
+    console.error('[API Assistante Students GET] Error:', error);
+    return NextResponse.json(
+      { error: 'Internal Server Error', message: 'Erreur lors de la récupération des élèves' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/coach/students/[studentId]/route.ts
+++ b/app/api/coach/students/[studentId]/route.ts
@@ -1,0 +1,129 @@
+import { NextResponse } from 'next/server';
+import { requireRole, isErrorResponse } from '@/lib/guards';
+import { can } from '@/lib/rbac';
+import { assertCoachCanAccessStudent } from '@/lib/rbac/coach-student-access';
+import { prisma } from '@/lib/prisma';
+import { UserRole } from '@prisma/client';
+
+interface RouteParams {
+  params: Promise<{ studentId: string }>;
+}
+
+/**
+ * GET /api/coach/students/[studentId]
+ *
+ * Returns detailed information about a specific student.
+ * Requires: COACH role + active assignment to this student
+ */
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { studentId } = await params;
+    const sessionOrError = await requireRole(UserRole.COACH);
+    if (isErrorResponse(sessionOrError)) return sessionOrError;
+
+    const session = sessionOrError;
+
+    // RBAC check
+    if (!can(session.user.role, 'READ_OWN', 'STUDENT')) {
+      return NextResponse.json(
+        { error: 'Forbidden', message: 'Permission insuffisante' },
+        { status: 403 }
+      );
+    }
+
+    // Ownership check - throws if not assigned
+    try {
+      await assertCoachCanAccessStudent({
+        coachUserId: session.user.id,
+        studentId,
+      });
+    } catch (accessError) {
+      return NextResponse.json(
+        { error: 'Forbidden', message: 'Vous n\'êtes pas assigné à cet élève' },
+        { status: 403 }
+      );
+    }
+
+    // Fetch detailed student data
+    const student = await prisma.student.findUnique({
+      where: { id: studentId },
+      include: {
+        user: {
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            email: true,
+            phone: true,
+          },
+        },
+        parent: {
+          include: {
+            user: {
+              select: {
+                firstName: true,
+                lastName: true,
+                email: true,
+                phone: true,
+              },
+            },
+          },
+        },
+        coachAssignments: {
+          where: { status: 'ACTIVE' },
+          include: {
+            coach: {
+              include: {
+                user: {
+                  select: {
+                    firstName: true,
+                    lastName: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+        assessments: {
+          orderBy: { createdAt: 'desc' },
+          take: 5,
+        },
+        sessions: {
+          orderBy: { scheduledAt: 'desc' },
+          take: 5,
+          include: {
+            coach: true,
+          },
+        },
+        trajectories: {
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+        },
+        _count: {
+          select: {
+            sessions: true,
+            assessments: true,
+          },
+        },
+      },
+    });
+
+    if (!student) {
+      return NextResponse.json(
+        { error: 'Not Found', message: 'Élève non trouvé' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      student,
+    });
+  } catch (error) {
+    console.error('[API Coach Student Detail GET] Error:', error);
+    return NextResponse.json(
+      { error: 'Internal Server Error', message: 'Erreur lors de la récupération des données' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/coach/students/route.ts
+++ b/app/api/coach/students/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { requireRole, isErrorResponse } from '@/lib/guards';
+import { can } from '@/lib/rbac';
+import { getAssignedStudentsForCoach } from '@/lib/rbac/coach-student-access';
+import { UserRole } from '@prisma/client';
+
+/**
+ * GET /api/coach/students
+ *
+ * Returns all students assigned to the authenticated coach.
+ * Requires: COACH role
+ * Enforces: Only assigned students (via CoachStudentAssignment)
+ */
+export async function GET() {
+  try {
+    const sessionOrError = await requireRole(UserRole.COACH);
+    if (isErrorResponse(sessionOrError)) return sessionOrError;
+
+    const session = sessionOrError;
+
+    // RBAC check
+    if (!can(session.user.role, 'READ_OWN', 'STUDENT')) {
+      return NextResponse.json(
+        { error: 'Forbidden', message: 'Vous n\'avez pas la permission de voir les élèves' },
+        { status: 403 }
+      );
+    }
+
+    // Get assigned students
+    const students = await getAssignedStudentsForCoach({
+      coachUserId: session.user.id,
+    });
+
+    return NextResponse.json({
+      success: true,
+      count: students.length,
+      students,
+    });
+  } catch (error) {
+    console.error('[API Coach Students GET] Error:', error);
+    return NextResponse.json(
+      { error: 'Internal Server Error', message: 'Erreur lors de la récupération des élèves' },
+      { status: 500 }
+    );
+  }
+}

--- a/docs/audits/AUDIT_DB_PROFILS_ROLES_PARCOURS_DOCUMENTS_2026-04-25.md
+++ b/docs/audits/AUDIT_DB_PROFILS_ROLES_PARCOURS_DOCUMENTS_2026-04-25.md
@@ -1,0 +1,1198 @@
+# AUDIT DB / PROFILS / RÔLES / PARCOURS / DOCUMENTS — NEXUS RÉUSSITE
+
+**Date** : 2026-04-25  
+**Version** : v1.0  
+**Statut** : Audit initial post-déploiement PR #24  
+**Auteur** : Cascade (AI Assistant)  
+**Scope** : Lecture seule, aucune modification production
+
+---
+
+## 1. Résumé Exécutif
+
+### 1.1 État Général
+| Aspect | Évaluation | Commentaire |
+|--------|------------|-------------|
+| **Schéma Prisma** | 🟡 Partiellement complet | Modèles de base présents mais manques structurels critiques |
+| **Alignement DB** | 🟢 Bon | 49 tables, migrations à jour, colonnes PR #24 déployées |
+| **RBAC** | 🟡 Fonctionnel mais limité | Permissions centralisées dans `lib/rbac.ts` |
+| **Associations Coach-Élève** | 🔴 **CRITIQUE : Manquant** | Pas de table de liaison explicite |
+| **Documents** | 🟡 Basique | Modèle `UserDocument` existant mais pas d'assignation fine |
+| **Dashboards** | 🟡 Partiels | Élève OK, Coach incomplet, Admin/Assistante limités |
+
+### 1.2 Risque Principal
+**Risque Critique** : L'absence d'une table `CoachStudentAssignment` ou équivalent empêche :
+- Un coach de voir explicitement "ses" élèves
+- L'assistante de gérer les associations coach-élève
+- La traçabilité historique des affectations
+- La segmentation claire des responsabilités pédagogiques
+
+### 1.3 Priorité
+1. **P0** : Créer le modèle d'association Coach-Élève
+2. **P1** : Compléter les dashboards Coach et Assistante
+3. **P2** : Implémenter l'assignation fine des documents
+4. **P3** : Standardiser les workflows d'onboarding
+
+---
+
+## 2. Cartographie Actuelle
+
+### 2.1 Modèles Utilisateurs et Rôles
+
+#### 2.1.1 Enum UserRole (Prisma)
+```prisma
+enum UserRole {
+  ADMIN         // Super administrateur
+  ASSISTANTE    // Gestion opérationnelle
+  COACH         // Accompagnement pédagogique
+  PARENT        // Parent d'élève
+  ELEVE         // Élève
+}
+```
+
+**Analyse** :
+- ✅ 5 rôles bien définis
+- ❌ Pas de SUPER_ADMIN distinct de ADMIN
+- ❌ Pas de granularité (ex: COACH_MATHS vs COACH_GENERAL)
+- ❌ Rôles mutuellement exclusifs (pas de multi-rôles)
+
+#### 2.1.2 Model User (Prisma)
+```prisma
+model User {
+  id              String    @id @default(cuid())
+  email           String    @unique
+  name            String?
+  firstName       String?
+  lastName        String?
+  phone           String?
+  userRole        UserRole  // Rôle principal
+  
+  // Relations profils
+  student         Student?
+  parentProfile   ParentProfile?
+  coachProfile    CoachProfile?
+  
+  // Relations documents
+  documents       UserDocument[]
+  documentsUploaded UserDocument[] @relation("DocumentUploader")
+  
+  // Relations stages et notes
+  stageReservations StageReservation[]
+  stageBilans     StageBilan[]
+  coachNotesAuthored CoachNote[]
+  coachNotesAbout CoachNote[]
+  
+  // Relations progression
+  mathsProgress   MathsProgress[]
+}
+```
+
+**Analyse** :
+- ✅ One-to-One avec profils spécifiques (Student, ParentProfile, CoachProfile)
+- ✅ Relations documents bidirectionnelles
+- ❌ Pas de champs pour permissions additionnelles
+- ❌ Pas d'audit trail (createdBy, updatedBy)
+
+### 2.2 Profil Élève (Student)
+
+#### 2.2.1 Model Student (Prisma)
+```prisma
+model Student {
+  id              String    @id @default(cuid())
+  userId          String    @unique
+  parentId        String?   // Lien vers parent
+  
+  // Informations pédagogiques (PR #24)
+  grade           String?   // Legacy, à migrer vers gradeLevel
+  gradeLevel      GradeLevel?        // PREMIERE, TERMINALE, etc.
+  academicTrack   AcademicTrack?     // EDS_GENERALE, STMG, etc.
+  specialties     Subject[]            // Spécialités choisies
+  stmgPathway     StmgPathway?       // RHC, MERCATIQUE, etc. (si STMG)
+  updatedTrackAt  DateTime?           // Date de dernière modification
+  
+  // Mode survie (PR #24)
+  survivalMode    Boolean   @default(false)
+  survivalModeReason String?
+  survivalModeBy  String?
+  survivalModeAt  DateTime?
+  
+  // Relations
+  user            User      @relation(fields: [userId], references: [id])
+  parent          ParentProfile? @relation(fields: [parentId], references: [id])
+  subscriptions   Subscription[]
+  sessions        Session[]
+  reports         StudentReport[]
+  trajectories    Trajectory[]
+  assessments     Assessment[]
+  survivalProgress SurvivalProgress?
+  badges          StudentBadge[]
+  
+  // Progression
+  mathsProgress   MathsProgress[]
+}
+```
+
+**Analyse** :
+- ✅ Champs PR #24 présents et conformes
+- ✅ Support EDS Maths et STMG avec pathway
+- ✅ Spécialités stockées comme array
+- ❌ Pas de "parcours actif" dénormalisé pour affichage rapide
+- ❌ Pas d'historique des changements de filière
+- ❌ Pas de lien explicite vers coach(s)
+
+#### 2.2.2 Enums Pédagogiques
+```prisma
+enum GradeLevel {
+  SECONDE
+  PREMIERE
+  TERMINALE
+  POSTBAC
+}
+
+enum AcademicTrack {
+  EDS_GENERALE    // Enseignement de spécialité Général
+  STMG            // Sciences et Technologies du Management et de la Gestion
+  STI2D           // Sciences et Technologies de l'Industrie et du Développement Durable
+  ST2S            // Sciences et Technologies de la Santé et du Social
+  STL             // Sciences et Technologies de Laboratoire
+  STD2A           // Sciences et Technologies du Design et des Arts
+  STMG_NON_LYCEEN // STMG hors lycée (post-bac?)
+}
+
+enum StmgPathway {
+  RHC             // Ressources Humaines et Communication
+  MERCATIQUE      // Mercatique (Marketing)
+  GF              // Gestion et Finance
+  SIG             // Systèmes d'Information et de Gestion
+  INDETERMINE     // Non choisi
+}
+
+enum Subject {
+  MATHS
+  NSI
+  PHYSIQUE_CHIMIE
+  SVT
+  SES
+  HISTOIRE_GEO
+  ANGLAIS
+  ESPAGNOL
+  // ... etc
+}
+```
+
+**Analyse** :
+- ✅ Granularité suffisante pour distinguer les filières
+- ✅ STMG avec pathways spécifiques
+- ❌ Pas d'enum `LearningPath` ou `ProductCode` explicite
+- ❌ Pas de correspondance automatique track → parcours disponibles
+
+### 2.3 Profil Coach (CoachProfile)
+
+```prisma
+model CoachProfile {
+  id              String    @id @default(cuid())
+  userId          String    @unique
+  
+  // Identité professionnelle
+  title           String?   // Agrégé, Certifié, etc.
+  pseudonym       String    @unique  // Hélios, Zénon, etc.
+  tag             String?   // 🎓, 🎯, etc.
+  description     String?
+  philosophy      String?
+  expertise       String?
+  
+  // Spécialités
+  subjects        Json      @default("[]") // Array des matières
+  
+  // Disponibilités
+  availableOnline   Boolean @default(true)
+  availableInPerson Boolean @default(true)
+  
+  // Relations
+  user            User      @relation(fields: [userId], references: [id])
+  sessions        Session[]
+  reports         StudentReport[]
+  stageSessions   StageSession[]
+  stageBilans     StageBilan[]
+  stageAssignments StageCoach[]
+  
+  // ❌ MANQUANT : Relation explicite vers élèves assignés
+}
+```
+
+**Analyse** :
+- ✅ Profil riche avec métadonnées
+- ✅ Spécialités flexibles (JSON)
+- ✅ Intégration Stages
+- 🔴 **CRITIQUE** : Aucune relation directe Student[] ou équivalent
+- 🔴 Le coach ne peut pas "voir ses élèves" sans passer par Session ou Stage
+
+### 2.4 Profil Parent (ParentProfile)
+
+```prisma
+model ParentProfile {
+  id              String    @id @default(cuid())
+  userId          String    @unique
+  
+  // Informations
+  address         String?
+  city            String?
+  country         String    @default("Tunisie")
+  
+  // Tracking bilan gratuit
+  bilanGratuitCompletedAt DateTime?
+  bilanGratuitDismissedAt DateTime?
+  
+  // Relations
+  user            User      @relation(fields: [userId], references: [id])
+  children        Student[] // One-to-Many : un parent peut avoir plusieurs enfants
+}
+```
+
+**Analyse** :
+- ✅ Un parent peut avoir plusieurs enfants (Student[])
+- ✅ Structure simple et fonctionnelle
+- ❌ Pas de lien vers coachs des enfants
+- ❌ Pas de permissions déléguées (ex: parent peut-il voir les notes?)
+
+### 2.5 Documents (UserDocument)
+
+```prisma
+model UserDocument {
+  id              String    @id @default(cuid())
+  
+  // Métadonnées
+  title           String
+  originalName    String
+  mimeType        String
+  sizeBytes       Int
+  localPath       String    // Chemin stockage interne
+  
+  // Propriétaire (élève ou autre)
+  userId          String
+  user            User      @relation("UserDocuments", fields: [userId], references: [id])
+  
+  // Uploadeur (coach, assistante, ou élève lui-même)
+  uploadedById    String?
+  uploadedBy      User?     @relation("DocumentUploader", fields: [uploadedById], references: [id])
+  
+  // Timestamps
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+  
+  // ❌ MANQUANT : 
+  // - Type de document (cours, exercice, bilan, etc.)
+  // - Visibilité (élève seul, parent, coach, etc.)
+  // - Parcours/matière associée
+  // - Groupe d'élèves (pour documents partagés)
+}
+```
+
+**Analyse** :
+- ✅ Stockage technique fonctionnel
+- ✅ Traçabilité de l'uploadeur
+- 🔴 **IMPORTANT** : Pas de typologie documentaire
+- 🔴 Pas de contrôle de visibilité fin
+- 🔴 Pas d'assignation à un groupe d'élèves
+- 🔴 Uniquement lié à un userId (pas de polymorphisme élève/groupe)
+
+---
+
+## 3. Relations et Associations
+
+### 3.1 Matrice des Relations Actuelles
+
+| Entité A | Relation | Entité B | Type | Commentaire |
+|----------|----------|----------|------|---------------|
+| User | 1:1 | Student | Optionnelle | Un user est optionnellement un élève |
+| User | 1:1 | CoachProfile | Optionnelle | Un user est optionnellement un coach |
+| User | 1:1 | ParentProfile | Optionnelle | Un user est optionnellement un parent |
+| ParentProfile | 1:N | Student | Multiple | Un parent a plusieurs enfants |
+| Student | N:1 | ParentProfile | Optionnelle | Un élève a un parent (optionnel) |
+| Student | 1:N | MathsProgress | Multiple | Progression par niveau (EDS/Terminale) |
+| Student | 1:1 | SurvivalProgress | Optionnelle | Mode survie STMG |
+| Student | 1:N | Assessment | Multiple | Bilans passés |
+| CoachProfile | 1:N | Session | Multiple | Séances données par le coach |
+| CoachProfile | 1:N | StageCoach | Multiple | Assignations stages |
+| **CoachProfile** | **??** | **Student** | **MANQUANT** | **Pas de lien direct !** |
+
+### 3.2 Diagnostic : Association Coach-Élève
+
+**Problème identifié** : Il n'existe actuellement aucun modèle explicite liant un coach à un élève en dehors du contexte d'une séance (Session) ou d'un stage (StageCoach).
+
+**Conséquences** :
+1. Un coach ne peut pas lister "ses élèves" sans passer par l'historique des séances
+2. Impossible de savoir quel coach est responsable d'un élève en dehors des séances programmées
+3. Pas de gestion d'équipe pédagogique (coach principal + coach secondaire)
+4. Pas d'historique des changements de coach
+5. Impossible d'assigner un document à "tous les élèves d'un coach"
+
+**Workarounds actuels possibles** (à vérifier dans le code) :
+- Via `StudentReport` (coachId est présent dans ce modèle)
+- Via `CoachNote` (coachId + studentId)
+- Via `Session` (coachId + studentId)
+
+Mais aucune de ces tables n'est une table d'association déclarative et gérable par l'assistante.
+
+---
+
+## 4. Dashboards
+
+### 4.1 Inventaire des Dashboards Existants
+
+| Dashboard | Route | État | Commentaire |
+|-----------|-------|------|-------------|
+| **Élève** | `/dashboard/eleve` | 🟢 Fonctionnel | PR #24 complété, SSoT via `/api/student/dashboard` |
+| **Parent** | `/dashboard/parent` | 🟡 Partiel | Page enfants présente, mais fonctionnalités limitées |
+| **Coach** | `/dashboard/coach` | 🔴 **Incomplet** | Stages présents, mais pas de "mes élèves" clair |
+| **Assistante** | `/dashboard/assistante` | 🟡 Limité | Stages OK, mais pas de gestion élèves/coaches |
+| **Admin** | `/dashboard/admin` | 🟡 Basique | Pas identifié dans l'audit |
+
+### 4.2 Analyse Dashboard Élève (Référence)
+
+**Points forts** (post-PR #24) :
+- SSoT (Single Source of Truth) via API `/api/student/dashboard`
+- Détection automatique EDS vs STMG
+- Cockpit adaptatif selon filière
+- Mode Survie STMG fonctionnel
+- Automatismes intégrés
+- Documents visibles (si présents)
+
+**API utilisées** :
+- `GET /api/student/dashboard` → Données agrégées
+- `GET /api/student/documents` → Documents
+- `GET /api/student/resources` → Ressources pédagogiques
+- `GET /api/student/survival/progress` → Mode survie
+- `GET /api/student/automatismes/*` → Entraînement
+
+### 4.3 Analyse Dashboard Coach
+
+**Constats** :
+- Route existante : `/dashboard/coach/*`
+- Stages : Fonctionnel (`/dashboard/coach/stages`)
+- Mais : **Pas de page "Mes élèves" claire**
+- Les coachs interagissent via :
+  - `Session` (séances)
+  - `StageCoach` (stages)
+  - `CoachNote` (notes privées)
+  - `StudentReport` (rapports)
+
+**Manques** :
+- Liste des élèves assignés
+- Vue d'ensemble des parcours
+- Déclenchement de bilans
+- Dépôt de documents ciblés
+
+### 4.4 Analyse Dashboard Assistante
+
+**Constats** :
+- Route : `/dashboard/assistante/*`
+- Stages : Fonctionnel
+- Gestion des réservations : Présente
+
+**Manques identifiés** :
+- Création d'élèves (probablement via admin ou inscription)
+- Création de coachs
+- Association coach-élève
+- Modification des parcours
+- Upload document groupe
+
+---
+
+## 5. Routes API Critiques
+
+### 5.1 Inventaire des Routes par Domaine
+
+#### 5.1.1 Élève (`/api/student/*`)
+```
+/api/student/dashboard           → Données agrégées dashboard
+/api/student/documents           → CRUD documents
+/api/student/resources           → Ressources pédagogiques
+/api/student/sessions            → Séances
+/api/student/stages              → Stages
+/api/student/trajectory          → Trajectoire
+/api/student/nexus-index         → Indice Nexus
+/api/student/survival/*          → Mode survie STMG
+/api/student/automatismes/*      → Entraînement EDS
+```
+
+#### 5.1.2 Documents (`/api/student/documents/*`)
+```
+GET    /api/student/documents              → Liste documents
+POST   /api/student/documents              → Upload
+GET    /api/student/documents/[id]/download → Download (protégé ?)
+```
+
+**Analyse sécurité documents** :
+- La route download vérifie-t-elle que l'utilisateur est bien le propriétaire ou a les droits ?
+- À vérifier dans le code source
+
+#### 5.1.3 Coach / Admin / Assistante
+```
+Routes identifiées dans l'audit :
+- /api/stages/* (gestion stages)
+- /api/students/[studentId]/badges
+```
+
+**Manques** :
+- Pas de `/api/coach/students` (liste élèves assignés)
+- Pas de `/api/admin/students` (gestion élèves)
+- Pas de `/api/admin/coaches` (gestion coaches)
+- Pas de `/api/assistante/assignments` (association coach-élève)
+
+---
+
+## 6. RBAC et Permissions
+
+### 6.1 Architecture Actuelle
+
+**Fichier** : `lib/rbac.ts`
+
+```typescript
+// Types d'actions
+export type Action = 
+  | 'CREATE' | 'READ' | 'UPDATE' | 'DELETE'
+  | 'MANAGE' | 'VALIDATE' | 'READ_SELF' | 'READ_OWN';
+
+// Ressources
+export type Resource = 
+  | 'USER' | 'STUDENT' | 'COACH' | 'PARENT'
+  | 'SESSION' | 'BILAN' | 'STAGE' | 'DOCUMENT'
+  | 'RESERVATION' | 'PAYMENT' | 'SUBSCRIPTION'
+  | 'TRAJECTORY' | 'NOTIFICATION' | 'CONFIG' | 'REPORT';
+
+// Matrice des permissions (simplifiée)
+const rolePermissions: Record<UserRole, Permission[]> = {
+  [UserRole.ADMIN]: [
+    { action: 'MANAGE', resource: 'USER' },
+    { action: 'MANAGE', resource: 'STUDENT' },
+    { action: 'MANAGE', resource: 'COACH' },
+    // ... tout est MANAGE
+  ],
+  [UserRole.ASSISTANTE]: [
+    { action: 'READ', resource: 'USER' },
+    { action: 'READ', resource: 'STUDENT' },
+    { action: 'UPDATE', resource: 'STUDENT' },
+    { action: 'VALIDATE', resource: 'BILAN' },
+    { action: 'MANAGE', resource: 'RESERVATION' },
+    // ... mais pas CREATE_USER, pas MANAGE_COACH
+  ],
+  [UserRole.COACH]: [
+    { action: 'READ', resource: 'STUDENT' }, // Tous les élèves ?
+    { action: 'CREATE', resource: 'SESSION' },
+    { action: 'READ', resource: 'BILAN' },
+    // ... manque READ_OWN_STUDENTS
+  ],
+  // ... etc
+};
+```
+
+### 6.2 Problèmes Identifiés
+
+| Problème | Sévérité | Description |
+|----------|----------|-------------|
+| Pas de `READ_OWN` pour Coach | 🔴 Haute | Un coach peut théoriquement lire tous les élèves, pas seulement les siens |
+| Pas de permission `ASSIGN` | 🔴 Haute | Impossible de contrôler qui peut associer coach-élève |
+| Pas de `DOCUMENT_UPLOAD` spécifique | 🟡 Moyenne | Pas de distinction upload pour soi vs pour autrui |
+| Pas de scope par parcours | 🟡 Moyenne | Un coach Maths ne devrait pas voir les bilans NSI ? |
+
+### 6.3 Fichier `lib/rbac/coach-student-access.ts`
+
+Ce fichier existe mais n'a pas été audité en détail. Il pourrait contenir la logique manquante d'association.
+
+---
+
+## 7. Gaps Identifiés (Synthèse)
+
+### 7.1 Gaps Modèles DB
+
+| Gap | Priorité | Impact | Solution esquissée |
+|-----|----------|--------|-------------------|
+| **Pas de CoachStudentAssignment** | P0 | 🔴 Bloquant | Créer modèle liaison avec dates, status, type |
+| **Pas de StudentGroup/Class** | P1 | 🟡 Limitant | Pour cohortes, classes, groupes de stages |
+| **Pas de DocumentAssignment** | P1 | 🟡 Limitant | Assignation documents à groupe ou élève |
+| **Pas d'historique Track changes** | P2 | 🟢 Info | Log changements de filière |
+| **Pas de LearningPath enum** | P2 | 🟡 Limitant | EDS_MATHS_P1, STMG_MATHS_P1, etc. |
+
+### 7.2 Gaps API
+
+| Gap | Priorité | Impact |
+|-----|----------|--------|
+| **GET /api/coach/students** | P0 | Coach ne peut pas lister ses élèves |
+| **POST /api/admin/students** | P1 | Pas de création élève par admin/assistante |
+| **POST /api/admin/coaches** | P1 | Pas de création coach |
+| **POST /api/assistante/assignments** | P0 | Pas d'association coach-élève |
+| **POST /api/documents/assign** | P1 | Pas d'assignation document groupe |
+
+### 7.3 Gaps Dashboards
+
+| Gap | Priorité | Impact |
+|-----|----------|--------|
+| **Dashboard Coach - Mes Élèves** | P0 | Vue d'ensemble manquante |
+| **Dashboard Coach - Dépôt Document** | P1 | Fonctionnalité probablement absente |
+| **Dashboard Assistante - Gestion Élèves** | P1 | Pas d'interface de gestion |
+| **Dashboard Assistante - Association** | P0 | Interface d'assignation manquante |
+
+---
+
+## 8. Architecture Cible Recommandée
+
+### 8.1 Modèles à Ajouter
+
+#### 8.1.1 CoachStudentAssignment (P0)
+```prisma
+model CoachStudentAssignment {
+  id              String    @id @default(cuid())
+  
+  // Relations
+  coachId         String
+  coach           CoachProfile @relation(fields: [coachId], references: [id])
+  
+  studentId       String
+  student         Student   @relation(fields: [studentId], references: [id])
+  
+  // Métadonnées d'assignation
+  assignedById    String    // Qui a fait l'assignation (assistante/admin)
+  assignedBy        User    @relation(fields: [assignedById], references: [id])
+  
+  // Période de validité
+  startsAt        DateTime  @default(now())
+  endsAt          DateTime?  // NULL = actif indéfiniment
+  
+  // Type d'assignation
+  assignmentType  AssignmentType @default(PRIMARY)
+  // PRIMARY = coach principal
+  // SECONDARY = coach secondaire (spécialiste)
+  // STAGE = assignation stage uniquement
+  
+  // Matières concernées (pour spécialistes)
+  subjects        Subject[] // Si vide = toutes matières
+  
+  // Status
+  status          AssignmentStatus @default(ACTIVE)
+  
+  // Notes
+  notes           String?
+  
+  // Timestamps
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+  
+  @@unique([coachId, studentId, status], name: "unique_active_assignment")
+  @@index([coachId, status])
+  @@index([studentId, status])
+  @@map("coach_student_assignments")
+}
+
+enum AssignmentType {
+  PRIMARY    // Coach référent
+  SECONDARY  // Spécialiste (maths, français...)
+  STAGE      // Uniquement pour un stage
+  TEMPORARY  // Remplacement
+}
+
+enum AssignmentStatus {
+  ACTIVE
+  SUSPENDED
+  ENDED
+}
+```
+
+#### 8.1.2 StudentGroup (P1)
+```prisma
+model StudentGroup {
+  id              String    @id @default(cuid())
+  name            String
+  description     String?
+  
+  // Type de groupe
+  groupType       GroupType @default(COHORT)
+  // COHORT = Cohorte annuelle
+  // CLASS = Classe physique
+  // STAGE = Groupe de stage
+  // CUSTOM = Groupe ad-hoc
+  
+  // Caractéristiques pédagogiques (optionnel)
+  targetGradeLevel    GradeLevel?
+  targetAcademicTrack AcademicTrack?
+  
+  // Relations
+  members         StudentGroupMember[]
+  documents       DocumentGroupAssignment[]
+  
+  // Gestion
+  createdById     String
+  createdBy       User      @relation(fields: [createdById], references: [id])
+  
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+  
+  @@map("student_groups")
+}
+
+model StudentGroupMember {
+  id          String    @id @default(cuid())
+  groupId     String
+  group       StudentGroup @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  
+  studentId   String
+  student     Student   @relation(fields: [studentId], references: [id], onDelete: Cascade)
+  
+  joinedAt    DateTime  @default(now())
+  leftAt      DateTime?
+  
+  @@unique([groupId, studentId, joinedAt])
+  @@map("student_group_members")
+}
+```
+
+#### 8.1.3 DocumentAssignment (P1)
+```prisma
+// Extension du modèle UserDocument existant
+// OU création d'un modèle d'assignation séparé
+
+model DocumentVisibility {
+  id              String    @id @default(cuid())
+  documentId      String
+  document        UserDocument @relation(fields: [documentId], references: [id], onDelete: Cascade)
+  
+  // Cible de l'assignation (un seul des deux)
+  userId          String?   // Élève individuel
+  user            User?     @relation(fields: [userId], references: [id])
+  
+  groupId         String?   // Groupe d'élèves
+  group           StudentGroup? @relation(fields: [groupId], references: [id])
+  
+  // Type de visibilité
+  visibilityType  VisibilityType @default(PRIVATE)
+  // PRIVATE = uniquement userId
+  // COACH = userId + son coach
+  // PARENT = userId + son parent
+  // GROUP = membres du groupId
+  
+  // Métadonnées
+  documentType    DocumentType @default(OTHER)
+  // COURS, EXERCICE, BILAN, CORRECTION, PLANNING, ANNEXE, OTHER
+  
+  subject         Subject?  // Matière concernée (optionnel)
+  
+  createdAt       DateTime  @default(now())
+  expiresAt       DateTime? // Date d'expiration (optionnel)
+  
+  @@index([documentId])
+  @@index([userId])
+  @@index([groupId])
+  @@map("document_visibilities")
+}
+
+enum DocumentType {
+  COURS
+  EXERCICE
+  BILAN
+  CORRECTION
+  PLANNING
+  ANNEXE
+  OTHER
+}
+
+enum VisibilityType {
+  PRIVATE    // Uniquement l'élève
+  COACH      // Élève + coach assigné
+  PARENT     // Élève + parent
+  GROUP      // Groupe entier
+  PUBLIC     // Tous (rare, pour documents communs)
+}
+```
+
+### 8.2 Enums à Ajouter
+
+```prisma
+// Dans le fichier schema.prisma
+
+enum AssignmentType {
+  PRIMARY
+  SECONDARY
+  STAGE
+  TEMPORARY
+}
+
+enum AssignmentStatus {
+  ACTIVE
+  SUSPENDED
+  ENDED
+}
+
+enum GroupType {
+  COHORT
+  CLASS
+  STAGE
+  CUSTOM
+}
+
+enum DocumentType {
+  COURS
+  EXERCICE
+  BILAN
+  CORRECTION
+  PLANNING
+  ANNEXE
+  OTHER
+}
+
+enum VisibilityType {
+  PRIVATE
+  COACH
+  PARENT
+  GROUP
+  PUBLIC
+}
+
+// Enum pour les parcours produits (optionnel mais recommandé)
+enum ProductPath {
+  EDS_MATHS_PREMIERE
+  EDS_MATHS_TERMINALE
+  STMG_MATHS_PREMIERE
+  STMG_MATHS_TERMINALE
+  NSI_PREMIERE
+  NSI_TERMINALE
+  EAF_PREMIERE
+  EAF_TERMINALE
+}
+```
+
+---
+
+## 9. Matrice de Permissions Cible
+
+### 9.1 Matrice Détaillée
+
+| Action | ÉLÈVE | PARENT | COACH | ASSISTANTE | ADMIN |
+|--------|-------|--------|-------|------------|-------|
+| **Voir dashboard** | ✅ Soi | ✅ Enfants | ✅ Élèves assignés | ✅ Tous | ✅ Tous |
+| **Modifier profil** | ✅ Soi | ❌ Non | ❌ Non | ✅ Tous | ✅ Tous |
+| **Voir documents** | ✅ Siens | ✅ Enfants | ✅ Assignés | ✅ Tous | ✅ Tous |
+| **Upload document** | ✅ Soi | ❌ Non | ✅ Assignés | ✅ Tous | ✅ Tous |
+| **Assigner document groupe** | ❌ Non | ❌ Non | ❌ Non | ✅ Oui | ✅ Oui |
+| **Voir bilans** | ✅ Siens | ✅ Enfants | ✅ Assignés | ✅ Tous | ✅ Tous |
+| **Créer bilan** | ❌ Non | ❌ Non | ❌ Non | ✅ Oui | ✅ Oui |
+| **Valider bilan** | ❌ Non | ❌ Non | ❌ Non | ✅ Oui | ✅ Oui |
+| **Voir progression** | ✅ Siennes | ✅ Enfants | ✅ Assignés | ✅ Toutes | ✅ Toutes |
+| **Créer élève** | ❌ Non | ❌ Non | ❌ Non | ✅ Oui | ✅ Oui |
+| **Créer coach** | ❌ Non | ❌ Non | ❌ Non | ❌ Non | ✅ Oui |
+| **Associer coach-élève** | ❌ Non | ❌ Non | ❌ Non | ✅ Oui | ✅ Oui |
+| **Modifier parcours** | ❌ Non | ❌ Non | ❌ Non | ✅ Oui | ✅ Oui |
+| **Gérer stages** | ❌ Non | ❌ Non | ✅ Si animateur | ✅ Oui | ✅ Oui |
+| **Voir paiements** | ❌ Non | ❌ Non | ❌ Non | ✅ Oui | ✅ Oui |
+| **Gérer réservations** | ❌ Non | ❌ Non | ❌ Non | ✅ Oui | ✅ Oui |
+
+### 9.2 Nouvelles Permissions à Ajouter au RBAC
+
+```typescript
+// Dans lib/rbac.ts
+
+export type Resource = 
+  | ... // existants
+  | 'COACH_ASSIGNMENT'  // Nouveau : gestion associations
+  | 'STUDENT_GROUP'     // Nouveau : gestion groupes
+  | 'DOCUMENT_ASSIGNMENT'; // Nouveau : assignation documents
+
+// Actions supplémentaires si nécessaire
+export type Action = 
+  | ... // existants
+  | 'ASSIGN'      // Pour assigner coach/élève/document
+  | 'UNASSIGN';   // Pour retirer une assignation
+```
+
+---
+
+## 10. Workflows Cibles
+
+### 10.1 Workflow : Association Coach-Élève (par Assistante)
+
+```
+1. Assistante se connecte → Dashboard Assistante
+2. Navigue vers "Gestion Coachs" ou "Associations"
+3. Sélectionne un coach (search/filter)
+4. Clique "Assigner des élèves"
+5. Interface de sélection multi-élèves :
+   - Liste des élèves sans coach principal
+   - Filtre par niveau/filière
+   - Checkbox pour sélection multiple
+6. Pour chaque élève, choisit :
+   - Type : Principal / Secondaire / Stage
+   - Matières (si Secondaire)
+   - Date début (défaut: maintenant)
+   - Date fin (optionnel)
+7. Valide → Création en batch des CoachStudentAssignment
+8. Notifications (optionnel) :
+   - Email au coach
+   - Notification élève (si activé)
+9. Dashboard coach mis à jour → Élèves visibles
+```
+
+### 10.2 Workflow : Dépôt de Document par Coach
+
+```
+1. Coach connecté → Dashboard Coach → "Mes Élèves"
+2. Sélectionne un élève (ou groupe via multi-select)
+3. Clique "Déposer un document"
+4. Formulaire d'upload :
+   - Fichier (drag & drop)
+   - Titre
+   - Type : Cours / Exercice / Bilan / Correction / Planning / Autre
+   - Matière (si applicable)
+   - Visibilité :
+     * Élève uniquement
+     * Élève + Parent
+     * Élève + Coach (soi)
+     * Groupe (si sélection groupe)
+   - Date d'expiration (optionnel)
+5. Upload → Création UserDocument + DocumentVisibility
+6. Élève voit le document dans son dashboard → Rubrique Documents
+7. Notifications (optionnel) :
+   - Notification push à l'élève
+   - Email récapitulatif au parent
+```
+
+### 10.3 Workflow : Changement de Parcours (par Assistante)
+
+```
+1. Assistante se connecte → "Gestion Élèves"
+2. Recherche l'élève (nom/email)
+3. Ouvre fiche élève
+4. Section "Parcours Actuel" affiche :
+   - Niveau : Première
+   - Filière : Générale
+   - Spécialités : Maths, NSI
+   - Parcours actif : EDS Maths Première
+5. Clique "Modifier le parcours"
+6. Formulaire de modification :
+   - Nouveau niveau (si changement année)
+   - Nouvelle filière (Générale ↔ STMG)
+   - Si STMG : choix de la voie (RHC, Mercatique...)
+   - Nouvelles spécialités (multi-select)
+7. Validation avec confirmation :
+   - "Attention : Changement de filière va migrer la progression"
+   - Option : "Conserver l'accès à l'ancien parcours en lecture"
+8. Sauvegarde :
+   - UPDATE Student
+   - Log dans une table d'historique (StudentTrackHistory ?)
+   - Recalcul des droits d'accès
+   - Mise à jour des entitlements
+9. Dashboard élève automatiquement adapté au nouveau parcours
+```
+
+---
+
+## 11. Plan d'Implémentation Recommandé
+
+### Phase A — Fondations (Semaine 1)
+
+**Objectif** : Poser les bases modèles et migrations
+
+| Tâche | Détails | Livrable |
+|-------|---------|----------|
+| A1 | Créer modèle `CoachStudentAssignment` | PR #1 |
+| A2 | Créer enums `AssignmentType`, `AssignmentStatus` | PR #1 |
+| A3 | Migration Prisma safe | migration.sql |
+| A4 | Seed données test | seed.ts |
+| A5 | Mettre à jour `CoachProfile` avec relation | PR #1 |
+| A6 | Mettre à jour `Student` avec relation inverse | PR #1 |
+
+**Validation** :
+- `prisma migrate dev` passe
+- `prisma generate` OK
+- Seeds créent des assignations test
+- Rétro-compatibilité : ancien code fonctionne toujours
+
+### Phase B — API Core (Semaine 2)
+
+**Objectif** : Rendre les données accessibles
+
+| Tâche | Détails | Livrable |
+|-------|---------|----------|
+| B1 | `GET /api/coach/students` | Route API |
+| B2 | `GET /api/assistante/coaches` | Route API |
+| B3 | `POST /api/assistante/assignments` | Route API |
+| B4 | `DELETE /api/assistante/assignments/[id]` | Route API |
+| B5 | `GET /api/assistante/students` avec filtres | Route API |
+| B6 | Guards ownership : coach ne voit que ses élèves | RBAC |
+| B7 | Tests unitaires API | Jest |
+
+**Validation** :
+- Postman/Insomnia : toutes routes fonctionnent
+- Tests Jest passent
+- Pas de régression routes existantes
+
+### Phase C — Dashboards (Semaine 3)
+
+**Objectif** : Interfaces utilisateur
+
+| Tâche | Détails | Livrable |
+|-------|---------|----------|
+| C1 | Dashboard Coach → Page "Mes Élèves" | page.tsx |
+| C2 | Dashboard Coach → Fiche élève détaillée | component |
+| C3 | Dashboard Coach → Upload document | feature |
+| C4 | Dashboard Assistante → Gestion Élèves | page.tsx |
+| C5 | Dashboard Assistante → Gestion Coachs | page.tsx |
+| C6 | Dashboard Assistante → Interface Association | component |
+| C7 | Dashboard Assistante → Modification Parcours | feature |
+
+**Validation** :
+- Tests E2E Playwright
+- Review UI/UX
+- Responsive mobile
+
+### Phase D — Documents Avancés (Semaine 4)
+
+**Objectif** : Système documentaire complet
+
+| Tâche | Détails | Livrable |
+|-------|---------|----------|
+| D1 | Créer modèle `StudentGroup` (si P1 validé) | PR |
+| D2 | Créer modèle `DocumentVisibility` | PR |
+| D3 | Migration et seeds | migration.sql |
+| D4 | `POST /api/documents/assign` (groupe) | Route API |
+| D5 | Dashboard Élève → Rubrique Documents enrichie | page.tsx |
+| D6 | Filtres documents (type, matière, date) | component |
+
+**Validation** :
+- Upload/download fonctionnels
+- Permissions respectées
+- Tests E2E
+
+### Phase E — Tests et Refinement (Semaine 5)
+
+**Objectif** : Qualité et robustesse
+
+| Tâche | Détails | Livrable |
+|-------|---------|----------|
+| E1 | Tests E2E complets workflows | test.spec.ts |
+| E2 | Tests de charge API | k6/artillery |
+| E3 | Audit sécurité permissions | rapport |
+| E4 | Documentation utilisateur | docs/ |
+| E5 | Formation équipe (si nécessaire) | session |
+
+---
+
+## 12. Fichiers à Modifier (Index)
+
+### 12.1 Prisma Schema
+- `prisma/schema.prisma` → Ajouter modèles et enums
+
+### 12.2 API Routes (Nouvelles)
+```
+app/api/coach/students/route.ts
+app/api/assistante/coaches/route.ts
+app/api/assistante/students/route.ts
+app/api/assistante/assignments/route.ts
+app/api/assistante/assignments/[id]/route.ts
+app/api/documents/assign/route.ts (si D4)
+```
+
+### 12.3 API Routes (Modifiées)
+```
+app/api/student/documents/route.ts → Ajouter visibilité
+app/api/student/dashboard/route.ts → Enrichir données coach si applicable
+```
+
+### 12.4 Dashboards (Nouveaux)
+```
+app/dashboard/coach/students/page.tsx
+app/dashboard/coach/students/[studentId]/page.tsx
+app/dashboard/assistante/students/page.tsx
+app/dashboard/assistante/coaches/page.tsx
+app/dashboard/assistante/assignments/page.tsx
+```
+
+### 12.5 Dashboards (Modifiés)
+```
+app/dashboard/coach/page.tsx → Ajouter lien "Mes Élèves"
+app/dashboard/coach/layout.tsx → Navigation mise à jour
+app/dashboard/eleve/documents/page.tsx → Enrichir affichage
+```
+
+### 12.6 Lib (Modifiés)
+```
+lib/rbac.ts → Ajouter permissions
+lib/rbac/coach-student-access.ts → Implémenter logique ownership
+types/index.ts → Ajouter types TypeScript
+```
+
+---
+
+## 13. Risques et Garde-Fous
+
+### 13.1 Risques Techniques
+
+| Risque | Probabilité | Impact | Mitigation |
+|--------|-------------|--------|------------|
+| Migration lourde échoue | Moyenne | Haut | Backup DB avant, test sur staging |
+| Régression permissions | Moyenne | Haut | Tests E2E exhaustifs avant merge |
+| Performance requêtes N+1 | Moyenne | Moyen | Index SQL, review requêtes Prisma |
+| Conflits avec PR #24 | Faible | Moyen | Rebase régulier, communication |
+
+### 13.2 Risques Métier
+
+| Risque | Probabilité | Impact | Mitigation |
+|--------|-------------|--------|------------|
+| Coachs perdent accès temporairement | Faible | Haut | Migration avec données seedées, rollback plan |
+| Assistantes ne comprennent pas interface | Moyenne | Moyen | Documentation, tooltips, formation |
+| Élèves voient documents non assignés | Faible | Critique | Tests permissions, audit avant déploiement |
+
+### 13.3 Garde-Fous à Implémenter
+
+```typescript
+// Dans les guards API
+
+// 1. Vérification ownership obligatoire
+if (user.role === 'COACH') {
+  const hasAssignment = await prisma.coachStudentAssignment.findFirst({
+    where: {
+      coachId: user.coachProfile.id,
+      studentId: requestedStudentId,
+      status: 'ACTIVE'
+    }
+  });
+  if (!hasAssignment) {
+    throw new ForbiddenException("Vous n'êtes pas assigné à cet élève");
+  }
+}
+
+// 2. Audit trail sur modifications sensibles
+await prisma.auditLog.create({
+  data: {
+    action: 'ASSIGN_COACH',
+    userId: assistant.id,
+    targetId: student.id,
+    metadata: { coachId: coach.id, assignmentId: newAssignment.id },
+    ipAddress: request.ip,
+    userAgent: request.headers['user-agent']
+  }
+});
+
+// 3. Soft delete sur assignations (pas de hard delete)
+// Utiliser status: 'ENDED' au lieu de delete()
+```
+
+---
+
+## 14. Questions à Arbitrer
+
+### 14.1 Questions Techniques
+
+1. **Multi-coach par élève ?**
+   - Option A : Un seul coach principal (simplifié)
+   - Option B : Coach principal + coachs secondaires par matière (complexe mais réaliste)
+   - **Recommandation** : Option B via `AssignmentType` et `subjects[]`
+
+2. **Historique des assignations ?**
+   - Option A : Soft delete (status ENDED)
+   - Option B : Table d'historique séparée
+   - **Recommandation** : Option A (suffisant)
+
+3. **Groupes d'élèves ?**
+   - Option A : Implémenter maintenant (StudentGroup)
+   - Option B : Différer (utiliser assignations individuelles)
+   - **Recommandation** : Option B pour Phase 1, Option A pour Phase D
+
+### 14.2 Questions Métier
+
+4. **Coach peut-il refuser un élève assigné ?**
+   - Si oui : besoin workflow validation coach
+   - **Hypothèse** : Non, l'assignation est faite par l'assistante
+
+5. **Parent peut-il voir les documents coach ?**
+   - **Recommandation** : Oui, par défaut (visibilité COACH = élève + coach)
+   - Option : checkbox "Visible par le parent" lors du dépôt
+
+6. **Documents expirables ?**
+   - **Recommandation** : Oui, champ `expiresAt` optionnel
+   - Usage : corrections d'examen à durée limitée, etc.
+
+---
+
+## 15. Conclusion
+
+### 15.1 Synthèse
+
+L'audit révèle une architecture de base solide mais **incomplète pour la gestion opérationnelle** :
+
+- ✅ **Base technique solide** : Next.js, Prisma, RBAC, Dashboards existants
+- ✅ **PR #24 réussi** : Filières EDS/STMG fonctionnelles
+- 🔴 **Gap critique** : Association Coach-Élève manquante
+- 🟡 **Gaps importants** : Gestion documents, Groupes, Dashboards Coach/Assistante
+
+### 15.2 Recommandation Immédiate
+
+**Lancer la Phase A dès que possible** : création du modèle `CoachStudentAssignment`.
+
+Ce modèle est **fondamental** et bloquant pour toute la suite. Sans lui :
+- Le coach n'a pas de "portefeuille élèves"
+- L'assistante ne peut pas gérer les associations
+- Les documents ne peuvent pas être assignés proprement
+- Les permissions restent floues
+
+### 15.3 Estimation Charge
+
+| Phase | Durée Estimée | Complexité |
+|-------|---------------|------------|
+| A — Fondations | 3-4 jours | Moyenne |
+| B — API Core | 4-5 jours | Moyenne |
+| C — Dashboards | 5-7 jours | Haute |
+| D — Documents | 4-5 jours | Moyenne |
+| E — Tests | 3-4 jours | Moyenne |
+| **Total** | **3-4 semaines** | **Élevée** |
+
+**Ressources nécessaires** :
+- 1 développeur backend (Phases A, B, E)
+- 1 développeur frontend (Phases C, D)
+- 1 QA/Tests (Phase E)
+
+### 15.4 Prochaines Étapes
+
+1. **Validation** de ce rapport par l'équipe métier
+2. **Arbitrage** des questions section 14
+3. **Création** des tickets/issues pour chaque tâche
+4. **Planification** des sprints
+5. **Démarrage** Phase A (modèle CoachStudentAssignment)
+
+---
+
+## Annexes
+
+### A.1 Détail des Tables DB Actuelles (49 tables)
+
+Tables identifiées :
+- `users` (169 lignes)
+- `students` (102 lignes)
+- `coach_profiles` (13 lignes)
+- `parent_profiles` (52 lignes)
+- `user_documents` (13 lignes)
+- `maths_progress` (lignes non comptées)
+- `survival_progress` (lignes non comptées)
+- `assessments`, `bilans`, `sessions`, `subscriptions`, etc.
+- Tables Stages : `stages`, `stage_sessions`, `stage_coaches`, `stage_reservations`, `stage_bilans`, `stage_documents`
+
+### A.2 Ressources Consultées
+
+- `prisma/schema.prisma` (intégralité)
+- `lib/rbac.ts` (permissions)
+- `lib/rbac/coach-student-access.ts` (existe, non audité en profondeur)
+- Structure `/app/dashboard/*` (inventaire)
+- Routes `/app/api/student/*` (inventaire)
+- Tables PostgreSQL (49 tables listées)
+
+### A.3 Limites de l'Audit
+
+- Pas de revue de code détaillée des composants React
+- Pas de test manuel des interfaces
+- Pas d'analyse des performances requêtes
+- Pas de revue sécurité approfondie (seulement identification des gaps)
+- Services EAF/Korrigo hors scope
+
+---
+
+**Fin du Rapport**
+
+*Document généré le 2026-04-25 suite à audit en lecture seule de la production nexusreussite.academy*

--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -20,6 +20,9 @@ import { UserRole } from '@prisma/client';
 export type Resource =
   | 'USER'
   | 'STUDENT'
+  | 'COACH_ASSIGNMENT'
+  | 'DOCUMENT'
+  | 'DOCUMENT_ASSIGNMENT'
   | 'BILAN'
   | 'SESSION'
   | 'RESERVATION'
@@ -40,7 +43,9 @@ export type Action =
   | 'DELETE'
   | 'MANAGE'
   | 'VALIDATE'
-  | 'EXPORT';
+  | 'EXPORT'
+  | 'ASSIGN'
+  | 'UNASSIGN';
 
 /** A single permission entry */
 export interface Permission {
@@ -58,6 +63,9 @@ const rolePermissions: Record<UserRole, Permission[]> = {
   [UserRole.ADMIN]: [
     { action: 'MANAGE', resource: 'USER' },
     { action: 'MANAGE', resource: 'STUDENT' },
+    { action: 'MANAGE', resource: 'COACH_ASSIGNMENT' },
+    { action: 'MANAGE', resource: 'DOCUMENT' },
+    { action: 'MANAGE', resource: 'DOCUMENT_ASSIGNMENT' },
     { action: 'MANAGE', resource: 'BILAN' },
     { action: 'MANAGE', resource: 'SESSION' },
     { action: 'MANAGE', resource: 'RESERVATION' },
@@ -71,7 +79,13 @@ const rolePermissions: Record<UserRole, Permission[]> = {
   [UserRole.ASSISTANTE]: [
     { action: 'READ', resource: 'USER' },
     { action: 'READ', resource: 'STUDENT' },
+    { action: 'CREATE', resource: 'STUDENT' },
     { action: 'UPDATE', resource: 'STUDENT' },
+    { action: 'ASSIGN', resource: 'COACH_ASSIGNMENT' },
+    { action: 'UNASSIGN', resource: 'COACH_ASSIGNMENT' },
+    { action: 'READ', resource: 'DOCUMENT' },
+    { action: 'CREATE', resource: 'DOCUMENT' },
+    { action: 'ASSIGN', resource: 'DOCUMENT_ASSIGNMENT' },
     { action: 'VALIDATE', resource: 'BILAN' },
     { action: 'READ', resource: 'BILAN' },
     { action: 'UPDATE', resource: 'SESSION' },
@@ -85,7 +99,10 @@ const rolePermissions: Record<UserRole, Permission[]> = {
   ],
   [UserRole.COACH]: [
     { action: 'READ', resource: 'USER' },
-    { action: 'READ', resource: 'STUDENT' },
+    { action: 'READ_OWN', resource: 'STUDENT' }, // Only assigned students
+    { action: 'READ', resource: 'DOCUMENT' },
+    { action: 'CREATE', resource: 'DOCUMENT' },
+    { action: 'ASSIGN', resource: 'DOCUMENT_ASSIGNMENT' },
     { action: 'READ', resource: 'BILAN' },
     { action: 'UPDATE', resource: 'SESSION' },
     { action: 'READ', resource: 'SESSION' },
@@ -97,6 +114,7 @@ const rolePermissions: Record<UserRole, Permission[]> = {
   [UserRole.PARENT]: [
     { action: 'READ_SELF', resource: 'USER' },
     { action: 'READ_OWN', resource: 'STUDENT' },
+    { action: 'READ', resource: 'DOCUMENT' },
     { action: 'CREATE', resource: 'BILAN' },
     { action: 'READ_OWN', resource: 'BILAN' },
     { action: 'READ_OWN', resource: 'SESSION' },
@@ -108,6 +126,7 @@ const rolePermissions: Record<UserRole, Permission[]> = {
   [UserRole.ELEVE]: [
     { action: 'READ_SELF', resource: 'USER' },
     { action: 'READ_SELF', resource: 'STUDENT' },
+    { action: 'READ', resource: 'DOCUMENT' },
     { action: 'READ', resource: 'BILAN' },
     { action: 'READ_OWN', resource: 'SESSION' },
     { action: 'READ', resource: 'RESOURCE_CONTENT' },

--- a/lib/rbac/coach-student-access.ts
+++ b/lib/rbac/coach-student-access.ts
@@ -1,22 +1,186 @@
 import { prisma } from '@/lib/prisma';
+import { AssignmentStatus } from '@prisma/client';
 
 /**
- * Phase 6 — RBAC helper: does the given coach have any pedagogical link
- * with the given student?
- *
- * A coach is authorized to access a student's dossier and write notes
- * if and only if at least one SessionBooking exists between them.
- * Admins bypass this check (handled by the caller).
+ * Get CoachProfile for a given user ID
+ * Returns null if user is not a coach
+ */
+export async function getCoachProfileForUser(userId: string) {
+  if (!userId) return null;
+  return prisma.coachProfile.findUnique({
+    where: { userId },
+  });
+}
+
+/**
+ * Check if a coach is assigned to a student via CoachStudentAssignment
+ * (New source of truth for coach-student relationships)
  *
  * @param coachUserId   User.id of the coach (session.user.id)
- * @param studentUserId User.id of the student (URL param)
- * @returns true if the coach is rattached to the student
+ * @param studentId     Student.id (not User.id)
+ * @returns true if active assignment exists
+ */
+export async function isCoachAssignedToStudent({
+  coachUserId,
+  studentId,
+}: {
+  coachUserId: string;
+  studentId: string;
+}): Promise<boolean> {
+  if (!coachUserId || !studentId) return false;
+
+  const coachProfile = await getCoachProfileForUser(coachUserId);
+  if (!coachProfile) return false;
+
+  const assignment = await prisma.coachStudentAssignment.findFirst({
+    where: {
+      coachId: coachProfile.id,
+      studentId,
+      status: AssignmentStatus.ACTIVE,
+      startsAt: { lte: new Date() },
+      OR: [{ endsAt: null }, { endsAt: { gte: new Date() } }],
+    },
+    select: { id: true },
+  });
+
+  return Boolean(assignment);
+}
+
+/**
+ * Assert that a coach can access a student, throw otherwise
+ * Use this in API routes for strict ownership enforcement
+ *
+ * @throws Error with 403 message if not assigned
+ */
+export async function assertCoachCanAccessStudent({
+  coachUserId,
+  studentId,
+}: {
+  coachUserId: string;
+  studentId: string;
+}): Promise<void> {
+  const hasAccess = await isCoachAssignedToStudent({ coachUserId, studentId });
+  if (!hasAccess) {
+    throw new Error('ACCESS_DENIED: Vous n\'êtes pas assigné à cet élève');
+  }
+}
+
+/**
+ * Get all students assigned to a coach
+ * Returns enriched student data for coach dashboard
+ *
+ * @param coachUserId User.id of the coach
+ * @returns Array of assigned students with assignment metadata
+ */
+export async function getAssignedStudentsForCoach({
+  coachUserId,
+}: {
+  coachUserId: string;
+}) {
+  if (!coachUserId) return [];
+
+  const coachProfile = await getCoachProfileForUser(coachUserId);
+  if (!coachProfile) return [];
+
+  const assignments = await prisma.coachStudentAssignment.findMany({
+    where: {
+      coachId: coachProfile.id,
+      status: AssignmentStatus.ACTIVE,
+      startsAt: { lte: new Date() },
+      OR: [{ endsAt: null }, { endsAt: { gte: new Date() } }],
+    },
+    include: {
+      student: {
+        include: {
+          user: {
+            select: {
+              id: true,
+              firstName: true,
+              lastName: true,
+              email: true,
+            },
+          },
+          parent: {
+            include: {
+              user: {
+                select: {
+                  firstName: true,
+                  lastName: true,
+                },
+              },
+            },
+          },
+          _count: {
+            select: {
+              sessions: true,
+              assessments: true,
+            },
+          },
+        },
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return assignments.map((assignment: any) => ({
+    assignmentId: assignment.id,
+    assignmentType: assignment.assignmentType,
+    subjects: assignment.subjects,
+    notes: assignment.notes,
+    startsAt: assignment.startsAt,
+    endsAt: assignment.endsAt,
+    student: {
+      id: assignment.student.id,
+      userId: assignment.student.userId,
+      firstName: assignment.student.user?.firstName,
+      lastName: assignment.student.user?.lastName,
+      email: assignment.student.user?.email,
+      parentName: assignment.student.parent?.user
+        ? `${assignment.student.parent.user.firstName || ''} ${assignment.student.parent.user.lastName || ''}`.trim()
+        : null,
+      gradeLevel: assignment.student.gradeLevel,
+      academicTrack: assignment.student.academicTrack,
+      specialties: assignment.student.specialties,
+      stmgPathway: assignment.student.stmgPathway,
+      survivalMode: assignment.student.survivalMode,
+      school: assignment.student.school,
+      credits: assignment.student.credits,
+      stats: {
+        sessionsCount: assignment.student._count?.sessions || 0,
+        assessmentsCount: assignment.student._count?.assessments || 0,
+      },
+    },
+  }));
+}
+
+/**
+ * Legacy compatibility: Check via SessionBooking (fallback)
+ * Kept for backward compatibility during migration period
+ *
+ * @deprecated Use isCoachAssignedToStudent instead
  */
 export async function isCoachRattachedToStudent(
   coachUserId: string,
   studentUserId: string,
 ): Promise<boolean> {
   if (!coachUserId || !studentUserId) return false;
+
+  // First check new CoachStudentAssignment system
+  const student = await prisma.student.findUnique({
+    where: { userId: studentUserId },
+    select: { id: true },
+  });
+
+  if (student) {
+    const hasAssignment = await isCoachAssignedToStudent({
+      coachUserId,
+      studentId: student.id,
+    });
+    if (hasAssignment) return true;
+  }
+
+  // Fallback to legacy SessionBooking check
   const link = await prisma.sessionBooking.findFirst({
     where: { coachId: coachUserId, studentId: studentUserId },
     select: { id: true },

--- a/prisma/migrations/20260425230000_add_coach_student_assignments/migration.sql
+++ b/prisma/migrations/20260425230000_add_coach_student_assignments/migration.sql
@@ -1,0 +1,141 @@
+-- Phase A+B: CoachStudentAssignment — Core model for coach-student pedagogical relationships
+-- Adds assignment tracking, document metadata, and visibility scopes
+
+-- ============================================
+-- 1. CREATE ENUMS (safe to create if not exists)
+-- ============================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'assignmenttype') THEN
+    CREATE TYPE "assignmenttype" AS ENUM ('PRIMARY', 'SECONDARY', 'STAGE', 'TEMPORARY');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'assignmentstatus') THEN
+    CREATE TYPE "assignmentstatus" AS ENUM ('ACTIVE', 'SUSPENDED', 'ENDED');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'documenttype') THEN
+    CREATE TYPE "documenttype" AS ENUM ('COURS', 'EXERCICE', 'BILAN', 'CORRECTION', 'PLANNING', 'ANNEXE', 'AUTRE');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'documentvisibilityscope') THEN
+    CREATE TYPE "documentvisibilityscope" AS ENUM ('STUDENT_ONLY', 'STUDENT_AND_PARENT', 'STUDENT_AND_COACH', 'STUDENT_PARENT_COACH', 'ADMIN_ONLY');
+  END IF;
+END $$;
+
+-- ============================================
+-- 2. CREATE CoachStudentAssignment TABLE
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS "coach_student_assignments" (
+    "id"             TEXT NOT NULL,
+    "coachId"        TEXT NOT NULL,
+    "studentId"      TEXT NOT NULL,
+    "assignedById"   TEXT,
+    "assignmentType" "assignmenttype" NOT NULL DEFAULT 'PRIMARY',
+    "status"         "assignmentstatus" NOT NULL DEFAULT 'ACTIVE',
+    "subjects"       TEXT[] NOT NULL DEFAULT '{}',
+    "notes"          TEXT,
+    "startsAt"       TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "endsAt"         TIMESTAMP(3),
+    "createdAt"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"      TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "coach_student_assignments_pkey" PRIMARY KEY ("id")
+);
+
+-- Indexes for CoachStudentAssignment
+CREATE INDEX IF NOT EXISTS "coach_student_assignments_coachId_status_idx"
+    ON "coach_student_assignments" ("coachId", "status");
+
+CREATE INDEX IF NOT EXISTS "coach_student_assignments_studentId_status_idx"
+    ON "coach_student_assignments" ("studentId", "status");
+
+CREATE INDEX IF NOT EXISTS "coach_student_assignments_assignedById_idx"
+    ON "coach_student_assignments" ("assignedById");
+
+-- Foreign keys for CoachStudentAssignment
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'coach_student_assignments_coachId_fkey'
+  ) THEN
+    ALTER TABLE "coach_student_assignments"
+      ADD CONSTRAINT "coach_student_assignments_coachId_fkey"
+      FOREIGN KEY ("coachId") REFERENCES "coach_profiles"("id")
+      ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'coach_student_assignments_studentId_fkey'
+  ) THEN
+    ALTER TABLE "coach_student_assignments"
+      ADD CONSTRAINT "coach_student_assignments_studentId_fkey"
+      FOREIGN KEY ("studentId") REFERENCES "students"("id")
+      ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'coach_student_assignments_assignedById_fkey'
+  ) THEN
+    ALTER TABLE "coach_student_assignments"
+      ADD CONSTRAINT "coach_student_assignments_assignedById_fkey"
+      FOREIGN KEY ("assignedById") REFERENCES "users"("id")
+      ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- ============================================
+-- 3. UPDATE UserDocument TABLE (safe additions)
+-- ============================================
+
+-- Add new columns to user_documents with defaults (safe for existing 13 documents)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns 
+    WHERE table_name = 'user_documents' AND column_name = 'documentType') THEN
+    ALTER TABLE "user_documents" ADD COLUMN "documentType" "documenttype" NOT NULL DEFAULT 'AUTRE';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns 
+    WHERE table_name = 'user_documents' AND column_name = 'visibilityScope') THEN
+    ALTER TABLE "user_documents" ADD COLUMN "visibilityScope" "documentvisibilityscope" NOT NULL DEFAULT 'STUDENT_ONLY';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns 
+    WHERE table_name = 'user_documents' AND column_name = 'subject') THEN
+    ALTER TABLE "user_documents" ADD COLUMN "subject" "subject";
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns 
+    WHERE table_name = 'user_documents' AND column_name = 'description') THEN
+    ALTER TABLE "user_documents" ADD COLUMN "description" TEXT;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns 
+    WHERE table_name = 'user_documents' AND column_name = 'expiresAt') THEN
+    ALTER TABLE "user_documents" ADD COLUMN "expiresAt" TIMESTAMP(3);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns 
+    WHERE table_name = 'user_documents' AND column_name = 'updatedAt') THEN
+    ALTER TABLE "user_documents" ADD COLUMN "updatedAt" TIMESTAMP(3);
+    UPDATE "user_documents" SET "updatedAt" = "createdAt" WHERE "updatedAt" IS NULL;
+  END IF;
+END $$;
+
+-- Indexes for UserDocument new columns
+CREATE INDEX IF NOT EXISTS "user_documents_documentType_idx" ON "user_documents" ("documentType");
+CREATE INDEX IF NOT EXISTS "user_documents_visibilityScope_idx" ON "user_documents" ("visibilityScope");
+CREATE INDEX IF NOT EXISTS "user_documents_subject_idx" ON "user_documents" ("subject");
+CREATE INDEX IF NOT EXISTS "user_documents_expiresAt_idx" ON "user_documents" ("expiresAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,6 +75,39 @@ enum StmgPathway {
   INDETERMINE
 }
 
+// Enums pour les assignations coach-élève
+enum AssignmentType {
+  PRIMARY    // Coach référent principal
+  SECONDARY  // Spécialiste (maths, français...)
+  STAGE      // Assignation stage uniquement
+  TEMPORARY  // Remplacement temporaire
+}
+
+enum AssignmentStatus {
+  ACTIVE
+  SUSPENDED
+  ENDED
+}
+
+// Enums pour les documents
+enum DocumentType {
+  COURS
+  EXERCICE
+  BILAN
+  CORRECTION
+  PLANNING
+  ANNEXE
+  AUTRE
+}
+
+enum DocumentVisibilityScope {
+  STUDENT_ONLY
+  STUDENT_AND_PARENT
+  STUDENT_AND_COACH
+  STUDENT_PARENT_COACH
+  ADMIN_ONLY
+}
+
 // Énumération des statuts de session
 enum SessionStatus {
   SCHEDULED
@@ -161,6 +194,9 @@ model User {
   coachNotesAuthored CoachNote[] @relation("CoachNoteAuthor")
   coachNotesAbout    CoachNote[] @relation("CoachNoteSubject")
 
+  // Coach-student assignments created by this user (assistant/admin)
+  coachStudentAssignmentsCreated CoachStudentAssignment[] @relation("CoachStudentAssignmentAssignedBy")
+
   @@index([role])
   @@map("users")
 }
@@ -238,6 +274,9 @@ model Student {
   // Bilan canonical (F49/F51)
   bilans Bilan[]
 
+  // Coach assignments (who can access this student)
+  coachAssignments CoachStudentAssignment[]
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -277,6 +316,9 @@ model CoachProfile {
 
   // Bilan canonical (F49/F51)
   bilans Bilan[]
+
+  // Coach-student assignments (source of truth for "my students")
+  studentAssignments CoachStudentAssignment[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1592,7 +1634,15 @@ model UserDocument {
   // Ex: /app/storage/documents/cl9...xyz.pdf
   localPath String @unique
 
+  // Document metadata (Phase A+B enhancement)
+  documentType    DocumentType            @default(AUTRE)
+  visibilityScope DocumentVisibilityScope @default(STUDENT_ONLY)
+  subject         Subject?
+  description     String?
+  expiresAt       DateTime?
+
   createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   // Relations
   userId String
@@ -1603,6 +1653,10 @@ model UserDocument {
 
   @@index([userId])
   @@index([uploadedById])
+  @@index([documentType])
+  @@index([visibilityScope])
+  @@index([subject])
+  @@index([expiresAt])
   @@map("user_documents")
 }
 
@@ -1685,6 +1739,38 @@ model CoachNote {
   @@index([coachId])
   @@index([studentId, pinned])
   @@map("coach_notes")
+}
+
+// Coach-Student Assignment — Core model for coach-student pedagogical relationship
+// This is the source of truth for "which students can a coach access"
+model CoachStudentAssignment {
+  id             String           @id @default(cuid())
+
+  coachId        String
+  coach          CoachProfile     @relation(fields: [coachId], references: [id], onDelete: Cascade)
+
+  studentId      String
+  student        Student          @relation(fields: [studentId], references: [id], onDelete: Cascade)
+
+  assignedById   String?
+  assignedBy     User?            @relation("CoachStudentAssignmentAssignedBy", fields: [assignedById], references: [id], onDelete: SetNull)
+
+  assignmentType AssignmentType   @default(PRIMARY)
+  status         AssignmentStatus @default(ACTIVE)
+
+  subjects       Subject[]        @default([])
+  notes          String?
+
+  startsAt       DateTime         @default(now())
+  endsAt         DateTime?
+
+  createdAt      DateTime         @default(now())
+  updatedAt      DateTime         @updatedAt
+
+  @@index([coachId, status])
+  @@index([studentId, status])
+  @@index([assignedById])
+  @@map("coach_student_assignments")
 }
 
 model SurvivalProgress {


### PR DESCRIPTION
## Objectif

Cette PR met en place la fondation DB/RBAC/API nécessaire pour rendre la plateforme Nexus exploitable avec des associations explicites coach ↔ élève.

Elle permet :
- d'associer explicitement un coach à un élève ;
- de filtrer côté serveur les élèves visibles par un coach ;
- de permettre à l'assistante/admin de créer ou terminer des assignations ;
- d'enrichir les documents élèves avec une typologie et une visibilité minimale ;
- de préparer les dashboards coach et assistante des phases suivantes.

---

## Changements principaux

### Prisma / DB

- Ajout du modèle `CoachStudentAssignment`
- Ajout des enums :
  - `AssignmentType`
  - `AssignmentStatus`
  - `DocumentType`
  - `DocumentVisibilityScope`
- Ajout des relations inverses :
  - `CoachProfile.studentAssignments`
  - `Student.coachAssignments`
  - `User.coachStudentAssignmentsCreated`
- Enrichissement de `UserDocument` :
  - `documentType`
  - `visibilityScope`
  - `subject`
  - `description`
  - `expiresAt`
- Migration :
  - `20260425230000_add_coach_student_assignments`

### RBAC / Ownership

- Ajout des ressources/actions liées aux assignations coach–élève
- Ajout/renforcement des helpers :
  - `isCoachAssignedToStudent`
  - `assertCoachCanAccessStudent`
  - `getAssignedStudentsForCoach`
- Règles prises en compte :
  - assignment `ACTIVE`
  - `startsAt <= now`
  - `endsAt IS NULL OR endsAt >= now`
  - exclusion des assignations `ENDED`, `SUSPENDED`, futures ou expirées

### API

Nouvelles routes :

- `GET /api/coach/students`
- `GET /api/coach/students/[studentId]`
- `GET /api/assistante/students`
- `GET /api/assistante/coaches`
- `POST /api/assistante/assignments`
- `PATCH /api/assistante/assignments/[id]`

Garanties :
- 401 si non connecté ;
- 403 si rôle interdit ;
- 404 si ressource inexistante ;
- 403 si coach non assigné à l'élève ;
- pas de hard delete des assignations ;
- validation des payloads ;
- anti-doublon actif.

### Tests

Ajout de 46 tests ciblés :

- `__tests__/rbac/coach-student-access.test.ts` — 18 tests
- `__tests__/api/coach-students.test.ts` — 11 tests
- `__tests__/api/assistante-assignments.test.ts` — 17 tests

Cas couverts :
- coach assigné ;
- coach non assigné ;
- assignation `ENDED` ;
- assignation `SUSPENDED` ;
- assignation future ;
- assignation expirée ;
- création assignment assistante/admin ;
- rôle interdit ;
- payload invalide ;
- doublon actif ;
- terminaison/suspension sans hard delete.

---

## Validation locale

- [x] `npx prisma validate`
- [x] `npx prisma generate`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npx jest __tests__/rbac/coach-student-access.test.ts --runInBand`
- [x] `npx jest __tests__/api/coach-students.test.ts --runInBand`
- [x] `npx jest __tests__/api/assistante-assignments.test.ts --runInBand`

Total ciblé : **46/46 tests verts**.

Note :
Les tests globaux complets n'ont pas été lancés localement. Ils doivent être validés par CI avant merge.

---

## Hors scope

Cette PR ne contient pas :
- UI complète dashboard coach ;
- UI complète dashboard assistante ;
- groupes d'élèves ;
- documents de groupe ;
- seeds avancés ;
- tests E2E Playwright ;
- déploiement production.

Ces éléments doivent faire l'objet de PRs séparées.

---

## Risques et garde-fous

### Risques

- Nouvelle migration Prisma à appliquer avec prudence en staging/prod.
- Les dashboards UI ne consomment pas encore toute la nouvelle fondation.
- Les tests globaux doivent être validés avant merge.

### Garde-fous

- Migration non destructive.
- Pas de `DROP TABLE`.
- Pas de `DROP COLUMN`.
- Nouveaux champs documents rétrocompatibles.
- Ownership coach–élève testé côté serveur.
- Pas de filtrage uniquement frontend.

---

## Plan post-merge recommandé

1. Tester migration sur staging.
2. Lancer suite complète CI.
3. Créer PR suivante :
   - dashboard coach "Mes élèves" ;
   - dashboard assistante "Associations" ;
   - seeds de démonstration ;
   - tests E2E.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds coach–student assignments as the source of truth with server-side ownership checks and new APIs for coaches and assistantes. This secures access to student data and prepares coach/assistante dashboards without breaking existing data.

- **New Features**
  - Database: added `CoachStudentAssignment` + enums `AssignmentType`, `AssignmentStatus`, `DocumentType`, `DocumentVisibilityScope`; extended `UserDocument` (type, visibilityScope, subject, description, expiresAt); added inverse relations; migration `20260425230000_add_coach_student_assignments`.
  - RBAC/Ownership: new resources `COACH_ASSIGNMENT`, `DOCUMENT`, `DOCUMENT_ASSIGNMENT` and actions `ASSIGN`, `UNASSIGN`; helpers `isCoachAssignedToStudent`, `assertCoachCanAccessStudent`, `getAssignedStudentsForCoach`; only ACTIVE assignments within date window are valid.
  - API: coach — `GET /api/coach/students`, `GET /api/coach/students/[studentId]`; assistante — `GET /api/assistante/students`, `GET /api/assistante/coaches`, `GET /api/assistante/assignments`, `POST /api/assistante/assignments`, `PATCH /api/assistante/assignments/[id]`; strict payload validation, 401/403/404 handling, anti-duplicate, no hard deletes.
  - Tests: 46 targeted tests covering RBAC and the new endpoints.

- **Migration**
  - Safe, non-destructive schema update. Run: `npx prisma migrate deploy && npx prisma generate`.

<sup>Written for commit 8f0b6ba25276f4203ed1c932d81a4c331d599c67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

