### PR TITLE
fix(db-rbac): address PR25 review feedback before staging

### DIFF
--- a/__tests__/api/assistante-assignments.test.ts
+++ b/__tests__/api/assistante-assignments.test.ts
@@ -278,8 +278,12 @@ describe('API Assistante Assignments', () => {
           subjects: [],
           availableOnline: true,
           availableInPerson: true,
-          studentAssignments: [],
-          _count: { studentAssignments: 2, sessions: 10 },
+          // activeStudents is now calculated from studentAssignments.length (filtered by active window)
+          studentAssignments: [
+            { id: 'assignment-1', student: { id: 's1', gradeLevel: 'PREMIERE', academicTrack: 'EDS_GENERALE' } },
+            { id: 'assignment-2', student: { id: 's2', gradeLevel: 'PREMIERE', academicTrack: 'EDS_GENERALE' } },
+          ],
+          _count: { studentAssignments: 5, sessions: 10 }, // _count includes historical assignments
           createdAt: new Date(),
         },
       ] as any);
@@ -290,6 +294,7 @@ describe('API Assistante Assignments', () => {
 
       expect(res.status).toBe(200);
       expect(body.coaches).toHaveLength(1);
+      // activeStudents reflects only currently active assignments (filtered by activeAssignmentWhere)
       expect(body.coaches[0].stats.activeStudents).toBe(2);
     });
   });

--- a/__tests__/api/assistante-assignments.test.ts
+++ b/__tests__/api/assistante-assignments.test.ts
@@ -18,7 +18,7 @@ jest.mock('@/lib/prisma', () => ({
   prisma: {
     coachProfile: { findUnique: jest.fn(), findMany: jest.fn(), count: jest.fn() },
     student: { findMany: jest.fn(), findUnique: jest.fn(), count: jest.fn() },
-    coachStudentAssignment: { findMany: jest.fn(), findFirst: jest.fn(), findUnique: jest.fn(), create: jest.fn(), update: jest.fn() },
+    coachStudentAssignment: { findMany: jest.fn(), findFirst: jest.fn(), findUnique: jest.fn(), create: jest.fn(), update: jest.fn(), count: jest.fn() },
     $transaction: jest.fn(),
   },
 }));
@@ -29,7 +29,7 @@ import { GET as getStudents } from '@/app/api/assistante/students/route';
 import { GET as getCoaches } from '@/app/api/assistante/coaches/route';
 import { requireAnyRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
-import { AssignmentStatus, AssignmentType, Subject } from '@prisma/client';
+import { AssignmentStatus, AssignmentType, Subject, Prisma } from '@prisma/client';
 
 const mockRequireAnyRole = requireAnyRole as unknown as jest.Mock;
 
@@ -186,6 +186,66 @@ describe('API Assistante Assignments', () => {
       expect(res.status).toBe(409);
       expect(body.error).toBe('Conflict');
     });
+
+    it('POST avec P2002 database conflict => 409', async () => {
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1', user: { firstName: 'Coach', lastName: 'X' } } as any);
+      (prisma.student.findMany as jest.Mock).mockResolvedValue([{ id: 'student-1', user: { firstName: 'Ahmed', lastName: 'B' } }] as any);
+      (prisma.coachStudentAssignment.findMany as jest.Mock).mockResolvedValue([]);
+      // Simulate P2002 unique constraint violation from partial index
+      // Create a mock PrismaClientKnownRequestError-like object
+      const prismaError = Object.assign(
+        new Error('Unique constraint failed on the fields: (`coachId`,`studentId`,`assignmentType`)'),
+        {
+          code: 'P2002',
+          clientVersion: '6.19.2',
+          meta: { target: ['coachId', 'studentId', 'assignmentType'] },
+        }
+      );
+      // Make it quack like a PrismaClientKnownRequestError for instanceof check
+      Object.setPrototypeOf(prismaError, Prisma.PrismaClientKnownRequestError.prototype);
+      (prisma.$transaction as jest.Mock).mockRejectedValue(prismaError);
+
+      const res = await postAssignments(makeRequest({
+        coachId: 'coach-1',
+        studentIds: ['student-1'],
+        assignmentType: AssignmentType.PRIMARY,
+      }));
+      const body = await res.json();
+
+      expect(res.status).toBe(409);
+      expect(body.error).toBe('Conflict');
+    });
+
+    it('POST déduplique studentIds automatiquement', async () => {
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1', user: { firstName: 'Coach', lastName: 'X' } } as any);
+      // Mock only one student found even if duplicates in request
+      (prisma.student.findMany as jest.Mock).mockResolvedValue([{ id: 'student-1', user: { firstName: 'Ahmed', lastName: 'B' } }] as any);
+      (prisma.coachStudentAssignment.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.$transaction as jest.Mock).mockImplementation(async (ops: any) => {
+        return ops.map((op: any) => op);
+      });
+      (prisma.coachStudentAssignment.create as jest.Mock).mockResolvedValue({
+        id: 'assignment-1',
+        coachId: 'coach-1',
+        studentId: 'student-1',
+        assignmentType: AssignmentType.PRIMARY,
+        status: AssignmentStatus.ACTIVE,
+      } as any);
+
+      // Send duplicate studentIds - should be deduplicated
+      const res = await postAssignments(makeRequest({
+        coachId: 'coach-1',
+        studentIds: ['student-1', 'student-1', 'student-1'],
+        assignmentType: AssignmentType.PRIMARY,
+      }));
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      // Should only create one assignment despite duplicates in request
+      expect(body.assignments).toHaveLength(1);
+    });
   });
 
   describe('PATCH /api/assistante/assignments/[id]', () => {
@@ -237,6 +297,30 @@ describe('API Assistante Assignments', () => {
 
       expect(res.status).toBe(404);
     });
+
+    it('PATCH status ENDED sans endsAt => force endsAt à current date', async () => {
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      (prisma.coachStudentAssignment.findUnique as jest.Mock).mockResolvedValue({ id: 'assignment-1' } as any);
+      const mockUpdate = jest.fn().mockResolvedValue({
+        id: 'assignment-1',
+        status: AssignmentStatus.ENDED,
+        endsAt: new Date(),
+      } as any);
+      (prisma.coachStudentAssignment.update as jest.Mock) = mockUpdate;
+
+      // Envoi sans endsAt
+      const res = await patchAssignment(
+        makeRequest({ status: AssignmentStatus.ENDED }),
+        makeDetailContext('assignment-1')
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.assignment.status).toBe(AssignmentStatus.ENDED);
+      // Vérifier que update a été appelé avec endsAt défini
+      const updateCall = mockUpdate.mock.calls[0];
+      expect(updateCall[0].data.endsAt).toBeDefined();
+    });
   });
 
   describe('GET /api/assistante/students', () => {
@@ -261,6 +345,54 @@ describe('API Assistante Assignments', () => {
       const res = await getStudents(new Request('http://localhost/?hasCoach=true'));
 
       expect(res.status).toBe(200);
+    });
+
+    it('rejects invalid gradeLevel enum with 400', async () => {
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+
+      const res = await getStudents(new Request('http://localhost/?gradeLevel=INVALID'));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects invalid academicTrack enum with 400', async () => {
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+
+      const res = await getStudents(new Request('http://localhost/?academicTrack=INVALID'));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects invalid stmgPathway enum with 400', async () => {
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+
+      const res = await getStudents(new Request('http://localhost/?stmgPathway=INVALID'));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('clamps page to minimum 1 when negative', async () => {
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      (prisma.student.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.student.count as jest.Mock).mockResolvedValue(0);
+
+      const res = await getStudents(new Request('http://localhost/?page=-1'));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.pagination.page).toBe(1);
+    });
+
+    it('clamps limit to maximum 100', async () => {
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      (prisma.student.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.student.count as jest.Mock).mockResolvedValue(0);
+
+      const res = await getStudents(new Request('http://localhost/?limit=1000'));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.pagination.limit).toBeLessThanOrEqual(100);
     });
   });
 
@@ -296,6 +428,28 @@ describe('API Assistante Assignments', () => {
       expect(body.coaches).toHaveLength(1);
       // activeStudents reflects only currently active assignments (filtered by activeAssignmentWhere)
       expect(body.coaches[0].stats.activeStudents).toBe(2);
+    });
+  });
+
+  describe('GET /api/assistante/assignments', () => {
+    it('rejects invalid status query param with 400', async () => {
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+
+      const res = await getAssignments(new Request('http://localhost/?status=INVALID'));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('accepts valid status query param', async () => {
+      mockRequireAnyRole.mockResolvedValue({ user: { id: 'assistant-1', role: 'ASSISTANTE' } });
+      (prisma.coachStudentAssignment.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.coachStudentAssignment.count as jest.Mock).mockResolvedValue(0);
+
+      const res = await getAssignments(new Request('http://localhost/?status=ACTIVE'));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
     });
   });
 });

--- a/__tests__/rbac/coach-student-access.test.ts
+++ b/__tests__/rbac/coach-student-access.test.ts
@@ -122,13 +122,13 @@ describe('RBAC / CoachStudentAccess', () => {
   });
 
   describe('assertCoachCanAccessStudent', () => {
-    it('throws ACCESS_DENIED when not assigned', async () => {
+    it('throws CoachNotAssignedError when not assigned', async () => {
       (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-1' } as any);
       (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue(null);
 
       await expect(
         assertCoachCanAccessStudent({ coachUserId: 'user-1', studentId: 'student-1' })
-      ).rejects.toThrow('ACCESS_DENIED');
+      ).rejects.toThrow("Vous n'êtes pas assigné à cet élève");
     });
 
     it('does not throw when assigned', async () => {

--- a/app/api/assistante/assignments/[id]/route.ts
+++ b/app/api/assistante/assignments/[id]/route.ts
@@ -29,6 +29,16 @@ export async function GET(request: Request, { params }: RouteParams) {
     const sessionOrError = await requireAnyRole(['ADMIN', 'ASSISTANTE']);
     if (isErrorResponse(sessionOrError)) return sessionOrError;
 
+    const session = sessionOrError;
+
+    // RBAC check: READ permission on COACH_ASSIGNMENT
+    if (!can(session.user.role, 'READ', 'COACH_ASSIGNMENT')) {
+      return NextResponse.json(
+        { error: 'Forbidden', message: 'Permission insuffisante' },
+        { status: 403 }
+      );
+    }
+
     const assignment = await prisma.coachStudentAssignment.findUnique({
       where: { id },
       include: {
@@ -125,10 +135,6 @@ export async function PATCH(request: Request, { params }: RouteParams) {
 
     if (validated.status !== undefined) {
       updateData.status = validated.status;
-      // If ending the assignment, set endsAt to now
-      if (validated.status === AssignmentStatus.ENDED && !validated.endsAt) {
-        updateData.endsAt = new Date();
-      }
     }
 
     if (validated.subjects !== undefined) {
@@ -139,7 +145,13 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       updateData.notes = validated.notes;
     }
 
-    if (validated.endsAt !== undefined) {
+    // Handle endsAt with priority rule: if status is ENDED, endsAt must be set
+    if (validated.status === AssignmentStatus.ENDED) {
+      // Force endsAt to now when ending, even if client sends null
+      updateData.endsAt = validated.endsAt
+        ? new Date(validated.endsAt)
+        : new Date();
+    } else if (validated.endsAt !== undefined) {
       updateData.endsAt = validated.endsAt ? new Date(validated.endsAt) : null;
     }
 

--- a/app/api/assistante/assignments/route.ts
+++ b/app/api/assistante/assignments/route.ts
@@ -2,13 +2,21 @@ import { NextResponse } from 'next/server';
 import { requireAnyRole, isErrorResponse } from '@/lib/guards';
 import { can } from '@/lib/rbac';
 import { prisma } from '@/lib/prisma';
-import { AssignmentType, AssignmentStatus, Subject } from '@prisma/client';
+import { AssignmentType, AssignmentStatus, Subject, Prisma } from '@prisma/client';
 import { z } from 'zod';
+import { parsePagination, createPaginationMeta } from '@/lib/api/pagination';
+
+// Validation schema for query parameters
+const statusQuerySchema = z.nativeEnum(AssignmentStatus).optional().default(AssignmentStatus.ACTIVE);
 
 // Validation schema for creating assignments
+// Deduplicates studentIds automatically
 const createAssignmentSchema = z.object({
   coachId: z.string().min(1, 'Coach ID requis'),
-  studentIds: z.array(z.string().min(1)).min(1, 'Au moins un élève requis'),
+  studentIds: z.array(z.string().min(1))
+    .min(1, 'Au moins un élève requis')
+    .transform((ids) => Array.from(new Set(ids)))
+    .refine((ids) => ids.length > 0, 'Au moins un élève unique requis'),
   assignmentType: z.nativeEnum(AssignmentType).default(AssignmentType.PRIMARY),
   subjects: z.array(z.nativeEnum(Subject)).optional().default([]),
   startsAt: z.string().datetime().optional(),
@@ -38,10 +46,18 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const coachId = searchParams.get('coachId');
     const studentId = searchParams.get('studentId');
-    const status = (searchParams.get('status') as AssignmentStatus) || AssignmentStatus.ACTIVE;
-    const page = parseInt(searchParams.get('page') || '1', 10);
-    const limit = Math.min(parseInt(searchParams.get('limit') || '20', 10), 100);
-    const skip = (page - 1) * limit;
+
+    // Validate status parameter with Zod
+    const statusResult = statusQuerySchema.safeParse(searchParams.get('status'));
+    if (!statusResult.success) {
+      return NextResponse.json(
+        { error: 'Bad Request', message: 'Statut invalide' },
+        { status: 400 }
+      );
+    }
+    const status = statusResult.data;
+
+    const { page, limit, skip } = parsePagination(searchParams);
 
     const where: any = {};
     if (coachId) where.coachId = coachId;
@@ -90,12 +106,7 @@ export async function GET(request: Request) {
 
     return NextResponse.json({
       success: true,
-      pagination: {
-        page,
-        limit,
-        total,
-        totalPages: Math.ceil(total / limit),
-      },
+      pagination: createPaginationMeta(page, limit, total),
       assignments,
     });
   } catch (error) {
@@ -158,12 +169,14 @@ export async function POST(request: Request) {
       );
     }
 
-    // Check for existing active assignments (prevent duplicates)
+    // Check for existing active assignments using active window (prevent duplicates)
+    const now = new Date();
+    const { activeAssignmentWhere } = await import('@/lib/rbac/coach-student-access');
     const existingAssignments = await prisma.coachStudentAssignment.findMany({
       where: {
         coachId: validated.coachId,
         studentId: { in: validated.studentIds },
-        status: AssignmentStatus.ACTIVE,
+        ...activeAssignmentWhere(now),
       },
     });
 
@@ -225,10 +238,23 @@ export async function POST(request: Request) {
       { status: 201 }
     );
   } catch (error) {
+    // Handle Zod validation errors
     if (error instanceof z.ZodError) {
       return NextResponse.json(
         { error: 'Validation Error', message: error.errors },
         { status: 400 }
+      );
+    }
+
+    // Handle Prisma unique constraint violation (P2002)
+    // This can happen due to the partial unique index on active assignments
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      return NextResponse.json(
+        {
+          error: 'Conflict',
+          message: 'Une assignation active existe déjà pour cette combinaison coach/élève/type',
+        },
+        { status: 409 }
       );
     }
 

--- a/app/api/assistante/coaches/route.ts
+++ b/app/api/assistante/coaches/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server';
 import { requireAnyRole, isErrorResponse } from '@/lib/guards';
 import { can } from '@/lib/rbac';
+import { activeAssignmentWhere } from '@/lib/rbac/coach-student-access';
 import { prisma } from '@/lib/prisma';
+import { parsePagination, createPaginationMeta } from '@/lib/api/pagination';
 
 /**
  * GET /api/assistante/coaches
@@ -10,10 +12,10 @@ import { prisma } from '@/lib/prisma';
  * Requires: ASSISTANTE or ADMIN role
  * Query params:
  *   - search: string (search by name, pseudonym, or email)
- *   - subject: Subject enum (filter by specialty)
  *   - availableOnline: 'true' | 'false'
  *   - page: number (default: 1)
  *   - limit: number (default: 20, max: 100)
+ * Note: subject filter not yet implemented (CoachProfile.subjects is Json)
  */
 export async function GET(request: Request) {
   try {
@@ -33,9 +35,7 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const search = searchParams.get('search') || '';
     const availableOnline = searchParams.get('availableOnline');
-    const page = parseInt(searchParams.get('page') || '1', 10);
-    const limit = Math.min(parseInt(searchParams.get('limit') || '20', 10), 100);
-    const skip = (page - 1) * limit;
+    const { page, limit, skip } = parsePagination(searchParams);
 
     // Build where clause
     const where: any = {};
@@ -56,6 +56,7 @@ export async function GET(request: Request) {
     }
 
     // Fetch coaches with pagination
+    const now = new Date();
     const [coaches, total] = await Promise.all([
       prisma.coachProfile.findMany({
         where,
@@ -72,7 +73,7 @@ export async function GET(request: Request) {
             },
           },
           studentAssignments: {
-            where: { status: 'ACTIVE' },
+            where: activeAssignmentWhere(now),
             include: {
               student: {
                 select: {
@@ -95,6 +96,8 @@ export async function GET(request: Request) {
     ]);
 
     // Transform data for response
+    // Note: activeStudents uses studentAssignments.length (already filtered by activeAssignmentWhere)
+    // instead of _count which would include historical assignments
     const formattedCoaches = coaches.map((coach) => ({
       id: coach.id,
       userId: coach.userId,
@@ -108,7 +111,7 @@ export async function GET(request: Request) {
       availableOnline: coach.availableOnline,
       availableInPerson: coach.availableInPerson,
       stats: {
-        activeStudents: coach._count.studentAssignments,
+        activeStudents: coach.studentAssignments.length,
         totalSessions: coach._count.sessions,
       },
       activeAssignments: coach.studentAssignments.map((assignment) => ({
@@ -123,12 +126,7 @@ export async function GET(request: Request) {
 
     return NextResponse.json({
       success: true,
-      pagination: {
-        page,
-        limit,
-        total,
-        totalPages: Math.ceil(total / limit),
-      },
+      pagination: createPaginationMeta(page, limit, total),
       coaches: formattedCoaches,
     });
   } catch (error) {

--- a/app/api/assistante/students/route.ts
+++ b/app/api/assistante/students/route.ts
@@ -39,10 +39,34 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const search = searchParams.get('search') || '';
 
-    // Validate enum parameters
-    const gradeLevel = parseEnumParam(searchParams.get('gradeLevel'), GradeLevel);
-    const academicTrack = parseEnumParam(searchParams.get('academicTrack'), AcademicTrack);
-    const stmgPathway = parseEnumParam(searchParams.get('stmgPathway'), StmgPathway);
+    // Validate enum parameters - return 400 if explicitly provided but invalid
+    const gradeLevelRaw = searchParams.get('gradeLevel');
+    const academicTrackRaw = searchParams.get('academicTrack');
+    const stmgPathwayRaw = searchParams.get('stmgPathway');
+
+    const gradeLevel = parseEnumParam(gradeLevelRaw, GradeLevel);
+    const academicTrack = parseEnumParam(academicTrackRaw, AcademicTrack);
+    const stmgPathway = parseEnumParam(stmgPathwayRaw, StmgPathway);
+
+    // Check for invalid enum values (param provided but not valid)
+    if (gradeLevelRaw && gradeLevel === null) {
+      return NextResponse.json(
+        { error: 'Bad Request', message: `gradeLevel invalide: ${gradeLevelRaw}` },
+        { status: 400 }
+      );
+    }
+    if (academicTrackRaw && academicTrack === null) {
+      return NextResponse.json(
+        { error: 'Bad Request', message: `academicTrack invalide: ${academicTrackRaw}` },
+        { status: 400 }
+      );
+    }
+    if (stmgPathwayRaw && stmgPathway === null) {
+      return NextResponse.json(
+        { error: 'Bad Request', message: `stmgPathway invalide: ${stmgPathwayRaw}` },
+        { status: 400 }
+      );
+    }
 
     const hasCoach = searchParams.get('hasCoach') || 'all';
     const { page, limit, skip } = parsePagination(searchParams);

--- a/app/api/assistante/students/route.ts
+++ b/app/api/assistante/students/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server';
 import { requireAnyRole, isErrorResponse } from '@/lib/guards';
 import { can } from '@/lib/rbac';
+import { activeAssignmentWhere } from '@/lib/rbac/coach-student-access';
 import { prisma } from '@/lib/prisma';
 import { GradeLevel, AcademicTrack, StmgPathway } from '@prisma/client';
+import { parsePagination, parseEnumParam, createPaginationMeta } from '@/lib/api/pagination';
 
 /**
  * GET /api/assistante/students
@@ -33,16 +35,17 @@ export async function GET(request: Request) {
       );
     }
 
-    // Parse query parameters
+    // Parse query parameters with validation
     const { searchParams } = new URL(request.url);
     const search = searchParams.get('search') || '';
-    const gradeLevel = searchParams.get('gradeLevel') as GradeLevel | null;
-    const academicTrack = searchParams.get('academicTrack') as AcademicTrack | null;
-    const stmgPathway = searchParams.get('stmgPathway') as StmgPathway | null;
+
+    // Validate enum parameters
+    const gradeLevel = parseEnumParam(searchParams.get('gradeLevel'), GradeLevel);
+    const academicTrack = parseEnumParam(searchParams.get('academicTrack'), AcademicTrack);
+    const stmgPathway = parseEnumParam(searchParams.get('stmgPathway'), StmgPathway);
+
     const hasCoach = searchParams.get('hasCoach') || 'all';
-    const page = parseInt(searchParams.get('page') || '1', 10);
-    const limit = Math.min(parseInt(searchParams.get('limit') || '20', 10), 100);
-    const skip = (page - 1) * limit;
+    const { page, limit, skip } = parsePagination(searchParams);
 
     // Build where clause
     const where: any = {};
@@ -59,13 +62,15 @@ export async function GET(request: Request) {
       where.stmgPathway = stmgPathway;
     }
 
+    // Apply active assignment window for hasCoach filter
+    const now = new Date();
     if (hasCoach === 'true') {
       where.coachAssignments = {
-        some: { status: 'ACTIVE' },
+        some: activeAssignmentWhere(now),
       };
     } else if (hasCoach === 'false') {
       where.coachAssignments = {
-        none: { status: 'ACTIVE' },
+        none: activeAssignmentWhere(now),
       };
     }
 
@@ -106,7 +111,7 @@ export async function GET(request: Request) {
             },
           },
           coachAssignments: {
-            where: { status: 'ACTIVE' },
+            where: activeAssignmentWhere(now),
             include: {
               coach: {
                 include: {
@@ -137,12 +142,7 @@ export async function GET(request: Request) {
 
     return NextResponse.json({
       success: true,
-      pagination: {
-        page,
-        limit,
-        total,
-        totalPages: Math.ceil(total / limit),
-      },
+      pagination: createPaginationMeta(page, limit, total),
       students,
     });
   } catch (error) {

--- a/app/api/coach/students/[studentId]/route.ts
+++ b/app/api/coach/students/[studentId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireRole, isErrorResponse } from '@/lib/guards';
 import { can } from '@/lib/rbac';
-import { assertCoachCanAccessStudent } from '@/lib/rbac/coach-student-access';
+import { assertCoachCanAccessStudent, CoachNotAssignedError, activeAssignmentWhere } from '@/lib/rbac/coach-student-access';
 import { prisma } from '@/lib/prisma';
 import { UserRole } from '@prisma/client';
 
@@ -31,20 +31,38 @@ export async function GET(request: Request, { params }: RouteParams) {
       );
     }
 
-    // Ownership check - throws if not assigned
+    // 1. Check student exists first (404 if not)
+    const studentExists = await prisma.student.findUnique({
+      where: { id: studentId },
+      select: { id: true },
+    });
+
+    if (!studentExists) {
+      return NextResponse.json(
+        { error: 'Not Found', message: 'Élève non trouvé' },
+        { status: 404 }
+      );
+    }
+
+    // 2. Ownership check - throws CoachNotAssignedError if not assigned
     try {
       await assertCoachCanAccessStudent({
         coachUserId: session.user.id,
         studentId,
       });
-    } catch (accessError) {
-      return NextResponse.json(
-        { error: 'Forbidden', message: 'Vous n\'êtes pas assigné à cet élève' },
-        { status: 403 }
-      );
+    } catch (error) {
+      if (error instanceof CoachNotAssignedError) {
+        return NextResponse.json(
+          { error: 'Forbidden', message: error.message },
+          { status: 403 }
+        );
+      }
+      // Re-throw other errors to be caught by outer catch (500)
+      throw error;
     }
 
-    // Fetch detailed student data
+    // 3. Fetch detailed student data
+    const now = new Date();
     const student = await prisma.student.findUnique({
       where: { id: studentId },
       include: {
@@ -70,7 +88,7 @@ export async function GET(request: Request, { params }: RouteParams) {
           },
         },
         coachAssignments: {
-          where: { status: 'ACTIVE' },
+          where: activeAssignmentWhere(now),
           include: {
             coach: {
               include: {

--- a/lib/api/pagination.ts
+++ b/lib/api/pagination.ts
@@ -1,0 +1,66 @@
+/**
+ * Pagination helpers for API routes
+ * Centralizes pagination logic with safe defaults
+ */
+
+export interface PaginationParams {
+  page: number;
+  limit: number;
+  skip: number;
+}
+
+/**
+ * Parse and validate pagination parameters from URL search params
+ * @param searchParams - URLSearchParams from request
+ * @returns Validated pagination params with safe defaults
+ */
+export function parsePagination(searchParams: URLSearchParams): PaginationParams {
+  const pageParam = Number.parseInt(searchParams.get('page') || '1', 10);
+  const limitParam = Number.parseInt(searchParams.get('limit') || '20', 10);
+
+  // Validate and clamp values
+  const page = Number.isFinite(pageParam) && pageParam > 0 ? pageParam : 1;
+  const limit = Number.isFinite(limitParam) && limitParam > 0
+    ? Math.min(limitParam, 100)  // Max 100 items per page
+    : 20;  // Default 20
+
+  return {
+    page,
+    limit,
+    skip: (page - 1) * limit,
+  };
+}
+
+/**
+ * Parse an enum parameter with validation
+ * Returns the valid enum value or null if invalid
+ */
+export function parseEnumParam<T extends Record<string, string>>(
+  value: string | null,
+  enumObject: T
+): T[keyof T] | null {
+  if (!value) return null;
+
+  const enumValues = Object.values(enumObject);
+  if (enumValues.includes(value as T[keyof T])) {
+    return value as T[keyof T];
+  }
+
+  return null;
+}
+
+/**
+ * Create pagination response metadata
+ */
+export function createPaginationMeta(
+  page: number,
+  limit: number,
+  total: number
+) {
+  return {
+    page,
+    limit,
+    total,
+    totalPages: Math.ceil(total / limit),
+  };
+}

--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -81,6 +81,7 @@ const rolePermissions: Record<UserRole, Permission[]> = {
     { action: 'READ', resource: 'STUDENT' },
     { action: 'CREATE', resource: 'STUDENT' },
     { action: 'UPDATE', resource: 'STUDENT' },
+    { action: 'READ', resource: 'COACH_ASSIGNMENT' },
     { action: 'ASSIGN', resource: 'COACH_ASSIGNMENT' },
     { action: 'UNASSIGN', resource: 'COACH_ASSIGNMENT' },
     { action: 'READ', resource: 'DOCUMENT' },

--- a/lib/rbac/coach-student-access.ts
+++ b/lib/rbac/coach-student-access.ts
@@ -1,5 +1,28 @@
 import { prisma } from '@/lib/prisma';
-import { AssignmentStatus } from '@prisma/client';
+import { AssignmentStatus, Prisma } from '@prisma/client';
+
+/**
+ * Error class for coach-student access denial
+ * Allows routes to distinguish between "not assigned" (403) and other errors (500)
+ */
+export class CoachNotAssignedError extends Error {
+  constructor(message = "Vous n'êtes pas assigné à cet élève") {
+    super(message);
+    this.name = 'CoachNotAssignedError';
+  }
+}
+
+/**
+ * Build the where clause for active assignments
+ * Centralizes the logic: ACTIVE status + started + not ended
+ */
+export function activeAssignmentWhere(now: Date = new Date()): Prisma.CoachStudentAssignmentWhereInput {
+  return {
+    status: AssignmentStatus.ACTIVE,
+    startsAt: { lte: now },
+    OR: [{ endsAt: null }, { endsAt: { gte: now } }],
+  };
+}
 
 /**
  * Get CoachProfile for a given user ID
@@ -32,13 +55,12 @@ export async function isCoachAssignedToStudent({
   const coachProfile = await getCoachProfileForUser(coachUserId);
   if (!coachProfile) return false;
 
+  const now = new Date();
   const assignment = await prisma.coachStudentAssignment.findFirst({
     where: {
       coachId: coachProfile.id,
       studentId,
-      status: AssignmentStatus.ACTIVE,
-      startsAt: { lte: new Date() },
-      OR: [{ endsAt: null }, { endsAt: { gte: new Date() } }],
+      ...activeAssignmentWhere(now),
     },
     select: { id: true },
   });
@@ -61,7 +83,7 @@ export async function assertCoachCanAccessStudent({
 }): Promise<void> {
   const hasAccess = await isCoachAssignedToStudent({ coachUserId, studentId });
   if (!hasAccess) {
-    throw new Error('ACCESS_DENIED: Vous n\'êtes pas assigné à cet élève');
+    throw new CoachNotAssignedError();
   }
 }
 
@@ -82,12 +104,11 @@ export async function getAssignedStudentsForCoach({
   const coachProfile = await getCoachProfileForUser(coachUserId);
   if (!coachProfile) return [];
 
+  const now = new Date();
   const assignments = await prisma.coachStudentAssignment.findMany({
     where: {
       coachId: coachProfile.id,
-      status: AssignmentStatus.ACTIVE,
-      startsAt: { lte: new Date() },
-      OR: [{ endsAt: null }, { endsAt: { gte: new Date() } }],
+      ...activeAssignmentWhere(now),
     },
     include: {
       student: {

--- a/prisma/migrations/20260425230000_add_coach_student_assignments/migration.sql
+++ b/prisma/migrations/20260425230000_add_coach_student_assignments/migration.sql
@@ -7,29 +7,29 @@
 
 DO $$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'assignmenttype') THEN
-    CREATE TYPE "assignmenttype" AS ENUM ('PRIMARY', 'SECONDARY', 'STAGE', 'TEMPORARY');
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'AssignmentType') THEN
+    CREATE TYPE "AssignmentType" AS ENUM ('PRIMARY', 'SECONDARY', 'STAGE', 'TEMPORARY');
   END IF;
 END $$;
 
 DO $$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'assignmentstatus') THEN
-    CREATE TYPE "assignmentstatus" AS ENUM ('ACTIVE', 'SUSPENDED', 'ENDED');
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'AssignmentStatus') THEN
+    CREATE TYPE "AssignmentStatus" AS ENUM ('ACTIVE', 'SUSPENDED', 'ENDED');
   END IF;
 END $$;
 
 DO $$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'documenttype') THEN
-    CREATE TYPE "documenttype" AS ENUM ('COURS', 'EXERCICE', 'BILAN', 'CORRECTION', 'PLANNING', 'ANNEXE', 'AUTRE');
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'DocumentType') THEN
+    CREATE TYPE "DocumentType" AS ENUM ('COURS', 'EXERCICE', 'BILAN', 'CORRECTION', 'PLANNING', 'ANNEXE', 'AUTRE');
   END IF;
 END $$;
 
 DO $$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'documentvisibilityscope') THEN
-    CREATE TYPE "documentvisibilityscope" AS ENUM ('STUDENT_ONLY', 'STUDENT_AND_PARENT', 'STUDENT_AND_COACH', 'STUDENT_PARENT_COACH', 'ADMIN_ONLY');
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'DocumentVisibilityScope') THEN
+    CREATE TYPE "DocumentVisibilityScope" AS ENUM ('STUDENT_ONLY', 'STUDENT_AND_PARENT', 'STUDENT_AND_COACH', 'STUDENT_PARENT_COACH', 'ADMIN_ONLY');
   END IF;
 END $$;
 
@@ -42,9 +42,9 @@ CREATE TABLE IF NOT EXISTS "coach_student_assignments" (
     "coachId"        TEXT NOT NULL,
     "studentId"      TEXT NOT NULL,
     "assignedById"   TEXT,
-    "assignmentType" "assignmenttype" NOT NULL DEFAULT 'PRIMARY',
-    "status"         "assignmentstatus" NOT NULL DEFAULT 'ACTIVE',
-    "subjects"       TEXT[] NOT NULL DEFAULT '{}',
+    "assignmentType" "AssignmentType" NOT NULL DEFAULT 'PRIMARY',
+    "status"         "AssignmentStatus" NOT NULL DEFAULT 'ACTIVE',
+    "subjects"       "Subject"[] NOT NULL DEFAULT ARRAY[]::"Subject"[],
     "notes"          TEXT,
     "startsAt"       TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "endsAt"         TIMESTAMP(3),
@@ -63,6 +63,12 @@ CREATE INDEX IF NOT EXISTS "coach_student_assignments_studentId_status_idx"
 
 CREATE INDEX IF NOT EXISTS "coach_student_assignments_assignedById_idx"
     ON "coach_student_assignments" ("assignedById");
+
+-- Partial unique index to prevent duplicate active assignments
+-- A coach can only have one active assignment of each type for a given student
+CREATE UNIQUE INDEX IF NOT EXISTS "coach_student_assignments_active_unique"
+    ON "coach_student_assignments" ("coachId", "studentId", "assignmentType")
+    WHERE "status" = 'ACTIVE';
 
 -- Foreign keys for CoachStudentAssignment
 DO $$
@@ -104,17 +110,17 @@ DO $$
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM information_schema.columns 
     WHERE table_name = 'user_documents' AND column_name = 'documentType') THEN
-    ALTER TABLE "user_documents" ADD COLUMN "documentType" "documenttype" NOT NULL DEFAULT 'AUTRE';
+    ALTER TABLE "user_documents" ADD COLUMN "documentType" "DocumentType" NOT NULL DEFAULT 'AUTRE';
   END IF;
 
   IF NOT EXISTS (SELECT 1 FROM information_schema.columns 
     WHERE table_name = 'user_documents' AND column_name = 'visibilityScope') THEN
-    ALTER TABLE "user_documents" ADD COLUMN "visibilityScope" "documentvisibilityscope" NOT NULL DEFAULT 'STUDENT_ONLY';
+    ALTER TABLE "user_documents" ADD COLUMN "visibilityScope" "DocumentVisibilityScope" NOT NULL DEFAULT 'STUDENT_ONLY';
   END IF;
 
   IF NOT EXISTS (SELECT 1 FROM information_schema.columns 
     WHERE table_name = 'user_documents' AND column_name = 'subject') THEN
-    ALTER TABLE "user_documents" ADD COLUMN "subject" "subject";
+    ALTER TABLE "user_documents" ADD COLUMN "subject" "Subject";
   END IF;
 
   IF NOT EXISTS (SELECT 1 FROM information_schema.columns 
@@ -130,7 +136,8 @@ BEGIN
   IF NOT EXISTS (SELECT 1 FROM information_schema.columns 
     WHERE table_name = 'user_documents' AND column_name = 'updatedAt') THEN
     ALTER TABLE "user_documents" ADD COLUMN "updatedAt" TIMESTAMP(3);
-    UPDATE "user_documents" SET "updatedAt" = "createdAt" WHERE "updatedAt" IS NULL;
+    UPDATE "user_documents" SET "updatedAt" = COALESCE("updatedAt", "createdAt", CURRENT_TIMESTAMP) WHERE "updatedAt" IS NULL;
+    ALTER TABLE "user_documents" ALTER COLUMN "updatedAt" SET NOT NULL;
   END IF;
 END $$;
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1743,6 +1743,9 @@ model CoachNote {
 
 // Coach-Student Assignment — Core model for coach-student pedagogical relationship
 // This is the source of truth for "which students can a coach access"
+/// Active duplicate protection is enforced by a partial unique index
+/// in migration 20260425230000_add_coach_student_assignments:
+/// coachId + studentId + assignmentType WHERE status = 'ACTIVE'
 model CoachStudentAssignment {
   id             String           @id @default(cuid())
 


### PR DESCRIPTION
## Summary

This hotfix PR addresses critical review feedback from AI reviewers (Codex/Cubic/Copilot) on PR #25 before it can be safely deployed to staging/production.

## Critical Issues Fixed

### 1. Migration SQL Drift (BLOCKING)
- **Problem**: Enums created in lowercase (`assignmenttype`, `assignmentstatus`) but Prisma expects PascalCase (`AssignmentType`, `AssignmentStatus`)
- **Fix**: Renamed all enum types to PascalCase
- **Problem**: `subjects` column was `TEXT[]` instead of `Subject[]`
- **Fix**: Changed to `"Subject"[] NOT NULL DEFAULT ARRAY[]::"Subject"[]`
- **Problem**: `user_documents.subject` used lowercase type
- **Fix**: Changed to `"Subject"`
- **Problem**: `updatedAt` nullable
- **Fix**: Added `NOT NULL` constraint with `COALESCE` for existing data

### 2. Database Race Condition (BLOCKING)
- **Problem**: No DB-level protection against concurrent duplicate active assignments
- **Fix**: Added partial unique index:
  ```sql
  CREATE UNIQUE INDEX IF NOT EXISTS "coach_student_assignments_active_unique"
    ON "coach_student_assignments" ("coachId", "studentId", "assignmentType")
    WHERE "status" = 'ACTIVE';
  ```

### 3. Active Assignment Logic (HIGH)
- **Problem**: Routes only checked `status: ACTIVE` without temporal window
- **Fix**: Created `activeAssignmentWhere()` helper ensuring:
  - `status: ACTIVE`
  - `startsAt <= now`
  - `endsAt IS NULL OR endsAt >= now`
- Applied to all queries using assignments

### 4. API Security & Validation (HIGH)
- **coach detail**: Now returns 404 if student doesn't exist, 403 only if exists but not assigned
- **assistante endpoints**: Added enum validation, pagination security (max 100), deduplication
- **assignments POST**: Handle P2002 conflict from unique index, deduplicate studentIds
- **assignments PATCH**: Force `endsAt` to current date when `status=ENDED`

## New Files
- `lib/api/pagination.ts`: Centralized pagination helpers

## Updated Files
- `prisma/migrations/20260425230000_add_coach_student_assignments/migration.sql`
- `prisma/schema.prisma`
- `lib/rbac/coach-student-access.ts`
- `lib/rbac.ts`
- `app/api/coach/students/[studentId]/route.ts`
- `app/api/assistante/students/route.ts`
- `app/api/assistante/coaches/route.ts`
- `app/api/assistante/assignments/route.ts`
- `app/api/assistante/assignments/[id]/route.ts`
- `__tests__/rbac/coach-student-access.test.ts`
- `__tests__/api/assistante-assignments.test.ts`

## Validation
- [x] 46/46 targeted tests pass
- [x] TypeScript: 0 errors
- [x] Prisma validate: OK
- [x] Prisma generate: OK
- [x] Lint: 0 errors (warnings pre-existing)

## Migration Safety
⚠️ **This migration modifies enum types** - requires careful deployment:
1. Backup database before migration
2. Test on staging first
3. Verify enum compatibility with existing data

## Deployment Notes
- **Staging**: Ready after PR merge
- **Production**: Requires migration verification on staging first
- **Rollback**: Migration is safe (IF NOT EXISTS guards), partial index can be dropped if needed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DB enum drift and hardens coach–student assignment logic before staging. Prevents duplicate active assignments, standardizes the active window across queries, and tightens RBAC and API validation.

- **Bug Fixes**
  - Centralized active assignment filter (status + dates) and applied across routes and RBAC.
  - Coach student detail: 404 if student doesn’t exist; 403 only when not assigned.
  - Assignments API: POST deduplicates studentIds and returns 409 on P2002; PATCH forces endsAt when status=ENDED; GET validates status query.
  - Assistante students/coaches: strict enum validation (400 on invalid), safe pagination (max 100) with shared helpers; activeStudents counts only current assignments.
  - RBAC: add `READ` on `COACH_ASSIGNMENT` and enforce it on assignment detail.

- **Migration**
  - Align enum types to PascalCase and fix `Subject[]` columns; make `updatedAt` NOT NULL with backfill (compatible with `@prisma/client`).
  - Add partial unique index to block duplicate active assignments (coachId + studentId + assignmentType WHERE status='ACTIVE').
  - Steps: back up DB → run on staging and verify → deploy to production.

<sup>Written for commit 68be345544c9592e2f3a0d06ce7355a162dbb3c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

