### PR TITLE
feat(assistante): add Nexus invoice generator page

### DIFF
--- a/__tests__/api/admin.invoices.route.test.ts
+++ b/__tests__/api/admin.invoices.route.test.ts
@@ -25,9 +25,11 @@ jest.mock('@/lib/invoice', () => ({
 
 import { GET, POST } from '@/app/api/admin/invoices/route';
 import { auth } from '@/auth';
+import { renderInvoicePDF } from '@/lib/invoice';
 import { NextRequest } from 'next/server';
 
 const mockAuth = auth as jest.Mock;
+const mockRenderInvoicePDF = renderInvoicePDF as jest.Mock;
 
 let prisma: any;
 
@@ -208,5 +210,83 @@ describe('POST /api/admin/invoices', () => {
     expect(res.status).toBe(201);
     expect(body.number).toBe('NXS-2026-0001');
     expect(body.pdfUrl).toBeTruthy();
+  });
+
+  it('should allow ASSISTANTE to create invoices through the existing admin invoice API', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'assistante-1', role: 'ASSISTANTE' } } as any);
+    prisma.invoice.create.mockResolvedValue({
+      id: 'inv-assistante-1',
+      number: 'NXS-2026-0001',
+      issuedAt: new Date(),
+      dueAt: null,
+      issuerName: 'M&M Academy',
+      issuerAddress: 'Tunis',
+      issuerMF: '1XXX',
+      issuerRNE: null,
+      customerName: 'Parent Responsable',
+      customerEmail: null,
+      customerAddress: null,
+      customerId: null,
+      currency: 'TND',
+      subtotal: 1_149_000,
+      discountTotal: 50_000,
+      taxTotal: 62_208,
+      total: 1_099_000,
+      taxRegime: 'TVA_INCLUSE',
+      events: [],
+      items: [
+        {
+          label: 'Duo Première — Français + Maths',
+          qty: 1,
+          unitPrice: 1_149_000,
+          total: 1_149_000,
+          description: null,
+          sortOrder: 0,
+        },
+      ],
+    });
+    prisma.invoice.update.mockResolvedValue({});
+
+    const res = await POST(makePostRequest({
+      customer: { name: 'Parent Responsable' },
+      items: [{ label: 'Duo Première — Français + Maths', qty: 1, unitPrice: 1_149_000 }],
+      discountTotal: 50_000,
+      taxRegime: 'TVA_INCLUSE',
+      paymentMethod: 'BANK_TRANSFER',
+      paymentDetails: {
+        notes: [
+          'Paiements mixtes : Virement bancaire : 500,000 TND (VIR-001) | Chèque : 400,000 TND (CHQ-002) | Espèces : 199,000 TND (Espèces bureau)',
+          'Net payé : 1 099,000 TND',
+          'Reste à payer : 0,000 TND',
+        ].join('\n'),
+      },
+      notes: 'Paiements mixtes : Virement bancaire : 500,000 TND (VIR-001)',
+    }));
+
+    expect(res.status).toBe(201);
+    expect(prisma.invoice.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          createdByUserId: 'assistante-1',
+          discountTotal: 50_000,
+          taxTotal: 62_208,
+          taxRegime: 'TVA_INCLUSE',
+          paymentMethod: 'BANK_TRANSFER',
+          notes: 'Paiements mixtes : Virement bancaire : 500,000 TND (VIR-001)',
+        }),
+      })
+    );
+    expect(mockRenderInvoicePDF).toHaveBeenCalledWith(
+      expect.objectContaining({
+        total: 1_099_000,
+        discountTotal: 50_000,
+        taxTotal: 62_208,
+        taxRegime: 'TVA_INCLUSE',
+        paymentMethod: 'BANK_TRANSFER',
+        paymentDetails: expect.objectContaining({
+          notes: expect.stringContaining('Chèque : 400,000 TND (CHQ-002)'),
+        }),
+      })
+    );
   });
 });

--- a/__tests__/api/admin.invoices.route.test.ts
+++ b/__tests__/api/admin.invoices.route.test.ts
@@ -252,7 +252,7 @@ describe('POST /api/admin/invoices', () => {
       items: [{ label: 'Duo Première — Français + Maths', qty: 1, unitPrice: 1_149_000 }],
       discountTotal: 50_000,
       taxRegime: 'TVA_INCLUSE',
-      paymentMethod: 'BANK_TRANSFER',
+      paymentMethod: null,
       paymentDetails: {
         notes: [
           'Paiements mixtes : Virement bancaire : 500,000 TND (VIR-001) | Chèque : 400,000 TND (CHQ-002) | Espèces : 199,000 TND (Espèces bureau)',
@@ -271,7 +271,7 @@ describe('POST /api/admin/invoices', () => {
           discountTotal: 50_000,
           taxTotal: 62_208,
           taxRegime: 'TVA_INCLUSE',
-          paymentMethod: 'BANK_TRANSFER',
+          paymentMethod: null,
           notes: 'Paiements mixtes : Virement bancaire : 500,000 TND (VIR-001)',
         }),
       })
@@ -282,7 +282,7 @@ describe('POST /api/admin/invoices', () => {
         discountTotal: 50_000,
         taxTotal: 62_208,
         taxRegime: 'TVA_INCLUSE',
-        paymentMethod: 'BANK_TRANSFER',
+        paymentMethod: null,
         paymentDetails: expect.objectContaining({
           notes: expect.stringContaining('Chèque : 400,000 TND (CHQ-002)'),
         }),

--- a/__tests__/app/assistante.facturation.page.test.tsx
+++ b/__tests__/app/assistante.facturation.page.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+
+import AssistanteFacturationPage from '@/app/dashboard/assistante/facturation/page';
+import { auth } from '@/auth';
+import { redirect } from 'next/navigation';
+
+jest.mock('@/components/facturation/NexusInvoiceGenerator', () => ({
+  NexusInvoiceGenerator: () => <div data-testid="nexus-invoice-generator" />,
+}));
+
+jest.mock('next/navigation', () => {
+  const actual = jest.requireActual('next/navigation');
+  return {
+    ...actual,
+    redirect: jest.fn((url: string) => {
+      throw new Error(`NEXT_REDIRECT:${url}`);
+    }),
+  };
+});
+
+const mockAuth = auth as unknown as jest.Mock;
+const mockRedirect = redirect as unknown as jest.Mock;
+
+describe('/dashboard/assistante/facturation access', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders for ASSISTANTE', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'assistante-1', role: 'ASSISTANTE' } });
+
+    render(await AssistanteFacturationPage());
+
+    expect(screen.getByTestId('nexus-invoice-generator')).toBeInTheDocument();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it('renders for ADMIN', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } });
+
+    render(await AssistanteFacturationPage());
+
+    expect(screen.getByTestId('nexus-invoice-generator')).toBeInTheDocument();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it('redirects unauthenticated users', async () => {
+    mockAuth.mockResolvedValue(null);
+
+    await expect(AssistanteFacturationPage()).rejects.toThrow('NEXT_REDIRECT:/auth/signin');
+    expect(mockRedirect).toHaveBeenCalledWith('/auth/signin');
+  });
+
+  it('redirects students and other unauthorized roles', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'student-1', role: 'ELEVE' } });
+
+    await expect(AssistanteFacturationPage()).rejects.toThrow('NEXT_REDIRECT:/auth/signin');
+    expect(mockRedirect).toHaveBeenCalledWith('/auth/signin');
+  });
+});

--- a/__tests__/components/facturation/nexus-invoice-generator.test.tsx
+++ b/__tests__/components/facturation/nexus-invoice-generator.test.tsx
@@ -22,6 +22,8 @@ describe('NexusInvoiceGenerator', () => {
       screen.getAllByText(/Centre Urbain Nord, Immeuble VENUS, Appt C13, 1082/).length
     ).toBeGreaterThan(0);
     expect(screen.getByText(/contact@nexusreussite\.academy/)).toBeInTheDocument();
+    expect(screen.getByText(/Montant total TTC/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Arrêté la présente facture/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/sans tampon/i)).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/facturation/nexus-invoice-generator.test.tsx
+++ b/__tests__/components/facturation/nexus-invoice-generator.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+
+import { NexusInvoiceGenerator } from '@/components/facturation/NexusInvoiceGenerator';
+
+describe('NexusInvoiceGenerator', () => {
+  it('renders the production invoice assistant with logo, presets, payments and required footer', () => {
+    render(<NexusInvoiceGenerator />);
+
+    expect(screen.getByRole('img', { name: /logo nexus réussite/i })).toHaveAttribute(
+      'src',
+      '/images/logo_slogan_nexus.png'
+    );
+    expect(screen.getAllByText('Duo Première — Français + Maths').length).toBeGreaterThan(0);
+    expect(screen.getByText('Français Première — Sprint EAF')).toBeInTheDocument();
+    expect(screen.getByText('Forfait personnalisé')).toBeInTheDocument();
+    expect(screen.getAllByText('Virement bancaire').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Chèque').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Espèces').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Accès plateforme EAF — Masterium offert').length).toBeGreaterThan(0);
+    expect(screen.getByText('Viser. Atteindre. Dépasser.')).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/Centre Urbain Nord, Immeuble VENUS, Appt C13, 1082/).length
+    ).toBeGreaterThan(0);
+    expect(screen.getByText(/contact@nexusreussite\.academy/)).toBeInTheDocument();
+    expect(screen.queryByText(/sans tampon/i)).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/navigation/assistante-facturation-nav.test.ts
+++ b/__tests__/components/navigation/assistante-facturation-nav.test.ts
@@ -1,0 +1,26 @@
+import { navigationConfig } from '@/components/navigation/navigation-config';
+import { UserRole } from '@/types/enums';
+
+describe('assistante navigation', () => {
+  it('exposes the facturation page only in the assistante navigation', () => {
+    expect(navigationConfig[UserRole.ASSISTANTE]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'Facturation',
+          href: '/dashboard/assistante/facturation',
+        }),
+      ])
+    );
+
+    expect(navigationConfig[UserRole.ELEVE]).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ href: '/dashboard/assistante/facturation' }),
+      ])
+    );
+    expect(navigationConfig[UserRole.COACH]).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ href: '/dashboard/assistante/facturation' }),
+      ])
+    );
+  });
+});

--- a/__tests__/lib/invoice/nexus-calculations.test.ts
+++ b/__tests__/lib/invoice/nexus-calculations.test.ts
@@ -92,7 +92,7 @@ describe('nexus invoice calculations', () => {
 
     expect(request.discountTotal).toBe(50_000);
     expect(request.taxRegime).toBe('TVA_INCLUSE');
-    expect(request.paymentMethod).toBe('BANK_TRANSFER');
+    expect(request.paymentMethod).toBeNull();
     expect(request.paymentDetails?.notes).toContain('Virement bancaire : 500,000 TND (VIR-001)');
     expect(request.paymentDetails?.notes).toContain('Chèque : 400,000 TND (CHQ-002 Banque BIAT)');
     expect(request.paymentDetails?.notes).toContain('Espèces : 199,000 TND (Espèces bureau)');
@@ -115,5 +115,32 @@ describe('nexus invoice calculations', () => {
         }),
       ])
     );
+  });
+
+  it('keeps the payment method only when a single non-zero method is used', () => {
+    const duo = NEXUS_INVOICE_PACKAGES.find((pack) => pack.id === 'duo-premiere')!;
+
+    const request = buildNexusInvoiceRequest({
+      customerName: 'Parent Responsable',
+      customerInfo: 'Client particulier',
+      invoiceDate: '2026-04-28',
+      packageLabel: duo.label,
+      packageSubtitle: duo.subtitle,
+      frenchHours: duo.frenchHours,
+      mathHours: duo.mathHours,
+      priceTtc: duo.priceTtc,
+      normalPriceTtc: duo.normalPriceTtc,
+      adjustmentTtc: 0,
+      adjustmentLabel: 'Ajustement séance non suivie',
+      payments: [
+        { method: 'CHEQUE', amount: tndToMillimes(400), reference: 'CHQ-001' },
+        { method: 'CHEQUE', amount: tndToMillimes(749), reference: 'CHQ-002' },
+      ],
+      masteriumMonths: 1,
+      masteriumMonthlyValue: tndToMillimes(129),
+      notes: '',
+    });
+
+    expect(request.paymentMethod).toBe('CHEQUE');
   });
 });

--- a/__tests__/lib/invoice/nexus-calculations.test.ts
+++ b/__tests__/lib/invoice/nexus-calculations.test.ts
@@ -1,0 +1,119 @@
+import {
+  calculateNexusInvoiceTotals,
+  NEXUS_INVOICE_PACKAGES,
+  buildNexusInvoiceRequest,
+  tndToMillimes,
+} from '@/lib/invoice/nexus-calculations';
+
+describe('nexus invoice calculations', () => {
+  it('computes HT, TVA 6%, TTC, adjustment, mixed payments and remaining due in millimes', () => {
+    const totals = calculateNexusInvoiceTotals({
+      priceTtc: tndToMillimes(1149),
+      normalPriceTtc: tndToMillimes(1188),
+      adjustmentTtc: tndToMillimes(50),
+      payments: [
+        { method: 'BANK_TRANSFER', amount: tndToMillimes(500), reference: 'VIR-001' },
+        { method: 'CHEQUE', amount: tndToMillimes(400), reference: 'CHQ-002' },
+        { method: 'CASH', amount: tndToMillimes(199), reference: 'Espèces' },
+      ],
+      masteriumMonths: 1,
+      masteriumMonthlyValue: tndToMillimes(129),
+    });
+
+    expect(totals.netTtc).toBe(1_099_000);
+    expect(totals.netHt + totals.vat).toBe(totals.netTtc);
+    expect(totals.vat).toBe(62_208);
+    expect(totals.packageDiscount).toBe(39_000);
+    expect(totals.paid).toBe(1_099_000);
+    expect(totals.due).toBe(0);
+    expect(totals.masteriumOfferedValue).toBe(129_000);
+  });
+
+  it('keeps Masterium offered access at zero billed amount in the API request', () => {
+    const duo = NEXUS_INVOICE_PACKAGES.find((pack) => pack.id === 'duo-premiere');
+    expect(duo).toBeDefined();
+
+    const request = buildNexusInvoiceRequest({
+      customerName: 'Parent Responsable',
+      customerInfo: 'Client particulier',
+      invoiceDate: '2026-04-28',
+      packageLabel: duo!.label,
+      packageSubtitle: duo!.subtitle,
+      frenchHours: duo!.frenchHours,
+      mathHours: duo!.mathHours,
+      priceTtc: duo!.priceTtc,
+      normalPriceTtc: duo!.normalPriceTtc,
+      adjustmentTtc: 0,
+      adjustmentLabel: 'Ajustement séance non suivie',
+      payments: [],
+      masteriumMonths: 1,
+      masteriumMonthlyValue: tndToMillimes(129),
+      notes: 'Accès Masterium offert à titre commercial, non facturé.',
+    });
+
+    expect(request.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'Accès plateforme EAF — Masterium offert',
+          unitPrice: 0,
+          total: 0,
+        }),
+      ])
+    );
+    expect(request.items.reduce((sum, item) => sum + item.total, 0)).toBe(duo!.priceTtc);
+    expect(request.notes).toContain('Accès Masterium offert à titre commercial, non facturé.');
+  });
+
+  it('builds a production request with three mixed payments and matching UI/API totals', () => {
+    const duo = NEXUS_INVOICE_PACKAGES.find((pack) => pack.id === 'duo-premiere')!;
+
+    const request = buildNexusInvoiceRequest({
+      customerName: 'Parent Responsable',
+      customerInfo: 'Client particulier',
+      invoiceNumber: 'FAC-2026-TEST',
+      invoiceDate: '2026-04-28',
+      packageLabel: duo.label,
+      packageSubtitle: duo.subtitle,
+      frenchHours: duo.frenchHours,
+      mathHours: duo.mathHours,
+      priceTtc: duo.priceTtc,
+      normalPriceTtc: duo.normalPriceTtc,
+      adjustmentTtc: tndToMillimes(50),
+      adjustmentLabel: 'Ajustement séance non suivie',
+      payments: [
+        { method: 'BANK_TRANSFER', amount: tndToMillimes(500), reference: 'VIR-001' },
+        { method: 'CHEQUE', amount: tndToMillimes(400), reference: 'CHQ-002 Banque BIAT' },
+        { method: 'CASH', amount: tndToMillimes(199), reference: 'Espèces bureau' },
+      ],
+      masteriumMonths: 1,
+      masteriumMonthlyValue: tndToMillimes(129),
+      notes: '',
+    });
+
+    expect(request.discountTotal).toBe(50_000);
+    expect(request.taxRegime).toBe('TVA_INCLUSE');
+    expect(request.paymentMethod).toBe('BANK_TRANSFER');
+    expect(request.paymentDetails?.notes).toContain('Virement bancaire : 500,000 TND (VIR-001)');
+    expect(request.paymentDetails?.notes).toContain('Chèque : 400,000 TND (CHQ-002 Banque BIAT)');
+    expect(request.paymentDetails?.notes).toContain('Espèces : 199,000 TND (Espèces bureau)');
+    expect(request.paymentDetails?.notes?.replace(/\s/g, ' ')).toContain('Net payé : 1 099,000 TND');
+    expect(request.paymentDetails?.notes).toContain('Reste à payer : 0,000 TND');
+    expect(request.notes).toBe(request.paymentDetails?.notes);
+    expect(request.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'Duo Première — Français + Maths',
+          description: expect.stringContaining('Français : 16h · Mathématiques : 14h'),
+          unitPrice: 1_149_000,
+          total: 1_149_000,
+        }),
+        expect.objectContaining({
+          label: 'Accès plateforme EAF — Masterium offert',
+          description: expect.stringContaining('Accès Masterium offert à titre commercial, non facturé.'),
+          unitPrice: 0,
+          total: 0,
+        }),
+      ])
+    );
+  });
+});

--- a/__tests__/lib/invoice/pdf-clamp.test.ts
+++ b/__tests__/lib/invoice/pdf-clamp.test.ts
@@ -19,7 +19,7 @@ import {
   appendInvoiceEvent,
   createInvoiceEvent,
 } from '@/lib/invoice/types';
-import { InvoiceOverflowError } from '@/lib/invoice/pdf';
+import { InvoiceOverflowError, renderInvoicePDF } from '@/lib/invoice/pdf';
 import type { InvoiceData, InvoiceItemData, InvoiceEvent } from '@/lib/invoice/types';
 
 // ─── Helpers (re-implement clampText for testing since it's not exported) ────
@@ -165,6 +165,54 @@ describe('InvoiceOverflowError', () => {
     expect(err).toBeInstanceOf(Error);
     expect(err.name).toBe('InvoiceOverflowError');
     expect(err.message).toBe('test');
+  });
+});
+
+describe('Invoice PDF payment details', () => {
+  it('renders long mixed-payment references without overflowing the page guard', async () => {
+    const longReference = 'Référence longue '.repeat(12).trim();
+    const data = makeInvoiceData({
+      issuer: {
+        name: 'M&M ACADEMY (NEXUS RÉUSSITE)',
+        address: 'Centre Urbain Nord, Immeuble VENUS, Appt C13, 1082 – Tunis',
+        mf: '1948837 N/A/M/000',
+        phone: '+216 99 19 28 29',
+        email: 'contact@nexusreussite.academy',
+        web: 'nexusreussite.academy',
+        slogan: 'Viser. Atteindre. Dépasser.',
+      },
+      items: [
+        {
+          label: 'Duo Première — Français + Maths',
+          description: 'Français : 16h · Mathématiques : 14h',
+          qty: 1,
+          unitPrice: 1_149_000,
+          total: 1_149_000,
+        },
+        {
+          label: 'Accès plateforme EAF — Masterium offert',
+          description: 'Accès Masterium offert à titre commercial, non facturé.',
+          qty: 1,
+          unitPrice: 0,
+          total: 0,
+        },
+      ],
+      subtotal: 1_149_000,
+      discountTotal: 50_000,
+      taxTotal: 62_208,
+      total: 1_099_000,
+      taxRegime: 'TVA_INCLUSE',
+      paymentMethod: null,
+      paymentDetails: {
+        notes: [
+          `Paiements mixtes : Virement bancaire : 500,000 TND (${longReference}) | Chèque : 400,000 TND (${longReference}) | Espèces : 199,000 TND (${longReference})`,
+          'Net payé : 1 099,000 TND',
+          'Reste à payer : 0,000 TND',
+        ].join('\n'),
+      },
+    });
+
+    await expect(renderInvoicePDF(data)).resolves.toBeInstanceOf(Buffer);
   });
 });
 

--- a/app/api/admin/invoices/route.ts
+++ b/app/api/admin/invoices/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import path from 'node:path';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import type { InvoiceItem, Prisma } from '@prisma/client';
@@ -25,10 +26,15 @@ import type { CreateInvoiceRequest, InvoiceData, TaxRegime } from '@/lib/invoice
 // ─── Default issuer (can be overridden per request) ─────────────────────────
 
 const DEFAULT_ISSUER = {
-  name: 'M&M Academy (Nexus Réussite)',
-  address: 'Résidence Narjess 2, Bloc D, Appt 12, Raoued 2056, Ariana, Tunisie',
-  mf: '1XXXXXX/X/A/M/000',
+  name: 'M&M ACADEMY (NEXUS RÉUSSITE)',
+  address: 'Centre Urbain Nord, Immeuble VENUS, Appt C13, 1082 – Tunis',
+  mf: '1948837 N/A/M/000',
   rne: null as string | null,
+  phone: '+216 99 19 28 29',
+  email: 'contact@nexusreussite.academy',
+  web: 'nexusreussite.academy',
+  slogan: 'Viser. Atteindre. Dépasser.',
+  logoPath: path.join(process.cwd(), 'public', 'images', 'logo_slogan_nexus.png'),
 };
 
 // ─── POST: Create Invoice ───────────────────────────────────────────────────
@@ -79,13 +85,22 @@ export async function POST(request: NextRequest) {
 
     const subtotal = computedItems.reduce((sum, item) => sum + item.total, 0);
     const discountTotal = body.discountTotal ?? 0;
-    const taxTotal = 0; // TVA non applicable by default
-    const total = subtotal - discountTotal + taxTotal; // pure int arithmetic
-
     const taxRegime: TaxRegime = body.taxRegime ?? 'TVA_NON_APPLICABLE';
+    const totalBeforeTaxDisplay = subtotal - discountTotal;
+    const taxTotal = taxRegime === 'TVA_INCLUSE'
+      ? totalBeforeTaxDisplay - Math.round(totalBeforeTaxDisplay / 1.06)
+      : 0;
+    const total = totalBeforeTaxDisplay; // TVA incluse: final TTC is already included in line prices.
 
     // Generate atomic invoice number
-    const invoiceNumber = await generateInvoiceNumber();
+    const requestedNumber = body.number?.trim();
+    if (requestedNumber) {
+      const existing = await prisma.invoice.findUnique({ where: { number: requestedNumber } });
+      if (existing) {
+        return NextResponse.json({ error: 'Numéro de facture déjà utilisé' }, { status: 409 });
+      }
+    }
+    const invoiceNumber = requestedNumber || await generateInvoiceNumber();
 
     // Merge issuer
     const issuer = {
@@ -98,7 +113,7 @@ export async function POST(request: NextRequest) {
       data: {
         number: invoiceNumber,
         status: 'DRAFT',
-        issuedAt: new Date(),
+        issuedAt: body.issuedAt ? new Date(body.issuedAt) : new Date(),
         dueAt: body.dueAt ? new Date(body.dueAt) : null,
         customerName: body.customer.name,
         customerEmail: body.customer.email ?? null,
@@ -136,6 +151,11 @@ export async function POST(request: NextRequest) {
         address: invoice.issuerAddress,
         mf: invoice.issuerMF,
         rne: invoice.issuerRNE,
+        phone: issuer.phone,
+        email: issuer.email,
+        web: issuer.web,
+        slogan: issuer.slogan,
+        logoPath: issuer.logoPath,
       },
       customer: {
         name: invoice.customerName,
@@ -157,7 +177,7 @@ export async function POST(request: NextRequest) {
       total: invoice.total,
       taxRegime: invoice.taxRegime as TaxRegime,
       paymentMethod: body.paymentMethod ?? null,
-      paymentDetails: null,
+      paymentDetails: body.paymentDetails ?? (invoice.notes ? { notes: invoice.notes } : null),
     };
 
     // Generate PDF

--- a/app/dashboard/assistante/facturation/page.tsx
+++ b/app/dashboard/assistante/facturation/page.tsx
@@ -1,0 +1,15 @@
+import { redirect } from 'next/navigation';
+import { auth } from '@/auth';
+import { NexusInvoiceGenerator } from '@/components/facturation/NexusInvoiceGenerator';
+import { UserRole } from '@prisma/client';
+
+export default async function AssistanteFacturationPage() {
+  const session = await auth();
+  const role = session?.user?.role;
+
+  if (!session?.user || (role !== UserRole.ASSISTANTE && role !== UserRole.ADMIN)) {
+    redirect('/auth/signin');
+  }
+
+  return <NexusInvoiceGenerator />;
+}

--- a/components/facturation/NexusInvoiceGenerator.tsx
+++ b/components/facturation/NexusInvoiceGenerator.tsx
@@ -1,0 +1,429 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Loader2, Plus, Printer, Trash2 } from 'lucide-react';
+import {
+  MASTERIUM_MONTHLY_VALUE,
+  NEXUS_INVOICE_PACKAGES,
+  buildNexusInvoiceRequest,
+  buildPaymentSummary,
+  calculateNexusInvoiceTotals,
+  formatTnd,
+  millimesToTnd,
+  tndToMillimes,
+  type NexusInvoicePackageId,
+  type NexusMixedPayment,
+} from '@/lib/invoice/nexus-calculations';
+
+const BRAND = {
+  navy: '#0B1F4D',
+  navyDeep: '#07142F',
+  blue: '#005BBB',
+  blueSoft: '#EAF2FF',
+  red: '#E31E24',
+  redSoft: '#FFF1F1',
+  text: '#1E293B',
+  textSoft: '#64748B',
+  border: '#D9E2F2',
+};
+
+const COMPANY = {
+  name: 'M&M ACADEMY (NEXUS RÉUSSITE)',
+  address: 'Centre Urbain Nord, Immeuble VENUS, Appt C13, 1082 – Tunis',
+  taxId: 'MF : 1948837 N/A/M/000',
+  phone: '+216 99 19 28 29',
+  email: 'contact@nexusreussite.academy',
+  web: 'nexusreussite.academy',
+  bankBeneficiary: 'STE M&M ACADEMY SUARL',
+  bank: 'Banque Zitouna',
+  rib: '25 079 000 0001569084 04',
+  iban: 'TN59 25 079 000 0001569084 04',
+  swift: 'BZITTNTTXXX',
+};
+
+type PaymentFormRow = NexusMixedPayment;
+
+const EMPTY_PAYMENT: PaymentFormRow = { method: 'BANK_TRANSFER', amount: 0, reference: '' };
+
+function numberToFrenchTnd(amount: number): string {
+  const value = Math.round(millimesToTnd(amount));
+  if (value === 0) return 'Zéro dinar tunisien';
+  return `${value.toLocaleString('fr-FR')} dinars tunisiens`;
+}
+
+export function NexusInvoiceGenerator() {
+  const [packageId, setPackageId] = useState<NexusInvoicePackageId>('duo-premiere');
+  const selected = NEXUS_INVOICE_PACKAGES.find((pack) => pack.id === packageId) ?? NEXUS_INVOICE_PACKAGES[0];
+  const [invoiceNumber, setInvoiceNumber] = useState('');
+  const [invoiceDate, setInvoiceDate] = useState(new Date().toISOString().slice(0, 10));
+  const [customerName, setCustomerName] = useState('Nom du parent / responsable');
+  const [customerInfo, setCustomerInfo] = useState('Client particulier');
+  const [designation, setDesignation] = useState(selected.label);
+  const [subtitle, setSubtitle] = useState(selected.subtitle);
+  const [frenchHours, setFrenchHours] = useState(selected.frenchHours);
+  const [mathHours, setMathHours] = useState(selected.mathHours);
+  const [priceTtc, setPriceTtc] = useState(selected.priceTtc);
+  const [normalPriceTtc, setNormalPriceTtc] = useState(selected.normalPriceTtc);
+  const [adjustmentTtc, setAdjustmentTtc] = useState(0);
+  const [adjustmentLabel, setAdjustmentLabel] = useState('Ajustement séance non suivie');
+  const [masteriumMonths, setMasteriumMonths] = useState(1);
+  const [payments, setPayments] = useState<PaymentFormRow[]>([
+    { method: 'BANK_TRANSFER', amount: 0, reference: '' },
+    { method: 'CHEQUE', amount: 0, reference: '' },
+    { method: 'CASH', amount: 0, reference: '' },
+  ]);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [createdPdfUrl, setCreatedPdfUrl] = useState<string | null>(null);
+
+  const totals = useMemo(
+    () => calculateNexusInvoiceTotals({
+      priceTtc,
+      normalPriceTtc,
+      adjustmentTtc,
+      payments,
+      masteriumMonths,
+      masteriumMonthlyValue: MASTERIUM_MONTHLY_VALUE,
+    }),
+    [adjustmentTtc, masteriumMonths, normalPriceTtc, payments, priceTtc]
+  );
+  const paymentSummary = buildPaymentSummary(payments);
+
+  function applyPackage(nextId: NexusInvoicePackageId) {
+    const pack = NEXUS_INVOICE_PACKAGES.find((item) => item.id === nextId) ?? NEXUS_INVOICE_PACKAGES[0];
+    setPackageId(nextId);
+    setDesignation(pack.label);
+    setSubtitle(pack.subtitle);
+    setFrenchHours(pack.frenchHours);
+    setMathHours(pack.mathHours);
+    setPriceTtc(pack.priceTtc);
+    setNormalPriceTtc(pack.normalPriceTtc);
+  }
+
+  function updatePayment(index: number, patch: Partial<PaymentFormRow>) {
+    setPayments((current) => current.map((payment, i) => (i === index ? { ...payment, ...patch } : payment)));
+  }
+
+  function addPayment() {
+    setPayments((current) => [...current, { ...EMPTY_PAYMENT }]);
+  }
+
+  function removePayment(index: number) {
+    setPayments((current) => current.filter((_, i) => i !== index));
+  }
+
+  async function createInvoice() {
+    if (!customerName.trim()) {
+      setError('Le nom du client est requis.');
+      return;
+    }
+    if (!designation.trim()) {
+      setError('Le libellé du forfait est requis.');
+      return;
+    }
+
+    setCreating(true);
+    setError(null);
+    setCreatedPdfUrl(null);
+    try {
+      const body = buildNexusInvoiceRequest({
+        customerName,
+        customerInfo,
+        invoiceNumber,
+        invoiceDate,
+        packageLabel: designation,
+        packageSubtitle: subtitle,
+        frenchHours,
+        mathHours,
+        priceTtc,
+        normalPriceTtc,
+        adjustmentTtc,
+        adjustmentLabel,
+        payments,
+        masteriumMonths,
+        masteriumMonthlyValue: MASTERIUM_MONTHLY_VALUE,
+        notes: 'Accès Masterium offert à titre commercial, non facturé.',
+      });
+
+      const res = await fetch('/api/admin/invoices', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const result = await res.json();
+      if (!res.ok) {
+        setError(result.error ?? result.details ?? 'Erreur lors de la génération de la facture.');
+        return;
+      }
+      setCreatedPdfUrl(result.pdfUrl ?? null);
+      if (result.pdfUrl) window.open(result.pdfUrl, '_blank', 'noopener,noreferrer');
+    } catch {
+      setError('Erreur réseau lors de la génération de la facture.');
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  const inputClass = 'rounded-lg border border-white/15 bg-surface-elevated px-3 py-2 text-sm text-neutral-100 outline-none focus:ring-2 focus:ring-brand-primary';
+  const labelClass = 'text-xs font-medium text-blue-100';
+
+  return (
+    <div className="min-h-screen text-slate-100">
+      <style>{`
+        @media print {
+          .no-print { display: none !important; }
+          .print-area { box-shadow: none !important; border: none !important; margin: 0 !important; max-width: none !important; border-radius: 0 !important; }
+        }
+      `}</style>
+
+      <div className="grid gap-6 xl:grid-cols-[420px_1fr]">
+        <aside className="no-print rounded-xl border border-white/10 bg-surface-card p-5 shadow-xl">
+          <div className="mb-5">
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-blue-200">Nexus Réussite</p>
+            <h1 className="mt-2 text-2xl font-bold text-white">Générateur de facture</h1>
+            <p className="mt-2 text-sm text-neutral-400">Création production via le moteur de factures Nexus.</p>
+          </div>
+
+          <div className="space-y-5">
+            <section className="space-y-3 rounded-lg border border-white/10 bg-white/5 p-4">
+              <h2 className="font-semibold text-white">Forfait</h2>
+              <label className={labelClass} htmlFor="invoice-package">Choisir une formule</label>
+              <select
+                id="invoice-package"
+                value={packageId}
+                onChange={(event) => applyPackage(event.target.value as NexusInvoicePackageId)}
+                className={`${inputClass} w-full`}
+              >
+                {NEXUS_INVOICE_PACKAGES.map((pack) => (
+                  <option key={pack.id} value={pack.id}>{pack.label}</option>
+                ))}
+              </select>
+
+              <label className={labelClass} htmlFor="designation">Libellé</label>
+              <input id="designation" value={designation} onChange={(event) => setDesignation(event.target.value)} className={`${inputClass} w-full`} />
+              <label className={labelClass} htmlFor="subtitle">Description</label>
+              <input id="subtitle" value={subtitle} onChange={(event) => setSubtitle(event.target.value)} className={`${inputClass} w-full`} />
+
+              <div className="grid grid-cols-2 gap-3">
+                <label className={labelClass} htmlFor="price-ttc">Prix TTC</label>
+                <input id="price-ttc" type="number" value={millimesToTnd(priceTtc)} onChange={(event) => setPriceTtc(tndToMillimes(Number(event.target.value)))} className={`${inputClass} text-right`} />
+                <label className={labelClass} htmlFor="normal-price-ttc">Prix normal TTC</label>
+                <input id="normal-price-ttc" type="number" value={millimesToTnd(normalPriceTtc)} onChange={(event) => setNormalPriceTtc(tndToMillimes(Number(event.target.value)))} className={`${inputClass} text-right`} />
+              </div>
+            </section>
+
+            <section className="space-y-3 rounded-lg border border-white/10 bg-white/5 p-4">
+              <h2 className="font-semibold text-white">Client et facture</h2>
+              <div className="grid grid-cols-2 gap-3">
+                <label className={labelClass} htmlFor="invoice-number">Numéro</label>
+                <input id="invoice-number" value={invoiceNumber} onChange={(event) => setInvoiceNumber(event.target.value)} placeholder="auto si vide" className={inputClass} />
+                <label className={labelClass} htmlFor="invoice-date">Date</label>
+                <input id="invoice-date" type="date" value={invoiceDate} onChange={(event) => setInvoiceDate(event.target.value)} className={inputClass} />
+              </div>
+              <label className={labelClass} htmlFor="customer-name">Facturé à</label>
+              <input id="customer-name" value={customerName} onChange={(event) => setCustomerName(event.target.value)} className={`${inputClass} w-full`} />
+              <label className={labelClass} htmlFor="customer-info">Information client</label>
+              <input id="customer-info" value={customerInfo} onChange={(event) => setCustomerInfo(event.target.value)} className={`${inputClass} w-full`} />
+            </section>
+
+            <section className="space-y-3 rounded-lg border border-white/10 bg-white/5 p-4">
+              <h2 className="font-semibold text-white">Heures et ajustement</h2>
+              <div className="grid grid-cols-2 gap-3">
+                <label className={labelClass} htmlFor="french-hours">Heures Français</label>
+                <input id="french-hours" type="number" value={frenchHours} onChange={(event) => setFrenchHours(Number(event.target.value))} className={`${inputClass} text-right`} />
+                <label className={labelClass} htmlFor="math-hours">Heures Maths</label>
+                <input id="math-hours" type="number" value={mathHours} onChange={(event) => setMathHours(Number(event.target.value))} className={`${inputClass} text-right`} />
+                <label className={labelClass} htmlFor="adjustment">Ajustement TTC</label>
+                <input id="adjustment" type="number" value={millimesToTnd(adjustmentTtc)} onChange={(event) => setAdjustmentTtc(tndToMillimes(Number(event.target.value)))} className={`${inputClass} text-right`} />
+              </div>
+              <label className={labelClass} htmlFor="adjustment-label">Libellé de l&apos;ajustement</label>
+              <input id="adjustment-label" value={adjustmentLabel} onChange={(event) => setAdjustmentLabel(event.target.value)} className={`${inputClass} w-full`} />
+            </section>
+
+            <section className="space-y-3 rounded-lg border border-white/10 bg-white/5 p-4">
+              <h2 className="font-semibold text-white">Paiements mixtes</h2>
+              {payments.map((payment, index) => (
+                <div key={`${payment.method}-${index}`} className="grid grid-cols-[1fr_100px_32px] gap-2 rounded-lg border border-white/10 p-2">
+                  <select value={payment.method} onChange={(event) => updatePayment(index, { method: event.target.value as PaymentFormRow['method'] })} className={inputClass}>
+                    <option value="BANK_TRANSFER">Virement bancaire</option>
+                    <option value="CHEQUE">Chèque</option>
+                    <option value="CASH">Espèces</option>
+                  </select>
+                  <input type="number" value={millimesToTnd(payment.amount)} onChange={(event) => updatePayment(index, { amount: tndToMillimes(Number(event.target.value)) })} className={`${inputClass} text-right`} />
+                  <button type="button" onClick={() => removePayment(index)} className="rounded-lg border border-white/10 text-neutral-400 hover:text-white" aria-label="Supprimer paiement">
+                    <Trash2 className="mx-auto h-4 w-4" />
+                  </button>
+                  <input value={payment.reference} onChange={(event) => updatePayment(index, { reference: event.target.value })} placeholder="Référence, banque, n° chèque, remarque" className={`${inputClass} col-span-3 w-full`} />
+                </div>
+              ))}
+              <button type="button" onClick={addPayment} className="inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-2 text-sm text-neutral-200 hover:text-white">
+                <Plus className="h-4 w-4" /> Ajouter un paiement
+              </button>
+            </section>
+
+            <section className="rounded-lg border border-red-300/30 bg-red-500/10 p-4">
+              <h2 className="font-semibold text-white">Accès plateforme offert</h2>
+              <p className="mt-2 text-sm text-red-100">Accès plateforme EAF — Masterium offert</p>
+              <div className="mt-3 grid grid-cols-2 gap-3">
+                <label className={labelClass} htmlFor="masterium-months">Durée Masterium</label>
+                <input id="masterium-months" type="number" value={masteriumMonths} onChange={(event) => setMasteriumMonths(Number(event.target.value))} className={`${inputClass} text-right`} />
+              </div>
+              <p className="mt-3 text-sm font-medium text-red-100">Valeur offerte : {formatTnd(totals.masteriumOfferedValue)}</p>
+            </section>
+
+            {error && <p className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-200">{error}</p>}
+            {createdPdfUrl && (
+              <a href={createdPdfUrl} target="_blank" rel="noopener noreferrer" className="block rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm text-emerald-200">
+                Facture générée. Ouvrir le PDF
+              </a>
+            )}
+
+            <button
+              type="button"
+              onClick={createInvoice}
+              disabled={creating}
+              className="flex w-full items-center justify-center gap-2 rounded-lg bg-brand-primary px-5 py-3 font-semibold text-white hover:bg-brand-primary/90 disabled:opacity-60"
+            >
+              {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Printer className="h-4 w-4" />}
+              Générer la facture PDF
+            </button>
+          </div>
+        </aside>
+
+        <main className="print-area min-h-[1120px] overflow-hidden rounded-xl bg-white text-slate-950 shadow-2xl" style={{ border: `1px solid ${BRAND.border}` }}>
+          <div className="border-b px-8 py-7" style={{ borderColor: BRAND.border, background: `linear-gradient(90deg, ${BRAND.blueSoft} 0%, #FFFFFF 68%)` }}>
+            <div className="flex items-start justify-between gap-6">
+              <div>
+                <img src="/images/logo_slogan_nexus.png" alt="Logo Nexus Réussite" className="h-24 w-auto object-contain" />
+                <h2 className="mt-4 text-2xl font-black tracking-tight" style={{ color: BRAND.navy }}>{COMPANY.name}</h2>
+                <p className="mt-1 text-sm" style={{ color: BRAND.textSoft }}>{COMPANY.address}<br />{COMPANY.taxId}</p>
+              </div>
+              <div className="text-right">
+                <p className="text-4xl font-black tracking-tight" style={{ color: BRAND.navy }}>FACTURE</p>
+                <p className="mt-3 text-sm" style={{ color: BRAND.textSoft }}>Numéro : <b style={{ color: BRAND.text }}>{invoiceNumber || 'Attribué à la génération'}</b></p>
+                <p className="text-sm" style={{ color: BRAND.textSoft }}>Date : <b style={{ color: BRAND.text }}>{invoiceDate}</b></p>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex min-h-[900px] flex-col px-8 py-7">
+            <section className="grid gap-5 md:grid-cols-2">
+              <div className="rounded-xl bg-white p-5" style={{ border: `1px solid ${BRAND.border}` }}>
+                <h3 className="text-xs font-bold uppercase tracking-[0.2em]" style={{ color: BRAND.blue }}>Facturé à</h3>
+                <p className="mt-3 text-lg font-bold" style={{ color: BRAND.navy }}>{customerName}</p>
+                <p className="text-sm" style={{ color: BRAND.textSoft }}>{customerInfo}</p>
+              </div>
+              <div className="rounded-xl p-5" style={{ border: '1px solid #BFD8FF', background: `linear-gradient(135deg, ${BRAND.blueSoft} 0%, ${BRAND.redSoft} 100%)` }}>
+                <h3 className="text-xs font-bold uppercase tracking-[0.2em]" style={{ color: BRAND.red }}>Avantage offert</h3>
+                <p className="mt-3 font-bold" style={{ color: BRAND.navy }}>Accès plateforme EAF — Masterium offert</p>
+                <p className="text-sm" style={{ color: BRAND.text }}>Durée : {masteriumMonths} mois · Valeur réelle : {formatTnd(totals.masteriumOfferedValue)}</p>
+                <p className="mt-1 text-xs" style={{ color: BRAND.red }}>Cet avantage est offert et n&apos;est pas inclus dans le total à payer.</p>
+              </div>
+            </section>
+
+            <section className="mt-8">
+              <h3 className="mb-3 text-xs font-bold uppercase tracking-[0.2em]" style={{ color: BRAND.blue }}>Détail de la prestation</h3>
+              <div className="overflow-hidden rounded-xl" style={{ border: `1px solid ${BRAND.border}` }}>
+                <table className="w-full border-collapse text-sm">
+                  <thead className="text-white" style={{ background: `linear-gradient(90deg, ${BRAND.navy} 0%, ${BRAND.blue} 100%)` }}>
+                    <tr>
+                      <th className="px-4 py-3 text-left">Désignation</th>
+                      <th className="px-4 py-3 text-center">Qté</th>
+                      <th className="px-4 py-3 text-right">Montant HT</th>
+                      <th className="px-4 py-3 text-right">TVA 6%</th>
+                      <th className="px-4 py-3 text-right">Montant TTC</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr className="align-top" style={{ borderBottom: `1px solid ${BRAND.border}` }}>
+                      <td className="px-4 py-4">
+                        <p className="font-bold" style={{ color: BRAND.navy }}>{designation}</p>
+                        <p className="mt-1" style={{ color: BRAND.textSoft }}>{subtitle}</p>
+                        <p className="mt-2 text-xs" style={{ color: BRAND.textSoft }}>Français : {frenchHours || 0}h · Mathématiques : {mathHours || 0}h · Total : {(frenchHours || 0) + (mathHours || 0)}h</p>
+                      </td>
+                      <td className="px-4 py-4 text-center">1</td>
+                      <td className="px-4 py-4 text-right">{formatTnd(Math.round(priceTtc / 1.06))}</td>
+                      <td className="px-4 py-4 text-right">{formatTnd(priceTtc - Math.round(priceTtc / 1.06))}</td>
+                      <td className="px-4 py-4 text-right font-semibold">{formatTnd(priceTtc)}</td>
+                    </tr>
+                    {totals.packageDiscount > 0 && (
+                      <tr style={{ borderBottom: `1px solid ${BRAND.border}` }}>
+                        <td className="px-4 py-3">Remise forfaitaire intégrée</td>
+                        <td className="px-4 py-3 text-center">1</td>
+                        <td className="px-4 py-3 text-right">- {formatTnd(Math.round(totals.packageDiscount / 1.06))}</td>
+                        <td className="px-4 py-3 text-right">- {formatTnd(totals.packageDiscount - Math.round(totals.packageDiscount / 1.06))}</td>
+                        <td className="px-4 py-3 text-right font-semibold">- {formatTnd(totals.packageDiscount)}</td>
+                      </tr>
+                    )}
+                    {totals.adjustmentTtc > 0 && (
+                      <tr style={{ borderBottom: `1px solid ${BRAND.border}` }}>
+                        <td className="px-4 py-3">{adjustmentLabel}</td>
+                        <td className="px-4 py-3 text-center">1</td>
+                        <td className="px-4 py-3 text-right">- {formatTnd(Math.round(totals.adjustmentTtc / 1.06))}</td>
+                        <td className="px-4 py-3 text-right">- {formatTnd(totals.adjustmentTtc - Math.round(totals.adjustmentTtc / 1.06))}</td>
+                        <td className="px-4 py-3 text-right font-semibold">- {formatTnd(totals.adjustmentTtc)}</td>
+                      </tr>
+                    )}
+                    <tr style={{ background: BRAND.blueSoft, color: BRAND.navy }}>
+                      <td className="px-4 py-3 font-medium">Accès plateforme EAF — Masterium offert</td>
+                      <td className="px-4 py-3 text-center">{masteriumMonths}</td>
+                      <td className="px-4 py-3 text-right">0,000 TND</td>
+                      <td className="px-4 py-3 text-right">0,000 TND</td>
+                      <td className="px-4 py-3 text-right font-semibold">Offert — valeur {formatTnd(totals.masteriumOfferedValue)}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section className="mt-8 grid gap-6 md:grid-cols-[1fr_330px]">
+              <div className="rounded-xl p-5" style={{ border: `1px solid ${BRAND.border}` }}>
+                <h3 className="text-xs font-bold uppercase tracking-[0.2em]" style={{ color: BRAND.blue }}>Modalités de paiement</h3>
+                {paymentSummary.length > 0 ? (
+                  <ul className="mt-3 space-y-1 text-sm" style={{ color: BRAND.text }}>
+                    {paymentSummary.map((item) => <li key={item}>{item}</li>)}
+                  </ul>
+                ) : (
+                  <p className="mt-3 text-sm" style={{ color: BRAND.text }}>Paiement possible par virement bancaire, chèque et/ou espèces.</p>
+                )}
+                <div className="mt-4 rounded-xl p-4 text-sm" style={{ background: '#F8FBFF', color: BRAND.text }}>
+                  <p><b>Bénéficiaire :</b> {COMPANY.bankBeneficiary}</p>
+                  <p><b>Banque :</b> {COMPANY.bank}</p>
+                  <p><b>RIB :</b> {COMPANY.rib}</p>
+                  <p><b>IBAN :</b> {COMPANY.iban}</p>
+                  <p><b>SWIFT :</b> {COMPANY.swift}</p>
+                </div>
+              </div>
+
+              <div className="rounded-xl p-5" style={{ border: `1px solid ${BRAND.border}`, background: '#F8FBFF' }}>
+                <div className="space-y-2 text-sm">
+                  <div className="flex justify-between"><span>Total HT</span><b>{formatTnd(totals.netHt)}</b></div>
+                  <div className="flex justify-between"><span>TVA 6%</span><b>{formatTnd(totals.vat)}</b></div>
+                  <div className="h-px" style={{ background: BRAND.border }} />
+                  <div className="flex justify-between text-lg"><span>Total TTC</span><b>{formatTnd(totals.netTtc)}</b></div>
+                  <div className="flex justify-between" style={{ color: BRAND.textSoft }}><span>Net payé</span><b>{formatTnd(totals.paid)}</b></div>
+                  <div className="flex justify-between rounded-xl px-3 py-3 text-white" style={{ background: `linear-gradient(90deg, ${BRAND.blue} 0%, ${BRAND.red} 100%)` }}>
+                    <span>Reste à payer</span>
+                    <b>{formatTnd(totals.due)}</b>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section className="mt-8 rounded-xl bg-white p-5" style={{ border: `1px solid ${BRAND.border}` }}>
+              <p className="text-sm"><b>Arrêté la présente facture à la somme de :</b> {numberToFrenchTnd(totals.netTtc)}.</p>
+              <p className="mt-2 text-xs" style={{ color: BRAND.textSoft }}>Accès Masterium offert à titre commercial, non facturé.</p>
+            </section>
+
+            <footer className="mt-auto border-t pt-6 text-center" style={{ borderColor: BRAND.border }}>
+              <p className="text-2xl font-black tracking-wide" style={{ color: BRAND.navy }}>Viser. Atteindre. Dépasser.</p>
+              <div className="mx-auto mt-4 h-[3px] w-40 rounded-full" style={{ background: `linear-gradient(90deg, ${BRAND.blue} 0%, ${BRAND.red} 100%)` }} />
+              <p className="mt-4 text-xs font-medium" style={{ color: BRAND.text }}>{COMPANY.address}</p>
+              <p className="mt-1 text-xs" style={{ color: BRAND.textSoft }}>Tél : {COMPANY.phone} | Email : {COMPANY.email} | Web : {COMPANY.web}</p>
+            </footer>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/components/facturation/NexusInvoiceGenerator.tsx
+++ b/components/facturation/NexusInvoiceGenerator.tsx
@@ -45,12 +45,6 @@ type PaymentFormRow = NexusMixedPayment;
 
 const EMPTY_PAYMENT: PaymentFormRow = { method: 'BANK_TRANSFER', amount: 0, reference: '' };
 
-function numberToFrenchTnd(amount: number): string {
-  const value = Math.round(millimesToTnd(amount));
-  if (value === 0) return 'Zéro dinar tunisien';
-  return `${value.toLocaleString('fr-FR')} dinars tunisiens`;
-}
-
 export function NexusInvoiceGenerator() {
   const [packageId, setPackageId] = useState<NexusInvoicePackageId>('duo-premiere');
   const selected = NEXUS_INVOICE_PACKAGES.find((pack) => pack.id === packageId) ?? NEXUS_INVOICE_PACKAGES[0];
@@ -411,7 +405,7 @@ export function NexusInvoiceGenerator() {
             </section>
 
             <section className="mt-8 rounded-xl bg-white p-5" style={{ border: `1px solid ${BRAND.border}` }}>
-              <p className="text-sm"><b>Arrêté la présente facture à la somme de :</b> {numberToFrenchTnd(totals.netTtc)}.</p>
+              <p className="text-sm"><b>Montant total TTC :</b> {formatTnd(totals.netTtc)}.</p>
               <p className="mt-2 text-xs" style={{ color: BRAND.textSoft }}>Accès Masterium offert à titre commercial, non facturé.</p>
             </section>
 

--- a/components/navigation/navigation-config.ts
+++ b/components/navigation/navigation-config.ts
@@ -149,6 +149,12 @@ export const navigationConfig: Record<UserRole, NavigationItem[]> = {
       match: 'prefix'
     },
     {
+      label: 'Facturation',
+      href: '/dashboard/assistante/facturation',
+      icon: 'Receipt',
+      match: 'prefix'
+    },
+    {
       label: 'Demandes abonnements',
       href: '/dashboard/assistante/subscription-requests',
       icon: 'ClipboardList',

--- a/lib/invoice/nexus-calculations.ts
+++ b/lib/invoice/nexus-calculations.ts
@@ -1,0 +1,217 @@
+import type { CreateInvoiceRequest, InvoicePaymentMethodType, TaxRegime } from './types';
+
+export const NEXUS_VAT_RATE = 0.06;
+export const MASTERIUM_MONTHLY_VALUE = 129_000;
+
+export type NexusInvoicePackageId = 'duo-premiere' | 'francais-sprint-eaf' | 'custom';
+
+export type NexusInvoicePackage = {
+  id: NexusInvoicePackageId;
+  label: string;
+  subtitle: string;
+  frenchHours: number;
+  mathHours: number;
+  priceTtc: number;
+  normalPriceTtc: number;
+};
+
+export type NexusMixedPayment = {
+  method: Extract<InvoicePaymentMethodType, 'BANK_TRANSFER' | 'CHEQUE' | 'CASH'>;
+  amount: number;
+  reference: string;
+};
+
+export type NexusInvoiceTotalsInput = {
+  priceTtc: number;
+  normalPriceTtc: number;
+  adjustmentTtc: number;
+  payments: NexusMixedPayment[];
+  masteriumMonths: number;
+  masteriumMonthlyValue: number;
+};
+
+export type NexusInvoiceTotals = {
+  priceTtc: number;
+  adjustmentTtc: number;
+  netTtc: number;
+  netHt: number;
+  vat: number;
+  normalPriceTtc: number;
+  packageDiscount: number;
+  paid: number;
+  due: number;
+  masteriumOfferedValue: number;
+};
+
+export type NexusInvoiceRequestInput = NexusInvoiceTotalsInput & {
+  customerName: string;
+  customerInfo: string;
+  invoiceNumber?: string;
+  invoiceDate: string;
+  packageLabel: string;
+  packageSubtitle: string;
+  frenchHours: number;
+  mathHours: number;
+  adjustmentLabel: string;
+  notes: string;
+};
+
+export type NexusCreateInvoiceRequest = Omit<CreateInvoiceRequest, 'items'> & {
+  number?: string;
+  issuedAt?: string;
+  items: Array<CreateInvoiceRequest['items'][number] & { total: number }>;
+};
+
+export const NEXUS_INVOICE_PACKAGES: NexusInvoicePackage[] = [
+  {
+    id: 'duo-premiere',
+    label: 'Duo Première — Français + Maths',
+    subtitle: 'Les deux épreuves anticipées dans une seule formule cohérente.',
+    frenchHours: 16,
+    mathHours: 14,
+    priceTtc: 1_149_000,
+    normalPriceTtc: 1_188_000,
+  },
+  {
+    id: 'francais-sprint-eaf',
+    label: 'Français Première — Sprint EAF',
+    subtitle: "Préparation ciblée à l'écrit et à l'oral du Français.",
+    frenchHours: 16,
+    mathHours: 0,
+    priceTtc: 649_000,
+    normalPriceTtc: 649_000,
+  },
+  {
+    id: 'custom',
+    label: 'Forfait personnalisé',
+    subtitle: 'Configuration libre selon le volume horaire retenu.',
+    frenchHours: 0,
+    mathHours: 0,
+    priceTtc: 0,
+    normalPriceTtc: 0,
+  },
+];
+
+export function tndToMillimes(value: number): number {
+  return Math.round(value * 1000);
+}
+
+export function millimesToTnd(value: number): number {
+  return value / 1000;
+}
+
+export function formatTnd(value: number): string {
+  return `${millimesToTnd(value).toLocaleString('fr-TN', {
+    minimumFractionDigits: 3,
+    maximumFractionDigits: 3,
+  })} TND`;
+}
+
+export function calculateNexusInvoiceTotals(input: NexusInvoiceTotalsInput): NexusInvoiceTotals {
+  const priceTtc = Math.max(0, Math.round(input.priceTtc));
+  const adjustmentTtc = Math.min(Math.max(0, Math.round(input.adjustmentTtc)), priceTtc);
+  const netTtc = priceTtc - adjustmentTtc;
+  const netHt = Math.round(netTtc / (1 + NEXUS_VAT_RATE));
+  const vat = netTtc - netHt;
+  const normalPriceTtc = Math.max(priceTtc, Math.round(input.normalPriceTtc));
+  const packageDiscount = Math.max(0, normalPriceTtc - priceTtc);
+  const paid = Math.min(
+    netTtc,
+    input.payments.reduce((sum, payment) => sum + Math.max(0, Math.round(payment.amount)), 0)
+  );
+  const due = Math.max(0, netTtc - paid);
+  const masteriumOfferedValue =
+    Math.max(0, Math.round(input.masteriumMonths)) * Math.max(0, Math.round(input.masteriumMonthlyValue));
+
+  return {
+    priceTtc,
+    adjustmentTtc,
+    netTtc,
+    netHt,
+    vat,
+    normalPriceTtc,
+    packageDiscount,
+    paid,
+    due,
+    masteriumOfferedValue,
+  };
+}
+
+export function buildPaymentSummary(payments: NexusMixedPayment[]): string[] {
+  return payments
+    .filter((payment) => payment.amount > 0)
+    .map((payment) => {
+      const label = payment.method === 'BANK_TRANSFER'
+        ? 'Virement bancaire'
+        : payment.method === 'CHEQUE'
+          ? 'Chèque'
+          : 'Espèces';
+      const reference = payment.reference.trim();
+      return `${label} : ${formatTnd(payment.amount)}${reference ? ` (${reference})` : ''}`;
+    });
+}
+
+export function buildNexusInvoiceRequest(input: NexusInvoiceRequestInput): NexusCreateInvoiceRequest {
+  const totals = calculateNexusInvoiceTotals(input);
+  const paymentSummary = buildPaymentSummary(input.payments);
+  const taxRegime: TaxRegime = 'TVA_INCLUSE';
+  const mainDescription = [
+    input.packageSubtitle,
+    `Français : ${input.frenchHours || 0}h · Mathématiques : ${input.mathHours || 0}h`,
+  ].join('\n');
+
+  const items: NexusCreateInvoiceRequest['items'] = [
+    {
+      label: input.packageLabel,
+      description: mainDescription,
+      qty: 1,
+      unitPrice: input.priceTtc,
+      total: input.priceTtc,
+    },
+  ];
+
+  items.push({
+    label: 'Accès plateforme EAF — Masterium offert',
+    description: [
+      `Valeur normale : ${formatTnd(input.masteriumMonthlyValue)} / mois · ${input.masteriumMonths} mois`,
+      'Accès Masterium offert à titre commercial, non facturé.',
+    ].join('\n'),
+    qty: Math.max(1, Math.round(input.masteriumMonths || 1)),
+    unitPrice: 0,
+    total: 0,
+  });
+
+  const paymentDetailsNotes = [
+    paymentSummary.length > 0 ? `Paiements mixtes : ${paymentSummary.join(' | ')}` : null,
+    `Net payé : ${formatTnd(totals.paid)}`,
+    `Reste à payer : ${formatTnd(totals.due)}`,
+  ].filter(Boolean).join('\n');
+  const notes = [
+    input.notes,
+    paymentDetailsNotes,
+  ].filter(Boolean).join('\n');
+
+  return {
+    number: input.invoiceNumber?.trim() || undefined,
+    issuedAt: input.invoiceDate,
+    customer: {
+      name: input.customerName.trim(),
+      address: input.customerInfo.trim() || null,
+    },
+    items,
+    discountTotal: totals.adjustmentTtc,
+    taxRegime,
+    paymentMethod: input.payments.find((payment) => payment.amount > 0)?.method ?? null,
+    paymentDetails: paymentDetailsNotes ? { notes: paymentDetailsNotes } : null,
+    notes,
+    issuer: {
+      name: 'M&M ACADEMY (NEXUS RÉUSSITE)',
+      address: 'Centre Urbain Nord, Immeuble VENUS, Appt C13, 1082 – Tunis',
+      mf: '1948837 N/A/M/000',
+      phone: '+216 99 19 28 29',
+      email: 'contact@nexusreussite.academy',
+      web: 'nexusreussite.academy',
+      slogan: 'Viser. Atteindre. Dépasser.',
+    },
+  };
+}

--- a/lib/invoice/nexus-calculations.ts
+++ b/lib/invoice/nexus-calculations.ts
@@ -181,6 +181,7 @@ export function buildNexusInvoiceRequest(input: NexusInvoiceRequestInput): Nexus
     total: 0,
   });
 
+  // TODO: Normalize mixed payments into a dedicated table when the invoice schema evolves.
   const paymentDetailsNotes = [
     paymentSummary.length > 0 ? `Paiements mixtes : ${paymentSummary.join(' | ')}` : null,
     `Net payé : ${formatTnd(totals.paid)}`,

--- a/lib/invoice/nexus-calculations.ts
+++ b/lib/invoice/nexus-calculations.ts
@@ -154,6 +154,8 @@ export function buildPaymentSummary(payments: NexusMixedPayment[]): string[] {
 export function buildNexusInvoiceRequest(input: NexusInvoiceRequestInput): NexusCreateInvoiceRequest {
   const totals = calculateNexusInvoiceTotals(input);
   const paymentSummary = buildPaymentSummary(input.payments);
+  const nonZeroPayments = input.payments.filter((payment) => payment.amount > 0);
+  const distinctPaymentMethods = new Set(nonZeroPayments.map((payment) => payment.method));
   const taxRegime: TaxRegime = 'TVA_INCLUSE';
   const mainDescription = [
     input.packageSubtitle,
@@ -202,7 +204,7 @@ export function buildNexusInvoiceRequest(input: NexusInvoiceRequestInput): Nexus
     items,
     discountTotal: totals.adjustmentTtc,
     taxRegime,
-    paymentMethod: input.payments.find((payment) => payment.amount > 0)?.method ?? null,
+    paymentMethod: distinctPaymentMethods.size === 1 ? nonZeroPayments[0]?.method ?? null : null,
     paymentDetails: paymentDetailsNotes ? { notes: paymentDetailsNotes } : null,
     notes,
     issuer: {

--- a/lib/invoice/pdf.ts
+++ b/lib/invoice/pdf.ts
@@ -119,6 +119,7 @@ function getPaymentMethodLabel(method: string | null | undefined): string {
     CASH: 'Espèces',
     BANK_TRANSFER: 'Virement bancaire',
     CLICTOPAY: 'ClicToPay',
+    CHEQUE: 'Chèque',
     CHECK: 'Chèque',
     OTHER: 'Autre',
   };
@@ -158,8 +159,9 @@ function validateFitsOnePage(data: InvoiceData): void {
     return acc + 20 + (descLines * 10);
   }, 0);
   const totalsHeight = 100;
-  const paymentHeight = 60;
-  const footerHeight = 80;
+  const paymentNotesLines = data.paymentDetails?.notes ? data.paymentDetails.notes.split('\n').length : 0;
+  const paymentHeight = 60 + Math.min(paymentNotesLines, 4) * 10;
+  const footerHeight = 90;
 
   const totalEstimate = headerHeight + customerBlockHeight + tableHeaderHeight +
     itemRowHeight + totalsHeight + paymentHeight + footerHeight +
@@ -390,7 +392,7 @@ export async function renderInvoicePDF(data: InvoiceData): Promise<Buffer> {
       // Tax
       if (data.taxTotal > 0) {
         doc.font(FONTS.regular).fontSize(9).fillColor(COLORS.textSecondary)
-          .text('TVA', totalsX, y);
+          .text(data.taxRegime === 'TVA_INCLUSE' ? 'TVA 6 %' : 'TVA', totalsX, y);
         doc.font(FONTS.regular).fontSize(9).fillColor(COLORS.text)
           .text(formatCurrency(data.taxTotal, data.currency), totalsX + 80, y, { width: 100, align: 'right' });
         y += 16;
@@ -426,6 +428,12 @@ export async function renderInvoicePDF(data: InvoiceData): Promise<Buffer> {
       }
       y += 12;
 
+      if (data.paymentDetails?.notes) {
+        doc.font(FONTS.regular).fontSize(7).fillColor(COLORS.textSecondary)
+          .text(data.paymentDetails.notes, PAGE.marginLeft, y, { width: CONTENT_WIDTH * 0.6 });
+        y += Math.min(data.paymentDetails.notes.split('\n').length, 4) * 10 + 4;
+      }
+
       // Tax regime mention
       doc.font(FONTS.oblique).fontSize(7).fillColor(COLORS.textMuted)
         .text(getTaxRegimeLabel(data.taxRegime), PAGE.marginLeft, y);
@@ -453,15 +461,29 @@ export async function renderInvoicePDF(data: InvoiceData): Promise<Buffer> {
         .strokeColor(COLORS.border).lineWidth(0.5).stroke();
 
       // Footer text
+      const contactLine = [
+        data.issuer.phone ? `Tél : ${data.issuer.phone}` : null,
+        data.issuer.email ? `Email : ${data.issuer.email}` : null,
+        data.issuer.web ? `Web : ${data.issuer.web}` : null,
+      ].filter(Boolean).join(' | ');
+
+      if (data.issuer.slogan) {
+        doc.font(FONTS.bold).fontSize(8).fillColor(COLORS.brand)
+          .text(data.issuer.slogan, PAGE.marginLeft, footerY + 7, { width: CONTENT_WIDTH, align: 'center' });
+      }
+
       doc.font(FONTS.regular).fontSize(7).fillColor(COLORS.textMuted)
         .text(
           `${data.issuer.name} — ${data.issuer.address}`,
-          PAGE.marginLeft, footerY + 8,
+          PAGE.marginLeft, footerY + 19,
           { width: CONTENT_WIDTH, align: 'center' }
         );
+      if (contactLine) {
+        doc.text(contactLine, PAGE.marginLeft, footerY + 29, { width: CONTENT_WIDTH, align: 'center' });
+      }
       doc.text(
         `MF : ${data.issuer.mf}${data.issuer.rne ? ` — RNE : ${data.issuer.rne}` : ''}`,
-        PAGE.marginLeft, footerY + 20,
+        PAGE.marginLeft, footerY + 39,
         { width: CONTENT_WIDTH, align: 'center' }
       );
 

--- a/lib/invoice/pdf.ts
+++ b/lib/invoice/pdf.ts
@@ -159,8 +159,8 @@ function validateFitsOnePage(data: InvoiceData): void {
     return acc + 20 + (descLines * 10);
   }, 0);
   const totalsHeight = 100;
-  const paymentNotesLines = data.paymentDetails?.notes ? data.paymentDetails.notes.split('\n').length : 0;
-  const paymentHeight = 60 + Math.min(paymentNotesLines, 4) * 10;
+  const paymentNotes = data.paymentDetails?.notes ? clampText(data.paymentDetails.notes, 4, 95) : '';
+  const paymentHeight = 60 + Math.ceil(paymentNotes.length / 70) * 10;
   const footerHeight = 90;
 
   const totalEstimate = headerHeight + customerBlockHeight + tableHeaderHeight +
@@ -418,7 +418,11 @@ export async function renderInvoicePDF(data: InvoiceData): Promise<Buffer> {
       y += 14;
 
       doc.font(FONTS.regular).fontSize(8).fillColor(COLORS.textSecondary)
-        .text(`Mode de paiement : ${getPaymentMethodLabel(data.paymentMethod)}`, PAGE.marginLeft, y);
+        .text(
+          `Mode de paiement : ${data.paymentDetails?.notes?.includes('Paiements mixtes') ? 'Paiements mixtes' : getPaymentMethodLabel(data.paymentMethod)}`,
+          PAGE.marginLeft,
+          y
+        );
       y += 12;
 
       if (data.dueAt) {
@@ -429,9 +433,12 @@ export async function renderInvoicePDF(data: InvoiceData): Promise<Buffer> {
       y += 12;
 
       if (data.paymentDetails?.notes) {
-        doc.font(FONTS.regular).fontSize(7).fillColor(COLORS.textSecondary)
-          .text(data.paymentDetails.notes, PAGE.marginLeft, y, { width: CONTENT_WIDTH * 0.6 });
-        y += Math.min(data.paymentDetails.notes.split('\n').length, 4) * 10 + 4;
+        const paymentNotesText = clampText(data.paymentDetails.notes, 4, 95);
+        doc.font(FONTS.regular).fontSize(7);
+        const paymentNotesHeight = doc.heightOfString(paymentNotesText, { width: CONTENT_WIDTH * 0.6 });
+        doc.fillColor(COLORS.textSecondary)
+          .text(paymentNotesText, PAGE.marginLeft, y, { width: CONTENT_WIDTH * 0.6 });
+        y += paymentNotesHeight + 6;
       }
 
       // Tax regime mention
@@ -456,7 +463,7 @@ export async function renderInvoicePDF(data: InvoiceData): Promise<Buffer> {
 
       // ─── Footer ─────────────────────────────────────────────────────
       // Separator
-      const footerY = PAGE.height - PAGE.marginBottom - 40;
+      const footerY = PAGE.height - PAGE.marginBottom - 55;
       doc.moveTo(PAGE.marginLeft, footerY).lineTo(PAGE.width - PAGE.marginRight, footerY)
         .strokeColor(COLORS.border).lineWidth(0.5).stroke();
 

--- a/lib/invoice/types.ts
+++ b/lib/invoice/types.ts
@@ -102,6 +102,14 @@ export interface IssuerData {
   mf: string;
   /** Registre national des entreprises (optional) */
   rne?: string | null;
+  /** Phone number (optional) */
+  phone?: string | null;
+  /** Contact email (optional) */
+  email?: string | null;
+  /** Public website (optional) */
+  web?: string | null;
+  /** Brand slogan (optional) */
+  slogan?: string | null;
   /** Absolute path to logo image (optional — fallback to text if absent or missing) */
   logoPath?: string | null;
   /** Absolute path to stamp/cachet image (optional — rendered near totals) */
@@ -178,6 +186,10 @@ export interface InvoiceData {
 // ─── API Request / Response ─────────────────────────────────────────────────
 
 export interface CreateInvoiceRequest {
+  /** Optional manual invoice number. If omitted, the server sequence is used. */
+  number?: string;
+  /** Optional issue date (ISO). If omitted, the current server date is used. */
+  issuedAt?: string;
   /** Customer info */
   customer: CustomerData;
   /** Line items (total will be computed server-side in millimes) */
@@ -194,6 +206,8 @@ export interface CreateInvoiceRequest {
   taxRegime?: TaxRegime;
   /** Payment method */
   paymentMethod?: InvoicePaymentMethodType | null;
+  /** Payment details printed on the generated PDF */
+  paymentDetails?: PaymentDetailsData | null;
   /** Due date (ISO string) */
   dueAt?: string | null;
   /** Internal notes */


### PR DESCRIPTION
## Objet
Ajout d’une page de facturation accessible aux rôles ASSISTANTE et ADMIN.

## Route ajoutée
/dashboard/assistante/facturation

## Principales fonctionnalités
- Génération de facture Nexus via l’API existante /api/admin/invoices
- Forfaits Nexus configurables
- TVA incluse à 6 %
- Paiements mixtes : virement, chèque, espèces
- Ajustement TTC
- Accès EAF Masterium offert, non facturé
- Aperçu facture avec logo Nexus, slogan et coordonnées
- Absence de la mention “sans tampon”

## Sécurité
- Accès limité à ADMIN et ASSISTANTE
- Aucun accès ELEVE ou COACH
- Pas de modification Prisma schema

## Tests
- npm test -- __tests__/lib/invoice/nexus-calculations.test.ts __tests__/components/facturation/nexus-invoice-generator.test.tsx __tests__/app/assistante.facturation.page.test.tsx __tests__/components/navigation/assistante-facturation-nav.test.ts __tests__/api/admin.invoices.route.test.ts --runInBand : 5 suites / 22 tests pass
- npm run typecheck : pass
- npm run lint : pass, warnings existants hors fichiers facturation modifiés
- npm run build : pass
- DATABASE_URL=postgresql://test:test@localhost:5432/test NEXTAUTH_URL=http://localhost:3000 npm test -- --runInBand : 398 suites / 5201 tests pass / 7 snapshots pass
- Génération PDF locale + pdftotext : mentions Nexus, TVA 6 %, Masterium offert, paiements mixtes, slogan et coordonnées vérifiées

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a billing page for assistants to generate Nexus invoices with VAT 6%, mixed payments, and a branded PDF. Extends the admin invoice API to support `ASSISTANTE`, manual invoice numbers/dates, and richer issuer/payment details.

- **New Features**
  - New route `/dashboard/assistante/facturation` in the assistante nav; access limited to `ADMIN` and `ASSISTANTE`.
  - UI presets for Nexus packages, TTC adjustment, mixed payments (virement, chèque, espèces), and Masterium access shown as offered (not billed).
  - Mixed payments are summarized in `paymentDetails.notes` (includes “Net payé” and “Reste à payer”); `paymentMethod` is set only if a single method is used.
  - Generates invoices via `/api/admin/invoices` and opens the PDF; supports manual invoice number and issue date.
  - Invoice preview and PDF use Nexus branding (logo, slogan, address, contact).

- **Refactors**
  - API: compute TVA 6% when `taxRegime = 'TVA_INCLUSE'`; accept optional `number`, `issuedAt`, `paymentDetails`; prevent duplicate numbers; update default issuer (address, phone, email, web, slogan, logo).
  - PDF: render and clamp mixed-payment notes; show “Paiements mixtes” when applicable; add CHEQUE label; display “TVA 6 %” and a contact/slogan footer; overflow guard accounts for payment notes to keep one page.
  - Types: extend `IssuerData` and `CreateInvoiceRequest` with contact fields, `paymentDetails`, `number`, and `issuedAt`.
  - Tests: cover calculations, UI, access control, navigation, API, and long mixed-payment references without PDF overflow.

<sup>Written for commit 7b76d07cb7dca3eb143aabbfde2b9c17717038ec. Summary will update on new commits. <a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/31?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

