### PR TITLE
fix(invoice): make package discount informational

### DIFF
--- a/__tests__/components/facturation/nexus-invoice-generator.test.tsx
+++ b/__tests__/components/facturation/nexus-invoice-generator.test.tsx
@@ -23,6 +23,8 @@ describe('NexusInvoiceGenerator', () => {
     ).toBeGreaterThan(0);
     expect(screen.getByText(/contact@nexusreussite\.academy/)).toBeInTheDocument();
     expect(screen.getByText(/Montant total TTC/i)).toBeInTheDocument();
+    expect(screen.getByText(/Prix forfaitaire incluant une remise commerciale/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Remise forfaitaire intégrée$/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Arrêté la présente facture/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/sans tampon/i)).not.toBeInTheDocument();
   });

--- a/__tests__/components/facturation/nexus-invoice-generator.test.tsx
+++ b/__tests__/components/facturation/nexus-invoice-generator.test.tsx
@@ -17,14 +17,14 @@ describe('NexusInvoiceGenerator', () => {
     expect(screen.getAllByText('Chèque').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Espèces').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Accès plateforme EAF — Masterium offert').length).toBeGreaterThan(0);
+    expect(screen.getByText(/Prix forfaitaire incluant une remise commerciale de 39,000 TND/)).toBeInTheDocument();
+    expect(screen.queryByText(/Remise forfaitaire intégrée/i)).not.toBeInTheDocument();
     expect(screen.getByText('Viser. Atteindre. Dépasser.')).toBeInTheDocument();
     expect(
       screen.getAllByText(/Centre Urbain Nord, Immeuble VENUS, Appt C13, 1082/).length
     ).toBeGreaterThan(0);
     expect(screen.getByText(/contact@nexusreussite\.academy/)).toBeInTheDocument();
     expect(screen.getByText(/Montant total TTC/i)).toBeInTheDocument();
-    expect(screen.getByText(/Prix forfaitaire incluant une remise commerciale/i)).toBeInTheDocument();
-    expect(screen.queryByText(/^Remise forfaitaire intégrée$/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Arrêté la présente facture/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/sans tampon/i)).not.toBeInTheDocument();
   });

--- a/__tests__/lib/invoice/nexus-calculations.test.ts
+++ b/__tests__/lib/invoice/nexus-calculations.test.ts
@@ -93,6 +93,7 @@ describe('nexus invoice calculations', () => {
     expect(request.discountTotal).toBe(50_000);
     expect(request.taxRegime).toBe('TVA_INCLUSE');
     expect(request.paymentMethod).toBeNull();
+    expect(request.items[0].description).toContain('Prix forfaitaire incluant une remise commerciale de 39,000 TND');
     expect(request.paymentDetails?.notes).toContain('Virement bancaire : 500,000 TND (VIR-001)');
     expect(request.paymentDetails?.notes).toContain('Chèque : 400,000 TND (CHQ-002 Banque BIAT)');
     expect(request.paymentDetails?.notes).toContain('Espèces : 199,000 TND (Espèces bureau)');

--- a/__tests__/lib/invoice/nexus-calculations.test.ts
+++ b/__tests__/lib/invoice/nexus-calculations.test.ts
@@ -93,7 +93,6 @@ describe('nexus invoice calculations', () => {
     expect(request.discountTotal).toBe(50_000);
     expect(request.taxRegime).toBe('TVA_INCLUSE');
     expect(request.paymentMethod).toBeNull();
-    expect(request.items[0].description).toContain('Prix forfaitaire incluant une remise commerciale de 39,000 TND');
     expect(request.paymentDetails?.notes).toContain('Virement bancaire : 500,000 TND (VIR-001)');
     expect(request.paymentDetails?.notes).toContain('Chèque : 400,000 TND (CHQ-002 Banque BIAT)');
     expect(request.paymentDetails?.notes).toContain('Espèces : 199,000 TND (Espèces bureau)');
@@ -116,6 +115,10 @@ describe('nexus invoice calculations', () => {
         }),
       ])
     );
+    expect(request.items[0].description).toContain(
+      'Prix forfaitaire incluant une remise commerciale de 39,000 TND par rapport au tarif normal.'
+    );
+    expect(request.discountTotal).toBe(50_000);
   });
 
   it('keeps the payment method only when a single non-zero method is used', () => {

--- a/components/facturation/NexusInvoiceGenerator.tsx
+++ b/components/facturation/NexusInvoiceGenerator.tsx
@@ -334,21 +334,17 @@ export function NexusInvoiceGenerator() {
                         <p className="font-bold" style={{ color: BRAND.navy }}>{designation}</p>
                         <p className="mt-1" style={{ color: BRAND.textSoft }}>{subtitle}</p>
                         <p className="mt-2 text-xs" style={{ color: BRAND.textSoft }}>Français : {frenchHours || 0}h · Mathématiques : {mathHours || 0}h · Total : {(frenchHours || 0) + (mathHours || 0)}h</p>
+                        {totals.packageDiscount > 0 && (
+                          <p className="mt-1 text-xs" style={{ color: BRAND.redSoft }}>
+                            Prix forfaitaire incluant une remise commerciale de {formatTnd(totals.packageDiscount)} par rapport au tarif normal ({formatTnd(totals.normalPriceTtc)}).
+                          </p>
+                        )}
                       </td>
                       <td className="px-4 py-4 text-center">1</td>
                       <td className="px-4 py-4 text-right">{formatTnd(Math.round(priceTtc / 1.06))}</td>
                       <td className="px-4 py-4 text-right">{formatTnd(priceTtc - Math.round(priceTtc / 1.06))}</td>
                       <td className="px-4 py-4 text-right font-semibold">{formatTnd(priceTtc)}</td>
                     </tr>
-                    {totals.packageDiscount > 0 && (
-                      <tr style={{ borderBottom: `1px solid ${BRAND.border}` }}>
-                        <td className="px-4 py-3">Remise forfaitaire intégrée</td>
-                        <td className="px-4 py-3 text-center">1</td>
-                        <td className="px-4 py-3 text-right">- {formatTnd(Math.round(totals.packageDiscount / 1.06))}</td>
-                        <td className="px-4 py-3 text-right">- {formatTnd(totals.packageDiscount - Math.round(totals.packageDiscount / 1.06))}</td>
-                        <td className="px-4 py-3 text-right font-semibold">- {formatTnd(totals.packageDiscount)}</td>
-                      </tr>
-                    )}
                     {totals.adjustmentTtc > 0 && (
                       <tr style={{ borderBottom: `1px solid ${BRAND.border}` }}>
                         <td className="px-4 py-3">{adjustmentLabel}</td>

--- a/components/facturation/NexusInvoiceGenerator.tsx
+++ b/components/facturation/NexusInvoiceGenerator.tsx
@@ -333,12 +333,12 @@ export function NexusInvoiceGenerator() {
                       <td className="px-4 py-4">
                         <p className="font-bold" style={{ color: BRAND.navy }}>{designation}</p>
                         <p className="mt-1" style={{ color: BRAND.textSoft }}>{subtitle}</p>
-                        <p className="mt-2 text-xs" style={{ color: BRAND.textSoft }}>Français : {frenchHours || 0}h · Mathématiques : {mathHours || 0}h · Total : {(frenchHours || 0) + (mathHours || 0)}h</p>
                         {totals.packageDiscount > 0 && (
-                          <p className="mt-1 text-xs" style={{ color: BRAND.redSoft }}>
-                            Prix forfaitaire incluant une remise commerciale de {formatTnd(totals.packageDiscount)} par rapport au tarif normal ({formatTnd(totals.normalPriceTtc)}).
+                          <p className="mt-1 text-xs" style={{ color: BRAND.textSoft }}>
+                            Prix forfaitaire incluant une remise commerciale de {formatTnd(totals.packageDiscount)} par rapport au tarif normal.
                           </p>
                         )}
+                        <p className="mt-2 text-xs" style={{ color: BRAND.textSoft }}>Français : {frenchHours || 0}h · Mathématiques : {mathHours || 0}h · Total : {(frenchHours || 0) + (mathHours || 0)}h</p>
                       </td>
                       <td className="px-4 py-4 text-center">1</td>
                       <td className="px-4 py-4 text-right">{formatTnd(Math.round(priceTtc / 1.06))}</td>

--- a/lib/invoice/nexus-calculations.ts
+++ b/lib/invoice/nexus-calculations.ts
@@ -157,9 +157,13 @@ export function buildNexusInvoiceRequest(input: NexusInvoiceRequestInput): Nexus
   const nonZeroPayments = input.payments.filter((payment) => payment.amount > 0);
   const distinctPaymentMethods = new Set(nonZeroPayments.map((payment) => payment.method));
   const taxRegime: TaxRegime = 'TVA_INCLUSE';
+  const packageDiscountInfo = totals.packageDiscount > 0
+    ? `Prix forfaitaire incluant une remise commerciale de ${formatTnd(totals.packageDiscount)} par rapport au tarif normal (${formatTnd(totals.normalPriceTtc)}).`
+    : null;
   const mainDescription = [
     input.packageSubtitle,
     `Français : ${input.frenchHours || 0}h · Mathématiques : ${input.mathHours || 0}h`,
+    packageDiscountInfo,
   ].join('\n');
 
   const items: NexusCreateInvoiceRequest['items'] = [

--- a/lib/invoice/nexus-calculations.ts
+++ b/lib/invoice/nexus-calculations.ts
@@ -157,14 +157,14 @@ export function buildNexusInvoiceRequest(input: NexusInvoiceRequestInput): Nexus
   const nonZeroPayments = input.payments.filter((payment) => payment.amount > 0);
   const distinctPaymentMethods = new Set(nonZeroPayments.map((payment) => payment.method));
   const taxRegime: TaxRegime = 'TVA_INCLUSE';
-  const packageDiscountInfo = totals.packageDiscount > 0
-    ? `Prix forfaitaire incluant une remise commerciale de ${formatTnd(totals.packageDiscount)} par rapport au tarif normal (${formatTnd(totals.normalPriceTtc)}).`
+  const packageDiscountNote = totals.packageDiscount > 0
+    ? `Prix forfaitaire incluant une remise commerciale de ${formatTnd(totals.packageDiscount)} par rapport au tarif normal.`
     : null;
   const mainDescription = [
     input.packageSubtitle,
     `Français : ${input.frenchHours || 0}h · Mathématiques : ${input.mathHours || 0}h`,
-    packageDiscountInfo,
-  ].join('\n');
+    packageDiscountNote,
+  ].filter(Boolean).join('\n');
 
   const items: NexusCreateInvoiceRequest['items'] = [
     {


### PR DESCRIPTION

## Objet
Corrige l'affichage de la remise forfaitaire Nexus : la remise commerciale du forfait devient informative et n'est plus une ligne comptable négative.

## Changements
- Supprime la ligne négative 'Remise forfaitaire intégrée' de l'aperçu facture.
- Ajoute une mention informative : prix forfaitaire incluant une remise commerciale.
- Garde discountTotal réservé aux ajustements réels.
- Ajoute/renforce les tests Duo Première.

## Non fait
- Aucun changement DB.
- Aucun smoke test production.
- Aucun cutover DB.
- Aucun déploiement.
- Aucune modification du canvas.

## Tests
- npm test -- __tests__/lib/invoice/nexus-calculations.test.ts --runInBand
- npm test -- __tests__/components/facturation/nexus-invoice-generator.test.tsx --runInBand
- rm -rf .next
- npm test -- __tests__/lib/invoice/nexus-calculations.test.ts --runInBand
- npm test -- __tests__/components/facturation __tests__/api/admin.invoices.route.test.ts --runInBand
- npm test -- __tests__/app/assistante.facturation.page.test.tsx --runInBand
- npm run typecheck
- npm run lint
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Nexus package discount informational-only and remove the negative invoice line. Also freezes time for the `SurvivalHeroBanner` snapshot to stabilize the test.

- **Bug Fixes**
  - Removed the "Remise forfaitaire intégrée" line; show an inline note before hours: "Prix forfaitaire incluant une remise commerciale de {amount} TND par rapport au tarif normal."; included in `buildNexusInvoiceRequest` via `packageDiscountNote` with `.filter(Boolean)`; dropped the explicit normal price from the note.
  - Kept `discountTotal` for real adjustments; totals stay correct (TTC 1 099 000 millimes; `discountTotal` 50 000); no double deduction of 39 TND.
  - Tightened invoice tests with exact text assertions and ensured the negative line is absent.

<sup>Written for commit 71f615b8a44f45f9f5d128dfc76fd85901c527f5. Summary will update on new commits. <a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/33?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

