### PR TITLE
fix(test): freeze time in SurvivalHeroBanner snapshot

### DIFF
--- a/__tests__/components/dashboard/eleve/survival/SurvivalHeroBanner.test.tsx
+++ b/__tests__/components/dashboard/eleve/survival/SurvivalHeroBanner.test.tsx
@@ -2,6 +2,15 @@ import { render } from '@testing-library/react';
 import { SurvivalHeroBanner } from '@/components/dashboard/eleve/survival/SurvivalHeroBanner';
 
 describe('SurvivalHeroBanner', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-05-01T00:00:00.000Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   it('matches snapshot', () => {
     const { container } = render(<SurvivalHeroBanner examDate={new Date('2026-06-08T08:00:00.000Z')} noteToday={4.5} />);
     expect(container).toMatchSnapshot();

--- a/__tests__/components/dashboard/eleve/survival/__snapshots__/SurvivalHeroBanner.test.tsx.snap
+++ b/__tests__/components/dashboard/eleve/survival/__snapshots__/SurvivalHeroBanner.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`SurvivalHeroBanner matches snapshot 1`] = `
           class="mt-2 font-fraunces text-2xl font-semibold text-eaf-text-primary"
         >
           J-
-          41
+          39
         </p>
       </div>
       <div


### PR DESCRIPTION
## Problème
Le snapshot `SurvivalHeroBanner` incluait `J-41` calculé depuis `Date.now()` au moment où il a été généré (28 avril). Chaque jour suivant, le CI obtient une valeur différente → mismatch systématique.

## Cause
```ts
const daysLeft = Math.max(0, Math.ceil((examDate.getTime() - Date.now()) / (24 * 60 * 60 * 1000)));
```
Sans gel du temps, la valeur dérive chaque jour.

## Correctif
- Ajout de `jest.useFakeTimers()` + `jest.setSystemTime(new Date('2026-05-01T00:00:00.000Z'))` dans `beforeAll`.
- Ajout de `jest.useRealTimers()` dans `afterAll`.
- Snapshot mis à jour : `J-39` (valeur déterministe depuis le 1er mai 2026 jusqu'à l'examen du 8 juin 2026 à 8h UTC).

## Tests
- `SurvivalHeroBanner.test.tsx` — 1/1 ✓ (stable, ne dérive plus)
- Ce correctif est aussi cherry-pické sur `fix/invoice-package-discount-option-b` (PR #33) pour débloquer son CI.

## Non fait
- Aucun changement de composant production.
- Aucun changement DB.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freeze time in the `SurvivalHeroBanner` snapshot test so the days-left calculation is deterministic and CI stops failing daily. Snapshot updated to show J-39 based on a fixed date.

- **Bug Fixes**
  - Freeze time with `jest.useFakeTimers()` and `jest.setSystemTime('2026-05-01T00:00:00.000Z')`; restore with `jest.useRealTimers()`.
  - Update snapshot to J-39 (exam on 2026-06-08 08:00 UTC). Tests no longer drift; no production changes.

<sup>Written for commit 42542696761d0a932d74661f5db1cdba3d7cee92. Summary will update on new commits. <a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/34?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

