### PR TITLE
fix(invoice): include PDF font assets in production build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,10 @@ COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 
+# [FIX P0] Copy pdfkit font assets to standalone build for PDF generation
+# pdfkit expects Helvetica.afm and other font files to be available at runtime
+COPY --from=builder /app/node_modules/pdfkit/js/data ./node_modules/pdfkit/js/data
+
 # [LA CORRECTION QUE VOUS ATTENDIEZ]
 # On copie le client Prisma généré ET le dossier prisma contenant le schéma.
 # Ces deux éléments sont nécessaires au runtime pour que Prisma fonctionne.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -20,6 +20,7 @@ const nextConfig = {
     'pino-pretty',
     'thread-stream',
     'pino-abstract-transport',
+    'pdfkit',
   ],
 
 


### PR DESCRIPTION

## Objet
Corrige le P0 de génération PDF facture en production : Helvetica.afm manquant.

## Contexte
Le smoke test post-cutover a créé une facture, mais le PDF n'a pas été généré :
ENOENT /app/.next/server/chunks/data/Helvetica.afm.

## Diagnostic
- Next.js standalone build ne copie pas les assets de polices pdfkit depuis node_modules
- pdfkit s'attend à ce que Helvetica.afm soit disponible au runtime
- Le répertoire /app/.next/server/chunks/data n'existe pas dans le conteneur production

## Changements
- Ajout de 'pdfkit' à serverExternalPackages dans next.config.mjs
- Ajout de COPY du répertoire pdfkit/js/data dans le Dockerfile pour le build standalone

## Périmètre PR
Cette PR contient UNIQUEMENT :
- Dockerfile (1 ligne ajoutée pour copier pdfkit/js/data)
- next.config.mjs (1 ligne ajoutée pour externaliser pdfkit)

## Non fait
- Aucune migration
- Aucun seed
- Aucun credential
- Aucun changement DB
- Aucun changement UI
- Aucun go-live déclaré

## Validation
- Typecheck OK
- Lint OK (warnings pré-existants seulement)
- À déployer puis smoke test complet après validation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix PDF invoice generation in production by bundling `pdfkit` font assets (Helvetica.afm) in the standalone build. Adds `pdfkit` to `serverExternalPackages` and copies `pdfkit/js/data` into the runtime image to ensure fonts are available at runtime.

<sup>Written for commit 4904ffc4a825b68ed3eccb7034518627c93136ce. Summary will update on new commits. <a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/36?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

