### PR TITLE
fix(invoice): add HT line and clarify discount label in PDF

### DIFF
--- a/lib/invoice/pdf.ts
+++ b/lib/invoice/pdf.ts
@@ -380,12 +380,22 @@ export async function renderInvoicePDF(data: InvoiceData): Promise<Buffer> {
         .text(formatCurrency(data.subtotal, data.currency), totalsX + 80, y, { width: 100, align: 'right' });
       y += 16;
 
-      // Discount (if any)
+      // Discount/Adjustment (if any)
       if (data.discountTotal > 0) {
         doc.font(FONTS.regular).fontSize(9).fillColor(COLORS.textSecondary)
-          .text('Remise', totalsX, y);
+          .text('Ajustement', totalsX, y);
         doc.font(FONTS.regular).fontSize(9).fillColor(COLORS.success)
           .text(`-${formatCurrency(data.discountTotal, data.currency)}`, totalsX + 80, y, { width: 100, align: 'right' });
+        y += 16;
+      }
+
+      // HT (Hors Taxe) - calculated from total before tax
+      if (data.taxRegime === 'TVA_INCLUSE' && data.taxTotal > 0) {
+        const htAmount = data.total - data.taxTotal;
+        doc.font(FONTS.regular).fontSize(9).fillColor(COLORS.textSecondary)
+          .text('HT', totalsX, y);
+        doc.font(FONTS.regular).fontSize(9).fillColor(COLORS.text)
+          .text(formatCurrency(htAmount, data.currency), totalsX + 80, y, { width: 100, align: 'right' });
         y += 16;
       }
 


### PR DESCRIPTION
Add HT (Hors Taxe) line in invoice PDF template for TVA_INCLUSE regime. Change 'Remise' label to 'Ajustement' to distinguish from commercial discount.

**Changes**:
- Add HT line calculated as: TOTAL - TVA
- Change 'Remise' label to 'Ajustement' 
- Commercial discount (39 TND) remains in item description
- Adjustment (50 TND) now clearly labeled as 'Ajustement'

**Reserves lifted**:
- HT now visible in PDF
- Discount/adjustment distinction clarified

**Tests**: All invoice tests pass (213 passed)

This fixes P1 blocking issue for go-live validation.