### PR TITLE
fix(ci): resolve preexisting lint blockers

### DIFF
--- a/__tests__/lib/auth-security.test.ts
+++ b/__tests__/lib/auth-security.test.ts
@@ -7,7 +7,6 @@ const mockNextUrl = (pathname: string) => {
 };
 
 describe('Middleware Security Rules', () => {
-  // @ts-ignore
   const authorized = authConfig.callbacks!.authorized!;
 
   // Mock Response
@@ -27,7 +26,6 @@ describe('Middleware Security Rules', () => {
     const req = { nextUrl: mockNextUrl('/dashboard') } as any;
     const auth = null;
     
-    // @ts-ignore
     const result = await authorized({ auth, request: req });
     expect(result).toBe(false);
   });
@@ -36,7 +34,6 @@ describe('Middleware Security Rules', () => {
     const req = { nextUrl: mockNextUrl('/dashboard') } as any;
     const auth = { user: { role: 'ELEVE' } } as any;
     
-    // @ts-ignore
     const result = await authorized({ auth, request: req });
     expect(result).toBe(true);
   });
@@ -45,8 +42,7 @@ describe('Middleware Security Rules', () => {
       const req = { nextUrl: mockNextUrl('/auth/signin') } as any;
       const auth = { user: { role: 'ELEVE' } } as any;
       
-      // @ts-ignore
-      const result = await authorized({ auth, request: req });
+      await authorized({ auth, request: req });
       
       // Should have called redirect
       expect(global.Response.redirect).toHaveBeenCalled();

--- a/app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts
+++ b/app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts
@@ -115,7 +115,7 @@ export async function POST(
       // If user exists but has no student profile (shouldn't happen with new logic but for safety)
       const gTrack = normalizeStudentLevelAndTrack(reservation.classe) || { level: GradeLevel.AUTRE, track: AcademicTrack.EDS_GENERALE };
       
-      let parentUser = await prisma.user.findFirst({
+      const parentUser = await prisma.user.findFirst({
         where: { email: SYSTEM_PARENT_EMAIL },
         include: { parentProfile: true }
       });


### PR DESCRIPTION
Corrige uniquement les erreurs ESLint préexistantes qui bloquent la CI :

**Corrections** :
- app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts : let parentUser → const parentUser (ligne 118 seulement, car ligne 55 est réassignée)
- __tests__/lib/auth-security.test.ts : suppression des @ts-ignore (lignes 10, 30, 39, 48) car TypeScript n'erre plus

**Aucun changement fonctionnel attendu**. Ces corrections sont nécessaires pour débloquer PR #40 (fix PDF HT/Remise).