### PR TITLE
feat(coach): add editable EAF preparation reports

### DIFF
--- a/__tests__/api/coach.dashboard.route.test.ts
+++ b/__tests__/api/coach.dashboard.route.test.ts
@@ -11,7 +11,8 @@ jest.mock('@/lib/prisma', () => ({
     coachProfile: { findUnique: jest.fn() },
     sessionBooking: { findMany: jest.fn() },
     user: { findUnique: jest.fn() },
-    student: { findFirst: jest.fn(), findMany: jest.fn() },
+    student: { findFirst: jest.fn(), findMany: jest.fn(), findUnique: jest.fn() },
+    coachStudentAssignment: { findMany: jest.fn() },
     mathsProgress: { findMany: jest.fn().mockResolvedValue([]) },
     bilan: { findMany: jest.fn().mockResolvedValue([]) },
   },
@@ -106,13 +107,29 @@ describe('GET /api/coach/dashboard', () => {
     (prisma.student.findFirst as jest.Mock).mockResolvedValue({
       id: 'student-entity-1',
       grade: 'Seconde',
+      gradeLevel: 'PREMIERE',
+      academicTrack: 'EDS_GENERALE',
       creditTransactions: [{ amount: 2 }],
     });
     (prisma.student.findMany as jest.Mock).mockResolvedValue([
       {
         id: 'student-entity-1',
         userId: 'student-1',
+        gradeLevel: 'PREMIERE',
+        academicTrack: 'EDS_GENERALE',
         creditTransactions: [{ amount: 2 }],
+      },
+    ]);
+    (prisma.student.findUnique as jest.Mock).mockResolvedValue({
+      id: 'student-entity-1',
+      gradeLevel: 'PREMIERE',
+      academicTrack: 'EDS_GENERALE',
+      credits: 2,
+    });
+    (prisma.coachStudentAssignment.findMany as jest.Mock).mockResolvedValue([
+      {
+        coachId: 'coach-profile-1',
+        studentId: 'student-entity-1',
       },
     ]);
 

--- a/__tests__/api/coach/eaf-preparation-report.test.ts
+++ b/__tests__/api/coach/eaf-preparation-report.test.ts
@@ -59,10 +59,10 @@ describe('API /api/coach/students/[studentId]/eaf-preparation-report', () => {
   describe('GET', () => {
     it('should return 403 if coach is not assigned to student', async () => {
       const { requireRole } = require('@/lib/guards');
-      const { assertCoachCanAccessStudent } = require('@/lib/rbac/coach-student-access');
+      const { assertCoachCanAccessStudent, CoachNotAssignedError } = require('@/lib/rbac/coach-student-access');
       
       requireRole.mockResolvedValue(mockSession);
-      assertCoachCanAccessStudent.mockRejectedValue(new Error('Not assigned'));
+      assertCoachCanAccessStudent.mockRejectedValue(new CoachNotAssignedError());
 
       const request = new NextRequest('http://localhost:3000/api/coach/students/student123/eaf-preparation-report');
       const response = await GET(request, { params: Promise.resolve({ studentId: mockStudentId }) });
@@ -94,7 +94,10 @@ describe('API /api/coach/students/[studentId]/eaf-preparation-report', () => {
 
       expect(response.status).toBe(200);
       expect(data.success).toBe(true);
-      expect(data.report).toEqual(mockReport);
+      expect(data.report.id).toBe(mockReport.id);
+      expect(data.report.studentId).toBe(mockReport.studentId);
+      expect(data.report.coachId).toBe(mockReport.coachId);
+      expect(data.report.linearReading).toBe(mockReport.linearReading);
     });
 
     it('should return empty report if none exists', async () => {
@@ -120,10 +123,10 @@ describe('API /api/coach/students/[studentId]/eaf-preparation-report', () => {
   describe('PUT', () => {
     it('should return 403 if coach is not assigned to student', async () => {
       const { requireRole } = require('@/lib/guards');
-      const { assertCoachCanAccessStudent } = require('@/lib/rbac/coach-student-access');
+      const { assertCoachCanAccessStudent, CoachNotAssignedError } = require('@/lib/rbac/coach-student-access');
       
       requireRole.mockResolvedValue(mockSession);
-      assertCoachCanAccessStudent.mockRejectedValue(new Error('Not assigned'));
+      assertCoachCanAccessStudent.mockRejectedValue(new CoachNotAssignedError());
 
       const request = new NextRequest('http://localhost:3000/api/coach/students/student123/eaf-preparation-report', {
         method: 'PUT',
@@ -161,7 +164,10 @@ describe('API /api/coach/students/[studentId]/eaf-preparation-report', () => {
 
       expect(response.status).toBe(200);
       expect(data.success).toBe(true);
-      expect(data.report).toEqual(mockReport);
+      expect(data.report.id).toBe(mockReport.id);
+      expect(data.report.studentId).toBe(mockReport.studentId);
+      expect(data.report.coachId).toBe(mockReport.coachId);
+      expect(data.report.linearReading).toBe(mockReport.linearReading);
       expect((prisma.eafPreparationReport.upsert as jest.Mock)).toHaveBeenCalledWith(
         expect.objectContaining({
           create: expect.objectContaining({

--- a/__tests__/api/coach/students/[studentId]/eaf-preparation-report.test.ts
+++ b/__tests__/api/coach/students/[studentId]/eaf-preparation-report.test.ts
@@ -1,0 +1,226 @@
+import { NextRequest } from 'next/server';
+import { GET, PUT } from '@/app/api/coach/students/[studentId]/eaf-preparation-report/route';
+import { prisma } from '@/lib/prisma';
+
+// Mock the guards module
+jest.mock('@/lib/guards', () => ({
+  requireRole: jest.fn(),
+  isErrorResponse: jest.fn(() => false),
+}));
+
+// Mock the coach-student-access module
+jest.mock('@/lib/rbac/coach-student-access', () => ({
+  assertCoachCanAccessStudent: jest.fn(),
+  getCoachProfileForUser: jest.fn(),
+  CoachNotAssignedError: class extends Error {
+    constructor(message = "Vous n'êtes pas assigné à cet élève") {
+      super(message);
+      this.name = 'CoachNotAssignedError';
+    }
+  },
+}));
+
+// Mock Prisma
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    eafPreparationReport: {
+      findUnique: jest.fn(),
+      upsert: jest.fn(),
+    },
+  },
+}));
+
+// Type-safe mock
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+
+// Mock logger
+jest.mock('@/lib/logger', () => ({
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+describe('API /api/coach/students/[studentId]/eaf-preparation-report', () => {
+  const mockCoachId = 'coach123';
+  const mockStudentId = 'student123';
+  const mockSession = {
+    user: {
+      id: 'user123',
+      email: 'coach@test.com',
+      role: 'COACH',
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET', () => {
+    it('should return 403 if coach is not assigned to student', async () => {
+      const { requireRole } = require('@/lib/guards');
+      const { assertCoachCanAccessStudent } = require('@/lib/rbac/coach-student-access');
+      
+      requireRole.mockResolvedValue(mockSession);
+      assertCoachCanAccessStudent.mockRejectedValue(new Error('Not assigned'));
+
+      const request = new NextRequest('http://localhost:3000/api/coach/students/student123/eaf-preparation-report');
+      const response = await GET(request, { params: Promise.resolve({ studentId: mockStudentId }) });
+
+      expect(response.status).toBe(403);
+    });
+
+    it('should return the report if it exists', async () => {
+      const { requireRole } = require('@/lib/guards');
+      const { assertCoachCanAccessStudent, getCoachProfileForUser } = require('@/lib/rbac/coach-student-access');
+      
+      requireRole.mockResolvedValue(mockSession);
+      assertCoachCanAccessStudent.mockResolvedValue(undefined);
+      getCoachProfileForUser.mockResolvedValue({ id: mockCoachId });
+
+      const mockReport = {
+        id: 'report123',
+        studentId: mockStudentId,
+        coachId: mockCoachId,
+        linearReading: 'Good',
+        updatedAt: new Date(),
+      };
+
+      (prisma.eafPreparationReport.findUnique as jest.Mock).mockResolvedValue(mockReport);
+
+      const request = new NextRequest('http://localhost:3000/api/coach/students/student123/eaf-preparation-report');
+      const response = await GET(request, { params: Promise.resolve({ studentId: mockStudentId }) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.report).toEqual(mockReport);
+    });
+
+    it('should return empty report if none exists', async () => {
+      const { requireRole } = require('@/lib/guards');
+      const { assertCoachCanAccessStudent, getCoachProfileForUser } = require('@/lib/rbac/coach-student-access');
+      
+      requireRole.mockResolvedValue(mockSession);
+      assertCoachCanAccessStudent.mockResolvedValue(undefined);
+      getCoachProfileForUser.mockResolvedValue({ id: mockCoachId });
+
+      (prisma.eafPreparationReport.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const request = new NextRequest('http://localhost:3000/api/coach/students/student123/eaf-preparation-report');
+      const response = await GET(request, { params: Promise.resolve({ studentId: mockStudentId }) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.report).toBeNull();
+    });
+  });
+
+  describe('PUT', () => {
+    it('should return 403 if coach is not assigned to student', async () => {
+      const { requireRole } = require('@/lib/guards');
+      const { assertCoachCanAccessStudent } = require('@/lib/rbac/coach-student-access');
+      
+      requireRole.mockResolvedValue(mockSession);
+      assertCoachCanAccessStudent.mockRejectedValue(new Error('Not assigned'));
+
+      const request = new NextRequest('http://localhost:3000/api/coach/students/student123/eaf-preparation-report', {
+        method: 'PUT',
+        body: JSON.stringify({ linearReading: 'Good' }),
+      });
+      const response = await PUT(request, { params: Promise.resolve({ studentId: mockStudentId }) });
+
+      expect(response.status).toBe(403);
+    });
+
+    it('should create a new report if none exists', async () => {
+      const { requireRole } = require('@/lib/guards');
+      const { assertCoachCanAccessStudent, getCoachProfileForUser } = require('@/lib/rbac/coach-student-access');
+      
+      requireRole.mockResolvedValue(mockSession);
+      assertCoachCanAccessStudent.mockResolvedValue(undefined);
+      getCoachProfileForUser.mockResolvedValue({ id: mockCoachId });
+
+      const mockReport = {
+        id: 'report123',
+        studentId: mockStudentId,
+        coachId: mockCoachId,
+        linearReading: 'Good',
+        updatedAt: new Date(),
+      };
+
+      (prisma.eafPreparationReport.upsert as jest.Mock).mockResolvedValue(mockReport);
+
+      const request = new NextRequest('http://localhost:3000/api/coach/students/student123/eaf-preparation-report', {
+        method: 'PUT',
+        body: JSON.stringify({ linearReading: 'Good' }),
+      });
+      const response = await PUT(request, { params: Promise.resolve({ studentId: mockStudentId }) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.report).toEqual(mockReport);
+      expect((prisma.eafPreparationReport.upsert as jest.Mock)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            studentId: mockStudentId,
+            coachId: mockCoachId,
+            linearReading: 'Good',
+          }),
+        })
+      );
+    });
+
+    it('should update an existing report', async () => {
+      const { requireRole } = require('@/lib/guards');
+      const { assertCoachCanAccessStudent, getCoachProfileForUser } = require('@/lib/rbac/coach-student-access');
+      
+      requireRole.mockResolvedValue(mockSession);
+      assertCoachCanAccessStudent.mockResolvedValue(undefined);
+      getCoachProfileForUser.mockResolvedValue({ id: mockCoachId });
+
+      const mockReport = {
+        id: 'report123',
+        studentId: mockStudentId,
+        coachId: mockCoachId,
+        linearReading: 'Good',
+        updatedAt: new Date(),
+      };
+
+      (prisma.eafPreparationReport.upsert as jest.Mock).mockResolvedValue(mockReport);
+
+      const request = new NextRequest('http://localhost:3000/api/coach/students/student123/eaf-preparation-report', {
+        method: 'PUT',
+        body: JSON.stringify({ linearReading: 'Good' }),
+      });
+      const response = await PUT(request, { params: Promise.resolve({ studentId: mockStudentId }) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+    });
+
+    it('should validate field length limits', async () => {
+      const { requireRole } = require('@/lib/guards');
+      const { assertCoachCanAccessStudent, getCoachProfileForUser } = require('@/lib/rbac/coach-student-access');
+      
+      requireRole.mockResolvedValue(mockSession);
+      assertCoachCanAccessStudent.mockResolvedValue(undefined);
+      getCoachProfileForUser.mockResolvedValue({ id: mockCoachId });
+
+      const longText = 'a'.repeat(6000); // Exceeds 5000 char limit
+
+      const request = new NextRequest('http://localhost:3000/api/coach/students/student123/eaf-preparation-report', {
+        method: 'PUT',
+        body: JSON.stringify({ linearReading: longText }),
+      });
+      const response = await PUT(request, { params: Promise.resolve({ studentId: mockStudentId }) });
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe('Bad Request');
+    });
+  });
+});

--- a/app/api/coach/students/[studentId]/eaf-preparation-report/route.ts
+++ b/app/api/coach/students/[studentId]/eaf-preparation-report/route.ts
@@ -1,0 +1,151 @@
+import { NextResponse } from 'next/server';
+import { requireRole, isErrorResponse } from '@/lib/guards';
+import {
+  assertCoachCanAccessStudent,
+  getCoachProfileForUser,
+  CoachNotAssignedError,
+} from '@/lib/rbac/coach-student-access';
+import { prisma } from '@/lib/prisma';
+import { logger } from '@/lib/logger';
+import { z } from 'zod';
+
+const MAX_FIELD_LENGTH = 5000;
+
+// Schema for EAF preparation report
+const eafPreparationReportSchema = z.object({
+  linearReading: z.string().max(MAX_FIELD_LENGTH).optional(),
+  workPresentation: z.string().max(MAX_FIELD_LENGTH).optional(),
+  interview: z.string().max(MAX_FIELD_LENGTH).optional(),
+  oralExpression: z.string().max(MAX_FIELD_LENGTH).optional(),
+  writingMethod: z.string().max(MAX_FIELD_LENGTH).optional(),
+  languageMastery: z.string().max(MAX_FIELD_LENGTH).optional(),
+  literaryCulture: z.string().max(MAX_FIELD_LENGTH).optional(),
+  strengths: z.string().max(MAX_FIELD_LENGTH).optional(),
+  areasToImprove: z.string().max(MAX_FIELD_LENGTH).optional(),
+  nextSessionGoals: z.string().max(MAX_FIELD_LENGTH).optional(),
+  coachFreeComment: z.string().max(MAX_FIELD_LENGTH).optional(),
+});
+
+interface RouteParams {
+  params: Promise<{ studentId: string }>;
+}
+
+/**
+ * GET /api/coach/students/[studentId]/eaf-preparation-report
+ * Returns the EAF preparation report for a student (if exists)
+ */
+export async function GET(_request: Request, { params }: RouteParams) {
+  try {
+    const { studentId } = await params;
+
+    const sessionOrError = await requireRole('COACH');
+    if (isErrorResponse(sessionOrError)) return sessionOrError;
+    const authSession = sessionOrError;
+
+    // Verify coach assignment
+    try {
+      await assertCoachCanAccessStudent({ coachUserId: authSession.user.id, studentId });
+    } catch (error) {
+      if (error instanceof CoachNotAssignedError) {
+        return NextResponse.json(
+          { error: 'Forbidden', message: "Vous n'êtes pas assigné à cet élève" },
+          { status: 403 }
+        );
+      }
+      throw error;
+    }
+
+    const coachProfile = await getCoachProfileForUser(authSession.user.id);
+
+    // Get EAF preparation report
+    const report = await prisma.eafPreparationReport.findUnique({
+      where: {
+        studentId_coachId: {
+          studentId,
+          coachId: coachProfile?.id || '',
+        },
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      report,
+    });
+  } catch (error) {
+    logger.error({ err: error }, '[API] coach/students/[studentId]/eaf-preparation-report GET failed');
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+/**
+ * PUT /api/coach/students/[studentId]/eaf-preparation-report
+ * Create or update the EAF preparation report
+ */
+export async function PUT(request: Request, { params }: RouteParams) {
+  try {
+    const { studentId } = await params;
+
+    const sessionOrError = await requireRole('COACH');
+    if (isErrorResponse(sessionOrError)) return sessionOrError;
+    const authSession = sessionOrError;
+
+    // Verify coach assignment
+    try {
+      await assertCoachCanAccessStudent({ coachUserId: authSession.user.id, studentId });
+    } catch (error) {
+      if (error instanceof CoachNotAssignedError) {
+        return NextResponse.json(
+          { error: 'Forbidden', message: "Vous n'êtes pas assigné à cet élève" },
+          { status: 403 }
+        );
+      }
+      throw error;
+    }
+
+    const coachProfile = await getCoachProfileForUser(authSession.user.id);
+    if (!coachProfile) {
+      return NextResponse.json({ error: 'Coach profile not found' }, { status: 404 });
+    }
+
+    const json = await request.json();
+    const parseResult = eafPreparationReportSchema.safeParse(json);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: 'Bad Request', message: 'Validation échouée', details: parseResult.error.format() },
+        { status: 400 }
+      );
+    }
+
+    const data = parseResult.data;
+
+    // Upsert the report
+    const report = await prisma.eafPreparationReport.upsert({
+      where: {
+        studentId_coachId: {
+          studentId,
+          coachId: coachProfile.id,
+        },
+      },
+      update: {
+        ...data,
+        updatedAt: new Date(),
+      },
+      create: {
+        studentId,
+        coachId: coachProfile.id,
+        ...data,
+      },
+    });
+
+    logger.info(
+      { reportId: report.id, studentId, coachId: coachProfile.id },
+      '[API] coach/students/[studentId]/eaf-preparation-report saved'
+    );
+
+    return NextResponse.json({ success: true, report });
+  } catch (error) {
+    logger.error({ err: error }, '[API] coach/students/[studentId]/eaf-preparation-report PUT failed');
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/app/api/coach/students/[studentId]/eaf-preparation-report/route.ts
+++ b/app/api/coach/students/[studentId]/eaf-preparation-report/route.ts
@@ -56,13 +56,16 @@ export async function GET(_request: Request, { params }: RouteParams) {
     }
 
     const coachProfile = await getCoachProfileForUser(authSession.user.id);
+    if (!coachProfile) {
+      return NextResponse.json({ error: 'Coach profile not found' }, { status: 404 });
+    }
 
     // Get EAF preparation report
     const report = await prisma.eafPreparationReport.findUnique({
       where: {
         studentId_coachId: {
           studentId,
-          coachId: coachProfile?.id || '',
+          coachId: coachProfile.id,
         },
       },
     });

--- a/components/dashboard/coach/EafPreparationReport.tsx
+++ b/components/dashboard/coach/EafPreparationReport.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Loader2, Save, FileText } from "lucide-react";
+
+interface EafReportData {
+  linearReading?: string;
+  workPresentation?: string;
+  interview?: string;
+  oralExpression?: string;
+  writingMethod?: string;
+  languageMastery?: string;
+  literaryCulture?: string;
+  strengths?: string;
+  areasToImprove?: string;
+  nextSessionGoals?: string;
+  coachFreeComment?: string;
+}
+
+interface EafPreparationReportProps {
+  studentId: string;
+  studentName: string;
+}
+
+export function EafPreparationReport({ studentId, studentName }: EafPreparationReportProps) {
+  const [report, setReport] = useState<EafReportData>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [lastSavedAt, setLastSavedAt] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchReport();
+  }, [studentId]);
+
+  const fetchReport = async () => {
+    try {
+      const res = await fetch(`/api/coach/students/${studentId}/eaf-preparation-report`);
+      if (res.ok) {
+        const data = await res.json();
+        if (data.report) {
+          setReport(data.report);
+          setLastSavedAt(data.report.updatedAt);
+        }
+      }
+    } catch (err) {
+      console.error("Failed to fetch EAF report:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/coach/students/${studentId}/eaf-preparation-report`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(report),
+      });
+
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+
+      const data = await res.json();
+      setLastSavedAt(data.report.updatedAt);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erreur lors de la sauvegarde");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleChange = (field: keyof EafReportData, value: string) => {
+    setReport((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const fields: { key: keyof EafReportData; label: string; placeholder: string }[] = [
+    { key: "linearReading", label: "Lecture linéaire", placeholder: "Capacité à lire et comprendre un texte de manière fluide..." },
+    { key: "workPresentation", label: "Présentation de l'œuvre", placeholder: "Capacité à présenter l'œuvre, le contexte, l'auteur..." },
+    { key: "interview", label: "Entretien", placeholder: "Capacité à répondre aux questions de l'examinateur..." },
+    { key: "oralExpression", label: "Expression orale", placeholder: "Qualité de l'expression, aisance, vocabulaire..." },
+    { key: "writingMethod", label: "Méthode de commentaire / dissertation", placeholder: "Maîtrise de la méthode, construction du plan..." },
+    { key: "languageMastery", label: "Maîtrise de la langue", placeholder: "Grammaire, orthographe, syntaxe, vocabulaire..." },
+    { key: "literaryCulture", label: "Culture littéraire", placeholder: "Connaissance des œuvres, des mouvements littéraires..." },
+    { key: "strengths", label: "Points forts", placeholder: "Ce que l'élève maîtrise bien..." },
+    { key: "areasToImprove", label: "Points à travailler", placeholder: "Ce qui nécessite encore du travail..." },
+    { key: "nextSessionGoals", label: "Objectifs pour la prochaine séance", placeholder: "Objectifs prioritaires pour la suite..." },
+    { key: "coachFreeComment", label: "Commentaire libre du coach", placeholder: "Remarques libres, suggestions, observations..." },
+  ];
+
+  if (loading) {
+    return (
+      <Card className="bg-surface-card border-white/10 shadow-premium">
+        <CardContent className="flex items-center justify-center py-8">
+          <Loader2 className="w-6 h-6 animate-spin text-brand-accent" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="bg-surface-card border-white/10 shadow-premium">
+      <CardHeader>
+        <CardTitle className="text-white text-base flex items-center gap-2">
+          <FileText className="w-4 h-4 text-brand-accent" />
+          Bilan de préparation à l'EAF
+        </CardTitle>
+        <p className="text-xs text-neutral-400 mt-1">
+          Notes pédagogiques du coach pour suivre la progression de l'élève dans la préparation à l'épreuve anticipée de français.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error && (
+          <div className="p-3 rounded-lg bg-rose-500/20 text-rose-400 text-sm border border-rose-500/20">
+            {error}
+          </div>
+        )}
+
+        {fields.map((field) => (
+          <div key={field.key} className="space-y-2">
+            <label className="text-sm font-medium text-neutral-300">{field.label}</label>
+            <textarea
+              value={report[field.key] || ""}
+              onChange={(e) => handleChange(field.key, e.target.value)}
+              placeholder={field.placeholder}
+              rows={3}
+              maxLength={5000}
+              className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-neutral-100 placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-brand-accent focus:border-transparent resize-y"
+            />
+          </div>
+        ))}
+
+        <div className="flex items-center justify-between pt-4 border-t border-white/10">
+          {lastSavedAt && (
+            <p className="text-xs text-neutral-500">
+              Dernière mise à jour le {new Date(lastSavedAt).toLocaleString("fr-FR")}
+            </p>
+          )}
+          {!lastSavedAt && (
+            <p className="text-xs text-neutral-500">Aucune donnée sauvegardée</p>
+          )}
+          <Button
+            onClick={handleSave}
+            disabled={saving}
+            className="bg-brand-accent hover:bg-brand-accent/90 text-white"
+          >
+            {saving ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                Sauvegarde...
+              </>
+            ) : (
+              <>
+                <Save className="w-4 h-4 mr-2" />
+                Enregistrer le bilan
+              </>
+            )}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/dashboard/coach/EafPreparationReport.tsx
+++ b/components/dashboard/coach/EafPreparationReport.tsx
@@ -32,6 +32,10 @@ export function EafPreparationReport({ studentId, studentName }: EafPreparationR
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    setReport({});
+    setLastSavedAt(null);
+    setError(null);
+    setLoading(true);
     fetchReport();
   }, [studentId]);
 
@@ -112,7 +116,7 @@ export function EafPreparationReport({ studentId, studentName }: EafPreparationR
           Bilan de préparation à l'EAF
         </CardTitle>
         <p className="text-xs text-neutral-400 mt-1">
-          Notes pédagogiques du coach pour suivre la progression de l'élève dans la préparation à l'épreuve anticipée de français.
+          Suivi EAF de {studentName}
         </p>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -122,19 +126,23 @@ export function EafPreparationReport({ studentId, studentName }: EafPreparationR
           </div>
         )}
 
-        {fields.map((field) => (
-          <div key={field.key} className="space-y-2">
-            <label className="text-sm font-medium text-neutral-300">{field.label}</label>
-            <textarea
-              value={report[field.key] || ""}
-              onChange={(e) => handleChange(field.key, e.target.value)}
-              placeholder={field.placeholder}
-              rows={3}
-              maxLength={5000}
-              className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-neutral-100 placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-brand-accent focus:border-transparent resize-y"
-            />
-          </div>
-        ))}
+        {fields.map((field) => {
+          const fieldId = `eaf-${studentId}-${field.key}`;
+          return (
+            <div key={field.key} className="space-y-2">
+              <label htmlFor={fieldId} className="text-sm font-medium text-neutral-300">{field.label}</label>
+              <textarea
+                id={fieldId}
+                value={report[field.key] || ""}
+                onChange={(e) => handleChange(field.key, e.target.value)}
+                placeholder={field.placeholder}
+                rows={3}
+                maxLength={5000}
+                className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-neutral-100 placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-brand-accent focus:border-transparent resize-y"
+              />
+            </div>
+          );
+        })}
 
         <div className="flex items-center justify-between pt-4 border-t border-white/10">
           {lastSavedAt && (

--- a/components/dashboard/coach/StudentDossier.tsx
+++ b/components/dashboard/coach/StudentDossier.tsx
@@ -13,6 +13,7 @@ import { AriaVerbatimsPanel, type AriaVerbatim } from "./AriaVerbatimsPanel";
 import { RagConsultedSources, type RagSource } from "./RagConsultedSources";
 import { BilanDiagMathsTerminaleCoach } from "./BilanDiagMathsTerminaleCoach";
 import { CoachDocumentsPanel } from "./CoachDocumentsPanel";
+import { EafPreparationReport } from "./EafPreparationReport";
 
 export interface DossierStudent {
   id: string;
@@ -153,6 +154,10 @@ export function StudentDossier({ data, children }: StudentDossierProps) {
               <BilanDiagMathsTerminaleCoach studentId={student.id} studentName={student.name} />
             )}
 
+          {/* Bilan de préparation à l'EAF — visible pour tous les élèves PREMIERE */}
+          {student.gradeLevel === 'PREMIERE' && (
+            <EafPreparationReport studentId={student.id} studentName={student.name} />
+          )}
 
           {/* Optional children (TrajectoryDesigner, etc.) */}
           {children}

--- a/docs/features/EAF_COACH_REPORTS.md
+++ b/docs/features/EAF_COACH_REPORTS.md
@@ -44,7 +44,7 @@ model EafPreparationReport {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  // One active report per coach-student pair
+  // One report per coach-student pair
   @@unique([studentId, coachId])
   @@index([coachId])
   @@index([studentId])
@@ -57,9 +57,9 @@ model EafPreparationReport {
 ### Règles d'accès
 
 - **COACH** : Peut lire et écrire les bilans EAF uniquement pour les élèves qui lui sont assignés via `CoachStudentAssignment`
-- **ADMIN** : Peut lire et écrire tous les bilans (selon règles existantes)
-- **ASSISTANTE** : Pas d'accès automatique (selon règles existantes)
-- **ELEVE/PARENT** : Pas d'accès en écriture (selon règles existantes)
+- **ADMIN** : Non supporté par cette route dans la version actuelle (évolution future possible)
+- **ASSISTANTE** : Pas d'accès via cette API
+- **ELEVE/PARENT** : Pas d'accès via cette API
 
 ### Vérification d'accès
 
@@ -102,18 +102,20 @@ Les rubriques suivantes sont disponibles (champs texte, max 5000 caractères cha
 - `PUT report as assigned coach => 200` - ✅
 - `GET report as unassigned coach => 403` - ✅
 - `PUT report as unassigned coach => 403` - ✅
-- `GET unauthenticated => 401` - ✅
-- `PUT unauthenticated => 401` - ✅
-- `upsert preserves same report for same coach/student` - ✅
 - `validate field length limits (max 5000 chars)` - ✅
 
-### Tests UI
+### Tests UI (manuels)
 
 - Rendu du formulaire - ✅
 - Chargement des valeurs existantes - ✅
 - Modification d'un champ - ✅
 - Bouton enregistrer appelle l'API - ✅
-- Message de succès - ✅
+
+### Tests recommandés (à ajouter)
+
+- `GET unauthenticated => 401` - À ajouter
+- `PUT unauthenticated => 401` - À ajouter
+- Tests UI automatisés avec Playwright - À ajouter
 
 ## Migration
 

--- a/docs/features/EAF_COACH_REPORTS.md
+++ b/docs/features/EAF_COACH_REPORTS.md
@@ -1,0 +1,164 @@
+# Bilan de préparation à l'EAF - Coach
+
+## Objectif
+
+Permettre aux coachs de remplir un bilan pédagogique de préparation à l'Épreuve Anticipée de Français (EAF) pour leurs élèves assignés. Ce bilan permet de suivre la progression de l'élève sur les compétences clés de l'EAF et de documenter les points forts, points à travailler et objectifs.
+
+## Routes
+
+### API
+
+- `GET /api/coach/students/[studentId]/eaf-preparation-report` - Récupérer le bilan EAF d'un élève
+- `PUT /api/coach/students/[studentId]/eaf-preparation-report` - Créer ou mettre à jour le bilan EAF
+
+### Dashboard
+
+- `/dashboard/coach/eleve/[studentId]` - Page détail élève avec section Bilan de préparation à l'EAF (visible uniquement pour les élèves PREMIERE)
+
+## Modèle de données
+
+### EafPreparationReport
+
+```prisma
+model EafPreparationReport {
+  id        String   @id @default(cuid())
+  studentId String
+  student   Student  @relation(fields: [studentId], references: [id], onDelete: Cascade)
+
+  coachId String
+  coach   CoachProfile @relation(fields: [coachId], references: [id], onDelete: Cascade)
+
+  // EAF rubrics (text fields, max 5000 chars each)
+  linearReading        String?  @db.Text
+  workPresentation     String?  @db.Text
+  interview            String?  @db.Text
+  oralExpression       String?  @db.Text
+  writingMethod        String?  @db.Text
+  languageMastery      String?  @db.Text
+  literaryCulture      String?  @db.Text
+  strengths            String?  @db.Text
+  areasToImprove       String?  @db.Text
+  nextSessionGoals     String?  @db.Text
+  coachFreeComment     String?  @db.Text
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // One active report per coach-student pair
+  @@unique([studentId, coachId])
+  @@index([coachId])
+  @@index([studentId])
+  @@map("eaf_preparation_reports")
+}
+```
+
+## RBAC
+
+### Règles d'accès
+
+- **COACH** : Peut lire et écrire les bilans EAF uniquement pour les élèves qui lui sont assignés via `CoachStudentAssignment`
+- **ADMIN** : Peut lire et écrire tous les bilans (selon règles existantes)
+- **ASSISTANTE** : Pas d'accès automatique (selon règles existantes)
+- **ELEVE/PARENT** : Pas d'accès en écriture (selon règles existantes)
+
+### Vérification d'accès
+
+La vérification d'accès utilise le module existant `lib/rbac/coach-student-access.ts` :
+
+```typescript
+assertCoachCanAccessStudent({ coachUserId, studentId })
+```
+
+Cette fonction vérifie qu'il existe une assignation active entre le coach et l'élève via `CoachStudentAssignment`.
+
+## Rubriques du bilan EAF
+
+Les rubriques suivantes sont disponibles (champs texte, max 5000 caractères chacune) :
+
+1. **Lecture linéaire** - Capacité à lire et comprendre un texte de manière fluide
+2. **Présentation de l'œuvre** - Capacité à présenter l'œuvre, le contexte, l'auteur
+3. **Entretien** - Capacité à répondre aux questions de l'examinateur
+4. **Expression orale** - Qualité de l'expression, aisance, vocabulaire
+5. **Méthode de commentaire / dissertation** - Maîtrise de la méthode, construction du plan
+6. **Maîtrise de la langue** - Grammaire, orthographe, syntaxe, vocabulaire
+7. **Culture littéraire** - Connaissance des œuvres, des mouvements littéraires
+8. **Points forts** - Ce que l'élève maîtrise bien
+9. **Points à travailler** - Ce qui nécessite encore du travail
+10. **Objectifs pour la prochaine séance** - Objectifs prioritaires pour la suite
+11. **Commentaire libre du coach** - Remarques libres, suggestions, observations
+
+## Limitations
+
+- Un seul bilan EAF actif par couple coach / élève (contrainte unique `[studentId, coachId]`)
+- Chaque champ texte limité à 5000 caractères
+- Le bilan est visible uniquement pour les élèves de niveau PREMIERE
+- Le coach ne peut modifier que les bilans de ses propres élèves assignés
+
+## Tests réalisés
+
+### Tests API
+
+- `GET report as assigned coach => 200` - ✅
+- `PUT report as assigned coach => 200` - ✅
+- `GET report as unassigned coach => 403` - ✅
+- `PUT report as unassigned coach => 403` - ✅
+- `GET unauthenticated => 401` - ✅
+- `PUT unauthenticated => 401` - ✅
+- `upsert preserves same report for same coach/student` - ✅
+- `validate field length limits (max 5000 chars)` - ✅
+
+### Tests UI
+
+- Rendu du formulaire - ✅
+- Chargement des valeurs existantes - ✅
+- Modification d'un champ - ✅
+- Bouton enregistrer appelle l'API - ✅
+- Message de succès - ✅
+
+## Migration
+
+La migration `20260501120000_add_eaf_preparation_reports` crée :
+
+- La table `eaf_preparation_reports`
+- Les contraintes de clé étrangère vers `students` et `coach_profiles`
+- L'index unique `[studentId, coachId]`
+- Les index `coachId` et `studentId`
+
+La migration est non destructive et ne modifie pas les tables existantes.
+
+## Déploiement
+
+### Prérequis
+
+- Le compte coach doit exister et avoir le rôle COACH
+- Les élèves doivent être assignés au coach via `CoachStudentAssignment`
+
+### Procédure de déploiement
+
+1. PR validée et CI verte
+2. Backup DB selon procédure production
+3. Git pull main sur serveur
+4. Build/restart app si nécessaire
+5. Exécution des migrations via `prisma migrate deploy` ou conteneur migrate officiel
+6. Healthchecks
+7. Smoke test
+
+### Smoke test attendu
+
+1. Connexion coach
+2. Ouverture dashboard coach
+3. Ouverture d'un élève assigné de niveau PREMIERE
+4. Vérification que la section "Bilan de préparation à l'EAF" est visible
+5. Saisie de texte dans 2-3 rubriques
+6. Sauvegarde
+7. Refresh page
+8. Vérification que le texte persiste
+9. Vérification qu'un autre coach non assigné ne peut pas accéder (403)
+10. Vérification des logs
+
+## Notes importantes
+
+- Cette fonctionnalité est générique et extensible à tous les coachs, pas seulement à un email spécifique
+- Aucune logique hardcodée autour d'un email spécifique n'est implémentée
+- Le système utilise l'infrastructure existante d'assignation coach-élève (`CoachStudentAssignment`)
+- Le bilan EAF est séparé du système de bilans de stage (`StageBilan`) et des bilans canoniques (`Bilan`)

--- a/prisma/migrations/20260501120000_add_eaf_preparation_reports/migration.sql
+++ b/prisma/migrations/20260501120000_add_eaf_preparation_reports/migration.sql
@@ -1,0 +1,45 @@
+-- Migration: Add EAF Preparation Reports table
+-- Description: Generic EAF preparation reports that coaches can fill for their assigned students
+-- Separate from StageBilan (stage-specific) and Bilan (canonical assessment)
+
+-- Create the eaf_preparation_reports table
+CREATE TABLE "eaf_preparation_reports" (
+    "id" TEXT NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "coachId" TEXT NOT NULL,
+    
+    -- EAF rubrics (text fields)
+    "linearReading" TEXT,
+    "workPresentation" TEXT,
+    "interview" TEXT,
+    "oralExpression" TEXT,
+    "writingMethod" TEXT,
+    "languageMastery" TEXT,
+    "literaryCulture" TEXT,
+    "strengths" TEXT,
+    "areasToImprove" TEXT,
+    "nextSessionGoals" TEXT,
+    "coachFreeComment" TEXT,
+    
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "eaf_preparation_reports_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "eaf_preparation_reports_studentId_coachId_key" UNIQUE ("studentId", "coachId")
+);
+
+-- Add foreign key constraints
+ALTER TABLE "eaf_preparation_reports" ADD CONSTRAINT "eaf_preparation_reports_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "students"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "eaf_preparation_reports" ADD CONSTRAINT "eaf_preparation_reports_coachId_fkey" FOREIGN KEY ("coachId") REFERENCES "coach_profiles"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Add indexes
+CREATE INDEX "eaf_preparation_reports_coachId_idx" ON "eaf_preparation_reports"("coachId");
+CREATE INDEX "eaf_preparation_reports_studentId_idx" ON "eaf_preparation_reports"("studentId");
+
+-- Add relation fields to students table (for Prisma)
+-- Note: This is a logical relation, no actual column needed in the table
+-- Prisma will handle this through the schema definition
+
+-- Add relation fields to coach_profiles table (for Prisma)
+-- Note: This is a logical relation, no actual column needed in the table
+-- Prisma will handle this through the schema definition

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -280,6 +280,9 @@ model Student {
   // Coach assignments (who can access this student)
   coachAssignments CoachStudentAssignment[]
 
+  // EAF preparation reports
+  eafPreparationReports EafPreparationReport[]
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -322,6 +325,9 @@ model CoachProfile {
 
   // Coach-student assignments (source of truth for "my students")
   studentAssignments CoachStudentAssignment[]
+
+  // EAF preparation reports
+  eafPreparationReports EafPreparationReport[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1819,3 +1825,36 @@ model SurvivalAttempt {
   @@map("survival_attempts")
 }
 
+// ─── EAF Preparation Report — Coach pedagogical reports for EAF preparation ───
+// Generic EAF preparation reports that coaches can fill for their assigned students
+// Separate from StageBilan (stage-specific) and Bilan (canonical assessment)
+model EafPreparationReport {
+  id        String   @id @default(cuid())
+  studentId String
+  student   Student  @relation(fields: [studentId], references: [id], onDelete: Cascade)
+
+  coachId String
+  coach   CoachProfile @relation(fields: [coachId], references: [id], onDelete: Cascade)
+
+  // EAF rubrics (text fields, max 5000 chars each)
+  linearReading        String?  @db.Text
+  workPresentation     String?  @db.Text
+  interview            String?  @db.Text
+  oralExpression       String?  @db.Text
+  writingMethod        String?  @db.Text
+  languageMastery      String?  @db.Text
+  literaryCulture      String?  @db.Text
+  strengths            String?  @db.Text
+  areasToImprove       String?  @db.Text
+  nextSessionGoals     String?  @db.Text
+  coachFreeComment     String?  @db.Text
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // One active report per coach-student pair
+  @@unique([studentId, coachId])
+  @@index([coachId])
+  @@index([studentId])
+  @@map("eaf_preparation_reports")
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1852,7 +1852,7 @@ model EafPreparationReport {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  // One active report per coach-student pair
+  // One report per coach-student pair
   @@unique([studentId, coachId])
   @@index([coachId])
   @@index([studentId])


### PR DESCRIPTION
Ajoute un bilan de préparation à l'EAF éditable par les coachs pour leurs élèves assignés. Inclut modèle Prisma, API sécurisée, UI coach, tests RBAC et documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an editable EAF preparation report for coaches to track Première students’ progress. Adds a new data model, secure `GET`/`PUT` API with RBAC, and a coach dashboard section in the student dossier.

- **New Features**
  - Secure API endpoints: `GET`/`PUT` `/api/coach/students/[studentId]/eaf-preparation-report` with RBAC (coach must be assigned).
  - Input validation with `zod` and 5000‑char limits per field; clear 403 on unassigned coach and 404 if coach profile missing.
  - New Prisma model `EafPreparationReport` with one report per coach-student pair.
  - UI: `EafPreparationReport` editor added to `StudentDossier` (visible for `PREMIERE` students).
  - Tests: cover RBAC, upsert behavior, and validation; moved EAF test to a stable path and updated coach dashboard test mocks for `gradeLevel` and assignments.
  - Docs: `docs/features/EAF_COACH_REPORTS.md`.

- **Migration**
  - Run `prisma migrate deploy` to create `eaf_preparation_reports` with unique `[studentId, coachId]` and indexes.
  - Ensure coach-student assignments exist; unassigned coaches get 403.
  - No breaking changes to existing tables.

<sup>Written for commit 9cb00e4607e86ddb23db675d21245e0f27f8898d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

