### PR TITLE
fix(coach): render EAF report for Premiere students

### DIFF
--- a/__tests__/components/coach/StudentDossier.test.tsx
+++ b/__tests__/components/coach/StudentDossier.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from '@jest/globals';
+import { isPremiereLevel, type StudentGradeLevel } from '@/lib/coach/gradeLevel';
+
+describe('isPremiereLevel helper', () => {
+  it('returns true for PREMIERE (uppercase)', () => {
+    const student: StudentGradeLevel = {
+      gradeLevel: 'PREMIERE',
+    };
+    expect(isPremiereLevel(student)).toBe(true);
+  });
+
+  it('returns true for premiere (lowercase)', () => {
+    const student: StudentGradeLevel = {
+      gradeLevel: 'premiere',
+    };
+    expect(isPremiereLevel(student)).toBe(true);
+  });
+
+  it('returns true for Premiere (mixed case)', () => {
+    const student: StudentGradeLevel = {
+      gradeLevel: 'Premiere',
+    };
+    expect(isPremiereLevel(student)).toBe(true);
+  });
+
+  it('returns false for TERMINALE', () => {
+    const student: StudentGradeLevel = {
+      gradeLevel: 'TERMINALE',
+    };
+    expect(isPremiereLevel(student)).toBe(false);
+  });
+
+  it('returns false for SECONDE', () => {
+    const student: StudentGradeLevel = {
+      gradeLevel: 'SECONDE',
+    };
+    expect(isPremiereLevel(student)).toBe(false);
+  });
+
+  it('returns false for undefined gradeLevel', () => {
+    const student: StudentGradeLevel = {};
+    expect(isPremiereLevel(student)).toBe(false);
+  });
+
+  it('returns false for null gradeLevel', () => {
+    const student: StudentGradeLevel = {
+      gradeLevel: undefined,
+    };
+    expect(isPremiereLevel(student)).toBe(false);
+  });
+
+  it('returns false for empty string gradeLevel', () => {
+    const student: StudentGradeLevel = {
+      gradeLevel: '',
+    };
+    expect(isPremiereLevel(student)).toBe(false);
+  });
+});

--- a/components/dashboard/coach/EafPreparationReport.tsx
+++ b/components/dashboard/coach/EafPreparationReport.tsx
@@ -109,7 +109,7 @@ export function EafPreparationReport({ studentId, studentName }: EafPreparationR
   }
 
   return (
-    <Card className="bg-surface-card border-white/10 shadow-premium">
+    <Card className="bg-surface-card border-white/10 shadow-premium" data-testid="eaf-preparation-report">
       <CardHeader>
         <CardTitle className="text-white text-base flex items-center gap-2">
           <FileText className="w-4 h-4 text-brand-accent" />

--- a/components/dashboard/coach/StudentDossier.tsx
+++ b/components/dashboard/coach/StudentDossier.tsx
@@ -14,6 +14,7 @@ import { RagConsultedSources, type RagSource } from "./RagConsultedSources";
 import { BilanDiagMathsTerminaleCoach } from "./BilanDiagMathsTerminaleCoach";
 import { CoachDocumentsPanel } from "./CoachDocumentsPanel";
 import { EafPreparationReport } from "./EafPreparationReport";
+import { isPremiereLevel } from "@/lib/coach/gradeLevel";
 
 export interface DossierStudent {
   id: string;
@@ -155,7 +156,7 @@ export function StudentDossier({ data, children }: StudentDossierProps) {
             )}
 
           {/* Bilan de préparation à l'EAF — visible pour tous les élèves PREMIERE */}
-          {student.gradeLevel === 'PREMIERE' && (
+          {isPremiereLevel(student) && (
             <EafPreparationReport studentId={student.id} studentName={student.name} />
           )}
 

--- a/lib/coach/gradeLevel.ts
+++ b/lib/coach/gradeLevel.ts
@@ -1,0 +1,8 @@
+export interface StudentGradeLevel {
+  gradeLevel?: string;
+}
+
+export function isPremiereLevel(student: StudentGradeLevel): boolean {
+  const gradeLevel = student.gradeLevel?.toUpperCase() ?? '';
+  return gradeLevel === 'PREMIERE';
+}


### PR DESCRIPTION
Corrige la condition d'affichage du bilan EAF dans le dossier coach pour les élèves de Première, ajoute un sélecteur fiable pour smoke test et couvre la visibilité par test.

Changements :
- Ajoute  helper pour vérification case-insensitive du niveau
- Met à jour StudentDossier pour utiliser le helper au lieu de la comparaison directe
- Ajoute  au composant Card pour smoke test fiable
- Ajoute tests anti-régression pour le helper 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes EAF report visibility for Première students by making the grade-level check case-insensitive and adding a reliable test selector. Ensures the report renders for students labeled PREMIERE, Premiere, or premiere.

- **Bug Fixes**
  - Added isPremiereLevel helper for case-insensitive grade-level check.
  - Updated StudentDossier to use the helper for EAF report visibility.
  - Added data-testid to the EafPreparationReport card and unit tests for the helper.

<sup>Written for commit 4604957610bfc45c64d7575028b3218898699ba0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

