### PR TITLE
feat(seo): enrich bac preparation landings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ e2e/.auth/*.json
 audit-public-front-*/
 *.local-audit.html
 nexus_prod_tree_*.txt
+nexus-codex-handoff/
+files (*).zip
 
 # Build artifacts
 .next/

--- a/__tests__/marketing/seo-landings-guard.test.ts
+++ b/__tests__/marketing/seo-landings-guard.test.ts
@@ -1,0 +1,120 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { PREPARATION_LINKS } from '@/content/marketing/preparation-links';
+import { seoLandings } from '@/content/marketing/seo-landings';
+
+const root = process.cwd();
+type LandingPath = keyof typeof seoLandings;
+
+const LANDINGS: Array<{
+  path: LandingPath;
+  file: string;
+  expectedTitle: string;
+  expectedLinks: string[];
+}> = [
+  {
+    path: '/candidat-libre-bac-francais',
+    file: 'app/candidat-libre-bac-francais/page.tsx',
+    expectedTitle: 'Candidat libre au bac français en Tunisie',
+    expectedLinks: ['/reussir-eaf', '/grand-oral', '/preparation-bac-francais-tunis'],
+  },
+  {
+    path: '/preparation-bac-francais-tunis',
+    file: 'app/preparation-bac-francais-tunis/page.tsx',
+    expectedTitle: 'Préparer le bac français à Tunis',
+    expectedLinks: ['/candidat-libre-bac-francais', '/reussir-eaf', '/grand-oral'],
+  },
+  {
+    path: '/reussir-eaf',
+    file: 'app/reussir-eaf/page.tsx',
+    expectedTitle: 'Réussir l’EAF : épreuves anticipées de français',
+    expectedLinks: ['/candidat-libre-bac-francais', '/grand-oral', '/preparation-bac-francais-tunis'],
+  },
+  {
+    path: '/grand-oral',
+    file: 'app/grand-oral/page.tsx',
+    expectedTitle: 'Préparer le Grand Oral du bac',
+    expectedLinks: ['/candidat-libre-bac-francais', '/reussir-eaf', '/preparation-bac-francais-tunis'],
+  },
+];
+
+function sourceFor(file: string): string {
+  return readFileSync(join(root, file), 'utf8');
+}
+
+type LandingContent = (typeof seoLandings)[keyof typeof seoLandings];
+
+function landingText(landing: LandingContent): string {
+  return [
+    landing.title,
+    landing.intro,
+    landing.jsonLdName,
+    landing.metadata.title,
+    landing.metadata.description,
+    ...landing.sections.flatMap((section) => [
+      section.heading,
+      ...(section.body ?? []),
+      ...(section.bullets ?? []),
+    ]),
+    ...landing.relatedLinks.flatMap((link) => [link.href, link.label, link.description ?? '']),
+    ...landing.faq.flatMap((item) => [item.question, item.answer]),
+  ].join(' ');
+}
+
+function visibleWordCount(text: string): number {
+  const cleaned = text
+    .replace(/[{}[\]()<>=:;.,'"`?/\\|_*#@+-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return cleaned.split(' ').filter((word) => /[A-Za-zÀ-ÿ0-9]/.test(word)).length;
+}
+
+describe('SEO landings T1.1 guard', () => {
+  test.each(LANDINGS)('$path has canonical metadata and one declared H1 title', ({ path, file, expectedTitle }) => {
+    const source = sourceFor(file);
+    const landing = seoLandings[path];
+
+    expect(source).toContain(`seoLandings['${path}']`);
+    expect(source.match(/title=\{landing\.title\}/g)?.length ?? 0).toBe(1);
+    expect(landing.title).toBe(expectedTitle);
+    expect(landing.metadata.alternates?.canonical).toBe(`https://nexusreussite.academy${path}`);
+  });
+
+  test.each(LANDINGS)('$path has long-form SSR content and a bilan CTA', ({ path }) => {
+    const landing = seoLandings[path];
+
+    expect(visibleWordCount(landingText(landing))).toBeGreaterThanOrEqual(600);
+    expect(landing.primaryCtaHref).toBe('/bilan-gratuit');
+  });
+
+  test.each(LANDINGS)('$path links to the preparation cluster', ({ path, expectedLinks }) => {
+    const landing = seoLandings[path];
+    const source = landingText(landing);
+
+    for (const link of expectedLinks) {
+      expect(source).toContain(link);
+    }
+  });
+
+  test('shared renderer exposes FAQPage JSON-LD and preparation related links', () => {
+    const source = sourceFor('components/marketing/LandingNiche.tsx');
+
+    expect(source).toContain('FAQPage');
+    expect(source).toContain('relatedLinks');
+    expect(source).toContain('sections');
+  });
+
+  test('navigation and footer expose the preparation cluster', () => {
+    const navbar = sourceFor('components/layout/CorporateNavbar.tsx');
+    const footer = sourceFor('components/layout/CorporateFooter.tsx');
+
+    expect(navbar).toContain('Préparations');
+    expect(footer).toContain('Préparations');
+    expect(navbar).toContain('PREPARATION_LINKS.map');
+    expect(footer).toContain('PREPARATION_LINKS.map');
+    for (const link of PREPARATION_LINKS) {
+      expect(link.href).toMatch(/^\/(preparation-bac-francais-tunis|candidat-libre-bac-francais|reussir-eaf|grand-oral)$/);
+    }
+  });
+});

--- a/__tests__/marketing/seo-landings-guard.test.ts
+++ b/__tests__/marketing/seo-landings-guard.test.ts
@@ -10,7 +10,7 @@ import CandidatLibreBacFrancaisPage from '@/app/candidat-libre-bac-francais/page
 import GrandOralPage from '@/app/grand-oral/page';
 import PreparationBacFrancaisTunisPage from '@/app/preparation-bac-francais-tunis/page';
 import ReussirEafPage from '@/app/reussir-eaf/page';
-import { getAnnualOffer, getPack, getPonctuelOffer } from '@/lib/pricing';
+import { getAllOffers, getAnnualOffer, getPack, getPacks, getPonctuelOffer } from '@/lib/pricing';
 
 const usePathnameMock = jest.fn();
 
@@ -186,12 +186,22 @@ describe('SEO landings T1.1 guard', () => {
     }
   });
 
-  test('landing service claims are present in the canonical catalog', () => {
-    const pricingSource = sourceFor('data/pricing.canonical.json');
+  test('landing service claims map to canonical included entries or pack services', () => {
+    const annualIncluded = getAllOffers().flatMap((offer) => offer.included);
+    const packServices = getPacks().flatMap((pack) =>
+      pack.components
+        .filter((component) => component.type === 'service')
+        .map((component) => component.label ?? ''),
+    );
+    const candidatLibreText = landingText(seoLandings['/candidat-libre-bac-francais']);
+    const hubText = landingText(seoLandings['/preparation-bac-francais-tunis']);
 
-    expect(pricingSource).toContain('Cellule Cyclades');
-    expect(pricingSource).toContain('Plateforme ARIA');
-    expect(pricingSource).toContain('Bacs blancs');
+    expect(candidatLibreText).toContain('Cyclades');
+    expect(candidatLibreText).toContain('épreuves blanches selon la formule');
+    expect(hubText).toContain('ARIA complète le travail humain');
+    expect(packServices).toContain('Cellule Cyclades');
+    expect(annualIncluded.some((item) => item.includes('Plateforme ARIA'))).toBe(true);
+    expect(annualIncluded.some((item) => item.includes('Bacs blancs'))).toBe(true);
   });
 
   test.each(LANDINGS)('$path renders sections, related links, offer cards and FAQ from page props', ({ Page, path }) => {

--- a/__tests__/marketing/seo-landings-guard.test.ts
+++ b/__tests__/marketing/seo-landings-guard.test.ts
@@ -1,7 +1,22 @@
-import { existsSync, readFileSync } from 'fs';
+import { readFileSync } from 'fs';
 import { join } from 'path';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { CorporateFooter } from '@/components/layout/CorporateFooter';
+import { CorporateNavbar } from '@/components/layout/CorporateNavbar';
 import { PREPARATION_LINKS } from '@/content/marketing/preparation-links';
 import { seoLandings } from '@/content/marketing/seo-landings';
+import CandidatLibreBacFrancaisPage from '@/app/candidat-libre-bac-francais/page';
+import GrandOralPage from '@/app/grand-oral/page';
+import PreparationBacFrancaisTunisPage from '@/app/preparation-bac-francais-tunis/page';
+import ReussirEafPage from '@/app/reussir-eaf/page';
+import { getAnnualOffer, getPack, getPonctuelOffer } from '@/lib/pricing';
+
+const usePathnameMock = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => usePathnameMock(),
+}));
 
 const root = process.cwd();
 type LandingPath = keyof typeof seoLandings;
@@ -11,30 +26,35 @@ const LANDINGS: Array<{
   file: string;
   expectedTitle: string;
   expectedLinks: string[];
+  Page: () => JSX.Element;
 }> = [
   {
     path: '/candidat-libre-bac-francais',
     file: 'app/candidat-libre-bac-francais/page.tsx',
     expectedTitle: 'Candidat libre au bac français en Tunisie',
     expectedLinks: ['/reussir-eaf', '/grand-oral', '/preparation-bac-francais-tunis'],
+    Page: CandidatLibreBacFrancaisPage,
   },
   {
     path: '/preparation-bac-francais-tunis',
     file: 'app/preparation-bac-francais-tunis/page.tsx',
     expectedTitle: 'Préparer le bac français à Tunis',
     expectedLinks: ['/candidat-libre-bac-francais', '/reussir-eaf', '/grand-oral'],
+    Page: PreparationBacFrancaisTunisPage,
   },
   {
     path: '/reussir-eaf',
     file: 'app/reussir-eaf/page.tsx',
     expectedTitle: 'Réussir l’EAF : épreuves anticipées de français',
     expectedLinks: ['/candidat-libre-bac-francais', '/grand-oral', '/preparation-bac-francais-tunis'],
+    Page: ReussirEafPage,
   },
   {
     path: '/grand-oral',
     file: 'app/grand-oral/page.tsx',
     expectedTitle: 'Préparer le Grand Oral du bac',
     expectedLinks: ['/candidat-libre-bac-francais', '/reussir-eaf', '/preparation-bac-francais-tunis'],
+    Page: GrandOralPage,
   },
 ];
 
@@ -70,7 +90,21 @@ function visibleWordCount(text: string): number {
   return cleaned.split(' ').filter((word) => /[A-Za-zÀ-ÿ0-9]/.test(word)).length;
 }
 
+function hrefs(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('a[href]')).map((link) => link.getAttribute('href') ?? '');
+}
+
+function resolvesOfferRef(ref: LandingContent['offerRefs'][number]): boolean {
+  if (ref.type === 'annual') return Boolean(getAnnualOffer(ref.id));
+  if (ref.type === 'ponctuel') return Boolean(getPonctuelOffer(ref.id));
+  return Boolean(getPack(ref.id));
+}
+
 describe('SEO landings T1.1 guard', () => {
+  beforeEach(() => {
+    usePathnameMock.mockReturnValue('/');
+  });
+
   test.each(LANDINGS)('$path has canonical metadata and one declared H1 title', ({ path, file, expectedTitle }) => {
     const source = sourceFor(file);
     const landing = seoLandings[path];
@@ -78,7 +112,54 @@ describe('SEO landings T1.1 guard', () => {
     expect(source).toContain(`seoLandings['${path}']`);
     expect(source.match(/title=\{landing\.title\}/g)?.length ?? 0).toBe(1);
     expect(landing.title).toBe(expectedTitle);
-    expect(landing.metadata.alternates?.canonical).toBe(`https://nexusreussite.academy${path}`);
+    expect(landing.metadata.alternates?.canonical).toBe(path);
+    expect(landing.metadata.openGraph?.url).toBe(path);
+  });
+
+  test('root layout defines metadataBase for relative canonical resolution', () => {
+    const source = sourceFor('app/layout.tsx');
+
+    expect(source).toContain('metadataBase');
+    expect(source).toContain('process.env.NEXTAUTH_URL');
+  });
+
+  test('marketing content and SEO guard do not duplicate the public domain literal', () => {
+    const forbiddenDomain = ['nexusreussite', 'academy'].join('.');
+    const checkedFiles = [
+      'content/marketing/preparation-links.ts',
+      'content/marketing/seo-landings.ts',
+      '__tests__/marketing/seo-landings-guard.test.ts',
+    ];
+
+    for (const file of checkedFiles) {
+      expect(sourceFor(file)).not.toContain(forbiddenDomain);
+    }
+  });
+
+  test('marketing content reuses the legal address source instead of hardcoding Mutuelleville', () => {
+    const source = sourceFor('content/marketing/seo-landings.ts');
+
+    expect(source).toContain('LEGAL.addresses.pedagogique');
+    expect(source).not.toContain('Mutuelleville');
+  });
+
+  test('LandingNiche is the single source for landing renderer types', () => {
+    const files = [
+      'components/marketing/LandingNiche.tsx',
+      'content/marketing/seo-landings.ts',
+    ];
+    const combined = files.map((file) => sourceFor(file)).join('\n');
+    const contentSource = sourceFor('content/marketing/seo-landings.ts');
+    const rendererSource = sourceFor('components/marketing/LandingNiche.tsx');
+
+    for (const typeName of ['OfferRef', 'NicheSection', 'RelatedLink']) {
+      const declarations = combined.match(new RegExp(`type ${typeName}\\b`, 'g')) ?? [];
+      expect(declarations).toHaveLength(1);
+      expect(rendererSource).toContain(`export type ${typeName}`);
+      expect(contentSource).toContain(typeName);
+    }
+
+    expect(contentSource).toContain("from '@/components/marketing/LandingNiche'");
   });
 
   test.each(LANDINGS)('$path has long-form SSR content and a bilan CTA', ({ path }) => {
@@ -97,6 +178,33 @@ describe('SEO landings T1.1 guard', () => {
     }
   });
 
+  test.each(LANDINGS)('$path offerRefs resolve against the canonical pricing catalog', ({ path }) => {
+    const landing = seoLandings[path];
+
+    for (const ref of landing.offerRefs) {
+      expect({ path, ref, resolves: resolvesOfferRef(ref) }).toMatchObject({ resolves: true });
+    }
+  });
+
+  test('landing service claims are present in the canonical catalog', () => {
+    const pricingSource = sourceFor('data/pricing.canonical.json');
+
+    expect(pricingSource).toContain('Cellule Cyclades');
+    expect(pricingSource).toContain('Plateforme ARIA');
+    expect(pricingSource).toContain('Bacs blancs');
+  });
+
+  test.each(LANDINGS)('$path renders sections, related links, offer cards and FAQ from page props', ({ Page, path }) => {
+    const landing = seoLandings[path];
+    const { container } = render(React.createElement(Page));
+
+    expect(screen.getByRole('heading', { level: 1, name: landing.title })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: landing.sections[0].heading })).toBeInTheDocument();
+    expect(hrefs(container)).toContain(landing.relatedLinks[0].href);
+    expect(screen.getByRole('heading', { name: landing.faq[0].question })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /parcours recommandés/i })).toBeInTheDocument();
+  });
+
   test('shared renderer exposes FAQPage JSON-LD and preparation related links', () => {
     const source = sourceFor('components/marketing/LandingNiche.tsx');
 
@@ -105,16 +213,21 @@ describe('SEO landings T1.1 guard', () => {
     expect(source).toContain('sections');
   });
 
-  test('navigation and footer expose the preparation cluster', () => {
-    const navbar = sourceFor('components/layout/CorporateNavbar.tsx');
-    const footer = sourceFor('components/layout/CorporateFooter.tsx');
+  test('navigation exposes the preparation cluster in rendered links', () => {
+    const { container } = render(React.createElement(CorporateNavbar));
 
-    expect(navbar).toContain('Préparations');
-    expect(footer).toContain('Préparations');
-    expect(navbar).toContain('PREPARATION_LINKS.map');
-    expect(footer).toContain('PREPARATION_LINKS.map');
+    expect(screen.getAllByText('Préparations').length).toBeGreaterThan(0);
     for (const link of PREPARATION_LINKS) {
-      expect(link.href).toMatch(/^\/(preparation-bac-francais-tunis|candidat-libre-bac-francais|reussir-eaf|grand-oral)$/);
+      expect(hrefs(container)).toContain(link.href);
+    }
+  });
+
+  test('footer exposes the preparation cluster in rendered links', () => {
+    const { container } = render(React.createElement(CorporateFooter));
+
+    expect(screen.getByRole('heading', { name: 'Préparations' })).toBeInTheDocument();
+    for (const link of PREPARATION_LINKS) {
+      expect(hrefs(container)).toContain(link.href);
     }
   });
 });

--- a/app/candidat-libre-bac-francais/page.tsx
+++ b/app/candidat-libre-bac-francais/page.tsx
@@ -1,37 +1,21 @@
 import type { Metadata } from 'next';
 import { LandingNiche } from '@/components/marketing/LandingNiche';
+import { seoLandings } from '@/content/marketing/seo-landings';
 
-export const metadata: Metadata = {
-  title: 'Candidat libre au bac français en Tunisie | Nexus Réussite',
-  description: 'Parcours candidat libre : cadre annuel, cellule Cyclades, épreuves blanches et suivi régulier.',
-  openGraph: {
-    title: 'Candidat libre au bac français en Tunisie | Nexus Réussite',
-    description: 'Un cadre structuré pour préparer le bac français en candidat libre.',
-    type: 'website',
-  },
-};
+const landing = seoLandings['/candidat-libre-bac-francais'];
+
+export const metadata: Metadata = landing.metadata;
 
 export default function CandidatLibreBacFrancaisPage() {
   return (
     <LandingNiche
-      title="Candidat libre au bac français en Tunisie"
-      intro="Préparer le bac français en candidat libre, c'est possible avec un vrai cadre : parcours dédiés (Essentiel, Mixte, Premium), cellule Cyclades pour l'administratif, épreuves blanches et suivi régulier. Vous n'êtes plus seul·e face à l'examen."
-      jsonLdName="Candidat libre bac français en Tunisie"
-      offerRefs={[
-        { type: 'annual', id: '1re-libre-accomp' },
-        { type: 'annual', id: 'term-libre-mixte' },
-        { type: 'pack', id: 'pass-candidat-libre' },
-      ]}
-      faq={[
-        {
-          question: 'Nexus aide-t-il pour Cyclades ?',
-          answer: 'Oui, les parcours candidats libres peuvent intégrer une cellule Cyclades pour sécuriser les étapes administratives.',
-        },
-        {
-          question: 'Peut-on suivre à distance ?',
-          answer: 'Certaines formules sont en ligne ou mixtes. Le bilan permet de confirmer le format le plus adapté.',
-        },
-      ]}
+      title={landing.title}
+      intro={landing.intro}
+      jsonLdName={landing.jsonLdName}
+      sections={landing.sections}
+      relatedLinks={landing.relatedLinks}
+      offerRefs={landing.offerRefs}
+      faq={landing.faq}
     />
   );
 }

--- a/app/grand-oral/page.tsx
+++ b/app/grand-oral/page.tsx
@@ -1,37 +1,21 @@
 import type { Metadata } from 'next';
 import { LandingNiche } from '@/components/marketing/LandingNiche';
+import { seoLandings } from '@/content/marketing/seo-landings';
 
-export const metadata: Metadata = {
-  title: 'Préparer le Grand Oral | Nexus Réussite',
-  description: 'Méthode, construction du propos et simulations pour préparer le Grand Oral du bac français.',
-  openGraph: {
-    title: 'Préparer le Grand Oral | Nexus Réussite',
-    description: 'Studio Grand Oral : posture, structure et entraînement.',
-    type: 'website',
-  },
-};
+const landing = seoLandings['/grand-oral'];
+
+export const metadata: Metadata = landing.metadata;
 
 export default function GrandOralPage() {
   return (
     <LandingNiche
-      title="Préparer le Grand Oral"
-      intro="Le Grand Oral (coef. 10) se joue sur la posture, la structuration et l'entraînement. Le Studio Grand Oral combine méthode, construction du propos et simulations filmées pour aborder l'épreuve avec assurance."
-      jsonLdName="Préparation Grand Oral"
-      offerRefs={[
-        { type: 'ponctuel', id: 'studio-grand-oral' },
-        { type: 'annual', id: 'term-duo' },
-        { type: 'pack', id: 'pass-go-sprint' },
-      ]}
-      faq={[
-        {
-          question: 'Que travaille-t-on pour le Grand Oral ?',
-          answer: 'La problématique, la structure, la posture, la clarté du propos et l’entraînement en conditions.',
-        },
-        {
-          question: 'Le Studio Grand Oral peut-il compléter un parcours annuel ?',
-          answer: 'Oui. Il peut être intégré comme module ponctuel ou dans un pass selon le besoin de l’élève.',
-        },
-      ]}
+      title={landing.title}
+      intro={landing.intro}
+      jsonLdName={landing.jsonLdName}
+      sections={landing.sections}
+      relatedLinks={landing.relatedLinks}
+      offerRefs={landing.offerRefs}
+      faq={landing.faq}
     />
   );
 }

--- a/app/preparation-bac-francais-tunis/page.tsx
+++ b/app/preparation-bac-francais-tunis/page.tsx
@@ -1,37 +1,21 @@
 import type { Metadata } from 'next';
 import { LandingNiche } from '@/components/marketing/LandingNiche';
+import { seoLandings } from '@/content/marketing/seo-landings';
 
-export const metadata: Metadata = {
-  title: 'Préparer le bac français à Tunis | Nexus Réussite',
-  description: 'Accompagnement bac français à Tunis : groupes de 5 maximum, bacs blancs, ARIA et suivi parent.',
-  openGraph: {
-    title: 'Préparer le bac français à Tunis | Nexus Réussite',
-    description: 'Un cadre structurant pour élèves du système français à Tunis et candidats libres.',
-    type: 'website',
-  },
-};
+const landing = seoLandings['/preparation-bac-francais-tunis'];
+
+export const metadata: Metadata = landing.metadata;
 
 export default function PreparationBacFrancaisTunisPage() {
   return (
     <LandingNiche
-      title="Préparer le bac français à Tunis"
-      intro="Nexus Réussite accompagne les élèves du système français à Tunis vers le baccalauréat : enseignants agrégés et certifiés, groupes de 5 maximum, bacs blancs sur grilles officielles et plateforme ARIA. Un cadre structurant, pour les élèves scolarisés comme pour les candidats libres."
-      jsonLdName="Préparation bac français à Tunis"
-      offerRefs={[
-        { type: 'annual', id: 'term-duo' },
-        { type: 'annual', id: '1re-double-secu' },
-        { type: 'pack', id: 'pass-candidat-libre' },
-      ]}
-      faq={[
-        {
-          question: 'Le parcours convient-il aux élèves scolarisés et aux candidats libres ?',
-          answer: 'Oui. Le bilan permet d’orienter vers un parcours annuel, un stage, un pass ou un accompagnement candidat libre.',
-        },
-        {
-          question: 'Les cours ont-ils lieu en présentiel ?',
-          answer: 'Les cours en présentiel et rendez-vous pédagogiques se déroulent à Mutuelleville, sur confirmation.',
-        },
-      ]}
+      title={landing.title}
+      intro={landing.intro}
+      jsonLdName={landing.jsonLdName}
+      sections={landing.sections}
+      relatedLinks={landing.relatedLinks}
+      offerRefs={landing.offerRefs}
+      faq={landing.faq}
     />
   );
 }

--- a/app/reussir-eaf/page.tsx
+++ b/app/reussir-eaf/page.tsx
@@ -1,37 +1,21 @@
 import type { Metadata } from 'next';
 import { LandingNiche } from '@/components/marketing/LandingNiche';
+import { seoLandings } from '@/content/marketing/seo-landings';
 
-export const metadata: Metadata = {
-  title: "Réussir l'EAF | Nexus Réussite",
-  description: "Préparation aux épreuves anticipées de français : écrit, oral, textes, méthode et grilles officielles.",
-  openGraph: {
-    title: "Réussir l'EAF | Nexus Réussite",
-    description: 'Cap EAF accompagne les élèves de première avec méthode et entraînement.',
-    type: 'website',
-  },
-};
+const landing = seoLandings['/reussir-eaf'];
+
+export const metadata: Metadata = landing.metadata;
 
 export default function ReussirEafPage() {
   return (
     <LandingNiche
-      title="Réussir l'EAF : épreuves anticipées de français"
-      intro="L'épreuve anticipée de français (écrit et oral, en première) se prépare tôt et avec méthode. Avec Cap EAF, nos enseignants travaillent les textes, la méthode du commentaire et de la dissertation, et l'oral, en conditions d'examen et sur grilles officielles."
-      jsonLdName="Réussir l'EAF"
-      offerRefs={[
-        { type: 'ponctuel', id: 'cap-eaf' },
-        { type: 'annual', id: '1re-eaf' },
-        { type: 'pack', id: 'pass-cap-bac-1re' },
-      ]}
-      faq={[
-        {
-          question: 'Quand commencer la préparation EAF ?',
-          answer: 'Le plus tôt possible en première, afin de travailler les textes, la méthode écrite et l’oral dans la durée.',
-        },
-        {
-          question: 'La préparation inclut-elle des entraînements en conditions ?',
-          answer: 'Oui, selon la formule : entraînements, corrections et épreuves blanches sur grilles officielles.',
-        },
-      ]}
+      title={landing.title}
+      intro={landing.intro}
+      jsonLdName={landing.jsonLdName}
+      sections={landing.sections}
+      relatedLinks={landing.relatedLinks}
+      offerRefs={landing.offerRefs}
+      faq={landing.faq}
     />
   );
 }

--- a/components/layout/CorporateFooter.tsx
+++ b/components/layout/CorporateFooter.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import { Mail, Phone, MapPin, ArrowRight } from 'lucide-react';
 import { FloatingAdvisorBubble, NewsletterSignup } from '@/components/marketing/acadomia-inspired';
 import { MobileStickyBar } from '@/components/marketing/MobileStickyBar';
+import { PREPARATION_LINKS } from '@/content/marketing/preparation-links';
 import { LEGAL } from '@/lib/legal';
 
 const CorporateFooter = () => {
@@ -32,7 +33,7 @@ const CorporateFooter = () => {
     return (
         <footer className="relative bg-surface-darker pt-24 pb-28 overflow-hidden z-20 border-t border-white/10 lg:pb-8">
             <div className="max-w-7xl mx-auto px-6">
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 mb-16">
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-12 mb-16">
 
                     {/* Brand */}
                     <div className="lg:col-span-1">
@@ -75,6 +76,24 @@ const CorporateFooter = () => {
                                             <ArrowRight className="w-3 h-3 opacity-0 hover:opacity-100" />
                                         </button>
                                     )}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    {/* Contact */}
+                    <div>
+                        <h2 className="font-fraunces text-lg font-medium text-lux-ivory mb-6">Préparations</h2>
+                        <ul className="space-y-4">
+                            {PREPARATION_LINKS.map((item) => (
+                                <li key={item.href}>
+                                    <Link
+                                        href={item.href}
+                                        className="inline-flex items-center gap-2 text-neutral-300 text-sm hover:text-lux-gold-wash hover:gap-3 transition-all duration-300"
+                                    >
+                                        <span>{item.label}</span>
+                                        <ArrowRight className="w-3 h-3 opacity-0 hover:opacity-100" />
+                                    </Link>
                                 </li>
                             ))}
                         </ul>

--- a/components/layout/CorporateFooter.tsx
+++ b/components/layout/CorporateFooter.tsx
@@ -62,18 +62,18 @@ const CorporateFooter = () => {
                                     {item.isPage ? (
                                         <Link
                                             href={item.href}
-                                            className="inline-flex items-center gap-2 text-neutral-300 text-sm hover:text-lux-gold-wash hover:gap-3 transition-all duration-300"
+                                            className="group inline-flex items-center gap-2 text-neutral-300 text-sm hover:text-lux-gold-wash hover:gap-3 transition-all duration-300"
                                         >
                                             <span>{item.label}</span>
-                                            <ArrowRight className="w-3 h-3 opacity-0 hover:opacity-100" />
+                                            <ArrowRight className="w-3 h-3 opacity-0 transition-opacity group-hover:opacity-100" />
                                         </Link>
                                     ) : (
                                         <button
                                             onClick={() => scrollToSection(item.href)}
-                                            className="inline-flex items-center gap-2 text-neutral-300 text-sm hover:text-lux-gold-wash hover:gap-3 transition-all duration-300"
+                                            className="group inline-flex items-center gap-2 text-neutral-300 text-sm hover:text-lux-gold-wash hover:gap-3 transition-all duration-300"
                                         >
                                             <span>{item.label}</span>
-                                            <ArrowRight className="w-3 h-3 opacity-0 hover:opacity-100" />
+                                            <ArrowRight className="w-3 h-3 opacity-0 transition-opacity group-hover:opacity-100" />
                                         </button>
                                     )}
                                 </li>
@@ -89,10 +89,10 @@ const CorporateFooter = () => {
                                 <li key={item.href}>
                                     <Link
                                         href={item.href}
-                                        className="inline-flex items-center gap-2 text-neutral-300 text-sm hover:text-lux-gold-wash hover:gap-3 transition-all duration-300"
+                                        className="group inline-flex items-center gap-2 text-neutral-300 text-sm hover:text-lux-gold-wash hover:gap-3 transition-all duration-300"
                                     >
                                         <span>{item.label}</span>
-                                        <ArrowRight className="w-3 h-3 opacity-0 hover:opacity-100" />
+                                        <ArrowRight className="w-3 h-3 opacity-0 transition-opacity group-hover:opacity-100" />
                                     </Link>
                                 </li>
                             ))}

--- a/components/layout/CorporateNavbar.tsx
+++ b/components/layout/CorporateNavbar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { Menu, X, Phone, ChevronDown, LogIn, UserPlus } from "lucide-react";
 import { usePathname } from "next/navigation";
+import { PREPARATION_LINKS } from '@/content/marketing/preparation-links';
 import { LEGAL } from '@/lib/legal';
 
 export function CorporateNavbar() {
@@ -181,6 +182,15 @@ export function CorporateNavbar() {
         { label: 'Plateforme ARIA', href: '/plateforme-aria', desc: 'Ressources & parcours en ligne', isPage: true },
         { label: 'Accompagnement scolaire', href: '/accompagnement-scolaire', desc: 'Suivi personnalisé', isPage: true },
       ]
+    },
+    {
+      title: 'Préparations',
+      items: PREPARATION_LINKS.map((item) => ({
+        label: item.label,
+        href: item.href,
+        desc: item.description,
+        isPage: true,
+      })),
     },
     {
       title: 'Contact',
@@ -428,7 +438,7 @@ export function CorporateNavbar() {
             <div className="flex items-center justify-center flex-1">
               {(isOpen || !reducedMotion) && (
                 <nav className="w-full max-w-5xl px-6 md:px-10" aria-label="Menu principal">
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-10">
+                      <div className="grid grid-cols-1 md:grid-cols-4 gap-10">
                     {menuGroups.map((group, groupIndex) => (
                       <div key={group.title} className="space-y-6">
                         <div className="text-xs uppercase tracking-[0.24em] text-lux-gold-wash font-mono">

--- a/components/marketing/LandingNiche.tsx
+++ b/components/marketing/LandingNiche.tsx
@@ -31,6 +31,8 @@ export type LandingNicheProps = {
   offerRefs: OfferRef[];
   faq: { question: string; answer: string }[];
   jsonLdName: string;
+  sections?: { heading: string; body?: string[]; bullets?: string[] }[];
+  relatedLinks?: { href: string; label: string; description?: string }[];
 };
 
 function resolveOffer(ref: OfferRef): ResolvedOffer | null {
@@ -66,7 +68,15 @@ function resolveOffer(ref: OfferRef): ResolvedOffer | null {
   };
 }
 
-export function LandingNiche({ title, intro, offerRefs, faq, jsonLdName }: LandingNicheProps) {
+export function LandingNiche({
+  title,
+  intro,
+  offerRefs,
+  faq,
+  jsonLdName,
+  sections = [],
+  relatedLinks = [],
+}: LandingNicheProps) {
   const offers = offerRefs.map(resolveOffer).filter((offer): offer is ResolvedOffer => Boolean(offer));
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -90,10 +100,25 @@ export function LandingNiche({ title, intro, offerRefs, faq, jsonLdName }: Landi
       url: `https://nexusreussite.academy/offres#${offer.id}`,
     })),
   };
+  const faqJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faq.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer,
+      },
+    })),
+  };
 
   return (
     <main className="luxury min-h-screen bg-lux-paper" id="main-content">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      {faq.length > 0 ? (
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
+      ) : null}
       <CorporateNavbar />
 
       <section className="bg-lux-ink px-4 pb-16 pt-32 md:px-6">
@@ -123,6 +148,35 @@ export function LandingNiche({ title, intro, offerRefs, faq, jsonLdName }: Landi
         </div>
       </section>
 
+      {sections.length > 0 ? (
+        <section className="px-4 py-14 md:px-6">
+          <div className="mx-auto max-w-4xl space-y-10">
+            {sections.map((section) => (
+              <article key={section.heading}>
+                <p className="lux-eyebrow">Repère</p>
+                <h2 className="mt-2 text-2xl font-fraunces text-lux-ink md:text-3xl">{section.heading}</h2>
+                <div className="lux-filet-gold mt-3 w-16" />
+                {section.body?.map((paragraph) => (
+                  <p key={paragraph} className="mt-4 text-base leading-8 text-lux-slate">
+                    {paragraph}
+                  </p>
+                ))}
+                {section.bullets ? (
+                  <ul className="mt-4 space-y-3">
+                    {section.bullets.map((bullet) => (
+                      <li key={bullet} className="flex items-start gap-3 text-base leading-7 text-lux-slate">
+                        <CheckCircle2 className="mt-1 h-4 w-4 flex-none text-lux-evergreen" aria-hidden="true" />
+                        <span>{bullet}</span>
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+              </article>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
       <section className="px-4 py-14 md:px-6">
         <div className="mx-auto max-w-6xl">
           <div className="mb-8">
@@ -151,6 +205,37 @@ export function LandingNiche({ title, intro, offerRefs, faq, jsonLdName }: Landi
       </section>
 
       <ProcessSteps />
+
+      {relatedLinks.length > 0 ? (
+        <section className="px-4 py-14 md:px-6">
+          <div className="mx-auto max-w-6xl">
+            <div className="mb-8">
+              <p className="lux-eyebrow">Aller plus loin</p>
+              <h2 className="mt-2 text-2xl font-fraunces text-lux-ink md:text-3xl">Préparations dédiées</h2>
+            </div>
+            <div className="grid gap-4 md:grid-cols-3">
+              {relatedLinks.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="group rounded-2xl border border-lux-line bg-lux-white p-5 lux-shadow"
+                >
+                  <h3 className="flex items-center justify-between gap-4 font-fraunces text-xl text-lux-ink">
+                    {link.label}
+                    <ArrowRight
+                      className="h-4 w-4 flex-none text-lux-slate transition-transform group-hover:translate-x-1"
+                      aria-hidden="true"
+                    />
+                  </h3>
+                  {link.description ? (
+                    <p className="mt-3 text-sm leading-6 text-lux-slate">{link.description}</p>
+                  ) : null}
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      ) : null}
 
       <section className="px-4 py-14 md:px-6">
         <div className="mx-auto max-w-4xl rounded-2xl border border-lux-line bg-lux-white p-6 lux-shadow md:p-8">

--- a/components/marketing/LandingNiche.tsx
+++ b/components/marketing/LandingNiche.tsx
@@ -4,6 +4,8 @@ import { CorporateNavbar } from '@/components/layout/CorporateNavbar';
 import { CorporateFooter } from '@/components/layout/CorporateFooter';
 import { fmtTND } from '@/components/premium/format';
 import { ProcessSteps, ReassuranceChips } from '@/components/marketing/acadomia-inspired';
+import type { PreparationLink } from '@/content/marketing/preparation-links';
+import { LEGAL } from '@/lib/legal';
 import {
   getAnnualOffer,
   getPack,
@@ -13,9 +15,21 @@ import {
   type PonctuelOffer,
 } from '@/lib/pricing';
 
-type OfferRef = {
+export type OfferRef = {
   type: 'annual' | 'ponctuel' | 'pack';
   id: string;
+};
+
+export type NicheSection = {
+  heading: string;
+  body?: string[];
+  bullets?: string[];
+};
+
+export type RelatedLink = {
+  href: PreparationLink['href'];
+  label: string;
+  description?: string;
 };
 
 type ResolvedOffer = {
@@ -31,8 +45,8 @@ export type LandingNicheProps = {
   offerRefs: OfferRef[];
   faq: { question: string; answer: string }[];
   jsonLdName: string;
-  sections?: { heading: string; body?: string[]; bullets?: string[] }[];
-  relatedLinks?: { href: string; label: string; description?: string }[];
+  sections?: NicheSection[];
+  relatedLinks?: RelatedLink[];
 };
 
 function resolveOffer(ref: OfferRef): ResolvedOffer | null {
@@ -85,7 +99,7 @@ export function LandingNiche({
     provider: {
       '@type': 'EducationalOrganization',
       name: 'Nexus Réussite',
-      url: 'https://nexusreussite.academy',
+      url: LEGAL.web.url,
       address: {
         '@type': 'PostalAddress',
         addressLocality: 'Tunis',
@@ -97,7 +111,7 @@ export function LandingNiche({
       name: offer.title,
       price: offer.price ?? undefined,
       priceCurrency: 'TND',
-      url: `https://nexusreussite.academy/offres#${offer.id}`,
+      url: `${LEGAL.web.url}/offres#${offer.id}`,
     })),
   };
   const faqJsonLd = {

--- a/content/marketing/preparation-links.ts
+++ b/content/marketing/preparation-links.ts
@@ -1,0 +1,28 @@
+export type PreparationLink = {
+  href: '/preparation-bac-francais-tunis' | '/candidat-libre-bac-francais' | '/reussir-eaf' | '/grand-oral';
+  label: string;
+  description: string;
+};
+
+export const PREPARATION_LINKS: PreparationLink[] = [
+  {
+    href: '/preparation-bac-francais-tunis',
+    label: 'Préparation bac français',
+    description: 'Hub pour élèves scolarisés, candidats libres, EAF, spécialités et Grand Oral.',
+  },
+  {
+    href: '/candidat-libre-bac-francais',
+    label: 'Candidat libre',
+    description: 'Modalités A/B, coefficients, Cyclades et organisation des épreuves ponctuelles.',
+  },
+  {
+    href: '/reussir-eaf',
+    label: 'Réussir l’EAF',
+    description: 'Écrit, oral, descriptif, méthode du commentaire et dissertation.',
+  },
+  {
+    href: '/grand-oral',
+    label: 'Grand Oral',
+    description: 'Deux questions, exposé, échange avec le jury et simulations.',
+  },
+];

--- a/content/marketing/seo-landings.ts
+++ b/content/marketing/seo-landings.ts
@@ -1,22 +1,7 @@
 import type { Metadata } from 'next';
+import type { OfferRef, NicheSection, RelatedLink } from '@/components/marketing/LandingNiche';
+import { LEGAL } from '@/lib/legal';
 import { PREPARATION_LINKS, type PreparationLink } from './preparation-links';
-
-export type OfferRef = {
-  type: 'annual' | 'ponctuel' | 'pack';
-  id: string;
-};
-
-export type NicheSection = {
-  heading: string;
-  body?: string[];
-  bullets?: string[];
-};
-
-export type RelatedLink = {
-  href: PreparationLink['href'];
-  label: string;
-  description?: string;
-};
 
 export type SeoLandingContent = {
   path: PreparationLink['href'];
@@ -36,12 +21,13 @@ function metadata(path: PreparationLink['href'], title: string, description: str
     title,
     description,
     alternates: {
-      canonical: `https://nexusreussite.academy${path}`,
+      canonical: path,
     },
     openGraph: {
       title,
       description,
       type: 'website',
+      url: path,
     },
   };
 }
@@ -49,6 +35,9 @@ function metadata(path: PreparationLink['href'], title: string, description: str
 function relatedLinksFor(path: PreparationLink['href']): RelatedLink[] {
   return PREPARATION_LINKS.filter((link) => link.href !== path);
 }
+
+const pedagogicalAddress = LEGAL.addresses.pedagogique.full;
+const pedagogicalAddressNote = LEGAL.addresses.pedagogique.note;
 
 export const seoLandings = {
   '/candidat-libre-bac-francais': {
@@ -157,14 +146,14 @@ export const seoLandings = {
     metadata: metadata(
       '/preparation-bac-francais-tunis',
       'Préparer le bac français à Tunis | Nexus Réussite',
-      'Accompagnement bac français à Tunis : méthode, groupes réduits, EAF, Grand Oral, spécialités, candidats libres, présentiel à Mutuelleville et formules en ligne.',
+      `Accompagnement bac français à Tunis : méthode, groupes réduits, EAF, Grand Oral, spécialités, candidats libres, présentiel à ${pedagogicalAddress} et formules en ligne.`,
     ),
     sections: [
       {
         heading: 'Un cadre de travail pour les familles à Tunis',
         body: [
           'La préparation du bac français ne se résume pas à quelques révisions en fin d’année. Entre les épreuves anticipées, les spécialités, le tronc commun, la philosophie et le Grand Oral, les familles ont besoin d’un cadre lisible pour savoir quoi travailler, dans quel ordre et avec quel niveau d’exigence.',
-          'Nexus Réussite construit ce cadre autour d’un diagnostic initial, de groupes réduits, de corrections régulières et d’un suivi parent clair. Les cours en présentiel et les rendez-vous pédagogiques se déroulent à Mutuelleville, sur confirmation, tandis que certaines formules permettent un suivi en ligne ou mixte pour les familles éloignées ou les candidats libres.',
+          `Nexus Réussite construit ce cadre autour d’un diagnostic initial, de groupes réduits, de corrections régulières et d’un suivi parent clair. ${pedagogicalAddressNote} Certaines formules permettent aussi un suivi en ligne ou mixte pour les familles éloignées ou les candidats libres.`,
         ],
       },
       {
@@ -213,9 +202,8 @@ export const seoLandings = {
           'Oui. Elle sert de hub général, puis renvoie vers la page candidat libre pour les modalités propres aux candidats individuels.',
       },
       {
-        question: 'Les cours ont-ils lieu à Mutuelleville ?',
-        answer:
-          'Les cours en présentiel et rendez-vous pédagogiques se déroulent au centre d’accompagnement pédagogique de Mutuelleville, sur confirmation.',
+        question: 'Où se déroulent les cours en présentiel ?',
+        answer: pedagogicalAddressNote,
       },
       {
         question: 'Le Grand Oral est-il préparé séparément ?',

--- a/content/marketing/seo-landings.ts
+++ b/content/marketing/seo-landings.ts
@@ -1,0 +1,413 @@
+import type { Metadata } from 'next';
+import { PREPARATION_LINKS, type PreparationLink } from './preparation-links';
+
+export type OfferRef = {
+  type: 'annual' | 'ponctuel' | 'pack';
+  id: string;
+};
+
+export type NicheSection = {
+  heading: string;
+  body?: string[];
+  bullets?: string[];
+};
+
+export type RelatedLink = {
+  href: PreparationLink['href'];
+  label: string;
+  description?: string;
+};
+
+export type SeoLandingContent = {
+  path: PreparationLink['href'];
+  title: string;
+  intro: string;
+  jsonLdName: string;
+  primaryCtaHref: '/bilan-gratuit';
+  metadata: Metadata;
+  sections: NicheSection[];
+  relatedLinks: RelatedLink[];
+  offerRefs: OfferRef[];
+  faq: { question: string; answer: string }[];
+};
+
+function metadata(path: PreparationLink['href'], title: string, description: string): Metadata {
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: `https://nexusreussite.academy${path}`,
+    },
+    openGraph: {
+      title,
+      description,
+      type: 'website',
+    },
+  };
+}
+
+function relatedLinksFor(path: PreparationLink['href']): RelatedLink[] {
+  return PREPARATION_LINKS.filter((link) => link.href !== path);
+}
+
+export const seoLandings = {
+  '/candidat-libre-bac-francais': {
+    path: '/candidat-libre-bac-francais',
+    title: 'Candidat libre au bac français en Tunisie',
+    intro:
+      'Passer le bac français en candidat libre depuis la Tunisie demande un cadre précis : le candidat individuel ne dispose pas de contrôle continu et doit organiser les démarches administratives, les épreuves ponctuelles, les épreuves anticipées et les épreuves terminales. Nexus Réussite accompagne cette préparation avec une méthode structurée, des entraînements en conditions, un suivi parent lisible et une cellule d’appui Cyclades selon la formule retenue.',
+    jsonLdName: 'Préparation au bac français en candidat libre en Tunisie',
+    primaryCtaHref: '/bilan-gratuit',
+    metadata: metadata(
+      '/candidat-libre-bac-francais',
+      'Candidat libre au bac français en Tunisie | Nexus Réussite',
+      'Préparer le bac français en candidat libre depuis la Tunisie : modalités A/B, coefficients session 2027, Cyclades, IFT, EAF, spécialités et Grand Oral.',
+    ),
+    sections: [
+      {
+        heading: 'Comprendre le statut de candidat individuel',
+        body: [
+          'Un candidat libre, appelé officiellement candidat individuel, n’est pas scolarisé dans un établissement sous contrat ni au CNED en scolarité réglementée. Le diplôme obtenu a la même valeur que celui d’un candidat scolarisé, mais l’organisation de l’année est différente : aucun livret scolaire ne vient alimenter la note finale.',
+          'La conséquence est structurante pour la préparation : le candidat individuel est évalué sur l’ensemble du diplôme. Les épreuves terminales et anticipées représentent 60 points, tandis que les 40 points normalement issus du contrôle continu sont remplacés par des évaluations ponctuelles organisées au niveau académique. Ce cadre impose une planification plus rigoureuse, car chaque matière évaluée doit être préparée comme une épreuve réelle.',
+        ],
+      },
+      {
+        heading: 'Modalités A/B : un choix qui cadence l’année',
+        body: [
+          'Lors de l’inscription, le candidat choisit une modalité de passation pour les évaluations ponctuelles. Ce choix est global, non discipline par discipline, et il doit être confirmé selon les consignes de la session, l’académie de rattachement et les informations transmises par l’Institut français de Tunisie.',
+        ],
+        bullets: [
+          'Modalité A : les évaluations ponctuelles sont regroupées en fin de terminale, sur le programme du cycle terminal selon les disciplines.',
+          'Modalité B : une partie des évaluations est passée dès la fin de première, puis le reste en terminale.',
+          'Pour une famille, ce choix change le calendrier de travail : un élève de première en modalité B doit déjà être prêt pour plusieurs épreuves en fin d’année.',
+        ],
+      },
+      {
+        heading: 'Coefficients de référence pour la session 2027',
+        body: [
+          'La structure de référence pour les cohortes accompagnées aujourd’hui est celle de la session 2027 : épreuve anticipée de mathématiques intégrée au baccalauréat et Grand Oral coefficient 8. Les coefficients doivent toujours être revérifiés dans la convocation et les textes de session, mais ils donnent un cadre solide pour hiérarchiser le travail.',
+        ],
+        bullets: [
+          'Français écrit et oral en fin de première : coefficient 5 chacun.',
+          'Mathématiques anticipées : coefficient 2.',
+          'Deux spécialités conservées en terminale : coefficient 16 chacune.',
+          'Philosophie : coefficient 8. Grand Oral : coefficient 8.',
+          'Évaluations ponctuelles : histoire-géographie, LVA, LVB, enseignement scientifique et EPS coefficient 6 ; EMC coefficient 2 ; spécialité abandonnée en première coefficient 8.',
+        ],
+      },
+      {
+        heading: 'Points de vigilance propres aux candidats libres',
+        body: [
+          'Certaines règles changent le travail concret. En NSI, physique-chimie et SVT, le candidat individuel est généralement dispensé des épreuves pratiques : la note de spécialité repose alors sur l’écrit, ramené sur 20. En français, le descriptif de lectures et de textes n’est pas fourni par un professeur de classe : il doit être construit, organisé et présenté dans un format conforme aux attentes de l’oral.',
+          'Les inscriptions passent généralement par Cyclades et par le circuit indiqué par l’Institut français de Tunisie. Les dates, pièces justificatives, frais éventuels, modalités EPS et options doivent être confirmés chaque année. Nexus Réussite accompagne l’organisation et la préparation, sans se substituer à l’inscription officielle ni à la convocation.',
+        ],
+      },
+      {
+        heading: 'L’accompagnement Nexus Réussite',
+        body: [
+          'L’objectif n’est pas de remplacer le travail personnel, mais de donner un cadre stable : diagnostic initial, choix de la modalité, priorisation des matières, planning, entraînements et bilans. Les parcours peuvent être en ligne, mixtes ou complétés par des stages selon le niveau, les spécialités, les contraintes familiales et le calendrier de l’élève.',
+          'Les familles disposent d’un suivi parent clair, de corrections appuyées sur les attendus des épreuves, d’épreuves blanches selon la formule et d’un accès aux ressources numériques prévues au catalogue. Le bilan gratuit sert à vérifier le statut, la modalité, les spécialités et le format le plus cohérent avant toute inscription.',
+        ],
+      },
+    ],
+    relatedLinks: relatedLinksFor('/candidat-libre-bac-francais'),
+    offerRefs: [
+      { type: 'annual', id: '1re-libre-essentiel' },
+      { type: 'annual', id: '1re-libre-accomp' },
+      { type: 'annual', id: 'term-libre-online' },
+      { type: 'annual', id: 'term-libre-mixte' },
+      { type: 'annual', id: 'term-libre-premium' },
+      { type: 'pack', id: 'pass-candidat-libre' },
+    ],
+    faq: [
+      {
+        question: 'Un candidat libre passe-t-il le même diplôme ?',
+        answer:
+          'Oui. Le diplôme est le même. La différence tient à l’évaluation : le candidat individuel ne dispose pas de contrôle continu et passe des évaluations ponctuelles pour les enseignements concernés.',
+      },
+      {
+        question: 'La modalité A ou B peut-elle être changée après inscription ?',
+        answer:
+          'Le choix est généralement définitif une fois l’inscription confirmée. Il faut donc le vérifier soigneusement avec les informations de la session et l’accompagnement administratif disponible.',
+      },
+      {
+        question: 'Nexus remplace-t-il l’inscription officielle ?',
+        answer:
+          'Non. Nexus accompagne l’organisation et la préparation, mais l’inscription officielle relève du candidat, de sa famille, de Cyclades et des consignes communiquées pour la session.',
+      },
+      {
+        question: 'Comment préparer le français en candidat libre ?',
+        answer:
+          'Le point sensible est le descriptif de l’oral : il faut construire une liste de textes et de lectures conforme au programme, puis s’entraîner à l’explication linéaire, à la grammaire et à l’entretien.',
+      },
+      {
+        question: 'Peut-on préparer à distance depuis la Tunisie ?',
+        answer:
+          'Oui, certaines formules sont en ligne ou mixtes. Le bilan gratuit permet de vérifier le format adapté à la situation familiale, au calendrier et aux spécialités choisies.',
+      },
+    ],
+  },
+  '/preparation-bac-francais-tunis': {
+    path: '/preparation-bac-francais-tunis',
+    title: 'Préparer le bac français à Tunis',
+    intro:
+      'Nexus Réussite accompagne les élèves du système français à Tunis, scolarisés ou candidats libres, avec une méthode structurée : diagnostic, groupes réduits, entraînements, corrections, bilans et suivi parent. Cette page sert de point d’entrée vers les préparations clés du bac français : EAF, Grand Oral, spécialités, stages et parcours candidat libre.',
+    jsonLdName: 'Préparation au bac français à Tunis',
+    primaryCtaHref: '/bilan-gratuit',
+    metadata: metadata(
+      '/preparation-bac-francais-tunis',
+      'Préparer le bac français à Tunis | Nexus Réussite',
+      'Accompagnement bac français à Tunis : méthode, groupes réduits, EAF, Grand Oral, spécialités, candidats libres, présentiel à Mutuelleville et formules en ligne.',
+    ),
+    sections: [
+      {
+        heading: 'Un cadre de travail pour les familles à Tunis',
+        body: [
+          'La préparation du bac français ne se résume pas à quelques révisions en fin d’année. Entre les épreuves anticipées, les spécialités, le tronc commun, la philosophie et le Grand Oral, les familles ont besoin d’un cadre lisible pour savoir quoi travailler, dans quel ordre et avec quel niveau d’exigence.',
+          'Nexus Réussite construit ce cadre autour d’un diagnostic initial, de groupes réduits, de corrections régulières et d’un suivi parent clair. Les cours en présentiel et les rendez-vous pédagogiques se déroulent à Mutuelleville, sur confirmation, tandis que certaines formules permettent un suivi en ligne ou mixte pour les familles éloignées ou les candidats libres.',
+        ],
+      },
+      {
+        heading: 'Les grandes étapes du bac français',
+        body: [
+          'En première, l’élève prépare l’épreuve anticipée de français : écrit de 4 heures et oral de 20 minutes après préparation. À partir de la session 2027, l’épreuve anticipée de mathématiques est intégrée à la note du baccalauréat. En terminale, les deux spécialités conservées, la philosophie et le Grand Oral structurent la fin de parcours.',
+          'Pour les élèves scolarisés, le contrôle continu reste un enjeu de régularité. Pour les candidats libres, les enseignements normalement évalués en contrôle continu sont remplacés par des évaluations ponctuelles. Le même diplôme est visé, mais l’organisation de l’année et la pression sur les épreuves sont différentes.',
+        ],
+      },
+      {
+        heading: 'Élève scolarisé ou candidat libre : deux logiques',
+        bullets: [
+          'Élève scolarisé : consolider les acquis, progresser dans les spécialités, préparer les épreuves terminales et maintenir une trajectoire régulière.',
+          'Candidat libre : couvrir tout le programme, anticiper les évaluations ponctuelles, construire le descriptif EAF et sécuriser l’organisation administrative.',
+          'Famille à Tunis : choisir entre présentiel, distanciel ou formule mixte selon le calendrier, la localisation, les spécialités et le niveau d’autonomie.',
+        ],
+      },
+      {
+        heading: 'Méthode Nexus Réussite',
+        body: [
+          'Le point de départ est un bilan : niveau actuel, matières prioritaires, statut de l’élève, objectifs, contraintes de temps et échéances d’examen. À partir de ce diagnostic, l’équipe propose un parcours : accompagnement annuel, module ciblé, stage intensif ou pass.',
+          'La méthode met l’accent sur les attendus officiels : travailler les consignes, structurer les copies, s’entraîner à l’oral, apprendre à relire et à corriger ses erreurs. Les outils numériques et ARIA complètent le suivi humain ; ils ne remplacent pas l’accompagnement pédagogique.',
+        ],
+      },
+      {
+        heading: 'Choisir la bonne porte d’entrée',
+        body: [
+          'Les familles qui préparent le français de première peuvent commencer par la page dédiée à l’EAF. Les élèves de terminale qui doivent construire leurs deux questions peuvent consulter la préparation Grand Oral. Les candidats individuels doivent lire le parcours candidat libre, car leurs modalités d’examen, d’inscription et de calendrier diffèrent sensiblement.',
+          'Le bilan gratuit permet ensuite de transformer ces repères en plan de travail concret. Il ne s’agit pas de promettre un résultat, mais de clarifier les priorités, les risques, les points forts et le format d’accompagnement le plus adapté.',
+        ],
+      },
+    ],
+    relatedLinks: relatedLinksFor('/preparation-bac-francais-tunis'),
+    offerRefs: [
+      { type: 'annual', id: '1re-double-secu' },
+      { type: 'annual', id: 'term-duo' },
+      { type: 'annual', id: 'term-excellence' },
+      { type: 'annual', id: 'term-libre-mixte' },
+      { type: 'pack', id: 'pass-intensifs-term' },
+      { type: 'pack', id: 'pass-candidat-libre' },
+    ],
+    faq: [
+      {
+        question: 'La page concerne-t-elle aussi les candidats libres ?',
+        answer:
+          'Oui. Elle sert de hub général, puis renvoie vers la page candidat libre pour les modalités propres aux candidats individuels.',
+      },
+      {
+        question: 'Les cours ont-ils lieu à Mutuelleville ?',
+        answer:
+          'Les cours en présentiel et rendez-vous pédagogiques se déroulent au centre d’accompagnement pédagogique de Mutuelleville, sur confirmation.',
+      },
+      {
+        question: 'Le Grand Oral est-il préparé séparément ?',
+        answer:
+          'Il peut être travaillé dans un parcours annuel, un pass ou un module dédié, selon le niveau de l’élève et l’avancement des deux questions.',
+      },
+      {
+        question: 'Comment éviter une formule mal choisie ?',
+        answer:
+          'Le bilan gratuit sert à identifier les matières prioritaires, le statut de l’élève, le calendrier et le volume de travail réaliste avant de recommander une formule.',
+      },
+      {
+        question: 'ARIA remplace-t-il le suivi humain ?',
+        answer:
+          'Non. ARIA complète le travail humain par des ressources et des exercices, mais l’accompagnement repose sur une méthode, des corrections et des bilans.',
+      },
+    ],
+  },
+  '/reussir-eaf': {
+    path: '/reussir-eaf',
+    title: 'Réussir l’EAF : épreuves anticipées de français',
+    intro:
+      'L’EAF se prépare en première, mais elle compte durablement dans le baccalauréat : écrit coefficient 5, oral coefficient 5. La réussite repose sur une méthode régulière : lire les œuvres, comprendre les textes, construire des plans, maîtriser l’expression écrite et s’entraîner à l’explication orale dans le format attendu.',
+    jsonLdName: 'Préparation aux épreuves anticipées de français',
+    primaryCtaHref: '/bilan-gratuit',
+    metadata: metadata(
+      '/reussir-eaf',
+      'Réussir l’EAF : épreuves anticipées de français | Nexus Réussite',
+      'Préparer l’EAF : écrit de français, oral, commentaire, dissertation, explication linéaire, grammaire, descriptif candidat libre et entraînements.',
+    ),
+    sections: [
+      {
+        heading: 'Deux épreuves de français en fin de première',
+        body: [
+          'L’épreuve anticipée de français comporte un écrit de 4 heures et un oral de 20 minutes après 30 minutes de préparation. Chaque partie compte coefficient 5. L’enjeu ne se limite donc pas à « aimer lire » : il faut maîtriser une méthode, savoir mobiliser les œuvres et produire une analyse claire.',
+          'Le programme s’organise autour de grands objets d’étude : roman et récit, poésie, théâtre, littérature d’idées. Les œuvres changent selon les sessions, ce qui impose de vérifier le programme de l’année et d’adapter les entraînements aux textes réellement étudiés.',
+        ],
+      },
+      {
+        heading: 'L’écrit : commentaire ou dissertation',
+        body: [
+          'Le jour de l’écrit, le candidat choisit entre le commentaire d’un texte et la dissertation sur une œuvre au programme. Le commentaire évalue la capacité à comprendre un texte, à repérer ses mouvements, à analyser les procédés et à organiser une interprétation. La dissertation demande une problématique, une progression argumentative et des exemples précis issus de l’œuvre.',
+          'Dans les deux cas, la copie doit être structurée, lisible et argumentée. Les erreurs les plus fréquentes sont connues : paraphrase, catalogue de procédés, absence de problématique, exemples insuffisamment exploités, conclusion trop rapide ou langue imprécise. Un entraînement efficace consiste à corriger ces points dans la durée, copie après copie.',
+        ],
+      },
+      {
+        heading: 'L’oral : explication linéaire, grammaire, entretien',
+        body: [
+          'L’oral dure 20 minutes. Le candidat présente d’abord une explication linéaire d’un texte, répond à une question de grammaire, puis présente une œuvre choisie et échange avec l’examinateur. Cette épreuve demande une parole structurée, mais aussi une compréhension personnelle des textes.',
+          'La préparation ne doit pas se limiter à apprendre des fiches. Il faut savoir annoncer un projet de lecture, découper le texte en mouvements, justifier les procédés, répondre avec précision et tenir l’entretien sans réciter mécaniquement.',
+        ],
+        bullets: [
+          'Explication linéaire : suivre le texte pas à pas et faire apparaître sa progression.',
+          'Question de grammaire : analyser précisément un passage, sans réponse vague.',
+          'Entretien : défendre une lecture personnelle, argumentée et reliée à l’œuvre.',
+        ],
+      },
+      {
+        heading: 'Spécificité candidat libre : le descriptif',
+        body: [
+          'Pour un candidat individuel, le descriptif est un point central. Il ne reçoit pas automatiquement la liste de textes fournie par un professeur de classe : il doit construire un descriptif conforme au programme, cohérent, exploitable à l’oral et présenté dans le format attendu.',
+          'Ce travail doit être anticipé. Le choix des textes, la répartition par objet d’étude, la préparation de l’œuvre présentée à l’entretien et la conformité administrative ne peuvent pas être improvisés à quelques semaines de l’épreuve.',
+        ],
+      },
+      {
+        heading: 'La préparation Nexus Réussite',
+        body: [
+          'Nexus Réussite combine méthode écrite, entraînement oral et corrections. Les élèves travaillent les textes, la dissertation, le commentaire, la grammaire et la prise de parole. Les candidats libres peuvent être accompagnés sur la constitution du descriptif et la préparation de l’entretien.',
+          'Selon la formule, le parcours inclut des entraînements en conditions, des corrections sur attendus officiels, des bilans de progression et des ressources numériques. Le bilan gratuit permet de déterminer si l’élève a besoin d’un module ciblé, d’un accompagnement annuel ou d’un stage intensif avant l’épreuve.',
+        ],
+      },
+    ],
+    relatedLinks: relatedLinksFor('/reussir-eaf'),
+    offerRefs: [
+      { type: 'ponctuel', id: 'cap-eaf' },
+      { type: 'annual', id: '1re-eaf' },
+      { type: 'annual', id: '1re-libre-accomp' },
+      { type: 'pack', id: 'pass-cap-bac-1re' },
+    ],
+    faq: [
+      {
+        question: 'Quels sont les coefficients de l’EAF ?',
+        answer:
+          'L’écrit et l’oral comptent chacun coefficient 5. L’ensemble représente donc 10 coefficients dans la note finale du baccalauréat.',
+      },
+      {
+        question: 'Faut-il choisir commentaire ou dissertation à l’avance ?',
+        answer:
+          'Il faut travailler les deux méthodes, car le choix se fait le jour de l’épreuve selon le sujet et la maîtrise de l’élève.',
+      },
+      {
+        question: 'Pourquoi l’oral ne se prépare-t-il pas uniquement avec des fiches ?',
+        answer:
+          'Parce que l’examinateur évalue aussi la clarté, l’appropriation du texte, la précision des réponses et la capacité à dialoguer sur une œuvre.',
+      },
+      {
+        question: 'Le descriptif est-il obligatoire pour un candidat libre ?',
+        answer:
+          'Le candidat individuel doit présenter un descriptif conforme aux attentes de la session. Les consignes précises doivent être vérifiées dans la convocation et les documents officiels.',
+      },
+      {
+        question: 'Comment commencer la préparation ?',
+        answer:
+          'Le bilan gratuit permet de situer le niveau en expression écrite, en lecture analytique et à l’oral, puis de proposer un rythme de travail adapté.',
+      },
+    ],
+  },
+  '/grand-oral': {
+    path: '/grand-oral',
+    title: 'Préparer le Grand Oral du bac',
+    intro:
+      'Le Grand Oral clôt le cycle terminal. À compter de la session 2027 en voie générale, il compte coefficient 8 et porte sur deux questions préparées pendant l’année, en lien avec les spécialités. L’épreuve évalue les connaissances, la clarté du propos, l’argumentation, l’échange avec le jury et la capacité à défendre une démarche personnelle.',
+    jsonLdName: 'Préparation au Grand Oral du baccalauréat',
+    primaryCtaHref: '/bilan-gratuit',
+    metadata: metadata(
+      '/grand-oral',
+      'Préparer le Grand Oral du bac | Nexus Réussite',
+      'Préparer le Grand Oral du bac : deux questions, spécialités, exposé de 10 minutes, échange avec le jury, posture, argumentation et simulations.',
+    ),
+    sections: [
+      {
+        heading: 'Une épreuve orale adossée aux spécialités',
+        body: [
+          'Le Grand Oral ne consiste pas à réciter un exposé générique. Le candidat prépare deux questions pendant l’année, liées à ses deux enseignements de spécialité, séparément ou de manière transversale. Le jour de l’épreuve, le jury choisit l’une des deux questions.',
+          'La qualité de la question compte autant que la performance orale : elle doit être problématisée, compatible avec les programmes, suffisamment précise pour être traitée en 10 minutes et assez riche pour ouvrir un échange avec le jury.',
+        ],
+      },
+      {
+        heading: 'Déroulé de l’épreuve',
+        body: [
+          'L’épreuve comprend 20 minutes de préparation, puis 20 minutes devant le jury : 10 minutes d’exposé et 10 minutes d’échange. Un support peut être préparé pendant le temps de préparation, mais il n’est ni remis au jury ni évalué comme document autonome.',
+          'Ces contraintes obligent à travailler le rythme. Un exposé trop court donne une impression d’impréparation ; un exposé trop long empêche de conclure proprement. La préparation doit donc intégrer des simulations chronométrées, des transitions et des réponses aux objections possibles.',
+        ],
+      },
+      {
+        heading: 'Ce que le jury observe',
+        bullets: [
+          'Solidité des connaissances mobilisées dans les spécialités.',
+          'Capacité à argumenter, nuancer et relier les savoirs.',
+          'Clarté de la parole, posture, regard, gestion du temps.',
+          'Esprit critique et capacité à répondre dans l’échange.',
+          'Cohérence entre la question choisie, le parcours de l’élève et la démarche présentée.',
+        ],
+      },
+      {
+        heading: 'Candidat libre : mêmes attendus, moins de cadre de classe',
+        body: [
+          'Le candidat libre passe le Grand Oral selon les mêmes attendus. La difficulté vient souvent du cadre : sans professeur de classe pour valider progressivement les questions, il faut vérifier soi-même la pertinence du sujet, l’ancrage dans les spécialités et la préparation de l’échange.',
+          'Pour les familles, le risque n’est pas seulement le trac. Il est aussi méthodologique : question trop large, problématique faible, plan descriptif, connaissances superficielles ou absence d’entraînement face à un jury.',
+        ],
+      },
+      {
+        heading: 'La préparation Nexus Réussite',
+        body: [
+          'Le Studio Grand Oral accompagne la construction des deux questions, la problématisation, le plan de l’exposé, la posture et les simulations. L’objectif est d’obtenir une parole claire, maîtrisée et reliée aux connaissances réelles de l’élève.',
+          'Le module peut compléter un parcours annuel, un pass intensif ou une préparation candidat libre. Le bilan gratuit permet de vérifier l’état d’avancement : questions déjà choisies, spécialités, niveau d’aisance orale, besoins de structuration et calendrier jusqu’à l’épreuve.',
+        ],
+      },
+    ],
+    relatedLinks: relatedLinksFor('/grand-oral'),
+    offerRefs: [
+      { type: 'ponctuel', id: 'studio-grand-oral' },
+      { type: 'annual', id: 'term-duo' },
+      { type: 'annual', id: 'term-libre-mixte' },
+      { type: 'pack', id: 'pass-go-sprint' },
+    ],
+    faq: [
+      {
+        question: 'Quel est le coefficient du Grand Oral ?',
+        answer:
+          'En voie générale, la structure de référence session 2027 indique un coefficient 8. Les informations de convocation restent la référence finale.',
+      },
+      {
+        question: 'Combien de questions faut-il préparer ?',
+        answer:
+          'Deux questions liées aux spécialités. Le jury en choisit une le jour de l’épreuve.',
+      },
+      {
+        question: 'Les questions peuvent-elles croiser deux spécialités ?',
+        answer:
+          'Oui, une question peut être adossée à une spécialité ou croiser les deux, si le lien avec les programmes reste clair.',
+      },
+      {
+        question: 'Le support préparé pendant l’épreuve est-il noté ?',
+        answer:
+          'Non. Il peut aider la prise de parole, mais il n’est pas remis au jury et ne constitue pas l’objet principal de l’évaluation.',
+      },
+      {
+        question: 'Le Studio Grand Oral convient-il aux candidats libres ?',
+        answer:
+          'Oui. Il aide notamment à valider les questions, structurer l’exposé et s’entraîner à l’échange avec le jury.',
+      },
+    ],
+  },
+} satisfies Record<PreparationLink['href'], SeoLandingContent>;

--- a/docs/audits/2026-06-24-lot-1-t11-landings-seo.md
+++ b/docs/audits/2026-06-24-lot-1-t11-landings-seo.md
@@ -1,0 +1,69 @@
+# Lot 1 T1.1 — Landings SEO
+
+## Date
+
+2026-06-24
+
+## Contexte
+
+Les quatre landings SEO déclarées dans le sitemap étaient trop courtes et peu reliées entre elles. Le dossier local `nexus-codex-handoff/` a servi de matière éditoriale et d’état cible, en l’adaptant au tree courant après le Lot 0 mergé.
+
+## Problèmes observés
+
+- Les pages `/candidat-libre-bac-francais`, `/preparation-bac-francais-tunis`, `/reussir-eaf` et `/grand-oral` reposaient sur un contenu court.
+- Les metadata ne déclaraient pas de canonical.
+- Le maillage interne entre les préparations était insuffisant.
+- Le renderer `LandingNiche` ne rendait pas encore de sections longues ni de JSON-LD `FAQPage`.
+
+## Décisions prises
+
+- Créer une source de contenu typée dans `content/marketing/seo-landings.ts`.
+- Garder les prix uniquement via `offerRefs` résolus par `lib/pricing.ts`.
+- Corriger les repères session 2027 du corpus : Grand Oral coefficient 8 et épreuve anticipée de mathématiques coefficient 2.
+- Formuler les éléments Cyclades/IFT avec prudence, car les dates et pièces varient selon la session.
+- Ajouter un groupe navbar et un bloc footer « Préparations » depuis `content/marketing/preparation-links.ts`.
+- Exclure `nexus-codex-handoff/` de TypeScript et de Git, car c’est une matière locale non source.
+
+## Fichiers modifiés
+
+- `content/marketing/seo-landings.ts`
+- `content/marketing/preparation-links.ts`
+- `components/marketing/LandingNiche.tsx`
+- `app/candidat-libre-bac-francais/page.tsx`
+- `app/preparation-bac-francais-tunis/page.tsx`
+- `app/reussir-eaf/page.tsx`
+- `app/grand-oral/page.tsx`
+- `components/layout/CorporateNavbar.tsx`
+- `components/layout/CorporateFooter.tsx`
+- `__tests__/marketing/seo-landings-guard.test.ts`
+- `.gitignore`
+- `tsconfig.json`
+
+## Tests exécutés
+
+- `npm run test -- --runInBand __tests__/marketing/seo-landings-guard.test.ts`
+- `npm run test -- --runInBand __tests__/lib/pricing-canonical-validator.test.ts __tests__/lib/pricing-display-coherence.test.ts __tests__/marketing/french-typography-guard.test.ts`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test -- --runInBand`
+- `npm run build`
+- `npm run check:docs-archive`
+- `git diff --check`
+- `HOSTNAME=localhost PORT=3017 node .next/standalone/server.js`, puis vérification HTTP locale par `fetch`.
+
+## Résultats
+
+- Garde SEO T1.1 : 14 tests passés.
+- Pricing/typographie ciblés : 54 tests passés.
+- Jest complet : 491 suites passées, 1 skipped ; 6242 tests passés, 4 skipped.
+- Build Next : 139 pages générées, assets standalone copiés.
+- SSR local : les quatre routes répondent 200, contiennent leur canonical, un JSON-LD `FAQPage`, le CTA bilan et plus de 1000 mots extraits du HTML.
+
+## Risques restants
+
+- Les informations administratives IFT/Cyclades doivent rester vérifiées chaque session avant communication nominative à une famille.
+- Le menu public contient désormais un groupe supplémentaire ; une passe visuelle mobile/desktop restera utile lors du lot marque/polish.
+
+## Rollback
+
+Revenir au commit précédent restaure les pages courtes et retire le contenu typé, la garde SEO T1.1 et le maillage « Préparations ».

--- a/docs/audits/2026-06-24-lot-1-t11-landings-seo.md
+++ b/docs/audits/2026-06-24-lot-1-t11-landings-seo.md
@@ -26,7 +26,7 @@ Les quatre landings SEO déclarées dans le sitemap étaient trop courtes et peu
 - Exclure `nexus-codex-handoff/` de TypeScript et de Git, car c’est une matière locale non source.
 - Laisser `metadataBase` dans `app/layout.tsx` résoudre les canonical relatifs, et ne plus recopier le domaine public dans `content/`.
 - Faire de `LandingNiche` la source des types `OfferRef`, `NicheSection` et `RelatedLink`.
-- Rattacher les adresses pédagogiques à `LEGAL.addresses.pedagogique` et les claims Cyclades/ARIA/bacs blancs au catalogue canonique.
+- Rattacher les adresses pédagogiques à `LEGAL.addresses.pedagogique` et les claims Cyclades/ARIA/bacs blancs aux surfaces opérationnelles du catalogue canonique : `included` pour ARIA/bacs blancs, composants `service` de packs pour Cyclades.
 
 ## Fichiers modifiés
 
@@ -67,6 +67,7 @@ Les quatre landings SEO déclarées dans le sitemap étaient trop courtes et peu
 - Grep demandé : aucune occurrence de `nexusreussite.academy` dans `content/` ni dans `__tests__/marketing/seo-landings-guard.test.ts`.
 - Grep demandé : une seule déclaration par type `OfferRef`, `NicheSection`, `RelatedLink`, toutes dans `components/marketing/LandingNiche.tsx`.
 - Responsive local : desktop 1440 et mobile 390 sans overflow horizontal, navbar/footer présents, liens du cluster présents sur les quatre landings.
+- P2.5 : la garde `landing service claims map to canonical included entries or pack services` a été vérifiée rouge puis verte ; elle échoue si les claims Cyclades/ARIA/bacs blancs ne correspondent plus aux `included` ou services du catalogue.
 
 ## Risques restants
 

--- a/docs/audits/2026-06-24-lot-1-t11-landings-seo.md
+++ b/docs/audits/2026-06-24-lot-1-t11-landings-seo.md
@@ -71,7 +71,7 @@ Les quatre landings SEO déclarées dans le sitemap étaient trop courtes et peu
 ## Risques restants
 
 - Les informations administratives IFT/Cyclades doivent rester vérifiées chaque session avant communication nominative à une famille.
-- La CI GitHub Actions reste à vérifier côté PR #48 : si elle est encore bloquée par la facturation, la PR doit rester draft et nécessiter une revue humaine explicite avant merge.
+- La CI GitHub Actions de la PR #48 est bloquée avant exécution : les annotations CheckRun indiquent `The job was not started because your account is locked due to a billing issue.` La PR doit rester draft et nécessiter soit le déblocage Actions, soit une revue humaine explicite avant merge.
 - Le dossier `nexus-codex-handoff/` et les exclusions associées restent à nettoyer après consommation complète du handoff en fin T1.2/T1.3.
 
 ## Rollback

--- a/docs/audits/2026-06-24-lot-1-t11-landings-seo.md
+++ b/docs/audits/2026-06-24-lot-1-t11-landings-seo.md
@@ -14,6 +14,7 @@ Les quatre landings SEO déclarées dans le sitemap étaient trop courtes et peu
 - Les metadata ne déclaraient pas de canonical.
 - Le maillage interne entre les préparations était insuffisant.
 - Le renderer `LandingNiche` ne rendait pas encore de sections longues ni de JSON-LD `FAQPage`.
+- La revue PR #48 a relevé des canonical absolus dans le contenu, des types de contenu dupliqués, des `offerRefs` filtrés sans garde et une garde SEO trop liée à la forme du code.
 
 ## Décisions prises
 
@@ -23,6 +24,9 @@ Les quatre landings SEO déclarées dans le sitemap étaient trop courtes et peu
 - Formuler les éléments Cyclades/IFT avec prudence, car les dates et pièces varient selon la session.
 - Ajouter un groupe navbar et un bloc footer « Préparations » depuis `content/marketing/preparation-links.ts`.
 - Exclure `nexus-codex-handoff/` de TypeScript et de Git, car c’est une matière locale non source.
+- Laisser `metadataBase` dans `app/layout.tsx` résoudre les canonical relatifs, et ne plus recopier le domaine public dans `content/`.
+- Faire de `LandingNiche` la source des types `OfferRef`, `NicheSection` et `RelatedLink`.
+- Rattacher les adresses pédagogiques à `LEGAL.addresses.pedagogique` et les claims Cyclades/ARIA/bacs blancs au catalogue canonique.
 
 ## Fichiers modifiés
 
@@ -47,22 +51,28 @@ Les quatre landings SEO déclarées dans le sitemap étaient trop courtes et peu
 - `npm run typecheck`
 - `npm run test -- --runInBand`
 - `npm run build`
+- `NEXTAUTH_URL=https://nexusreussite.academy npm run build`
 - `npm run check:docs-archive`
 - `git diff --check`
-- `HOSTNAME=localhost PORT=3017 node .next/standalone/server.js`, puis vérification HTTP locale par `fetch`.
+- `NEXTAUTH_URL=https://nexusreussite.academy HOSTNAME=localhost PORT=3017 node .next/standalone/server.js`, puis vérification HTTP locale par `fetch`.
+- Script Playwright temporaire `/tmp/playwright-t11-responsive.js` sur desktop 1440 et mobile 390.
 
 ## Résultats
 
-- Garde SEO T1.1 : 14 tests passés.
+- Garde SEO T1.1 : 28 tests passés.
 - Pricing/typographie ciblés : 54 tests passés.
-- Jest complet : 491 suites passées, 1 skipped ; 6242 tests passés, 4 skipped.
+- Jest complet : 491 suites passées, 1 skipped ; 6256 tests passés, 4 skipped.
 - Build Next : 139 pages générées, assets standalone copiés.
-- SSR local : les quatre routes répondent 200, contiennent leur canonical, un JSON-LD `FAQPage`, le CTA bilan et plus de 1000 mots extraits du HTML.
+- SSR local : les quatre routes répondent 200, contiennent leur canonical résolu `https://nexusreussite.academy/...`, un JSON-LD `FAQPage`, le CTA bilan et un H1.
+- Grep demandé : aucune occurrence de `nexusreussite.academy` dans `content/` ni dans `__tests__/marketing/seo-landings-guard.test.ts`.
+- Grep demandé : une seule déclaration par type `OfferRef`, `NicheSection`, `RelatedLink`, toutes dans `components/marketing/LandingNiche.tsx`.
+- Responsive local : desktop 1440 et mobile 390 sans overflow horizontal, navbar/footer présents, liens du cluster présents sur les quatre landings.
 
 ## Risques restants
 
 - Les informations administratives IFT/Cyclades doivent rester vérifiées chaque session avant communication nominative à une famille.
-- Le menu public contient désormais un groupe supplémentaire ; une passe visuelle mobile/desktop restera utile lors du lot marque/polish.
+- La CI GitHub Actions reste à vérifier côté PR #48 : si elle est encore bloquée par la facturation, la PR doit rester draft et nécessiter une revue humaine explicite avant merge.
+- Le dossier `nexus-codex-handoff/` et les exclusions associées restent à nettoyer après consommation complète du handoff en fin T1.2/T1.3.
 
 ## Rollback
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,6 +44,7 @@
     "nexus-src",
     "scripts",
     "academic-luxury-design",
+    "nexus-codex-handoff",
     "playwright.config.ts",
     "playwright.config.e2e.ts"
   ]


### PR DESCRIPTION
## Résumé
- Enrichit les 4 landings SEO T1.1 avec contenu long SSR, metadata canonical, FAQ JSON-LD et maillage interne.
- Centralise le contenu dans `content/marketing/seo-landings.ts` et les liens de préparation dans `content/marketing/preparation-links.ts`.
- Ajoute le groupe/bloc "Préparations" à la navbar et au footer, sans prix TND hardcodé.

## Critères d’acceptation
- [x] 4 pages > 600 mots de contenu réel.
- [x] H1 unique par page via `LandingNiche`.
- [x] Canonical présent par page.
- [x] Contenu visible dans le HTML SSR.
- [x] FAQ + JSON-LD `FAQPage`.
- [x] Maillage interne + entrées nav/footer.
- [x] Prix uniquement via `offerRefs` / `lib/pricing.ts`.
- [x] Garde SEO ajoutée.

## Vérifications
- `npm run test -- --runInBand __tests__/marketing/seo-landings-guard.test.ts` : 14 passed.
- `npm run test -- --runInBand __tests__/lib/pricing-canonical-validator.test.ts __tests__/lib/pricing-display-coherence.test.ts __tests__/marketing/french-typography-guard.test.ts` : 54 passed.
- `npm run lint` : exit 0, warnings préexistants.
- `npm run typecheck` : exit 0.
- `npm run test -- --runInBand` : 491 suites passed, 1 skipped ; 6242 tests passed, 4 skipped.
- `npm run build` : exit 0, 139 pages generated, standalone assets copied.
- `npm run check:docs-archive` : exit 0.
- `git diff --check` : exit 0.
- SSR local `localhost:3017` : les 4 routes répondent 200 avec canonical, FAQPage, CTA bilan et >1000 mots extraits du HTML.

## Notes
- `nexus-codex-handoff/` reste un artefact local de travail, ignoré et exclu du typecheck.
- Pas de déploiement prod demandé pour ce lot.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enriched the 4 bac preparation SEO landings with long-form SSR content, canonical metadata, FAQ JSON-LD, and a “Préparations” cluster in the navbar/footer. Tightened SEO invariants (canonical resolution, domain hygiene, pricing) and bound marketing claims to the canonical pricing catalog.

- **New Features**
  - Long-form SSR content for 4 landings with a unique H1 and a bilan CTA.
  - Canonical metadata and `FAQPage` JSON-LD on each page.
  - Internal linking between landings; navbar/footer “Préparations” cluster.
  - SEO guard tests covering canonical, H1, JSON-LD, SSR length, nav/footer links, and claim-to-catalog mapping (Cyclades/ARIA/bacs blancs).

- **Refactors**
  - Pages source metadata/content from `content/marketing/seo-landings.ts`; nav/footer links from `content/marketing/preparation-links.ts`.
  - `LandingNiche` renders sections and related links, emits `FAQPage` JSON-LD, and exports the single source of `OfferRef`/`NicheSection`/`RelatedLink` types.
  - JSON-LD and offer URLs use `LEGAL.web.url`; addresses come from `LEGAL.addresses.pedagogique`; relative canonicals resolved via root `metadataBase`; guard ensures no hardcoded public domain.
  - Pricing driven only by `offerRefs`/`lib/pricing.ts` (no hardcoded TND).
  - Ignore local handoff assets: `.gitignore` and `tsconfig` exclude `nexus-codex-handoff/`.
  - Added an audit doc in `docs/audits/2026-06-24-lot-1-t11-landings-seo.md` capturing the SEO work and noting the CI Actions billing blocker.

<sup>Written for commit f77a88328e7377522da974bd85667d8063183de2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

