### PR TITLE
feat(marketing): surface card payment at conversion

### DIFF
--- a/__tests__/components/offer-detail-dialog.test.tsx
+++ b/__tests__/components/offer-detail-dialog.test.tsx
@@ -6,6 +6,8 @@ import {
   getStageFormat, getPonctuelOffer, getCoachingOffer, getPack,
 } from '@/lib/pricing';
 import { fmtTND } from '@/components/premium/format';
+import { CGV_POLICY } from '@/lib/cgv-policy';
+import { LEGAL } from '@/lib/legal';
 
 // Suppress ResizeObserver warnings in jsdom
 beforeAll(() => {
@@ -112,6 +114,16 @@ describe('OfferDetailDialog', () => {
     const waLink = screen.getByRole('link', { name: /poser une question/i });
     expect(waLink.getAttribute('href')).toContain('wa.me/');
     expect(decodeURIComponent(waLink.getAttribute('href')!)).toContain('Terminale Duo');
+  });
+
+  it('shows card payment policy from CGV without exposing RIB/IBAN', () => {
+    const { container } = render(<OfferDetailDialog offer={sampleOffer} onClose={jest.fn()} />);
+
+    expect(screen.getByText(new RegExp(CGV_POLICY.payment.provider, 'i'))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(CGV_POLICY.payment.acceptedCards, 'i'))).toBeInTheDocument();
+    expect(screen.getByText(CGV_POLICY.payment.cardFee)).toBeInTheDocument();
+    expect(container.textContent).not.toContain(LEGAL.billing.rib);
+    expect(container.textContent).not.toContain(LEGAL.billing.iban);
   });
 
   it('group max never exceeds 5', () => {

--- a/__tests__/components/offres-page.test.tsx
+++ b/__tests__/components/offres-page.test.tsx
@@ -2,6 +2,8 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import OffresPage from '@/app/offres/page';
 import { getRules } from '@/lib/pricing';
+import { CGV_POLICY } from '@/lib/cgv-policy';
+import { LEGAL } from '@/lib/legal';
 
 jest.mock('next/link', () => {
   return function MockLink({ children, href, ...props }: any) {
@@ -59,5 +61,16 @@ describe('OffresPage', () => {
     expect(screen.getAllByRole('link', { name: /réserver ma place/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole('link', { name: /poser une question/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole('link', { name: /demander un bilan/i }).length).toBeGreaterThan(0);
+  });
+
+  it('surfaces ClicToPay card payment without exposing bank identifiers publicly', () => {
+    const { container } = render(<OffresPage />);
+
+    expect(screen.getByText(new RegExp(CGV_POLICY.payment.provider, 'i'))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(CGV_POLICY.payment.bank, 'i'))).toBeInTheDocument();
+    expect(screen.getByText(CGV_POLICY.payment.acceptedCards)).toBeInTheDocument();
+    expect(screen.getByText(CGV_POLICY.payment.cardFee)).toBeInTheDocument();
+    expect(container.textContent).not.toContain(LEGAL.billing.rib);
+    expect(container.textContent).not.toContain(LEGAL.billing.iban);
   });
 });

--- a/__tests__/lib/bilan-gratuit-form.test.tsx
+++ b/__tests__/lib/bilan-gratuit-form.test.tsx
@@ -3,9 +3,12 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import BilanGratuitPage from '../../app/bilan-gratuit/page';
+import { CGV_POLICY } from '@/lib/cgv-policy';
+import { LEGAL } from '@/lib/legal';
 
 const mockPush = jest.fn();
 const mockFetch = jest.fn();
+let mockSearchParams = new URLSearchParams();
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
@@ -16,7 +19,7 @@ jest.mock('next/navigation', () => ({
     replace: jest.fn(),
     prefetch: jest.fn(),
   }),
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => mockSearchParams,
   usePathname: () => '/bilan-gratuit',
 }));
 
@@ -38,6 +41,7 @@ jest.mock('framer-motion', () => ({
 describe('BilanGratuitPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
     (global as any).fetch = mockFetch;
     mockFetch.mockResolvedValue({
       ok: true,
@@ -57,6 +61,18 @@ describe('BilanGratuitPage', () => {
     expect(screen.getByRole('heading', { level: 1, name: 'Bilan stratégique gratuit' })).toBeInTheDocument();
     expect(screen.getByText(/Identifier les priorités de votre enfant/i)).toBeInTheDocument();
     expect(screen.queryByLabelText(/mot de passe/i)).not.toBeInTheDocument();
+  });
+
+  it('shows card payment policy for a selected offer without public RIB/IBAN', () => {
+    mockSearchParams = new URLSearchParams('offer=term-spe-simple');
+    const { container } = render(<BilanGratuitPage />);
+
+    expect(screen.getByText(/offre repérée/i)).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(CGV_POLICY.payment.provider, 'i'))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(CGV_POLICY.payment.bank, 'i'))).toBeInTheDocument();
+    expect(screen.getByText(CGV_POLICY.payment.cardFee)).toBeInTheDocument();
+    expect(container.textContent).not.toContain(LEGAL.billing.rib);
+    expect(container.textContent).not.toContain(LEGAL.billing.iban);
   });
 
   it('submits the public form and redirects to confirmation', async () => {

--- a/app/bilan-gratuit/BilanStrategiqueClient.tsx
+++ b/app/bilan-gratuit/BilanStrategiqueClient.tsx
@@ -15,6 +15,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { ConseillerCard, ProcessSteps } from '@/components/marketing/acadomia-inspired';
+import { PaymentMethodsNote } from '@/components/marketing/PaymentMethodsNote';
 import { fmtTND } from '@/components/premium/format';
 import {
   getAnnualOffer,
@@ -316,6 +317,9 @@ export function BilanStrategiqueClient() {
                         ? ` · ${selectedOffer.solde_schedule.length} soldes`
                         : ''}
               </p>
+              <div className="mt-4">
+                <PaymentMethodsNote tone="dark" />
+              </div>
             </div>
           )}
 

--- a/app/offres/page.tsx
+++ b/app/offres/page.tsx
@@ -37,6 +37,7 @@ import {
   Testimonials,
   TransparencyBanner,
 } from '@/components/marketing/acadomia-inspired';
+import { PaymentMethodsNote } from '@/components/marketing/PaymentMethodsNote';
 import { buildWhatsAppUrl } from '@/lib/whatsapp';
 
 // ── Category filter ──
@@ -177,6 +178,9 @@ export default function OffresPage() {
           <div className="mt-8 grid gap-4 lg:grid-cols-[0.9fr_1.1fr]">
             <TransparencyBanner compact />
             <ReassuranceChips compact />
+          </div>
+          <div className="mt-4 max-w-2xl">
+            <PaymentMethodsNote tone="dark" />
           </div>
         </div>
       </section>

--- a/components/marketing/OfferDetailDialog.tsx
+++ b/components/marketing/OfferDetailDialog.tsx
@@ -7,6 +7,7 @@ import { WhatsAppLogo, WHATSAPP_BRAND_GREEN } from '@/components/ui/whatsapp-log
 import { buildWhatsAppUrl } from '@/lib/whatsapp';
 import { fmtTND } from '@/components/premium/format';
 import { getRules } from '@/lib/pricing';
+import { PaymentMethodsNote } from '@/components/marketing/PaymentMethodsNote';
 
 // ── Types ──
 
@@ -256,6 +257,10 @@ export function OfferDetailDialog({ offer, onClose }: OfferDetailDialogProps) {
               </p>
             </div>
           )}
+
+          <div className="mb-6">
+            <PaymentMethodsNote />
+          </div>
 
           {/* Included */}
           {offer.included.length > 0 && (

--- a/components/marketing/PaymentMethodsNote.tsx
+++ b/components/marketing/PaymentMethodsNote.tsx
@@ -1,0 +1,41 @@
+import { CreditCard, ShieldCheck } from 'lucide-react';
+import { CGV_POLICY } from '@/lib/cgv-policy';
+
+type PaymentMethodsNoteProps = {
+  tone?: 'light' | 'dark';
+  compact?: boolean;
+};
+
+export function PaymentMethodsNote({ tone = 'light', compact = false }: PaymentMethodsNoteProps) {
+  const isDark = tone === 'dark';
+
+  return (
+    <div
+      className={
+        isDark
+          ? 'rounded-2xl border border-lux-line/30 bg-white/5 p-4 text-lux-on-dark-muted'
+          : 'rounded-2xl border border-lux-line bg-lux-paper/70 p-4 text-lux-slate'
+      }
+      data-testid="payment-methods-note"
+    >
+      <div className="flex items-start gap-3">
+        <CreditCard className={isDark ? 'mt-0.5 h-5 w-5 text-lux-gold-wash' : 'mt-0.5 h-5 w-5 text-lux-gold-deep'} aria-hidden="true" />
+        <div className="min-w-0">
+          <p className={isDark ? 'text-sm font-semibold text-lux-ivory' : 'text-sm font-semibold text-lux-ink'}>
+            Paiement par carte via {CGV_POLICY.payment.provider} ({CGV_POLICY.payment.bank})
+          </p>
+          <p className="mt-1 text-sm">{CGV_POLICY.payment.acceptedCards}</p>
+          {!compact && (
+            <div className="mt-3 flex items-start gap-2 text-xs">
+              <ShieldCheck className={isDark ? 'mt-0.5 h-4 w-4 text-lux-gold-wash' : 'mt-0.5 h-4 w-4 text-lux-evergreen'} aria-hidden="true" />
+              <div className="space-y-1">
+                <p>{CGV_POLICY.payment.cardFee}</p>
+                <p>{CGV_POLICY.payment.security} {CGV_POLICY.payment.cvvStorage}</p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/audits/2026-06-24-lot-1-t13-paiement-carte.md
+++ b/docs/audits/2026-06-24-lot-1-t13-paiement-carte.md
@@ -1,0 +1,52 @@
+# Lot 1 T1.3 - Paiement carte au point de conversion
+
+## Date
+
+2026-06-24
+
+## Contexte
+
+Les mentions legales et les CGV exposent deja la politique de paiement carte via ClicToPay / Banque Zitouna, mais cette information n'etait pas visible dans les points de conversion publics. Le lot T1.3 vise a rendre ce moyen de paiement visible sans creer de nouveau flux transactionnel et sans exposer de RIB/IBAN sur les surfaces marketing.
+
+## Problemes observes
+
+- `/offres` ne signalait pas le paiement par carte avant la demande de bilan.
+- Le detail d'offre ne rappelait pas les moyens de paiement.
+- `/bilan-gratuit?offer=...` affichait l'offre reperee sans la politique carte associee.
+
+## Decisions prises
+
+- Creer un composant reutilisable `PaymentMethodsNote` alimente par `CGV_POLICY.payment`.
+- Afficher ClicToPay / Banque Zitouna, cartes acceptees, absence de frais carte et securisation CVV2 + 3D Secure.
+- Ne pas afficher de RIB ni d'IBAN sur les surfaces publiques.
+- Ne pas brancher de nouveau paiement en ligne : l'integration ClicToPay reste un sujet operationnel distinct du surfacage marketing.
+
+## Fichiers modifies
+
+- `components/marketing/PaymentMethodsNote.tsx`
+- `app/offres/page.tsx`
+- `components/marketing/OfferDetailDialog.tsx`
+- `app/bilan-gratuit/BilanStrategiqueClient.tsx`
+- `__tests__/components/offres-page.test.tsx`
+- `__tests__/components/offer-detail-dialog.test.tsx`
+- `__tests__/lib/bilan-gratuit-form.test.tsx`
+- `e2e/pages-public-offres.spec.ts`
+
+## Tests executes
+
+- `npm run test -- --runInBand __tests__/components/offres-page.test.tsx __tests__/components/offer-detail-dialog.test.tsx __tests__/lib/bilan-gratuit-form.test.tsx`
+- `npm run test:e2e -- e2e/pages-public-offres.spec.ts`
+
+## Resultats
+
+- Les tests ciblés Jest passent et prouvent l'affichage ClicToPay sans RIB/IBAN rendu.
+- Le spec Playwright `/offres` passe et prouve la visibilite publique de ClicToPay sans RIB/IBAN dans le texte de page.
+
+## Risques restants
+
+- Ce lot ne valide pas la disponibilite technique du terminal ClicToPay ni le parcours transactionnel parent.
+- Le paiement par virement reste autorise sur les surfaces non publiques quand le contexte metier le requiert.
+
+## Rollback
+
+- Retirer les rendus `PaymentMethodsNote` des trois points de conversion et supprimer le composant.

--- a/e2e/pages-public-offres.spec.ts
+++ b/e2e/pages-public-offres.spec.ts
@@ -1,4 +1,6 @@
 import { test, expect } from '@playwright/test';
+import { CGV_POLICY } from '@/lib/cgv-policy';
+import { LEGAL } from '@/lib/legal';
 
 test.describe('/offres — Page Tarifs', () => {
   test.beforeEach(async ({ page }) => {
@@ -33,6 +35,17 @@ test.describe('/offres — Page Tarifs', () => {
     await expect(page.getByText(/Tarifs\s+en\s+TND/).first()).toBeVisible();
     await expect(page.getByText(/Acompte\s+30\s*%/).first()).toBeVisible();
     await expect(page.getByText(/[ÉE]ch[ée]anciers\s+transparents/).first()).toBeVisible();
+  });
+
+  test('paiement carte ClicToPay visible sans RIB public', async ({ page }) => {
+    await expect(page.getByTestId('payment-methods-note').first()).toBeVisible();
+    await expect(page.getByText(CGV_POLICY.payment.provider).first()).toBeVisible();
+    await expect(page.getByText(CGV_POLICY.payment.acceptedCards).first()).toBeVisible();
+    await expect(page.getByText(CGV_POLICY.payment.cardFee).first()).toBeVisible();
+
+    const body = await page.textContent('body');
+    expect(body).not.toContain(LEGAL.billing.rib);
+    expect(body).not.toContain(LEGAL.billing.iban);
   });
 
   test('page charge sans erreur 500', async ({ page }) => {


### PR DESCRIPTION
## Résumé
- Affiche le paiement carte ClicToPay / Banque Zitouna sur /offres, dans le détail d’offre et dans /bilan-gratuit?offer=...
- Source unique: CGV_POLICY.payment
- Ajoute une preuve Jest + Playwright que ClicToPay est visible sans RIB/IBAN rendu publiquement
- Documente le lot dans docs/audits/2026-06-24-lot-1-t13-paiement-carte.md

## Gate local sans CI
- [x] npm run lint — exit 0
- [x] npm run typecheck — exit 0
- [x] npm run test -- --runInBand — 497 suites passed, 1 skipped; 6278 passed, 4 skipped
- [x] npm run test:e2e — 185 passed
- [x] npm run build — exit 0, 139 pages generated
- [x] npm run check:docs-archive — exit 0
- [x] git diff --check — exit 0
- [x] SSR standalone localhost:3010 — public routes 200, no visible undefined, /offres anchors present, ClicToPay visible, no RIB/IBAN rendered

## Notes
- CI GitHub remains unavailable due billing; validation is local by project decision.
- This PR surfaces payment-card information only; it does not claim the live transaction provider flow is newly wired.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface card payment info (ClicToPay via Banque Zitouna) on key conversion screens to set clear payment expectations. Uses `CGV_POLICY.payment` as the single source of truth and avoids exposing any RIB/IBAN.

- **New Features**
  - Added `PaymentMethodsNote` component powered by `CGV_POLICY.payment` (provider, bank, accepted cards, card fee, security), without showing bank identifiers.
  - Rendered on `/offres`, OfferDetailDialog, and `/bilan-gratuit?offer=...` (dark tone where appropriate).
  - Added Jest and Playwright checks proving ClicToPay visibility and no public `LEGAL.billing` RIB/IBAN; documented in audits; display-only (no new transaction flow).

<sup>Written for commit 912da78dee1ff20691411762bdaf4335f89dd457. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

