### PR TITLE
feat: render bilan offer context server-side

### DIFF
--- a/__tests__/lib/bilan-gratuit-form.test.tsx
+++ b/__tests__/lib/bilan-gratuit-form.test.tsx
@@ -8,7 +8,6 @@ import { LEGAL } from '@/lib/legal';
 
 const mockPush = jest.fn();
 const mockFetch = jest.fn();
-let mockSearchParams = new URLSearchParams();
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
@@ -19,7 +18,6 @@ jest.mock('next/navigation', () => ({
     replace: jest.fn(),
     prefetch: jest.fn(),
   }),
-  useSearchParams: () => mockSearchParams,
   usePathname: () => '/bilan-gratuit',
 }));
 
@@ -41,7 +39,6 @@ jest.mock('framer-motion', () => ({
 describe('BilanGratuitPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSearchParams = new URLSearchParams();
     (global as any).fetch = mockFetch;
     mockFetch.mockResolvedValue({
       ok: true,
@@ -49,23 +46,26 @@ describe('BilanGratuitPage', () => {
     });
   });
 
+  async function renderPage(params: Record<string, string> = {}) {
+    render(await BilanGratuitPage({ searchParams: Promise.resolve(params) }));
+  }
+
   function fillInput(id: string, value: string) {
     const el = document.getElementById(id) as HTMLInputElement | HTMLTextAreaElement | null;
     if (!el) throw new Error(`Input ${id} not found`);
     fireEvent.change(el, { target: { value } });
   }
 
-  it('renders the strategic bilan funnel without a password field', () => {
-    render(<BilanGratuitPage />);
+  it('renders the strategic bilan funnel without a password field', async () => {
+    await renderPage();
 
     expect(screen.getByRole('heading', { level: 1, name: 'Bilan stratégique gratuit' })).toBeInTheDocument();
     expect(screen.getByText(/Identifier les priorités de votre enfant/i)).toBeInTheDocument();
     expect(screen.queryByLabelText(/mot de passe/i)).not.toBeInTheDocument();
   });
 
-  it('shows card payment policy for a selected offer without public RIB/IBAN', () => {
-    mockSearchParams = new URLSearchParams('offer=term-spe-simple');
-    const { container } = render(<BilanGratuitPage />);
+  it('shows card payment policy for a selected offer without public RIB/IBAN', async () => {
+    const { container } = render(await BilanGratuitPage({ searchParams: Promise.resolve({ offer: 'term-spe-simple' }) }));
 
     expect(screen.getByText(/offre repérée/i)).toBeInTheDocument();
     expect(screen.getByText(new RegExp(CGV_POLICY.payment.provider, 'i'))).toBeInTheDocument();
@@ -77,7 +77,7 @@ describe('BilanGratuitPage', () => {
 
   it('submits the public form and redirects to confirmation', async () => {
     const user = userEvent.setup();
-    render(<BilanGratuitPage />);
+    await renderPage();
 
     fillInput('parentFirstName', 'Jean');
     fillInput('parentLastName', 'Dupont');

--- a/__tests__/marketing/echeancier-reconciliation.test.ts
+++ b/__tests__/marketing/echeancier-reconciliation.test.ts
@@ -21,8 +21,8 @@ import {
   getAnnualOfferPaymentSchedule,
 } from '@/lib/pricing';
 
-// Import the actual resolver used by the bilan-gratuit banner
-import { resolveSelectedOfferContext } from '@/app/bilan-gratuit/BilanStrategiqueClient';
+// Import the actual resolver used by the server-rendered bilan-gratuit banner
+import { resolveSelectedOfferContext } from '@/app/bilan-gratuit/selected-offer';
 
 describe('Échéancier reconciliation — canonical payment data', () => {
   const rules = getRules();

--- a/app/bilan-gratuit/BilanStrategiqueClient.tsx
+++ b/app/bilan-gratuit/BilanStrategiqueClient.tsx
@@ -1,34 +1,22 @@
 'use client';
 
-import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import Link from 'next/link';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { CheckCircle2, GraduationCap, Phone } from 'lucide-react';
 import { WhatsAppLogo, WHATSAPP_BRAND_GREEN } from '@/components/ui/whatsapp-logo';
 import { toast, Toaster } from 'sonner';
 import { track } from '@/lib/analytics';
 import { CorporateFooter } from '@/components/layout/CorporateFooter';
-import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { ConseillerCard, ProcessSteps } from '@/components/marketing/acadomia-inspired';
-import { PaymentMethodsNote } from '@/components/marketing/PaymentMethodsNote';
-import { fmtTND } from '@/components/premium/format';
-import {
-  getAnnualOffer,
-  getAnnualOfferPaymentSchedule,
-  getCarte,
-  getCoachingOffer,
-  getEffectivePrice,
-  getPack,
-  getPonctuelOffer,
-  getStageFormat,
-} from '@/lib/pricing';
 import { buildWhatsAppUrl } from '@/lib/whatsapp';
 import { LEGAL } from '@/lib/legal';
+import type { SelectedOfferContext } from './selected-offer';
 
 const SUBJECTS = [
   { value: 'MATHEMATIQUES', label: 'Mathématiques' },
@@ -77,117 +65,16 @@ const initialFormData: FormData = {
 };
 
 
-/** Canonical payment breakdown — same structure used by OfferDetailDialog. */
-export type SelectedOfferContext = {
-  id: string;
-  title: string;
-  price: number;
-  deposit?: number;
-  /** Individual installment amounts (same values the modal renders). */
-  installments?: number[];
-  /** Single solde amount (stages, ponctuel). */
-  solde?: number;
-  /** Multiple solde amounts (packs, coaching with schedule). */
-  solde_schedule?: number[];
-  /** Full payment at booking (no échéancier). */
-  full_at_booking?: boolean;
+type BilanStrategiqueClientProps = {
+  programme?: string | null;
+  selectedOffer?: SelectedOfferContext | null;
 };
 
-export function resolveSelectedOfferContext(id: string | null): SelectedOfferContext | null {
-  if (!id) return null;
-
-  const annual = getAnnualOffer(id);
-  if (annual) {
-    const price = getEffectivePrice(annual);
-    const payment = getAnnualOfferPaymentSchedule(annual);
-    if (!price) return null;
-    return {
-      id: annual.id,
-      title: annual.title,
-      price,
-      deposit: payment?.deposit,
-      installments: payment?.installments,
-    };
-  }
-
-  const stage = getStageFormat(id);
-  if (stage) {
-    return {
-      id: stage.format_id,
-      title: stage.title,
-      price: stage.price_per_student,
-      deposit: stage.payment.deposit,
-      solde: stage.payment.solde,
-    };
-  }
-
-  const ponctuel = getPonctuelOffer(id);
-  if (ponctuel) {
-    return {
-      id: ponctuel.id,
-      title: ponctuel.title,
-      price: ponctuel.price_per_student,
-      deposit: ponctuel.payment.deposit,
-      solde: ponctuel.payment.full_at_booking ? undefined : ponctuel.payment.solde,
-      full_at_booking: ponctuel.payment.full_at_booking,
-    };
-  }
-
-  const coaching = getCoachingOffer(id);
-  if (coaching) {
-    return {
-      id: coaching.id,
-      title: coaching.title,
-      price: coaching.price,
-      deposit: coaching.payment.full_at_booking ? coaching.price : coaching.payment.deposit,
-      solde: coaching.payment.solde,
-      solde_schedule: coaching.payment.solde_schedule,
-      full_at_booking: coaching.payment.full_at_booking,
-    };
-  }
-
-  const pack = getPack(id);
-  if (pack) {
-    return {
-      id: pack.id,
-      title: pack.title,
-      price: pack.price,
-      deposit: pack.payment.deposit,
-      solde_schedule: pack.payment.solde_schedule,
-    };
-  }
-
-  const carte = getCarte();
-  if (carte.id === id) {
-    return {
-      id: carte.id,
-      title: carte.title,
-      price: carte.price_annual,
-      full_at_booking: true,
-      deposit: carte.price_annual,
-    };
-  }
-
-  return null;
-}
-
-export function BilanStrategiqueClient() {
+export function BilanStrategiqueClient({
+  programme = null,
+  selectedOffer = null,
+}: BilanStrategiqueClientProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const programme = searchParams?.get('programme');
-  const offerId = searchParams?.get('offer');
-  const selectedOffer = useMemo(() => resolveSelectedOfferContext(offerId), [offerId]);
-  const programmeLabel = useMemo(() => {
-    if (!programme) return null;
-    const labels: Record<string, string> = {
-      excellence: 'Excellence',
-      plateforme: 'Plateforme',
-      hybride: 'Hybride',
-      immersion: 'Immersion',
-      'pack-specialise': 'Pack spécialisé',
-    };
-    return labels[programme] ?? programme;
-  }, [programme]);
 
   const [formData, setFormData] = useState<FormData>(initialFormData);
   const [selectedSubjects, setSelectedSubjects] = useState<string[]>([]);
@@ -277,68 +164,6 @@ export function BilanStrategiqueClient() {
   return (
     <>
       {/* Toaster is provided globally by components/providers.tsx */}
-
-      <section className="bg-lux-ink px-4 py-16 pt-28 md:px-6">
-        <div className="mx-auto max-w-5xl text-center">
-          <Badge className="mb-4 border border-lux-line/40 bg-white/5 text-lux-gold-wash">
-            Diagnostic gratuit
-          </Badge>
-          <h1 className="font-fraunces text-4xl font-light tracking-tight text-lux-ivory md:text-5xl">
-            Bilan stratégique gratuit
-          </h1>
-          <p className="mx-auto mt-4 max-w-2xl text-lg text-lux-on-dark-muted">
-            Identifier les priorités de votre enfant avant de choisir une formule. Réponse personnalisée,
-            orientation vers la bonne solution et échange humain avec notre équipe pédagogique.
-          </p>
-          {programmeLabel && (
-            <p className="mt-3 text-sm text-lux-gold-wash">
-              Contexte repéré&nbsp;: {programmeLabel}
-            </p>
-          )}
-          {selectedOffer && (
-            <div className="mx-auto mt-5 max-w-2xl rounded-2xl border border-lux-line/30 bg-white/5 p-4 text-left text-sm text-lux-on-dark-muted">
-              <p className="font-semibold text-lux-gold-wash">Offre repérée&nbsp;: {selectedOffer.title}</p>
-              <p className="mt-1">
-                Tarif {fmtTND(selectedOffer.price)}
-                {selectedOffer.deposit != null && !selectedOffer.full_at_booking
-                  ? ` · acompte ${fmtTND(selectedOffer.deposit)}`
-                  : ''}
-                {selectedOffer.full_at_booking
-                  ? ` · règlement intégral à la réservation`
-                  : selectedOffer.installments && selectedOffer.installments.length > 0
-                    ? ` · ${selectedOffer.installments.length}\u00A0×\u00A0${fmtTND(selectedOffer.installments[0])}${
-                        selectedOffer.installments[selectedOffer.installments.length - 1] !== selectedOffer.installments[0]
-                          ? ` puis ${fmtTND(selectedOffer.installments[selectedOffer.installments.length - 1])}`
-                          : ''
-                      }`
-                    : selectedOffer.solde != null
-                      ? ` · solde ${fmtTND(selectedOffer.solde)}`
-                      : selectedOffer.solde_schedule && selectedOffer.solde_schedule.length > 0
-                        ? ` · ${selectedOffer.solde_schedule.length} soldes`
-                        : ''}
-              </p>
-              <div className="mt-4">
-                <PaymentMethodsNote tone="dark" />
-              </div>
-            </div>
-          )}
-
-          <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
-            <a
-              href={buildWhatsAppUrl('le bilan gratuit')}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="lux-cta-secondary rounded-lg px-6 py-3.5 text-sm font-semibold text-lux-ivory border-lux-line/40"
-            >
-              <WhatsAppLogo className="mr-2 h-4 w-4" style={{ color: WHATSAPP_BRAND_GREEN }} />
-              Écrire sur WhatsApp
-            </a>
-            <Link href="/offres" className="lux-cta-reserve rounded-lg px-6 py-3.5 text-sm font-semibold">
-              Voir les offres
-            </Link>
-          </div>
-        </div>
-      </section>
 
       <section className="bg-lux-paper px-4 py-14 md:px-6">
         <div className="mx-auto grid max-w-6xl gap-6 lg:grid-cols-[1.15fr_0.85fr]">

--- a/app/bilan-gratuit/page.tsx
+++ b/app/bilan-gratuit/page.tsx
@@ -1,7 +1,17 @@
 import type { Metadata } from 'next';
-import { Suspense } from 'react';
+import Link from 'next/link';
 import { CorporateNavbar } from '@/components/layout/CorporateNavbar';
 import { BilanStrategiqueClient } from './BilanStrategiqueClient';
+import { Badge } from '@/components/ui/badge';
+import { WhatsAppLogo, WHATSAPP_BRAND_GREEN } from '@/components/ui/whatsapp-logo';
+import { PaymentMethodsNote } from '@/components/marketing/PaymentMethodsNote';
+import { fmtTND } from '@/components/premium/format';
+import { buildWhatsAppUrl } from '@/lib/whatsapp';
+import {
+  resolveProgrammeLabel,
+  resolveSelectedOfferContext,
+  type SelectedOfferContext,
+} from './selected-offer';
 
 export const metadata: Metadata = {
   title: 'Bilan stratégique gratuit | Nexus Réussite',
@@ -16,26 +26,101 @@ export const metadata: Metadata = {
   robots: { index: true, follow: true },
 };
 
-export default function BilanGratuitPage() {
+type BilanGratuitPageProps = {
+  searchParams?: Promise<{
+    programme?: string;
+    offer?: string;
+  }>;
+};
+
+function SelectedOfferSummary({ selectedOffer }: { selectedOffer: SelectedOfferContext }) {
+  return (
+    <div className="mx-auto mt-5 max-w-2xl rounded-2xl border border-lux-line/30 bg-white/5 p-4 text-left text-sm text-lux-on-dark-muted">
+      <p className="font-semibold text-lux-gold-wash">Offre repérée&nbsp;: {selectedOffer.title}</p>
+      <p className="mt-1">
+        Tarif {fmtTND(selectedOffer.price)}
+        {selectedOffer.deposit != null && !selectedOffer.full_at_booking
+          ? ` · acompte ${fmtTND(selectedOffer.deposit)}`
+          : ''}
+        {selectedOffer.full_at_booking
+          ? ` · règlement intégral à la réservation`
+          : selectedOffer.installments && selectedOffer.installments.length > 0
+            ? ` · ${selectedOffer.installments.length}\u00A0×\u00A0${fmtTND(selectedOffer.installments[0])}${
+                selectedOffer.installments[selectedOffer.installments.length - 1] !== selectedOffer.installments[0]
+                  ? ` puis ${fmtTND(selectedOffer.installments[selectedOffer.installments.length - 1])}`
+                  : ''
+              }`
+            : selectedOffer.solde != null
+              ? ` · solde ${fmtTND(selectedOffer.solde)}`
+              : selectedOffer.solde_schedule && selectedOffer.solde_schedule.length > 0
+                ? ` · ${selectedOffer.solde_schedule.length} soldes`
+                : ''}
+      </p>
+      <div className="mt-4">
+        <PaymentMethodsNote tone="dark" />
+      </div>
+    </div>
+  );
+}
+
+function BilanHero({
+  programmeLabel,
+  selectedOffer,
+}: {
+  programmeLabel: string | null;
+  selectedOffer: SelectedOfferContext | null;
+}) {
+  return (
+    <section className="bg-lux-ink px-4 py-16 pt-28 md:px-6">
+      <div className="mx-auto max-w-5xl text-center">
+        <Badge className="mb-4 border border-lux-line/40 bg-white/5 text-lux-gold-wash">
+          Diagnostic gratuit
+        </Badge>
+        <h1 className="font-fraunces text-4xl font-light tracking-tight text-lux-ivory md:text-5xl">
+          Bilan stratégique gratuit
+        </h1>
+        <p className="mx-auto mt-4 max-w-2xl text-lg text-lux-on-dark-muted">
+          Identifier les priorités de votre enfant avant de choisir une formule. Réponse personnalisée,
+          orientation vers la bonne solution et échange humain avec notre équipe pédagogique.
+        </p>
+        {programmeLabel && (
+          <p className="mt-3 text-sm text-lux-gold-wash">
+            Contexte repéré&nbsp;: {programmeLabel}
+          </p>
+        )}
+        {selectedOffer && <SelectedOfferSummary selectedOffer={selectedOffer} />}
+
+        <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+          <a
+            href={buildWhatsAppUrl('le bilan gratuit')}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="lux-cta-secondary rounded-lg px-6 py-3.5 text-sm font-semibold text-lux-ivory border-lux-line/40"
+          >
+            <WhatsAppLogo className="mr-2 h-4 w-4" style={{ color: WHATSAPP_BRAND_GREEN }} />
+            Écrire sur WhatsApp
+          </a>
+          <Link href="/offres" className="lux-cta-reserve rounded-lg px-6 py-3.5 text-sm font-semibold">
+            Voir les offres
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default async function BilanGratuitPage({ searchParams }: BilanGratuitPageProps) {
+  const params = await searchParams;
+  const programme = params?.programme ?? null;
+  const offerId = params?.offer ?? null;
+  const programmeLabel = resolveProgrammeLabel(programme);
+  const selectedOffer = resolveSelectedOfferContext(offerId);
+
   return (
     <main className="luxury min-h-screen" id="main-content">
       <CorporateNavbar />
-      <Suspense
-        fallback={
-          <section className="bg-lux-ink px-4 py-16 pt-28 md:px-6 min-h-[60vh]">
-            <div className="mx-auto max-w-5xl text-center">
-              <h1 className="font-fraunces text-4xl font-light tracking-tight text-lux-ivory md:text-5xl">
-                Bilan stratégique gratuit
-              </h1>
-              <p className="mx-auto mt-4 max-w-2xl text-lg text-lux-on-dark-muted">
-                Chargement du formulaire…
-              </p>
-            </div>
-          </section>
-        }
-      >
-        <BilanStrategiqueClient />
-      </Suspense>
+      <BilanHero programmeLabel={programmeLabel} selectedOffer={selectedOffer} />
+      <BilanStrategiqueClient programme={programme} selectedOffer={selectedOffer} />
     </main>
   );
 }

--- a/app/bilan-gratuit/selected-offer.ts
+++ b/app/bilan-gratuit/selected-offer.ts
@@ -1,0 +1,113 @@
+import {
+  getAnnualOffer,
+  getAnnualOfferPaymentSchedule,
+  getCarte,
+  getCoachingOffer,
+  getEffectivePrice,
+  getPack,
+  getPonctuelOffer,
+  getStageFormat,
+} from '@/lib/pricing';
+
+export type SelectedOfferContext = {
+  id: string;
+  title: string;
+  price: number;
+  deposit?: number;
+  installments?: number[];
+  solde?: number;
+  solde_schedule?: number[];
+  full_at_booking?: boolean;
+};
+
+export function resolveProgrammeLabel(programme: string | null | undefined) {
+  if (!programme) return null;
+
+  const labels: Record<string, string> = {
+    excellence: 'Excellence',
+    plateforme: 'Plateforme',
+    hybride: 'Hybride',
+    immersion: 'Immersion',
+    'pack-specialise': 'Pack spécialisé',
+  };
+
+  return labels[programme] ?? programme;
+}
+
+export function resolveSelectedOfferContext(id: string | null | undefined): SelectedOfferContext | null {
+  if (!id) return null;
+
+  const annual = getAnnualOffer(id);
+  if (annual) {
+    const price = getEffectivePrice(annual);
+    const payment = getAnnualOfferPaymentSchedule(annual);
+    if (!price) return null;
+    return {
+      id: annual.id,
+      title: annual.title,
+      price,
+      deposit: payment?.deposit,
+      installments: payment?.installments,
+    };
+  }
+
+  const stage = getStageFormat(id);
+  if (stage) {
+    return {
+      id: stage.format_id,
+      title: stage.title,
+      price: stage.price_per_student,
+      deposit: stage.payment.deposit,
+      solde: stage.payment.solde,
+    };
+  }
+
+  const ponctuel = getPonctuelOffer(id);
+  if (ponctuel) {
+    return {
+      id: ponctuel.id,
+      title: ponctuel.title,
+      price: ponctuel.price_per_student,
+      deposit: ponctuel.payment.deposit,
+      solde: ponctuel.payment.full_at_booking ? undefined : ponctuel.payment.solde,
+      full_at_booking: ponctuel.payment.full_at_booking,
+    };
+  }
+
+  const coaching = getCoachingOffer(id);
+  if (coaching) {
+    return {
+      id: coaching.id,
+      title: coaching.title,
+      price: coaching.price,
+      deposit: coaching.payment.full_at_booking ? coaching.price : coaching.payment.deposit,
+      solde: coaching.payment.solde,
+      solde_schedule: coaching.payment.solde_schedule,
+      full_at_booking: coaching.payment.full_at_booking,
+    };
+  }
+
+  const pack = getPack(id);
+  if (pack) {
+    return {
+      id: pack.id,
+      title: pack.title,
+      price: pack.price,
+      deposit: pack.payment.deposit,
+      solde_schedule: pack.payment.solde_schedule,
+    };
+  }
+
+  const carte = getCarte();
+  if (carte.id === id) {
+    return {
+      id: carte.id,
+      title: carte.title,
+      price: carte.price_annual,
+      full_at_booking: true,
+      deposit: carte.price_annual,
+    };
+  }
+
+  return null;
+}

--- a/docs/audits/2026-06-24-lot-2-polish.md
+++ b/docs/audits/2026-06-24-lot-2-polish.md
@@ -1,0 +1,61 @@
+# Lot 2 - Decisions produit et polish
+
+## Date
+
+2026-06-24
+
+## Contexte
+
+Le plan de finalisation demande trois sujets Lot 2 : arbitrage Carte Nexus, rendu SSR de `/bilan-gratuit`, et harmonisation tutoiement / vouvoiement.
+
+## Problemes observes
+
+- `/bilan-gratuit?offer=...` rendait un fallback HTML avec `BAILOUT_TO_CLIENT_SIDE_RENDERING` parce que le composant client lisait `useSearchParams`.
+- L'offre reperee et la note de paiement carte etaient visibles apres hydratation, mais pas garanties dans le HTML initial.
+- Carte Nexus reste une decision produit : `carte-nexus` a 290 TND / an inclut `ARIA Autonomie`, vendue en standalone a 590 TND / an.
+
+## Decisions prises
+
+- Deplacer la resolution `programme` / `offer` dans le server component `app/bilan-gratuit/page.tsx`.
+- Sortir le resolver d'offre dans `app/bilan-gratuit/selected-offer.ts`, module partage et testable.
+- Rendre le hero, l'offre reperee et la politique ClicToPay dans le HTML initial.
+- Conserver le tutoiement dans les surfaces pedagogiques eleve (`dashboard/eleve`, ARIA widget, LAMIS, automatismes), car elles s'adressent directement a l'eleve. Les surfaces marketing scannees restent au vouvoiement.
+
+## Fichiers modifies
+
+- `app/bilan-gratuit/page.tsx`
+- `app/bilan-gratuit/BilanStrategiqueClient.tsx`
+- `app/bilan-gratuit/selected-offer.ts`
+- `__tests__/lib/bilan-gratuit-form.test.tsx`
+- `__tests__/marketing/echeancier-reconciliation.test.ts`
+- `e2e/pages-public-bilan-gratuit.spec.ts`
+
+## Tests executes
+
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test -- --runInBand`
+- `npm run test:e2e`
+- `npm run test -- --runInBand __tests__/lib/bilan-gratuit-form.test.tsx __tests__/marketing/echeancier-reconciliation.test.ts`
+- `npm run test:e2e -- e2e/pages-public-bilan-gratuit.spec.ts`
+- `npm run build`
+- `npm run check:docs-archive`
+- `git diff --check`
+- Smoke SSR standalone `HOSTNAME=localhost PORT=3010 node .next/standalone/server.js`
+
+## Resultats
+
+- Le test e2e RED a d'abord echoue sur l'absence d'offre reperee dans le HTML initial.
+- Apres correction, le spec `/bilan-gratuit` passe avec 8 tests verts.
+- L'HTML initial de `/bilan-gratuit?offer=term-spe-simple` contient l'offre reperee, ClicToPay et Banque Zitouna, sans RIB/IBAN, et sans `BAILOUT_TO_CLIENT_SIDE_RENDERING`.
+- Gate local complet vert : Jest `497 passed, 1 skipped` suites / `6278 passed, 4 skipped` tests ; Playwright public `186 passed` ; build Next `139/139` pages.
+- Smoke SSR standalone vert sur `/`, `/offres`, `/recommandation`, `/bilan-gratuit`, `/bilan-gratuit?offer=term-spe-simple`, `/stages`, `/plateforme-aria`, `/accompagnement-scolaire`, `/contact` : HTTP 200, H1 unique, aucune occurrence visible de `undefined`.
+
+## Risques restants
+
+- Carte Nexus necessite un arbitrage Shark : loss-leader assume ou correction du perimetre/prix.
+- L'unification de charte necessite une decision Shark sur le systeme cible.
+
+## Rollback
+
+- Replacer la lecture des query params dans le composant client et retirer `selected-offer.ts`, en acceptant le retour au fallback client.

--- a/e2e/pages-public-bilan-gratuit.spec.ts
+++ b/e2e/pages-public-bilan-gratuit.spec.ts
@@ -57,4 +57,18 @@ test.describe('Bilan Gratuit — Formulaire stratégique', () => {
   test('CTA WhatsApp est visible', async ({ page }) => {
     await expect(page.locator('a[href*="wa.me"]').first()).toBeVisible();
   });
+
+  test('offre repérée et paiement carte sont présents dans le HTML initial', async ({ page }) => {
+    const response = await page.request.get('/bilan-gratuit?offer=term-spe-simple');
+    expect(response.status()).toBe(200);
+
+    const html = await response.text();
+    expect(html).not.toContain('BAILOUT_TO_CLIENT_SIDE_RENDERING');
+    expect(html).toContain('Offre repérée');
+    expect(html).toContain('Terminale Spécialité simple');
+    expect(html).toContain('ClicToPay');
+    expect(html).toContain('Banque Zitouna');
+    expect(html).not.toContain('25 079 000 0001569084 04');
+    expect(html).not.toContain('TN59 25 079 000 0001569084 04');
+  });
 });


### PR DESCRIPTION
## Résumé
- Rend le hero de /bilan-gratuit côté serveur, y compris le contexte programme/offre sélectionnée.
- Déplace le resolver d'offre dans app/bilan-gratuit/selected-offer.ts pour réutilisation testable.
- Ajoute une spec e2e qui vérifie l'offre repérée et ClicToPay dans le HTML initial, sans RIB/IBAN public.
- Documente Lot 2, avec Carte Nexus et unification charte restées en décision Shark.

## Validation locale
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run test -- --runInBand — 497 suites passed, 1 skipped ; 6278 tests passed, 4 skipped
- [x] npm run test:e2e — 186 passed
- [x] npm run build — 139/139 pages
- [x] npm run check:docs-archive
- [x] git diff --check
- [x] Smoke SSR standalone localhost:3010 — routes critiques 200, H1 unique, pas de undefined visible ; /bilan-gratuit?offer=term-spe-simple contient Offre repérée, ClicToPay, Banque Zitouna, sans BAILOUT ni RIB/IBAN

CI GitHub indisponible durablement côté facturation : validation locale complète conformément au nouveau cadre.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Server-render the /bilan-gratuit hero with programme and selected offer so key info is in the initial HTML and we avoid client-side bailout. The page now shows the spotted offer and card payment policy on first paint, without exposing RIB/IBAN.

- **New Features**
  - Render hero server-side in `app/bilan-gratuit/page.tsx`, including programme label and selected offer.
  - Extract offer resolver to `app/bilan-gratuit/selected-offer.ts` for reuse and tests.
  - Update `BilanStrategiqueClient` to receive `programme` and `selectedOffer` via props (no `useSearchParams`).
  - Add e2e check ensuring SSR HTML contains “Offre repérée”, “ClicToPay”, bank name, and no RIB/IBAN or client render bailout.
  - Adjust unit tests for new page signature and shared resolver; add Lot 2 notes in docs.

<sup>Written for commit 3d2efb45f0fcf18a261a2ecca53c0f73a48adab9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

