### PR TITLE
fix: cubic #53 followup — timezone + guard self-selection

### DIFF
--- a/__tests__/marketing/brand-trust-guard.test.ts
+++ b/__tests__/marketing/brand-trust-guard.test.ts
@@ -139,17 +139,20 @@ describe('Lot 1 T1.2 brand trust guardrails', () => {
   });
 
   test('client marketing surfaces read group rules from canonical SSOT (lib/pricing-client), not a duplicate', () => {
-    // Dynamically find all .tsx files under app/ and components/ that are
-    // 'use client' AND import getRules from @/lib/pricing-client.
     const glob = require('glob');
     const candidates: string[] = glob.sync('{app,components}/**/*.tsx', {
       ignore: ['**/node_modules/**', '**/.next/**'],
     });
 
-    const clientFiles: string[] = [];
+    // Two complementary checks:
+    // (A) Positive: files importing getRules must use pricing-client
+    // (B) Negative: NO client file anywhere imports group-rules (forbidden pattern)
+
+    const clientFilesWithGetRules: string[] = [];
+    const groupRulesViolations: string[] = [];
+
     for (const file of candidates) {
       const source = readFileSync(join(root, file), 'utf8');
-      // Detect 'use client' directive
       const firstLine = source.split('\n').find((l: string) => {
         const t = l.trim();
         return t !== '' && !t.startsWith('//') && !t.startsWith('/*') && !t.startsWith('*');
@@ -157,22 +160,28 @@ describe('Lot 1 T1.2 brand trust guardrails', () => {
       const isClient = firstLine && (firstLine.trim() === "'use client';" || firstLine.trim() === '"use client";'
         || firstLine.trim() === "'use client'" || firstLine.trim() === '"use client"');
       if (!isClient) continue;
-      // Check if file imports getRules from @/lib/pricing-client
-      if (/\bgetRules\b/.test(source) && /from ['"]@\/lib\/pricing-client['"]/.test(source)) {
-        clientFiles.push(file);
+
+      // (B) Forbidden: no client file should import group-rules
+      if (/group-rules/.test(source)) {
+        groupRulesViolations.push(file);
+      }
+
+      // (A) Positive: files using getRules must import from pricing-client
+      if (/\bgetRules\b/.test(source)) {
+        clientFilesWithGetRules.push(file);
       }
     }
 
-    expect(clientFiles.length).toBeGreaterThan(0);
+    // At least some client files use getRules (sanity check)
+    expect(clientFilesWithGetRules.length).toBeGreaterThan(0);
 
-    for (const file of clientFiles) {
+    for (const file of clientFilesWithGetRules) {
       const source = sourceFor(file);
-      // Must use getRules() from lib/pricing-client (client-safe SSOT subset)
-      expect(source).toMatch(/\bgetRules\b/);
       expect(source).toMatch(/from ['"]@\/lib\/pricing-client['"]/);
-      // Must NOT import from the deleted duplicate
-      expect(source).not.toContain('group-rules');
     }
+
+    // No client file anywhere uses the deleted group-rules module
+    expect(groupRulesViolations).toEqual([]);
   });
 
   test('legacy range names are not exposed in active app or component copy', () => {

--- a/lib/pricing-client.ts
+++ b/lib/pricing-client.ts
@@ -33,12 +33,11 @@ export function getReperes(): typeof PRICING_REPERES {
 
 export function getNextStage(referenceDate?: Date): { title: string; dates_display: string; date_start: string } | null {
   const now = referenceDate ?? new Date();
-  // Truncate to start of local day so that date_start strings like '2026-08-24'
-  // (parsed as midnight UTC) are not excluded by local-time hour offset.
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  // Compare YYYY-MM-DD strings to avoid UTC-vs-local timezone skew entirely.
+  const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
   const upcoming = (stageCalendarMini as Array<{ title: string; date_start: string; dates_display: string }>)
-    .filter((e) => new Date(e.date_start) >= today)
-    .sort((a, b) => new Date(a.date_start).getTime() - new Date(b.date_start).getTime());
+    .filter((e) => e.date_start >= todayStr)
+    .sort((a, b) => a.date_start.localeCompare(b.date_start));
   if (upcoming.length === 0) return null;
   const next = upcoming[0];
   return { title: next.title, dates_display: next.dates_display, date_start: next.date_start };

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -389,13 +389,12 @@ export function getStageCalendar(): StageCalendarEntry[] {
  */
 export function getNextStage(referenceDate?: Date): { title: string; dates_display: string; date_start: string } | null {
   const now = referenceDate ?? new Date();
-  // Truncate to start of local day so that date_start strings like '2026-08-24'
-  // (parsed as midnight UTC) are not excluded by local-time hour offset.
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  // Compare YYYY-MM-DD strings to avoid UTC-vs-local timezone skew entirely.
+  const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
   const calendar = getStageCalendar();
   const upcoming = calendar
-    .filter((e) => new Date(e.date_start) >= today)
-    .sort((a, b) => new Date(a.date_start).getTime() - new Date(b.date_start).getTime());
+    .filter((e) => e.date_start >= todayStr)
+    .sort((a, b) => a.date_start.localeCompare(b.date_start));
   if (upcoming.length === 0) return null;
   const next = upcoming[0];
   return {


### PR DESCRIPTION
## Summary

Cubic review on PR#53 found 2 valid issues — both fixed:

1. **getNextStage timezone skew**: Date-only strings parse as UTC midnight but local truncation diverges for UTC- users. Fixed by comparing YYYY-MM-DD strings directly — no Date objects, no timezone.

2. **brand-trust-guard self-selection**: Dynamic discovery only found conforming files, so regressions dropped silently. Fixed with dual check: (A) files using getRules must import pricing-client, (B) ALL client files scanned for forbidden group-rules.

## Proof — issue 2a route-missing guard

```
✗  /recommandation: not found in build output (protected route vanished)
EXIT=1
```

12/12 baseline routes confirmed present in current build.

## Test plan
- [x] typecheck, lint, 6296 tests passed, build:gate 12/12, site-map, docs-archive, diff-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `getNextStage` timezone skew and hardens the brand‑trust guard so forbidden imports can’t slip through. Users in UTC− timezones now see the correct next stage; client files using `getRules` must import from `@/lib/pricing-client`.

- **Bug Fixes**
  - Compare YYYY-MM-DD strings (no `Date` objects) and sort via `localeCompare` in `lib/pricing.ts` and `lib/pricing-client.ts` to remove UTC vs local skew.
  - Guardrail now does dual checks: positive—files using `getRules` must import from `@/lib/pricing-client`; negative—scan all client `.tsx` files and fail on any `group-rules` import.

<sup>Written for commit 2b094b814f58486fe1c2dd6d08fe9fe1c8563eab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

