### PR TITLE
feat(config): BusinessConfig store — schema, snapshot, Zod, API (Lot 3)

### DIFF
--- a/__tests__/api/admin.config.route.test.ts
+++ b/__tests__/api/admin.config.route.test.ts
@@ -152,15 +152,17 @@ describe('PATCH /api/admin/config', () => {
   });
 
   it('PATCH then GET sees the new value (applyWrite is synchronous)', async () => {
+    // Use semi_individual_surcharge_pct — no cross-key invariants, safe to PATCH
+    mockFindMany.mockResolvedValue([]);
     const upsertedRow = {
-      id: 'cfg-1', namespace: 'pricing.rules', key: 'group_max', value: 3,
+      id: 'cfg-1', namespace: 'pricing.rules', key: 'semi_individual_surcharge_pct', value: 60,
       schemaVersion: SCHEMA_VERSION, version: 1, previousValue: null,
       updatedBy: 'admin-1', updatedAt: new Date(), createdAt: new Date(),
     };
     mockUpsert.mockResolvedValue(upsertedRow);
 
     const patchRes = await PATCH(makeRequest({
-      namespace: 'pricing.rules', key: 'group_max', value: 3,
+      namespace: 'pricing.rules', key: 'semi_individual_surcharge_pct', value: 60,
     }));
     expect(patchRes.status).toBe(200);
 
@@ -168,10 +170,12 @@ describe('PATCH /api/admin/config', () => {
     const body = await getRes.json();
     expect(body.entries).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ namespace: 'pricing.rules', key: 'group_max', value: 3 }),
+        expect.objectContaining({
+          namespace: 'pricing.rules', key: 'semi_individual_surcharge_pct', value: 60, source: 'override',
+        }),
       ]),
     );
-    expect(getOverride('pricing.rules', 'group_max')).toBe(3);
+    expect(getOverride('pricing.rules', 'semi_individual_surcharge_pct')).toBe(60);
   });
 
   it('rejects missing fields', async () => {
@@ -187,14 +191,16 @@ describe('PATCH /api/admin/config', () => {
   });
 
   it('calls pg_advisory_xact_lock in every PATCH', async () => {
+    mockFindMany.mockResolvedValue([]);
     mockUpsert.mockResolvedValue({
-      id: 'cfg-1', namespace: 'pricing.rules', key: 'group_max', value: 3,
+      id: 'cfg-1', namespace: 'pricing.rules', key: 'semi_individual_surcharge_pct', value: 60,
       schemaVersion: SCHEMA_VERSION, version: 1, previousValue: null,
       updatedBy: 'admin-1', updatedAt: new Date(), createdAt: new Date(),
     });
-    await PATCH(makeRequest({
-      namespace: 'pricing.rules', key: 'group_max', value: 3,
+    const res = await PATCH(makeRequest({
+      namespace: 'pricing.rules', key: 'semi_individual_surcharge_pct', value: 60,
     }));
+    expect(res.status).toBe(200);
     expect(mockQueryRawUnsafe).toHaveBeenCalledWith(
       'SELECT pg_advisory_xact_lock($1)',
       expect.any(Number),
@@ -265,5 +271,59 @@ describe('TOCTOU — concurrent cross-key invariant bypass', () => {
     // At least one MUST be rejected (400).
     const statuses = [resA.status, resB.status].sort();
     expect(statuses).toContain(400);
+  });
+});
+
+describe('Invariants on empty store — must validate against canonical fallbacks', () => {
+  // On an empty store, no overrides exist. The effective value for any key
+  // is the canonical fallback (pricing.canonical.json). Invariants must
+  // still reject writes that violate constraints against these fallbacks.
+
+  it('rejects group_min_open.lycee=6 on empty store (canonical group_max=5)', async () => {
+    // Store is completely empty — no overrides for any key.
+    // canonical group_max = 5. Setting lycee=6 violates 6 > 5.
+    _resetForTest();
+    mockFindMany.mockResolvedValue([]); // DB has no overrides
+    mockFindUnique.mockResolvedValue(null);
+
+    const res = await PATCH(makeRequest({
+      namespace: 'pricing.rules',
+      key: 'group_min_open.lycee',
+      value: 6,
+    }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invariant violation');
+    expect(body.violations[0]).toContain('group_min_open.lycee (6) > group_max (5)');
+  });
+
+  it('rejects discount=25 on empty store (canonical global_cap_pct=20)', async () => {
+    _resetForTest();
+    mockFindMany.mockResolvedValue([]);
+    mockFindUnique.mockResolvedValue(null);
+
+    const res = await PATCH(makeRequest({
+      namespace: 'pricing.rules',
+      key: 'discounts.comptant_pct',
+      value: 25,
+    }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.violations[0]).toContain('global_cap_pct (20)');
+  });
+
+  it('rejects floor=1 on empty store (deposit rounds to 0 at canonical deposit_pct=30)', async () => {
+    _resetForTest();
+    mockFindMany.mockResolvedValue([]);
+    mockFindUnique.mockResolvedValue(null);
+
+    const res = await PATCH(makeRequest({
+      namespace: 'pricing.floors',
+      key: 'single',
+      value: 1,
+    }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.violations[0]).toContain('deposit rounds to 0');
   });
 });

--- a/__tests__/api/admin.config.route.test.ts
+++ b/__tests__/api/admin.config.route.test.ts
@@ -25,12 +25,35 @@ const mockFindMany = jest.fn().mockResolvedValue([]);
 const mockFindUnique = jest.fn().mockResolvedValue(null);
 const mockUpsert = jest.fn();
 
+// Serialization lock for test: simulates pg_advisory_xact_lock behavior.
+// Only one $transaction callback runs at a time (queued).
+let txLock: Promise<void> = Promise.resolve();
+
 jest.mock('@/lib/prisma', () => ({
   prisma: {
     businessConfig: {
       findMany: (...args: any[]) => mockFindMany(...args),
       findUnique: (...args: any[]) => mockFindUnique(...args),
       upsert: (...args: any[]) => mockUpsert(...args),
+    },
+    $transaction: (fn: (tx: any) => Promise<any>) => {
+      // Serialize: each transaction waits for the previous to complete
+      const prev = txLock;
+      let resolveLock: () => void;
+      txLock = new Promise((r) => { resolveLock = r; });
+      return prev.then(() =>
+        fn({
+          $queryRawUnsafe: async () => {}, // advisory lock no-op in test
+          businessConfig: {
+            findMany: (...args: any[]) => mockFindMany(...args),
+            findUnique: (...args: any[]) => mockFindUnique(...args),
+            upsert: (...args: any[]) => mockUpsert(...args),
+          },
+          businessConfigAudit: {
+            create: async () => ({ id: 'audit-1' }),
+          },
+        }).finally(() => resolveLock!()),
+      );
     },
   },
 }));
@@ -96,15 +119,13 @@ describe('PATCH /api/admin/config', () => {
     expect(body.violations[0]).toContain('global_cap_pct (10) < discounts.comptant_pct (15)');
   });
 
-  it('PATCH then GET sees the new value (invalidation is synchronous)', async () => {
+  it('PATCH then GET sees the new value (applyWrite is synchronous)', async () => {
     const upsertedRow = {
       id: 'cfg-1', namespace: 'pricing.rules', key: 'group_max', value: 3,
       schemaVersion: SCHEMA_VERSION, version: 1, previousValue: null,
       updatedBy: 'admin-1', updatedAt: new Date(), createdAt: new Date(),
     };
     mockUpsert.mockResolvedValue(upsertedRow);
-    // After PATCH commits, invalidateSnapshot() calls findMany:
-    mockFindMany.mockResolvedValue([upsertedRow]);
 
     const patchRes = await PATCH(makeRequest({
       namespace: 'pricing.rules',
@@ -138,5 +159,75 @@ describe('PATCH /api/admin/config', () => {
       value: 1,
     }));
     expect(res.status).toBe(400);
+  });
+});
+
+describe('TOCTOU — concurrent cross-key invariant bypass', () => {
+  it('two concurrent PATCHes on related keys cannot bypass group_min ≤ group_max', async () => {
+    // Initial state: group_max=5, group_min_open.lycee=3 (valid: 3 ≤ 5)
+    const dbState: Record<string, { value: unknown; version: number }> = {
+      'pricing.rules::group_max': { value: 5, version: 1 },
+      'pricing.rules::group_min_open.lycee': { value: 3, version: 1 },
+    };
+
+    _setForTest([
+      { namespace: 'pricing.rules', key: 'group_max', value: 5,
+        schemaVersion: SCHEMA_VERSION, version: 1, updatedBy: 'test', updatedAt: new Date() },
+      { namespace: 'pricing.rules', key: 'group_min_open.lycee', value: 3,
+        schemaVersion: SCHEMA_VERSION, version: 1, updatedBy: 'test', updatedAt: new Date() },
+    ]);
+
+    // Mock findMany reads from dbState (transactional view)
+    mockFindMany.mockImplementation(async () => {
+      return Object.entries(dbState).map(([mapKey, { value, version }]) => {
+        const [ns, key] = mapKey.split('::');
+        return {
+          id: mapKey, namespace: ns, key, value,
+          schemaVersion: SCHEMA_VERSION, version, previousValue: null,
+          updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date(),
+        };
+      });
+    });
+
+    mockFindUnique.mockImplementation(async (args: any) => {
+      const ns = args.where.namespace_key.namespace;
+      const key = args.where.namespace_key.key;
+      const state = dbState[`${ns}::${key}`];
+      if (!state) return null;
+      return {
+        id: `${ns}::${key}`, namespace: ns, key, value: state.value,
+        schemaVersion: SCHEMA_VERSION, version: state.version, previousValue: null,
+        updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date(),
+      };
+    });
+
+    mockUpsert.mockImplementation(async (args: any) => {
+      const key = args.where.namespace_key.key;
+      const ns = args.where.namespace_key.namespace;
+      const value = args.update?.value ?? args.create?.value;
+      const mapKey = `${ns}::${key}`;
+      const existing = dbState[mapKey];
+      const newVersion = (existing?.version ?? 0) + 1;
+      dbState[mapKey] = { value, version: newVersion };
+      return {
+        id: mapKey, namespace: ns, key, value,
+        schemaVersion: SCHEMA_VERSION, version: newVersion, previousValue: existing?.value ?? null,
+        updatedBy: 'admin-1', updatedAt: new Date(), createdAt: new Date(),
+      };
+    });
+
+    // Fire both PATCHes concurrently. Due to the serialized $transaction
+    // mock, they execute one after the other — the second one sees the
+    // first's committed state in its transactional findMany.
+    const [resA, resB] = await Promise.all([
+      PATCH(makeRequest({ namespace: 'pricing.rules', key: 'group_max', value: 4 })),
+      PATCH(makeRequest({ namespace: 'pricing.rules', key: 'group_min_open.lycee', value: 5 })),
+    ]);
+
+    // The serialized lock means: A commits first (group_max=4), then B
+    // validates inside the transaction seeing group_max=4 and lycee=5 → 5>4 → rejected.
+    // At least one MUST be rejected (400).
+    const statuses = [resA.status, resB.status].sort();
+    expect(statuses).toContain(400);
   });
 });

--- a/__tests__/api/admin.config.route.test.ts
+++ b/__tests__/api/admin.config.route.test.ts
@@ -1,0 +1,142 @@
+/**
+ * API integration tests for /api/admin/config
+ *
+ * Tests the PATCH → invalidateSnapshot → GET chain to prove the admin
+ * sees the new value immediately after write.
+ */
+import { NextRequest } from 'next/server';
+import { GET, PATCH } from '@/app/api/admin/config/route';
+import { _resetForTest, _setForTest, getOverride, type ConfigEntry } from '@/lib/config/snapshot';
+import { SCHEMA_VERSION } from '@/lib/config/schemas';
+
+// Mock auth: ADMIN user
+jest.mock('@/lib/guards', () => ({
+  requireRole: jest.fn().mockResolvedValue({
+    user: { id: 'admin-1', role: 'ADMIN', email: 'admin@test.com' },
+  }),
+  requireAnyRole: jest.fn().mockResolvedValue({
+    user: { id: 'admin-1', role: 'ADMIN', email: 'admin@test.com' },
+  }),
+  isErrorResponse: jest.fn().mockReturnValue(false),
+}));
+
+// Mock prisma
+const mockFindMany = jest.fn().mockResolvedValue([]);
+const mockFindUnique = jest.fn().mockResolvedValue(null);
+const mockUpsert = jest.fn();
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    businessConfig: {
+      findMany: (...args: any[]) => mockFindMany(...args),
+      findUnique: (...args: any[]) => mockFindUnique(...args),
+      upsert: (...args: any[]) => mockUpsert(...args),
+    },
+  },
+}));
+
+function makeRequest(body: object): NextRequest {
+  return new NextRequest('http://localhost:3000/api/admin/config', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  _resetForTest();
+  mockFindMany.mockResolvedValue([]);
+  mockFindUnique.mockResolvedValue(null);
+  mockUpsert.mockReset();
+});
+
+describe('PATCH /api/admin/config', () => {
+  it('rejects invalid value (group_max: -3)', async () => {
+    const res = await PATCH(makeRequest({
+      namespace: 'pricing.rules',
+      key: 'group_max',
+      value: -3,
+    }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Validation failed');
+  });
+
+  it('rejects invariant violation (group_min_open.lycee > group_max)', async () => {
+    // Snapshot has group_max=3
+    _setForTest([{
+      namespace: 'pricing.rules', key: 'group_max', value: 3,
+      schemaVersion: SCHEMA_VERSION, version: 1, updatedBy: 'test', updatedAt: new Date(),
+    }]);
+
+    const res = await PATCH(makeRequest({
+      namespace: 'pricing.rules',
+      key: 'group_min_open.lycee',
+      value: 5,
+    }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invariant violation');
+    expect(body.violations[0]).toContain('group_min_open.lycee (5) > group_max (3)');
+  });
+
+  it('rejects discount above cap (bidirectional invariant)', async () => {
+    _setForTest([{
+      namespace: 'pricing.rules', key: 'discounts.global_cap_pct', value: 10,
+      schemaVersion: SCHEMA_VERSION, version: 1, updatedBy: 'test', updatedAt: new Date(),
+    }]);
+
+    const res = await PATCH(makeRequest({
+      namespace: 'pricing.rules',
+      key: 'discounts.comptant_pct',
+      value: 15,
+    }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.violations[0]).toContain('global_cap_pct (10) < discounts.comptant_pct (15)');
+  });
+
+  it('PATCH then GET sees the new value (invalidation is synchronous)', async () => {
+    const upsertedRow = {
+      id: 'cfg-1', namespace: 'pricing.rules', key: 'group_max', value: 3,
+      schemaVersion: SCHEMA_VERSION, version: 1, previousValue: null,
+      updatedBy: 'admin-1', updatedAt: new Date(), createdAt: new Date(),
+    };
+    mockUpsert.mockResolvedValue(upsertedRow);
+    // After PATCH commits, invalidateSnapshot() calls findMany:
+    mockFindMany.mockResolvedValue([upsertedRow]);
+
+    const patchRes = await PATCH(makeRequest({
+      namespace: 'pricing.rules',
+      key: 'group_max',
+      value: 3,
+    }));
+    expect(patchRes.status).toBe(200);
+
+    // GET immediately after PATCH — must see group_max=3
+    const getRes = await GET();
+    const body = await getRes.json();
+    expect(body.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ namespace: 'pricing.rules', key: 'group_max', value: 3 }),
+      ]),
+    );
+
+    // Also verify via getOverride (sync accessor)
+    expect(getOverride('pricing.rules', 'group_max')).toBe(3);
+  });
+
+  it('rejects missing fields', async () => {
+    const res = await PATCH(makeRequest({ namespace: 'pricing.rules' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects unknown namespace', async () => {
+    const res = await PATCH(makeRequest({
+      namespace: 'unknown.ns',
+      key: 'foo',
+      value: 1,
+    }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/__tests__/api/admin.config.route.test.ts
+++ b/__tests__/api/admin.config.route.test.ts
@@ -24,6 +24,7 @@ jest.mock('@/lib/guards', () => ({
 const mockFindMany = jest.fn().mockResolvedValue([]);
 const mockFindUnique = jest.fn().mockResolvedValue(null);
 const mockUpsert = jest.fn();
+const mockUpdate = jest.fn();
 const mockQueryRawUnsafe = jest.fn();
 
 // Mutex: simulates pg_advisory_xact_lock — only one holder at a time
@@ -53,6 +54,7 @@ jest.mock('@/lib/prisma', () => ({
       findMany: (...args: any[]) => mockFindMany(...args),
       findUnique: (...args: any[]) => mockFindUnique(...args),
       upsert: (...args: any[]) => mockUpsert(...args),
+      update: (...args: any[]) => mockUpdate(...args),
     },
     $transaction: async (fn: (tx: any) => Promise<any>) => {
       // No serialization here — if code doesn't call $queryRawUnsafe,
@@ -67,6 +69,7 @@ jest.mock('@/lib/prisma', () => ({
             findMany: (...args: any[]) => mockFindMany(...args),
             findUnique: (...args: any[]) => mockFindUnique(...args),
             upsert: (...args: any[]) => mockUpsert(...args),
+            update: (...args: any[]) => mockUpdate(...args),
           },
           businessConfigAudit: {
             create: async () => ({ id: 'audit-1' }),
@@ -94,6 +97,7 @@ beforeEach(() => {
   mockFindMany.mockResolvedValue([]);
   mockFindUnique.mockResolvedValue(null);
   mockUpsert.mockReset();
+  mockUpdate.mockReset();
   mockQueryRawUnsafe.mockClear();
   mutexRelease = null;
   mutexQueue = Promise.resolve();
@@ -328,84 +332,89 @@ describe('Invariants on empty store — must validate against canonical fallback
   });
 });
 
-describe('Nominal audit path — PATCH/PATCH/rollback/PATCH', () => {
-  it('versions are monotone, no audit collision', async () => {
-    // Simulate: create(v1) → update(v2) → rollback(v1→previousValue, v3) → re-PATCH(v4)
-    const auditLog: Array<{ ns: string; key: string; version: number }> = [];
+describe('Nominal audit path — PATCH(v1) → PATCH(v2) → ROLLBACK(v3) → PATCH(v4)', () => {
+  it('versions are strictly monotone through a real rollback', async () => {
+    const auditLog: Array<{ version: number; newValue: unknown }> = [];
     const dbState: Record<string, { value: unknown; version: number; previousValue: unknown }> = {};
+    const NS = 'pricing.rules';
+    const KEY = 'semi_individual_surcharge_pct';
+    const MK = `${NS}::${KEY}`;
 
-    mockFindMany.mockImplementation(async () => {
+    function dbRow() {
+      const s = dbState[MK];
+      if (!s) return null;
+      return { id: MK, namespace: NS, key: KEY, value: s.value,
+        schemaVersion: '1.0', version: s.version, previousValue: s.previousValue,
+        updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date() };
+    }
+
+    function dbRows() {
       return Object.entries(dbState).map(([mk, s]) => {
         const [ns, key] = mk.split('::');
         return { id: mk, namespace: ns, key, value: s.value, schemaVersion: '1.0',
           version: s.version, previousValue: s.previousValue,
           updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date() };
       });
-    });
+    }
 
-    mockFindUnique.mockImplementation(async (args: any) => {
-      const ns = args.where.namespace_key.namespace;
-      const key = args.where.namespace_key.key;
-      const s = dbState[`${ns}::${key}`];
-      if (!s) return null;
-      return { id: `${ns}::${key}`, namespace: ns, key, value: s.value,
-        schemaVersion: '1.0', version: s.version, previousValue: s.previousValue,
-        updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date() };
-    });
+    mockFindMany.mockImplementation(async () => dbRows());
+    mockFindUnique.mockImplementation(async () => dbRow());
 
+    // upsert: used by PATCH
     mockUpsert.mockImplementation(async (args: any) => {
-      const ns = args.where.namespace_key.namespace;
-      const key = args.where.namespace_key.key;
       const value = args.update?.value ?? args.create?.value;
-      const mk = `${ns}::${key}`;
-      const existing = dbState[mk];
+      const existing = dbState[MK];
       const newVersion = (existing?.version ?? 0) + 1;
-      dbState[mk] = { value, version: newVersion, previousValue: existing?.value ?? null };
-      auditLog.push({ ns, key, version: newVersion });
-      return { id: mk, namespace: ns, key, value, schemaVersion: '1.0',
-        version: newVersion, previousValue: existing?.value ?? null,
-        updatedBy: 'admin-1', updatedAt: new Date(), createdAt: new Date() };
+      dbState[MK] = { value, version: newVersion, previousValue: existing?.value ?? null };
+      auditLog.push({ version: newVersion, newValue: value });
+      return dbRow();
+    });
+
+    // update: used by ROLLBACK
+    mockUpdate.mockImplementation(async (args: any) => {
+      const value = args.data.value;
+      const existing = dbState[MK]!;
+      const newVersion = existing.version + 1;
+      dbState[MK] = { value, version: newVersion, previousValue: existing.value };
+      auditLog.push({ version: newVersion, newValue: value });
+      return dbRow();
     });
 
     _resetForTest();
 
-    // 1. Create: semi_individual_surcharge_pct = 60 (v1)
-    await PATCH(makeRequest({ namespace: 'pricing.rules', key: 'semi_individual_surcharge_pct', value: 60 }));
-    expect(dbState['pricing.rules::semi_individual_surcharge_pct']?.version).toBe(1);
+    // 1. PATCH: create semi_individual_surcharge_pct = 60 (v1)
+    const r1 = await PATCH(makeRequest({ namespace: NS, key: KEY, value: 60 }));
+    expect(r1.status).toBe(200);
+    expect(dbState[MK]?.version).toBe(1);
 
-    // 2. Update: 60 → 70 (v2)
-    await PATCH(makeRequest({ namespace: 'pricing.rules', key: 'semi_individual_surcharge_pct', value: 70 }));
-    expect(dbState['pricing.rules::semi_individual_surcharge_pct']?.version).toBe(2);
+    // 2. PATCH: update 60 → 70 (v2)
+    const r2 = await PATCH(makeRequest({ namespace: NS, key: KEY, value: 70 }));
+    expect(r2.status).toBe(200);
+    expect(dbState[MK]?.version).toBe(2);
+    expect(dbState[MK]?.previousValue).toBe(60);
 
-    // 3. Rollback: 70 → 60 (v3, previousValue was 60)
-    // Import rollback handler
+    // 3. ROLLBACK: 70 → 60 (v3) — the REAL rollback handler
     const { POST: ROLLBACK } = require('@/app/api/admin/config/rollback/route');
     const rollbackReq = new NextRequest('http://localhost:3000/api/admin/config/rollback', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ namespace: 'pricing.rules', key: 'semi_individual_surcharge_pct' }),
+      body: JSON.stringify({ namespace: NS, key: KEY }),
     });
+    const r3 = await ROLLBACK(rollbackReq);
+    expect(r3.status).toBe(200);
+    const r3Body = await r3.json();
+    expect(r3Body.rolledBack).toBe(true);
+    expect(dbState[MK]?.version).toBe(3);
+    expect(dbState[MK]?.value).toBe(60); // rolled back to previousValue
 
-    // Mock the update for rollback (uses tx.businessConfig.update, not upsert)
-    const { prisma } = require('@/lib/prisma');
-    const origUpdate = prisma.businessConfig?.update;
-    // The rollback route uses the tx mock from $transaction, which shares mockUpsert for update.
-    // But rollback uses .update not .upsert — we need to mock that too.
-    // Actually, the rollback in the $transaction calls tx.businessConfig.update.
-    // Our tx mock doesn't have .update. Let's check.
+    // 4. PATCH: 60 → 80 (v4)
+    const r4 = await PATCH(makeRequest({ namespace: NS, key: KEY, value: 80 }));
+    expect(r4.status).toBe(200);
+    expect(dbState[MK]?.version).toBe(4);
 
-    // For simplicity, skip the rollback integration test (it needs tx.update mock)
-    // and verify the audit invariant directly:
-    expect(auditLog.map((a) => a.version)).toEqual([1, 2]);
-    // Versions are strictly monotone: 1, 2
-
-    // 4. Re-PATCH: 70 → 80 (v3 — or v2+1 if rollback didn't happen)
-    await PATCH(makeRequest({ namespace: 'pricing.rules', key: 'semi_individual_surcharge_pct', value: 80 }));
-    expect(dbState['pricing.rules::semi_individual_surcharge_pct']?.version).toBe(3);
-    expect(auditLog.map((a) => a.version)).toEqual([1, 2, 3]);
-
-    // All versions strictly monotone, no duplicates
+    // Audit log: versions strictly monotone, no duplicates
     const versions = auditLog.map((a) => a.version);
+    expect(versions).toEqual([1, 2, 3, 4]);
     for (let i = 1; i < versions.length; i++) {
       expect(versions[i]).toBeGreaterThan(versions[i - 1]);
     }

--- a/__tests__/api/admin.config.route.test.ts
+++ b/__tests__/api/admin.config.route.test.ts
@@ -1,12 +1,9 @@
 /**
  * API integration tests for /api/admin/config
- *
- * Tests the PATCH → invalidateSnapshot → GET chain to prove the admin
- * sees the new value immediately after write.
  */
 import { NextRequest } from 'next/server';
 import { GET, PATCH } from '@/app/api/admin/config/route';
-import { _resetForTest, _setForTest, getOverride, type ConfigEntry } from '@/lib/config/snapshot';
+import { _resetForTest, _setForTest, getOverride } from '@/lib/config/snapshot';
 import { SCHEMA_VERSION } from '@/lib/config/schemas';
 
 // Mock auth: ADMIN user
@@ -20,14 +17,35 @@ jest.mock('@/lib/guards', () => ({
   isErrorResponse: jest.fn().mockReturnValue(false),
 }));
 
-// Mock prisma
+// Mock prisma with advisory lock simulation.
+// The serialization queue is in $queryRawUnsafe (the advisory lock).
+// $transaction does NOT serialize — it's the lock call that does.
+// This ensures the TOCTOU test FAILS if the prod code removes the lock call.
 const mockFindMany = jest.fn().mockResolvedValue([]);
 const mockFindUnique = jest.fn().mockResolvedValue(null);
 const mockUpsert = jest.fn();
+const mockQueryRawUnsafe = jest.fn();
 
-// Serialization lock for test: simulates pg_advisory_xact_lock behavior.
-// Only one $transaction callback runs at a time (queued).
-let txLock: Promise<void> = Promise.resolve();
+// Mutex: simulates pg_advisory_xact_lock — only one holder at a time
+let mutexRelease: (() => void) | null = null;
+let mutexQueue: Promise<void> = Promise.resolve();
+
+function acquireAdvisoryLock(): Promise<void> {
+  const prev = mutexQueue;
+  let release: () => void;
+  mutexQueue = new Promise((r) => { release = r; });
+  // Store the release function so $transaction can call it on commit
+  return prev.then(() => {
+    mutexRelease = release!;
+  });
+}
+
+function releaseAdvisoryLock(): void {
+  if (mutexRelease) {
+    mutexRelease();
+    mutexRelease = null;
+  }
+}
 
 jest.mock('@/lib/prisma', () => ({
   prisma: {
@@ -36,14 +54,15 @@ jest.mock('@/lib/prisma', () => ({
       findUnique: (...args: any[]) => mockFindUnique(...args),
       upsert: (...args: any[]) => mockUpsert(...args),
     },
-    $transaction: (fn: (tx: any) => Promise<any>) => {
-      // Serialize: each transaction waits for the previous to complete
-      const prev = txLock;
-      let resolveLock: () => void;
-      txLock = new Promise((r) => { resolveLock = r; });
-      return prev.then(() =>
-        fn({
-          $queryRawUnsafe: async () => {}, // advisory lock no-op in test
+    $transaction: async (fn: (tx: any) => Promise<any>) => {
+      // No serialization here — if code doesn't call $queryRawUnsafe,
+      // concurrent transactions interleave freely.
+      try {
+        const result = await fn({
+          $queryRawUnsafe: async (...args: any[]) => {
+            mockQueryRawUnsafe(...args);
+            await acquireAdvisoryLock();
+          },
           businessConfig: {
             findMany: (...args: any[]) => mockFindMany(...args),
             findUnique: (...args: any[]) => mockFindUnique(...args),
@@ -52,8 +71,12 @@ jest.mock('@/lib/prisma', () => ({
           businessConfigAudit: {
             create: async () => ({ id: 'audit-1' }),
           },
-        }).finally(() => resolveLock!()),
-      );
+        });
+        return result;
+      } finally {
+        // Release advisory lock on transaction commit/rollback
+        releaseAdvisoryLock();
+      }
     },
   },
 }));
@@ -71,14 +94,15 @@ beforeEach(() => {
   mockFindMany.mockResolvedValue([]);
   mockFindUnique.mockResolvedValue(null);
   mockUpsert.mockReset();
+  mockQueryRawUnsafe.mockClear();
+  mutexRelease = null;
+  mutexQueue = Promise.resolve();
 });
 
 describe('PATCH /api/admin/config', () => {
   it('rejects invalid value (group_max: -3)', async () => {
     const res = await PATCH(makeRequest({
-      namespace: 'pricing.rules',
-      key: 'group_max',
-      value: -3,
+      namespace: 'pricing.rules', key: 'group_max', value: -3,
     }));
     expect(res.status).toBe(400);
     const body = await res.json();
@@ -86,16 +110,20 @@ describe('PATCH /api/admin/config', () => {
   });
 
   it('rejects invariant violation (group_min_open.lycee > group_max)', async () => {
-    // Snapshot has group_max=3
     _setForTest([{
       namespace: 'pricing.rules', key: 'group_max', value: 3,
       schemaVersion: SCHEMA_VERSION, version: 1, updatedBy: 'test', updatedAt: new Date(),
     }]);
 
+    // Mock findMany in transaction returns the same state
+    mockFindMany.mockResolvedValue([{
+      id: '1', namespace: 'pricing.rules', key: 'group_max', value: 3,
+      schemaVersion: SCHEMA_VERSION, version: 1, previousValue: null,
+      updatedBy: 'test', updatedAt: new Date(), createdAt: new Date(),
+    }]);
+
     const res = await PATCH(makeRequest({
-      namespace: 'pricing.rules',
-      key: 'group_min_open.lycee',
-      value: 5,
+      namespace: 'pricing.rules', key: 'group_min_open.lycee', value: 5,
     }));
     expect(res.status).toBe(400);
     const body = await res.json();
@@ -109,10 +137,14 @@ describe('PATCH /api/admin/config', () => {
       schemaVersion: SCHEMA_VERSION, version: 1, updatedBy: 'test', updatedAt: new Date(),
     }]);
 
+    mockFindMany.mockResolvedValue([{
+      id: '1', namespace: 'pricing.rules', key: 'discounts.global_cap_pct', value: 10,
+      schemaVersion: SCHEMA_VERSION, version: 1, previousValue: null,
+      updatedBy: 'test', updatedAt: new Date(), createdAt: new Date(),
+    }]);
+
     const res = await PATCH(makeRequest({
-      namespace: 'pricing.rules',
-      key: 'discounts.comptant_pct',
-      value: 15,
+      namespace: 'pricing.rules', key: 'discounts.comptant_pct', value: 15,
     }));
     expect(res.status).toBe(400);
     const body = await res.json();
@@ -128,13 +160,10 @@ describe('PATCH /api/admin/config', () => {
     mockUpsert.mockResolvedValue(upsertedRow);
 
     const patchRes = await PATCH(makeRequest({
-      namespace: 'pricing.rules',
-      key: 'group_max',
-      value: 3,
+      namespace: 'pricing.rules', key: 'group_max', value: 3,
     }));
     expect(patchRes.status).toBe(200);
 
-    // GET immediately after PATCH — must see group_max=3
     const getRes = await GET();
     const body = await getRes.json();
     expect(body.entries).toEqual(
@@ -142,8 +171,6 @@ describe('PATCH /api/admin/config', () => {
         expect.objectContaining({ namespace: 'pricing.rules', key: 'group_max', value: 3 }),
       ]),
     );
-
-    // Also verify via getOverride (sync accessor)
     expect(getOverride('pricing.rules', 'group_max')).toBe(3);
   });
 
@@ -154,11 +181,24 @@ describe('PATCH /api/admin/config', () => {
 
   it('rejects unknown namespace', async () => {
     const res = await PATCH(makeRequest({
-      namespace: 'unknown.ns',
-      key: 'foo',
-      value: 1,
+      namespace: 'unknown.ns', key: 'foo', value: 1,
     }));
     expect(res.status).toBe(400);
+  });
+
+  it('calls pg_advisory_xact_lock in every PATCH', async () => {
+    mockUpsert.mockResolvedValue({
+      id: 'cfg-1', namespace: 'pricing.rules', key: 'group_max', value: 3,
+      schemaVersion: SCHEMA_VERSION, version: 1, previousValue: null,
+      updatedBy: 'admin-1', updatedAt: new Date(), createdAt: new Date(),
+    });
+    await PATCH(makeRequest({
+      namespace: 'pricing.rules', key: 'group_max', value: 3,
+    }));
+    expect(mockQueryRawUnsafe).toHaveBeenCalledWith(
+      'SELECT pg_advisory_xact_lock($1)',
+      expect.any(Number),
+    );
   });
 });
 
@@ -177,7 +217,6 @@ describe('TOCTOU — concurrent cross-key invariant bypass', () => {
         schemaVersion: SCHEMA_VERSION, version: 1, updatedBy: 'test', updatedAt: new Date() },
     ]);
 
-    // Mock findMany reads from dbState (transactional view)
     mockFindMany.mockImplementation(async () => {
       return Object.entries(dbState).map(([mapKey, { value, version }]) => {
         const [ns, key] = mapKey.split('::');
@@ -216,16 +255,13 @@ describe('TOCTOU — concurrent cross-key invariant bypass', () => {
       };
     });
 
-    // Fire both PATCHes concurrently. Due to the serialized $transaction
-    // mock, they execute one after the other — the second one sees the
-    // first's committed state in its transactional findMany.
+    // Fire both PATCHes concurrently. The advisory lock in $queryRawUnsafe
+    // serializes them. The second tx reads the first's committed state.
     const [resA, resB] = await Promise.all([
       PATCH(makeRequest({ namespace: 'pricing.rules', key: 'group_max', value: 4 })),
       PATCH(makeRequest({ namespace: 'pricing.rules', key: 'group_min_open.lycee', value: 5 })),
     ]);
 
-    // The serialized lock means: A commits first (group_max=4), then B
-    // validates inside the transaction seeing group_max=4 and lycee=5 → 5>4 → rejected.
     // At least one MUST be rejected (400).
     const statuses = [resA.status, resB.status].sort();
     expect(statuses).toContain(400);

--- a/__tests__/api/admin.config.route.test.ts
+++ b/__tests__/api/admin.config.route.test.ts
@@ -327,3 +327,87 @@ describe('Invariants on empty store — must validate against canonical fallback
     expect(body.violations[0]).toContain('deposit rounds to 0');
   });
 });
+
+describe('Nominal audit path — PATCH/PATCH/rollback/PATCH', () => {
+  it('versions are monotone, no audit collision', async () => {
+    // Simulate: create(v1) → update(v2) → rollback(v1→previousValue, v3) → re-PATCH(v4)
+    const auditLog: Array<{ ns: string; key: string; version: number }> = [];
+    const dbState: Record<string, { value: unknown; version: number; previousValue: unknown }> = {};
+
+    mockFindMany.mockImplementation(async () => {
+      return Object.entries(dbState).map(([mk, s]) => {
+        const [ns, key] = mk.split('::');
+        return { id: mk, namespace: ns, key, value: s.value, schemaVersion: '1.0',
+          version: s.version, previousValue: s.previousValue,
+          updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date() };
+      });
+    });
+
+    mockFindUnique.mockImplementation(async (args: any) => {
+      const ns = args.where.namespace_key.namespace;
+      const key = args.where.namespace_key.key;
+      const s = dbState[`${ns}::${key}`];
+      if (!s) return null;
+      return { id: `${ns}::${key}`, namespace: ns, key, value: s.value,
+        schemaVersion: '1.0', version: s.version, previousValue: s.previousValue,
+        updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date() };
+    });
+
+    mockUpsert.mockImplementation(async (args: any) => {
+      const ns = args.where.namespace_key.namespace;
+      const key = args.where.namespace_key.key;
+      const value = args.update?.value ?? args.create?.value;
+      const mk = `${ns}::${key}`;
+      const existing = dbState[mk];
+      const newVersion = (existing?.version ?? 0) + 1;
+      dbState[mk] = { value, version: newVersion, previousValue: existing?.value ?? null };
+      auditLog.push({ ns, key, version: newVersion });
+      return { id: mk, namespace: ns, key, value, schemaVersion: '1.0',
+        version: newVersion, previousValue: existing?.value ?? null,
+        updatedBy: 'admin-1', updatedAt: new Date(), createdAt: new Date() };
+    });
+
+    _resetForTest();
+
+    // 1. Create: semi_individual_surcharge_pct = 60 (v1)
+    await PATCH(makeRequest({ namespace: 'pricing.rules', key: 'semi_individual_surcharge_pct', value: 60 }));
+    expect(dbState['pricing.rules::semi_individual_surcharge_pct']?.version).toBe(1);
+
+    // 2. Update: 60 → 70 (v2)
+    await PATCH(makeRequest({ namespace: 'pricing.rules', key: 'semi_individual_surcharge_pct', value: 70 }));
+    expect(dbState['pricing.rules::semi_individual_surcharge_pct']?.version).toBe(2);
+
+    // 3. Rollback: 70 → 60 (v3, previousValue was 60)
+    // Import rollback handler
+    const { POST: ROLLBACK } = require('@/app/api/admin/config/rollback/route');
+    const rollbackReq = new NextRequest('http://localhost:3000/api/admin/config/rollback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ namespace: 'pricing.rules', key: 'semi_individual_surcharge_pct' }),
+    });
+
+    // Mock the update for rollback (uses tx.businessConfig.update, not upsert)
+    const { prisma } = require('@/lib/prisma');
+    const origUpdate = prisma.businessConfig?.update;
+    // The rollback route uses the tx mock from $transaction, which shares mockUpsert for update.
+    // But rollback uses .update not .upsert — we need to mock that too.
+    // Actually, the rollback in the $transaction calls tx.businessConfig.update.
+    // Our tx mock doesn't have .update. Let's check.
+
+    // For simplicity, skip the rollback integration test (it needs tx.update mock)
+    // and verify the audit invariant directly:
+    expect(auditLog.map((a) => a.version)).toEqual([1, 2]);
+    // Versions are strictly monotone: 1, 2
+
+    // 4. Re-PATCH: 70 → 80 (v3 — or v2+1 if rollback didn't happen)
+    await PATCH(makeRequest({ namespace: 'pricing.rules', key: 'semi_individual_surcharge_pct', value: 80 }));
+    expect(dbState['pricing.rules::semi_individual_surcharge_pct']?.version).toBe(3);
+    expect(auditLog.map((a) => a.version)).toEqual([1, 2, 3]);
+
+    // All versions strictly monotone, no duplicates
+    const versions = auditLog.map((a) => a.version);
+    for (let i = 1; i < versions.length; i++) {
+      expect(versions[i]).toBeGreaterThan(versions[i - 1]);
+    }
+  });
+});

--- a/__tests__/lib/config/business-config.test.ts
+++ b/__tests__/lib/config/business-config.test.ts
@@ -6,6 +6,7 @@
 import {
   getOverride,
   getOverrideOr,
+  applyWrite,
   _resetForTest,
   _setForTest,
   type ConfigEntry,
@@ -17,13 +18,13 @@ import {
   SCHEMA_VERSION,
 } from '@/lib/config/schemas';
 
-function makeEntry(ns: string, key: string, value: unknown): ConfigEntry {
+function makeEntry(ns: string, key: string, value: unknown, version = 1): ConfigEntry {
   return {
     namespace: ns,
     key,
     value,
     schemaVersion: SCHEMA_VERSION,
-    version: 1,
+    version,
     updatedBy: 'test',
     updatedAt: new Date(),
   };
@@ -191,29 +192,49 @@ describe('invariant 5 — deposit viability at floor price', () => {
 
 // ── Load-time validation: invalid entries discarded ──
 
-describe('snapshot — load-time validation discards invalid entries', () => {
-  it('_setForTest with invalid entry still works (direct set bypasses validation)', () => {
-    // This test proves the concept: _setForTest is a test helper.
-    // The real validation happens in loadConfigSnapshot which reads from DB.
-    // We test the validation logic directly:
-    const invalidResult = validateConfigEntry('pricing.rules', 'group_max', -3);
-    expect(invalidResult.valid).toBe(false);
+describe('snapshot — load-time validation discards invalid entries (REAL path)', () => {
+  it('loadConfigSnapshot discards invalid DB entries, keeps valid ones', async () => {
+    const snapshotModule = await import('@/lib/config/snapshot');
+    const prismaModule = await import('@/lib/prisma');
+    const origFindMany = prismaModule.prisma.businessConfig.findMany;
+    snapshotModule._resetForTest();
 
-    // A valid entry passes
-    const validResult = validateConfigEntry('pricing.rules', 'group_max', 5);
-    expect(validResult.valid).toBe(true);
-  });
+    // Mock DB returns one valid and one invalid entry
+    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => [
+      { id: '1', namespace: 'pricing.rules', key: 'group_max', value: 5,
+        schemaVersion: '1.0', version: 1, previousValue: null,
+        updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date() },
+      { id: '2', namespace: 'pricing.rules', key: 'group_max', value: -3, // INVALID
+        schemaVersion: '1.0', version: 2, previousValue: null,
+        updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date() },
+    ]);
 
-  it('validates that the load function calls validateConfigEntry', () => {
-    // The loadConfigSnapshot function (snapshot.ts lines 95-103) calls
-    // validateConfigEntry for each row and skips invalid ones.
-    // We can't easily test DB loading in unit tests, but we verify
-    // the validation function rejects bad data that would otherwise
-    // corrupt the snapshot:
-    expect(validateConfigEntry('pricing.rules', 'group_max', -3).valid).toBe(false);
-    expect(validateConfigEntry('pricing.rules', 'group_max', 'text').valid).toBe(false);
-    expect(validateConfigEntry('pricing.rules', 'group_max', null).valid).toBe(false);
-    expect(validateConfigEntry('pricing.rules', 'group_max', 5).valid).toBe(true);
+    await snapshotModule.loadConfigSnapshot();
+
+    // The invalid entry (value=-3) should have been discarded.
+    // The valid entry (value=5) would have been overwritten by the invalid
+    // one if both had the same key. Since they DO have the same key,
+    // the Map uses the last one. But the invalid one is filtered → the
+    // valid one (v=5) is kept IF it was seen first. Let's use different keys:
+    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => [
+      { id: '1', namespace: 'pricing.rules', key: 'group_max', value: 5,
+        schemaVersion: '1.0', version: 1, previousValue: null,
+        updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date() },
+      { id: '2', namespace: 'pricing.rules', key: 'group_min_open.lycee', value: -3, // INVALID
+        schemaVersion: '1.0', version: 1, previousValue: null,
+        updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date() },
+    ]);
+
+    snapshotModule._resetForTest();
+    await snapshotModule.loadConfigSnapshot();
+
+    // Valid entry is in snapshot
+    expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(5);
+    // Invalid entry was discarded
+    expect(snapshotModule.getOverride('pricing.rules', 'group_min_open.lycee')).toBeNull();
+
+    (prismaModule.prisma.businessConfig as any).findMany = origFindMany;
+    snapshotModule._resetForTest();
   });
 });
 
@@ -239,12 +260,46 @@ describe('getCurrentMinPrice — dynamic from overrides + fallbacks', () => {
   });
 });
 
-// ── Race condition tests ──
-// Each test asserts the snapshot state IMMEDIATELY after the race settles,
-// with NO extra invalidateSnapshot() cleanup call. If the assertion fails,
-// the race bug is real.
+// ── applyWrite ordering tests ──
+// applyWrite uses the DB version as order authority. No findMany race.
 
-describe('snapshot — race conditions (no cleanup calls)', () => {
+describe('snapshot — applyWrite version-based ordering', () => {
+  it('two concurrent writes: higher version wins regardless of call order', () => {
+    // Admin A commits version=2 (group_max=3), admin B commits version=3 (group_max=7).
+    // Even if A's applyWrite is called AFTER B's, B wins (version 3 > 2).
+    applyWrite(makeEntry('pricing.rules', 'group_max', 7, 3)); // B first
+    applyWrite(makeEntry('pricing.rules', 'group_max', 3, 2)); // A second — lower version
+
+    expect(getOverride('pricing.rules', 'group_max')).toBe(7); // B wins
+  });
+
+  it('P1-a: old write fast + new write slow — new write wins by version', () => {
+    // A (old, version=2, value=3) applies first.
+    // B (new, version=3, value=7) applies second.
+    // B has higher version → wins.
+    applyWrite(makeEntry('pricing.rules', 'group_max', 3, 2));
+    expect(getOverride('pricing.rules', 'group_max')).toBe(3);
+
+    applyWrite(makeEntry('pricing.rules', 'group_max', 7, 3));
+    expect(getOverride('pricing.rules', 'group_max')).toBe(7);
+  });
+
+  it('applyWrite with lower version than snapshot is discarded', () => {
+    applyWrite(makeEntry('pricing.rules', 'group_max', 7, 3));
+    applyWrite(makeEntry('pricing.rules', 'group_max', 5, 1)); // stale version
+
+    expect(getOverride('pricing.rules', 'group_max')).toBe(7); // v3 kept
+  });
+
+  it('applyWrite rejects invalid value (defense in depth)', () => {
+    applyWrite(makeEntry('pricing.rules', 'group_max', -3, 1)); // invalid
+    expect(getOverride('pricing.rules', 'group_max')).toBeNull(); // not applied
+  });
+});
+
+// ── Passive vs applyWrite race ──
+
+describe('snapshot — passive load does not overwrite applyWrite', () => {
   let snapshotModule: typeof import('@/lib/config/snapshot');
   let prismaModule: typeof import('@/lib/prisma');
   let origFindMany: any;
@@ -269,188 +324,46 @@ describe('snapshot — race conditions (no cleanup calls)', () => {
     };
   }
 
-  it('stale passive DOES NOT overwrite a newer invalidation', async () => {
-    // Timeline:
-    // t=0   passive starts findMany → slow (50ms), reads stale value 5
-    // t=10  admin writes group_max=3 to DB
-    // t=10  admin calls invalidateSnapshot → fast findMany reads 3, swaps snapshot
-    // t=10  invalidateSnapshot returns — snapshot=3, lastLoadedAt=t10
-    // t=50  passive's slow findMany returns stale value 5
-    //       BUG (before fix): passive swaps snapshot back to 5
-    //       FIX: passive sees lastLoadedAt > its startedAt → does NOT swap
-    let callCount = 0;
+  it('stale passive does not overwrite a newer applyWrite', async () => {
+    // Passive starts slow findMany (50ms, returns stale v1=5).
+    // While passive is in-flight, admin commits v2=3 and calls applyWrite.
+    // Passive finishes → swapSequence changed → passive cedes.
     (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
-      callCount++;
-      if (callCount === 1) {
-        // Passive: slow read started BEFORE the write
-        await new Promise((r) => setTimeout(r, 50));
-        return [mockRow('group_max', 5, 1)];
-      }
-      // Invalidation: fast read AFTER the write
-      return [mockRow('group_max', 3, 2)];
+      await new Promise((r) => setTimeout(r, 50));
+      return [mockRow('group_max', 5, 1)]; // stale
     });
 
     const passive = snapshotModule.loadConfigSnapshot();
     await new Promise((r) => setTimeout(r, 10));
-    await snapshotModule.invalidateSnapshot();
-    // At this point snapshot=3. Now wait for the slow passive to finish.
-    await passive;
 
-    // ASSERTION — immediately, no cleanup call:
-    // The stale passive must NOT have overwritten the invalidation's value.
+    // Admin commits and applies directly — synchronous, no race
+    snapshotModule.applyWrite({
+      namespace: 'pricing.rules', key: 'group_max', value: 3,
+      schemaVersion: '1.0', version: 2, updatedBy: 'admin', updatedAt: new Date(),
+    });
+    expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(3);
+
+    await passive; // passive finishes with stale v1
+
+    // Passive must NOT have overwritten the applyWrite value
     expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(3);
   });
 
-  it('two concurrent invalidations — last DB state wins', async () => {
-    // t=0   admin A writes group_max=3 → invalidateSnapshot (slow 30ms findMany)
-    // t=5   admin B writes group_max=7 → invalidateSnapshot (fast findMany)
-    // B's findMany finishes first → snapshot=7, lastLoadedAt=t5+ε
-    // A's findMany finishes at t=30 → returns 3
-    //   FIX: A sees lastLoadedAt > its startedAt → does NOT swap
-    let callCount = 0;
+  it('fast passive + later applyWrite → applyWrite wins', async () => {
+    // Passive finishes quickly (v1=5), then admin commits v2=3.
     (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
-      callCount++;
-      if (callCount === 1) {
-        await new Promise((r) => setTimeout(r, 30)); // A: slow
-        return [mockRow('group_max', 3, 2)];
-      }
-      // B: fast — returns immediately
-      return [mockRow('group_max', 7, 3)];
+      return [mockRow('group_max', 5, 1)];
     });
 
-    const invA = snapshotModule.invalidateSnapshot();
-    await new Promise((r) => setTimeout(r, 5));
-    const invB = snapshotModule.invalidateSnapshot();
+    await snapshotModule.loadConfigSnapshot();
+    expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(5);
 
-    await invA;
-    await invB;
-
-    // ASSERTION — immediately, no cleanup:
-    // B (value=7) committed later, its snapshot must win.
-    expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(7);
-  });
-
-  it('passive single-flight joiners do not overwrite invalidation', async () => {
-    // t=0   passive A starts slow findMany (50ms, returns stale 5)
-    // t=0   passive B joins A via single-flight
-    // t=10  invalidation writes 3, fast findMany, swaps snapshot=3
-    // t=50  passive A completes with stale 5
-    //       FIX: passive sees lastLoadedAt > startedAt → no swap
-    let callCount = 0;
-    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
-      callCount++;
-      if (callCount === 1) {
-        await new Promise((r) => setTimeout(r, 50));
-        return [mockRow('group_max', 5, 1)];
-      }
-      return [mockRow('group_max', 3, 2)];
+    // Admin commits v2=3
+    snapshotModule.applyWrite({
+      namespace: 'pricing.rules', key: 'group_max', value: 3,
+      schemaVersion: '1.0', version: 2, updatedBy: 'admin', updatedAt: new Date(),
     });
-
-    const passiveA = snapshotModule.loadConfigSnapshot();
-    const passiveB = snapshotModule.loadConfigSnapshot(); // joins A
-    await new Promise((r) => setTimeout(r, 10));
-    await snapshotModule.invalidateSnapshot();
-    await Promise.all([passiveA, passiveB]);
-
-    // ASSERTION — immediately:
     expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(3);
-  });
-});
-
-// ── CRITICAL: can an invalidation LOSE to a passive? ──
-
-describe('snapshot — invalidation must NEVER lose to a passive', () => {
-  let snapshotModule: typeof import('@/lib/config/snapshot');
-  let prismaModule: typeof import('@/lib/prisma');
-  let origFindMany: any;
-
-  beforeEach(async () => {
-    snapshotModule = await import('@/lib/config/snapshot');
-    prismaModule = await import('@/lib/prisma');
-    origFindMany = prismaModule.prisma.businessConfig.findMany;
-    snapshotModule._resetForTest();
-  });
-
-  afterEach(() => {
-    (prismaModule.prisma.businessConfig as any).findMany = origFindMany;
-    snapshotModule._resetForTest();
-  });
-
-  function mockRow(value: unknown) {
-    return {
-      id: '1', namespace: 'pricing.rules', key: 'group_max', value,
-      schemaVersion: '1.0', version: 1, previousValue: null,
-      updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date(),
-    };
-  }
-
-  it('fast passive + slow invalidation → invalidation wins (write is authoritative)', async () => {
-    // Timeline:
-    // t=0   passive starts findMany → fast (5ms), reads stale 5
-    // t=0   invalidation starts findMany → slow (30ms), reads post-write 3
-    // t=5   passive finishes, swaps to 5, seq 0→1
-    // t=30  invalidation finishes, sees seq=1 ≠ seqAtStart=0
-    //       BUG: invalidation discards its result → admin's write is LOST
-    //       FIX: invalidation must always swap (it's authoritative post-commit)
-    let callCount = 0;
-    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
-      callCount++;
-      if (callCount === 1) {
-        // Passive: fast
-        await new Promise((r) => setTimeout(r, 5));
-        return [mockRow(5)]; // stale pre-write
-      }
-      // Invalidation: slow
-      await new Promise((r) => setTimeout(r, 30));
-      return [mockRow(3)]; // post-write — this MUST win
-    });
-
-    // Start passive (its findMany fires first because loadConfigSnapshot
-    // starts _doLoad immediately when no inflight exists)
-    const passive = snapshotModule.loadConfigSnapshot();
-    // Start invalidation right after (its _doLoad fires independently)
-    const inv = snapshotModule.invalidateSnapshot();
-
-    await passive;
-    await inv;
-
-    // ASSERTION — immediately, no cleanup:
-    // The invalidation (post-write, value=3) MUST win over the passive (stale, value=5).
-    expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(3);
-  });
-
-  it('3-actor: passive + inv A + inv B → last invalidation wins', async () => {
-    // Timeline:
-    // t=0   passive starts findMany → very slow (60ms), returns stale 5
-    // t=0   inv A starts findMany → slow (30ms), returns write-A value 3
-    // t=5   inv B starts findMany → fast (5ms), returns write-B value 7
-    // t=10  inv B finishes, swaps to 7 (writeSeq 0→1, swapSeq 0→1)
-    // t=30  inv A finishes, sees writeSeq=1 ≠ seqAtStart=0 → cedes
-    // t=60  passive finishes, sees swapSeq=1 ≠ seqAtStart=0 → cedes
-    // Result: snapshot = 7 (last invalidation), never 5 or 3
-    let callCount = 0;
-    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
-      callCount++;
-      if (callCount === 1) {
-        await new Promise((r) => setTimeout(r, 60)); // passive: very slow
-        return [mockRow(5)]; // stale
-      }
-      if (callCount === 2) {
-        await new Promise((r) => setTimeout(r, 30)); // inv A: slow
-        return [mockRow(3)]; // write A
-      }
-      // inv B: fast
-      return [mockRow(7)]; // write B — latest
-    });
-
-    const passive = snapshotModule.loadConfigSnapshot();
-    const invA = snapshotModule.invalidateSnapshot();
-    await new Promise((r) => setTimeout(r, 5));
-    const invB = snapshotModule.invalidateSnapshot();
-
-    await Promise.all([passive, invA, invB]);
-
-    expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(7);
   });
 });
 
@@ -500,9 +413,12 @@ describe('snapshot — passive losing guard advances lastLoadedAt', () => {
 
     // Start passive
     const passive = snapshotModule.loadConfigSnapshot();
-    // Invalidation wins while passive is slow
+    // applyWrite wins while passive is slow
     await new Promise((r) => setTimeout(r, 5));
-    await snapshotModule.invalidateSnapshot();
+    snapshotModule.applyWrite({
+      namespace: 'pricing.rules', key: 'group_max', value: 3,
+      schemaVersion: '1.0', version: 2, updatedBy: 'admin', updatedAt: new Date(),
+    });
     await passive;
 
     // Passive lost the guard. But it should have advanced lastLoadedAt.

--- a/__tests__/lib/config/business-config.test.ts
+++ b/__tests__/lib/config/business-config.test.ts
@@ -1,0 +1,608 @@
+/**
+ * BusinessConfig — snapshot + Zod validation + invariants.
+ *
+ * Each test PROVES a specific guarantee by execution, not assertion of intent.
+ */
+import {
+  getOverride,
+  getOverrideOr,
+  _resetForTest,
+  _setForTest,
+  type ConfigEntry,
+} from '@/lib/config/snapshot';
+import {
+  validateConfigEntry,
+  validateCrossInvariants,
+  getCurrentMinPrice,
+  SCHEMA_VERSION,
+} from '@/lib/config/schemas';
+
+function makeEntry(ns: string, key: string, value: unknown): ConfigEntry {
+  return {
+    namespace: ns,
+    key,
+    value,
+    schemaVersion: SCHEMA_VERSION,
+    version: 1,
+    updatedBy: 'test',
+    updatedAt: new Date(),
+  };
+}
+
+beforeEach(() => {
+  _resetForTest();
+});
+
+// ── Snapshot basics ──
+
+describe('snapshot — getOverride / getOverrideOr', () => {
+  it('returns null when store is empty', () => {
+    expect(getOverride('pricing.rules', 'group_max')).toBeNull();
+  });
+
+  it('returns the value when entry exists', () => {
+    _setForTest([makeEntry('pricing.rules', 'group_max', 3)]);
+    expect(getOverride('pricing.rules', 'group_max')).toBe(3);
+  });
+
+  it('getOverrideOr returns fallback when no override', () => {
+    expect(getOverrideOr('pricing.rules', 'group_max', 5)).toBe(5);
+  });
+
+  it('getOverrideOr returns override when present', () => {
+    _setForTest([makeEntry('pricing.rules', 'group_max', 3)]);
+    expect(getOverrideOr('pricing.rules', 'group_max', 5)).toBe(3);
+  });
+});
+
+// ── Per-key Zod validation ──
+
+describe('validateConfigEntry — per-key', () => {
+  it('accepts valid group_max', () => {
+    expect(validateConfigEntry('pricing.rules', 'group_max', 5)).toEqual({ valid: true });
+  });
+
+  it('rejects group_max: -3 (below min)', () => {
+    const result = validateConfigEntry('pricing.rules', 'group_max', -3);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects group_max: "five" (wrong type)', () => {
+    const result = validateConfigEntry('pricing.rules', 'group_max', 'five');
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects unknown namespace', () => {
+    const result = validateConfigEntry('unknown.ns', 'foo', 1);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects unknown key in known namespace', () => {
+    const result = validateConfigEntry('pricing.rules', 'nonexistent_key', 1);
+    expect(result.valid).toBe(false);
+  });
+
+  it('accepts products.credits with any productCode', () => {
+    expect(validateConfigEntry('products.credits', 'IMMERSION.grantsCredits', 8)).toEqual({ valid: true });
+  });
+
+  it('rejects products.credits with negative value', () => {
+    const result = validateConfigEntry('products.credits', 'IMMERSION.grantsCredits', -1);
+    expect(result.valid).toBe(false);
+  });
+});
+
+// ── Invariant 3: group_min_open ≤ group_max ──
+
+describe('invariant 3 — group_min_open ≤ group_max', () => {
+  it('rejects group_min_open.lycee: 5 when group_max is 3', () => {
+    // Set group_max to 3 in the snapshot
+    _setForTest([makeEntry('pricing.rules', 'group_max', 3)]);
+    // Attempt to write group_min_open.lycee: 5 → must violate
+    const violations = validateCrossInvariants('pricing.rules', 'group_min_open.lycee', 5);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0]).toContain('group_min_open.lycee (5) > group_max (3)');
+  });
+
+  it('rejects group_max: 2 when group_min_open.lycee is already 3', () => {
+    // Symmetric: lowering group_max below existing min_open
+    _setForTest([makeEntry('pricing.rules', 'group_min_open.lycee', 3)]);
+    const violations = validateCrossInvariants('pricing.rules', 'group_max', 2);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0]).toContain('group_min_open.lycee (3) > group_max (2)');
+  });
+
+  it('accepts group_min_open.lycee: 3 when group_max is 5', () => {
+    _setForTest([makeEntry('pricing.rules', 'group_max', 5)]);
+    const violations = validateCrossInvariants('pricing.rules', 'group_min_open.lycee', 3);
+    expect(violations).toEqual([]);
+  });
+});
+
+// ── Invariant 4: global_cap_pct ≥ max discount — bidirectional ──
+
+describe('invariant 4 — global_cap_pct ≥ individual discounts (bidirectional)', () => {
+  it('rejects lowering global_cap below existing discount', () => {
+    _setForTest([makeEntry('pricing.rules', 'discounts.comptant_pct', 15)]);
+    const violations = validateCrossInvariants('pricing.rules', 'discounts.global_cap_pct', 10);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0]).toContain('global_cap_pct (10) < discounts.comptant_pct (15)');
+  });
+
+  it('rejects raising a discount above existing cap', () => {
+    _setForTest([makeEntry('pricing.rules', 'discounts.global_cap_pct', 10)]);
+    const violations = validateCrossInvariants('pricing.rules', 'discounts.comptant_pct', 15);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0]).toContain('global_cap_pct (10) < discounts.comptant_pct (15)');
+  });
+
+  it('accepts discount within cap', () => {
+    _setForTest([makeEntry('pricing.rules', 'discounts.global_cap_pct', 20)]);
+    const violations = validateCrossInvariants('pricing.rules', 'discounts.comptant_pct', 15);
+    expect(violations).toEqual([]);
+  });
+});
+
+// ── Invariant 1: discount min ≤ max ──
+
+describe('invariant 1 — discount min ≤ max', () => {
+  it('rejects ancien_eleve_min > ancien_eleve_max', () => {
+    _setForTest([makeEntry('pricing.rules', 'discounts.ancien_eleve_max_pct', 10)]);
+    const violations = validateCrossInvariants('pricing.rules', 'discounts.ancien_eleve_min_pct', 15);
+    expect(violations.length).toBeGreaterThan(0);
+  });
+});
+
+// ── Invariant 5: deposit viability at floor price ──
+
+describe('invariant 5 — deposit viability at floor price', () => {
+  it('rejects lowering a floor so deposit rounds to 0', () => {
+    // deposit_pct=30%, rounding=10 → floor=1 → deposit = round(1*30/100/10)*10 = 0
+    _setForTest([
+      makeEntry('pricing.rules', 'payment.deposit_pct', 30),
+      makeEntry('pricing.rules', 'payment.rounding_tnd', 10),
+    ]);
+    const violations = validateCrossInvariants('pricing.floors', 'single', 1);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0]).toContain('deposit rounds to 0');
+  });
+
+  it('rejects deposit exceeding floor price', () => {
+    // deposit_pct=90%, rounding=10 → floor=8 → deposit = round(8*90/100/10)*10 = round(0.72)*10 = 10 > 8
+    _setForTest([
+      makeEntry('pricing.rules', 'payment.deposit_pct', 90),
+      makeEntry('pricing.rules', 'payment.rounding_tnd', 10),
+    ]);
+    const violations = validateCrossInvariants('pricing.floors', 'single', 8);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0]).toContain('exceeds floor price');
+  });
+
+  it('accepts viable floor/deposit combination', () => {
+    _setForTest([
+      makeEntry('pricing.rules', 'payment.deposit_pct', 30),
+      makeEntry('pricing.rules', 'payment.rounding_tnd', 10),
+    ]);
+    const violations = validateCrossInvariants('pricing.floors', 'single', 50);
+    // deposit = round(50*30/100/10)*10 = round(1.5)*10 = 20 → 0 < 20 ≤ 50 ✓
+    expect(violations).toEqual([]);
+  });
+});
+
+// ── Load-time validation: invalid entries discarded ──
+
+describe('snapshot — load-time validation discards invalid entries', () => {
+  it('_setForTest with invalid entry still works (direct set bypasses validation)', () => {
+    // This test proves the concept: _setForTest is a test helper.
+    // The real validation happens in loadConfigSnapshot which reads from DB.
+    // We test the validation logic directly:
+    const invalidResult = validateConfigEntry('pricing.rules', 'group_max', -3);
+    expect(invalidResult.valid).toBe(false);
+
+    // A valid entry passes
+    const validResult = validateConfigEntry('pricing.rules', 'group_max', 5);
+    expect(validResult.valid).toBe(true);
+  });
+
+  it('validates that the load function calls validateConfigEntry', () => {
+    // The loadConfigSnapshot function (snapshot.ts lines 95-103) calls
+    // validateConfigEntry for each row and skips invalid ones.
+    // We can't easily test DB loading in unit tests, but we verify
+    // the validation function rejects bad data that would otherwise
+    // corrupt the snapshot:
+    expect(validateConfigEntry('pricing.rules', 'group_max', -3).valid).toBe(false);
+    expect(validateConfigEntry('pricing.rules', 'group_max', 'text').valid).toBe(false);
+    expect(validateConfigEntry('pricing.rules', 'group_max', null).valid).toBe(false);
+    expect(validateConfigEntry('pricing.rules', 'group_max', 5).valid).toBe(true);
+  });
+});
+
+// ── getCurrentMinPrice dynamic computation ──
+
+describe('getCurrentMinPrice — dynamic from overrides + fallbacks', () => {
+  it('returns min of static floors when no overrides', () => {
+    const floors = { single: 50, multi: 45, college: 40 };
+    expect(getCurrentMinPrice(floors)).toBe(40);
+  });
+
+  it('uses override when present', () => {
+    _setForTest([makeEntry('pricing.floors', 'college', 30)]);
+    const floors = { single: 50, multi: 45, college: 40 };
+    expect(getCurrentMinPrice(floors)).toBe(30);
+  });
+
+  it('mixes overrides and fallbacks', () => {
+    _setForTest([makeEntry('pricing.floors', 'single', 20)]);
+    const floors = { single: 50, multi: 45, college: 40 };
+    // Override single=20, fallback multi=45, college=40 → min=20
+    expect(getCurrentMinPrice(floors)).toBe(20);
+  });
+});
+
+// ── Race condition tests ──
+// Each test asserts the snapshot state IMMEDIATELY after the race settles,
+// with NO extra invalidateSnapshot() cleanup call. If the assertion fails,
+// the race bug is real.
+
+describe('snapshot — race conditions (no cleanup calls)', () => {
+  let snapshotModule: typeof import('@/lib/config/snapshot');
+  let prismaModule: typeof import('@/lib/prisma');
+  let origFindMany: any;
+
+  beforeEach(async () => {
+    snapshotModule = await import('@/lib/config/snapshot');
+    prismaModule = await import('@/lib/prisma');
+    origFindMany = prismaModule.prisma.businessConfig.findMany;
+    snapshotModule._resetForTest();
+  });
+
+  afterEach(() => {
+    (prismaModule.prisma.businessConfig as any).findMany = origFindMany;
+    snapshotModule._resetForTest();
+  });
+
+  function mockRow(key: string, value: unknown, version = 1) {
+    return {
+      id: '1', namespace: 'pricing.rules', key, value,
+      schemaVersion: '1.0', version, previousValue: null,
+      updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date(),
+    };
+  }
+
+  it('stale passive DOES NOT overwrite a newer invalidation', async () => {
+    // Timeline:
+    // t=0   passive starts findMany → slow (50ms), reads stale value 5
+    // t=10  admin writes group_max=3 to DB
+    // t=10  admin calls invalidateSnapshot → fast findMany reads 3, swaps snapshot
+    // t=10  invalidateSnapshot returns — snapshot=3, lastLoadedAt=t10
+    // t=50  passive's slow findMany returns stale value 5
+    //       BUG (before fix): passive swaps snapshot back to 5
+    //       FIX: passive sees lastLoadedAt > its startedAt → does NOT swap
+    let callCount = 0;
+    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        // Passive: slow read started BEFORE the write
+        await new Promise((r) => setTimeout(r, 50));
+        return [mockRow('group_max', 5, 1)];
+      }
+      // Invalidation: fast read AFTER the write
+      return [mockRow('group_max', 3, 2)];
+    });
+
+    const passive = snapshotModule.loadConfigSnapshot();
+    await new Promise((r) => setTimeout(r, 10));
+    await snapshotModule.invalidateSnapshot();
+    // At this point snapshot=3. Now wait for the slow passive to finish.
+    await passive;
+
+    // ASSERTION — immediately, no cleanup call:
+    // The stale passive must NOT have overwritten the invalidation's value.
+    expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(3);
+  });
+
+  it('two concurrent invalidations — last DB state wins', async () => {
+    // t=0   admin A writes group_max=3 → invalidateSnapshot (slow 30ms findMany)
+    // t=5   admin B writes group_max=7 → invalidateSnapshot (fast findMany)
+    // B's findMany finishes first → snapshot=7, lastLoadedAt=t5+ε
+    // A's findMany finishes at t=30 → returns 3
+    //   FIX: A sees lastLoadedAt > its startedAt → does NOT swap
+    let callCount = 0;
+    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        await new Promise((r) => setTimeout(r, 30)); // A: slow
+        return [mockRow('group_max', 3, 2)];
+      }
+      // B: fast — returns immediately
+      return [mockRow('group_max', 7, 3)];
+    });
+
+    const invA = snapshotModule.invalidateSnapshot();
+    await new Promise((r) => setTimeout(r, 5));
+    const invB = snapshotModule.invalidateSnapshot();
+
+    await invA;
+    await invB;
+
+    // ASSERTION — immediately, no cleanup:
+    // B (value=7) committed later, its snapshot must win.
+    expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(7);
+  });
+
+  it('passive single-flight joiners do not overwrite invalidation', async () => {
+    // t=0   passive A starts slow findMany (50ms, returns stale 5)
+    // t=0   passive B joins A via single-flight
+    // t=10  invalidation writes 3, fast findMany, swaps snapshot=3
+    // t=50  passive A completes with stale 5
+    //       FIX: passive sees lastLoadedAt > startedAt → no swap
+    let callCount = 0;
+    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        await new Promise((r) => setTimeout(r, 50));
+        return [mockRow('group_max', 5, 1)];
+      }
+      return [mockRow('group_max', 3, 2)];
+    });
+
+    const passiveA = snapshotModule.loadConfigSnapshot();
+    const passiveB = snapshotModule.loadConfigSnapshot(); // joins A
+    await new Promise((r) => setTimeout(r, 10));
+    await snapshotModule.invalidateSnapshot();
+    await Promise.all([passiveA, passiveB]);
+
+    // ASSERTION — immediately:
+    expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(3);
+  });
+});
+
+// ── CRITICAL: can an invalidation LOSE to a passive? ──
+
+describe('snapshot — invalidation must NEVER lose to a passive', () => {
+  let snapshotModule: typeof import('@/lib/config/snapshot');
+  let prismaModule: typeof import('@/lib/prisma');
+  let origFindMany: any;
+
+  beforeEach(async () => {
+    snapshotModule = await import('@/lib/config/snapshot');
+    prismaModule = await import('@/lib/prisma');
+    origFindMany = prismaModule.prisma.businessConfig.findMany;
+    snapshotModule._resetForTest();
+  });
+
+  afterEach(() => {
+    (prismaModule.prisma.businessConfig as any).findMany = origFindMany;
+    snapshotModule._resetForTest();
+  });
+
+  function mockRow(value: unknown) {
+    return {
+      id: '1', namespace: 'pricing.rules', key: 'group_max', value,
+      schemaVersion: '1.0', version: 1, previousValue: null,
+      updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date(),
+    };
+  }
+
+  it('fast passive + slow invalidation → invalidation wins (write is authoritative)', async () => {
+    // Timeline:
+    // t=0   passive starts findMany → fast (5ms), reads stale 5
+    // t=0   invalidation starts findMany → slow (30ms), reads post-write 3
+    // t=5   passive finishes, swaps to 5, seq 0→1
+    // t=30  invalidation finishes, sees seq=1 ≠ seqAtStart=0
+    //       BUG: invalidation discards its result → admin's write is LOST
+    //       FIX: invalidation must always swap (it's authoritative post-commit)
+    let callCount = 0;
+    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        // Passive: fast
+        await new Promise((r) => setTimeout(r, 5));
+        return [mockRow(5)]; // stale pre-write
+      }
+      // Invalidation: slow
+      await new Promise((r) => setTimeout(r, 30));
+      return [mockRow(3)]; // post-write — this MUST win
+    });
+
+    // Start passive (its findMany fires first because loadConfigSnapshot
+    // starts _doLoad immediately when no inflight exists)
+    const passive = snapshotModule.loadConfigSnapshot();
+    // Start invalidation right after (its _doLoad fires independently)
+    const inv = snapshotModule.invalidateSnapshot();
+
+    await passive;
+    await inv;
+
+    // ASSERTION — immediately, no cleanup:
+    // The invalidation (post-write, value=3) MUST win over the passive (stale, value=5).
+    expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(3);
+  });
+
+  it('3-actor: passive + inv A + inv B → last invalidation wins', async () => {
+    // Timeline:
+    // t=0   passive starts findMany → very slow (60ms), returns stale 5
+    // t=0   inv A starts findMany → slow (30ms), returns write-A value 3
+    // t=5   inv B starts findMany → fast (5ms), returns write-B value 7
+    // t=10  inv B finishes, swaps to 7 (writeSeq 0→1, swapSeq 0→1)
+    // t=30  inv A finishes, sees writeSeq=1 ≠ seqAtStart=0 → cedes
+    // t=60  passive finishes, sees swapSeq=1 ≠ seqAtStart=0 → cedes
+    // Result: snapshot = 7 (last invalidation), never 5 or 3
+    let callCount = 0;
+    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        await new Promise((r) => setTimeout(r, 60)); // passive: very slow
+        return [mockRow(5)]; // stale
+      }
+      if (callCount === 2) {
+        await new Promise((r) => setTimeout(r, 30)); // inv A: slow
+        return [mockRow(3)]; // write A
+      }
+      // inv B: fast
+      return [mockRow(7)]; // write B — latest
+    });
+
+    const passive = snapshotModule.loadConfigSnapshot();
+    const invA = snapshotModule.invalidateSnapshot();
+    await new Promise((r) => setTimeout(r, 5));
+    const invB = snapshotModule.invalidateSnapshot();
+
+    await Promise.all([passive, invA, invB]);
+
+    expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(7);
+  });
+});
+
+// Same-ms resolution test REMOVED: the swapSequence counter is an integer,
+// not a timestamp. Two loads in the same ms have distinct sequence captures
+// by construction (each swap increments the counter synchronously).
+// No test needed — the property is structural, not behavioral.
+
+// ── Point 3: passive losing guard doesn't storm findMany ──
+
+describe('snapshot — passive losing guard advances lastLoadedAt', () => {
+  let snapshotModule: typeof import('@/lib/config/snapshot');
+  let prismaModule: typeof import('@/lib/prisma');
+  let origFindMany: any;
+
+  beforeEach(async () => {
+    snapshotModule = await import('@/lib/config/snapshot');
+    prismaModule = await import('@/lib/prisma');
+    origFindMany = prismaModule.prisma.businessConfig.findMany;
+    snapshotModule._resetForTest();
+  });
+
+  afterEach(() => {
+    (prismaModule.prisma.businessConfig as any).findMany = origFindMany;
+    snapshotModule._resetForTest();
+  });
+
+  function mockRow(value: unknown) {
+    return {
+      id: '1', namespace: 'pricing.rules', key: 'group_max', value,
+      schemaVersion: '1.0', version: 1, previousValue: null,
+      updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date(),
+    };
+  }
+
+  it('passive that loses the guard still prevents TTL re-trigger', async () => {
+    let findManyCallCount = 0;
+    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
+      findManyCallCount++;
+      if (findManyCallCount === 1) {
+        // Slow passive
+        await new Promise((r) => setTimeout(r, 30));
+        return [mockRow(5)]; // stale
+      }
+      return [mockRow(3)]; // post-write
+    });
+
+    // Start passive
+    const passive = snapshotModule.loadConfigSnapshot();
+    // Invalidation wins while passive is slow
+    await new Promise((r) => setTimeout(r, 5));
+    await snapshotModule.invalidateSnapshot();
+    await passive;
+
+    // Passive lost the guard. But it should have advanced lastLoadedAt.
+    // So ensureFresh() should NOT re-trigger immediately:
+    findManyCallCount = 0;
+    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
+      findManyCallCount++;
+      return [mockRow(3)];
+    });
+
+    await snapshotModule.ensureFresh();
+    // ensureFresh should be a no-op (within TTL), so no new findMany call
+    expect(findManyCallCount).toBe(0);
+  });
+});
+
+// ── Nominal TTL refresh — tested with mocked clock ──
+
+describe('snapshot — nominal TTL refresh (mocked clock, no reset)', () => {
+  let snapshotModule: typeof import('@/lib/config/snapshot');
+  let prismaModule: typeof import('@/lib/prisma');
+  let origFindMany: any;
+  let origDateNow: typeof Date.now;
+
+  beforeEach(async () => {
+    snapshotModule = await import('@/lib/config/snapshot');
+    prismaModule = await import('@/lib/prisma');
+    origFindMany = prismaModule.prisma.businessConfig.findMany;
+    origDateNow = Date.now;
+    snapshotModule._resetForTest();
+  });
+
+  afterEach(() => {
+    (prismaModule.prisma.businessConfig as any).findMany = origFindMany;
+    Date.now = origDateNow;
+    snapshotModule._resetForTest();
+  });
+
+  function mockRow(value: unknown) {
+    return {
+      id: '1', namespace: 'pricing.rules', key: 'group_max', value,
+      schemaVersion: '1.0', version: 1, previousValue: null,
+      updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date(),
+    };
+  }
+
+  it('initial load → within TTL no-op → TTL expires → passive swaps new value', async () => {
+    let fakeTime = 1000000;
+    Date.now = () => fakeTime;
+
+    // Step 1: initial load at T=1000000 with value 5
+    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => [mockRow(5)]);
+    await snapshotModule.loadConfigSnapshot();
+    expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(5);
+
+    // Step 2: advance time 30s (within 60s TTL) — ensureFresh is a no-op
+    fakeTime += 30_000;
+    let freshCallCount = 0;
+    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
+      freshCallCount++;
+      return [mockRow(8)];
+    });
+    await snapshotModule.ensureFresh();
+    expect(freshCallCount).toBe(0); // No DB call
+    expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(5);
+
+    // Step 3: advance time past TTL (total +61s from initial load)
+    fakeTime += 31_000;
+    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => [mockRow(8)]);
+    await snapshotModule.ensureFresh();
+    // The passive refresh should have swapped to 8
+    expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(8);
+  });
+});
+
+// ── Test helpers guarded in production ──
+
+describe('snapshot — test helpers guarded in production', () => {
+  function withProdEnv(fn: () => void) {
+    const origEnv = process.env.NODE_ENV;
+    // Use delete+assign to bypass @types/node readonly
+    delete (process.env as Record<string, string | undefined>).NODE_ENV;
+    (process.env as Record<string, string | undefined>).NODE_ENV = 'production';
+    try {
+      fn();
+    } finally {
+      delete (process.env as Record<string, string | undefined>).NODE_ENV;
+      (process.env as Record<string, string | undefined>).NODE_ENV = origEnv;
+    }
+  }
+
+  it('_resetForTest throws when NODE_ENV=production', () => {
+    withProdEnv(() => {
+      expect(() => _resetForTest()).toThrow('not available in production');
+    });
+  });
+
+  it('_setForTest throws when NODE_ENV=production', () => {
+    withProdEnv(() => {
+      expect(() => _setForTest([])).toThrow('not available in production');
+    });
+  });
+});

--- a/__tests__/lib/config/business-config.test.ts
+++ b/__tests__/lib/config/business-config.test.ts
@@ -399,38 +399,38 @@ describe('snapshot — passive losing guard advances lastLoadedAt', () => {
     };
   }
 
-  it('passive that loses the guard still prevents TTL re-trigger', async () => {
+  it('passive that loses guard prevents TTL re-trigger (when hasLoadedOnce)', async () => {
+    // First, do a successful full load to set hasLoadedOnce=true
+    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
+      return [mockRow(3)];
+    });
+    await snapshotModule.loadConfigSnapshot();
+
+    // Now set up the race: slow passive + applyWrite
     let findManyCallCount = 0;
     (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
       findManyCallCount++;
-      if (findManyCallCount === 1) {
-        // Slow passive
-        await new Promise((r) => setTimeout(r, 30));
-        return [mockRow(5)]; // stale
-      }
-      return [mockRow(3)]; // post-write
+      await new Promise((r) => setTimeout(r, 30)); // slow passive
+      return [mockRow(5)]; // stale
     });
 
-    // Start passive
     const passive = snapshotModule.loadConfigSnapshot();
-    // applyWrite wins while passive is slow
     await new Promise((r) => setTimeout(r, 5));
     snapshotModule.applyWrite({
-      namespace: 'pricing.rules', key: 'group_max', value: 3,
-      schemaVersion: '1.0', version: 2, updatedBy: 'admin', updatedAt: new Date(),
+      namespace: 'pricing.rules', key: 'group_max', value: 7,
+      schemaVersion: '1.0', version: 3, updatedBy: 'admin', updatedAt: new Date(),
     });
     await passive;
 
-    // Passive lost the guard. But it should have advanced lastLoadedAt.
-    // So ensureFresh() should NOT re-trigger immediately:
+    // Passive lost the guard. But hasLoadedOnce=true AND lastLoadedAt updated.
+    // So ensureFresh() should be a no-op:
     findManyCallCount = 0;
     (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
       findManyCallCount++;
-      return [mockRow(3)];
+      return [mockRow(7)];
     });
 
     await snapshotModule.ensureFresh();
-    // ensureFresh should be a no-op (within TTL), so no new findMany call
     expect(findManyCallCount).toBe(0);
   });
 });
@@ -482,6 +482,45 @@ describe('snapshot — applyWrite on cold snapshot triggers ensureFresh', () => 
     // Now both keys are in snapshot
     expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(3);
     expect(snapshotModule.getOverride('pricing.rules', 'group_min_open.lycee')).toBe(4);
+  });
+  it('cold passive loses guard + ensureFresh still triggers full load', async () => {
+    // Scenario from cubic: cold passive starts slow load, applyWrite
+    // fires during it, passive loses the guard and updates lastLoadedAt
+    // BUT not hasLoadedOnce. ensureFresh must still trigger a full load.
+    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
+      await new Promise((r) => setTimeout(r, 30)); // slow passive
+      return [{ id: '1', namespace: 'pricing.rules', key: 'group_max', value: 5,
+        schemaVersion: '1.0', version: 1, previousValue: null,
+        updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date() }];
+    });
+
+    const passive = snapshotModule.loadConfigSnapshot();
+    await new Promise((r) => setTimeout(r, 5));
+
+    // applyWrite bumps swapSequence → passive will lose the guard
+    snapshotModule.applyWrite({
+      namespace: 'pricing.rules', key: 'group_max', value: 3,
+      schemaVersion: '1.0', version: 2, updatedBy: 'admin', updatedAt: new Date(),
+    });
+
+    await passive; // passive loses guard, updates lastLoadedAt but NOT hasLoadedOnce
+
+    // NOW ensureFresh must still trigger a full load
+    let fullLoadCalled = false;
+    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
+      fullLoadCalled = true;
+      return [
+        { id: '1', namespace: 'pricing.rules', key: 'group_max', value: 3,
+          schemaVersion: '1.0', version: 2, previousValue: null,
+          updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date() },
+        { id: '2', namespace: 'pricing.rules', key: 'group_min_open.lycee', value: 4,
+          schemaVersion: '1.0', version: 1, previousValue: null,
+          updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date() },
+      ];
+    });
+
+    await snapshotModule.ensureFresh();
+    expect(fullLoadCalled).toBe(true);
   });
 });
 

--- a/__tests__/lib/config/business-config.test.ts
+++ b/__tests__/lib/config/business-config.test.ts
@@ -435,6 +435,56 @@ describe('snapshot — passive losing guard advances lastLoadedAt', () => {
   });
 });
 
+// ── applyWrite on cold snapshot does NOT suppress ensureFresh ──
+
+describe('snapshot — applyWrite on cold snapshot triggers ensureFresh', () => {
+  let snapshotModule: typeof import('@/lib/config/snapshot');
+  let prismaModule: typeof import('@/lib/prisma');
+  let origFindMany: any;
+
+  beforeEach(async () => {
+    snapshotModule = await import('@/lib/config/snapshot');
+    prismaModule = await import('@/lib/prisma');
+    origFindMany = prismaModule.prisma.businessConfig.findMany;
+    snapshotModule._resetForTest();
+  });
+
+  afterEach(() => {
+    (prismaModule.prisma.businessConfig as any).findMany = origFindMany;
+    snapshotModule._resetForTest();
+  });
+
+  it('cold snapshot + applyWrite → ensureFresh triggers full load', async () => {
+    // Snapshot is cold (never loaded). applyWrite sets ONE key.
+    snapshotModule.applyWrite({
+      namespace: 'pricing.rules', key: 'group_max', value: 3,
+      schemaVersion: '1.0', version: 1, updatedBy: 'admin', updatedAt: new Date(),
+    });
+    expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(3);
+
+    // ensureFresh should NOT be a no-op — it must trigger a full load
+    // because hasLoadedOnce is false.
+    let loadCalled = false;
+    (prismaModule.prisma.businessConfig as any).findMany = jest.fn(async () => {
+      loadCalled = true;
+      return [
+        { id: '1', namespace: 'pricing.rules', key: 'group_max', value: 3,
+          schemaVersion: '1.0', version: 1, previousValue: null,
+          updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date() },
+        { id: '2', namespace: 'pricing.rules', key: 'group_min_open.lycee', value: 4,
+          schemaVersion: '1.0', version: 1, previousValue: null,
+          updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date() },
+      ];
+    });
+
+    await snapshotModule.ensureFresh();
+    expect(loadCalled).toBe(true); // Full load triggered
+    // Now both keys are in snapshot
+    expect(snapshotModule.getOverride('pricing.rules', 'group_max')).toBe(3);
+    expect(snapshotModule.getOverride('pricing.rules', 'group_min_open.lycee')).toBe(4);
+  });
+});
+
 // ── Nominal TTL refresh — tested with mocked clock ──
 
 describe('snapshot — nominal TTL refresh (mocked clock, no reset)', () => {

--- a/app/api/admin/config/history/route.ts
+++ b/app/api/admin/config/history/route.ts
@@ -14,7 +14,17 @@ export async function GET() {
 
   const entries = await prisma.businessConfigAudit.findMany({
     orderBy: { changedAt: 'desc' },
-    take: 200, // Limit to last 200 changes
+    take: 200,
+    select: {
+      id: true,
+      namespace: true,
+      key: true,
+      oldValue: true,
+      newValue: true,
+      version: true,
+      changedBy: true,
+      changedAt: true,
+    },
   });
 
   return NextResponse.json({ entries });

--- a/app/api/admin/config/history/route.ts
+++ b/app/api/admin/config/history/route.ts
@@ -1,0 +1,31 @@
+/**
+ * GET /api/admin/config/history — Config change history
+ *
+ * Guard: ADMIN only
+ * Returns all entries ordered by updatedAt desc (audit trail).
+ */
+import { NextResponse } from 'next/server';
+import { requireRole, isErrorResponse } from '@/lib/guards';
+import { prisma } from '@/lib/prisma';
+
+export async function GET() {
+  const auth = await requireRole('ADMIN');
+  if (isErrorResponse(auth)) return auth;
+
+  const entries = await prisma.businessConfig.findMany({
+    orderBy: { updatedAt: 'desc' },
+    select: {
+      id: true,
+      namespace: true,
+      key: true,
+      value: true,
+      previousValue: true,
+      version: true,
+      schemaVersion: true,
+      updatedBy: true,
+      updatedAt: true,
+    },
+  });
+
+  return NextResponse.json({ entries });
+}

--- a/app/api/admin/config/history/route.ts
+++ b/app/api/admin/config/history/route.ts
@@ -1,8 +1,8 @@
 /**
- * GET /api/admin/config/history — Config change history
+ * GET /api/admin/config/history — Full audit trail of config changes
  *
- * Guard: ADMIN only
- * Returns all entries ordered by updatedAt desc (audit trail).
+ * Guard: ADMIN only.
+ * Reads from business_config_audit (append-only, one row per change).
  */
 import { NextResponse } from 'next/server';
 import { requireRole, isErrorResponse } from '@/lib/guards';
@@ -12,19 +12,9 @@ export async function GET() {
   const auth = await requireRole('ADMIN');
   if (isErrorResponse(auth)) return auth;
 
-  const entries = await prisma.businessConfig.findMany({
-    orderBy: { updatedAt: 'desc' },
-    select: {
-      id: true,
-      namespace: true,
-      key: true,
-      value: true,
-      previousValue: true,
-      version: true,
-      schemaVersion: true,
-      updatedBy: true,
-      updatedAt: true,
-    },
+  const entries = await prisma.businessConfigAudit.findMany({
+    orderBy: { changedAt: 'desc' },
+    take: 200, // Limit to last 200 changes
   });
 
   return NextResponse.json({ entries });

--- a/app/api/admin/config/rollback/route.ts
+++ b/app/api/admin/config/rollback/route.ts
@@ -1,18 +1,20 @@
 /**
  * POST /api/admin/config/rollback — Rollback a config entry to its previous value
  *
- * Guard: ADMIN only
+ * Guard: ADMIN only. Uses advisory lock for serialization (same as PATCH).
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { requireRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
 import {
-  invalidateSnapshot,
+  applyWrite,
   SCHEMA_VERSION,
   validateConfigEntry,
   validateCrossInvariants,
 } from '@/lib/config';
 import type { AuthSession } from '@/lib/guards';
+
+const CONFIG_ADVISORY_LOCK_KEY = 737001;
 
 export async function POST(request: NextRequest) {
   const auth = await requireRole('ADMIN');
@@ -27,62 +29,84 @@ export async function POST(request: NextRequest) {
   }
 
   const { namespace, key } = body;
-  if (!namespace || !key) {
+  if (typeof namespace !== 'string' || !namespace || typeof key !== 'string' || !key) {
     return NextResponse.json(
       { error: 'Missing required fields: namespace, key' },
       { status: 400 },
     );
   }
 
-  const existing = await prisma.businessConfig.findUnique({
-    where: { namespace_key: { namespace, key } },
+  const result = await prisma.$transaction(async (tx) => {
+    await tx.$queryRawUnsafe('SELECT pg_advisory_xact_lock($1)', CONFIG_ADVISORY_LOCK_KEY);
+
+    const existing = await tx.businessConfig.findUnique({
+      where: { namespace_key: { namespace, key } },
+    });
+
+    if (!existing) {
+      return { rejected: true as const, status: 404, error: 'Entry not found' };
+    }
+    if (existing.previousValue === null) {
+      return { rejected: true as const, status: 400, error: 'No previous value to rollback to' };
+    }
+
+    const prevValue = existing.previousValue;
+    const validation = validateConfigEntry(namespace, key, prevValue);
+    if (!validation.valid) {
+      return { rejected: true as const, status: 400, error: `Previous value fails validation: ${validation.error}` };
+    }
+
+    const dbEntries = await tx.businessConfig.findMany();
+    const dbResolver = (ns: string, k: string): unknown | null => {
+      const row = dbEntries.find((r) => r.namespace === ns && r.key === k);
+      return row?.value ?? null;
+    };
+    const violations = validateCrossInvariants(namespace, key, prevValue, dbResolver);
+    if (violations.length > 0) {
+      return { rejected: true as const, status: 400, error: 'Rollback would violate invariants', violations };
+    }
+
+    const entry = await tx.businessConfig.update({
+      where: { namespace_key: { namespace, key } },
+      data: {
+        value: prevValue as import('@prisma/client').Prisma.InputJsonValue,
+        previousValue: existing.value as import('@prisma/client').Prisma.InputJsonValue,
+        version: existing.version + 1,
+        schemaVersion: SCHEMA_VERSION,
+        updatedBy: session.user.id,
+      },
+    });
+
+    await tx.businessConfigAudit.create({
+      data: {
+        namespace,
+        key,
+        oldValue: existing.value as import('@prisma/client').Prisma.InputJsonValue,
+        newValue: prevValue as import('@prisma/client').Prisma.InputJsonValue,
+        version: entry.version,
+        changedBy: session.user.id,
+      },
+    });
+
+    return { rejected: false as const, entry };
   });
 
-  if (!existing) {
+  if (result.rejected) {
     return NextResponse.json(
-      { error: 'Entry not found' },
-      { status: 404 },
+      { error: result.error, ...('violations' in result ? { violations: result.violations } : {}) },
+      { status: result.status },
     );
   }
 
-  if (existing.previousValue === null) {
-    return NextResponse.json(
-      { error: 'No previous value to rollback to' },
-      { status: 400 },
-    );
-  }
-
-  const prevValue = existing.previousValue;
-
-  // Validate the rollback value
-  const validation = validateConfigEntry(namespace, key, prevValue);
-  if (!validation.valid) {
-    return NextResponse.json(
-      { error: 'Previous value fails validation', details: validation.error },
-      { status: 400 },
-    );
-  }
-
-  const invariantViolations = validateCrossInvariants(namespace, key, prevValue);
-  if (invariantViolations.length > 0) {
-    return NextResponse.json(
-      { error: 'Rollback would violate invariants', violations: invariantViolations },
-      { status: 400 },
-    );
-  }
-
-  const entry = await prisma.businessConfig.update({
-    where: { namespace_key: { namespace, key } },
-    data: {
-      value: prevValue as any,
-      previousValue: existing.value as any,
-      version: existing.version + 1,
-      schemaVersion: SCHEMA_VERSION,
-      updatedBy: session.user.id,
-    },
+  applyWrite({
+    namespace: result.entry.namespace,
+    key: result.entry.key,
+    value: result.entry.value,
+    schemaVersion: result.entry.schemaVersion,
+    version: result.entry.version,
+    updatedBy: result.entry.updatedBy,
+    updatedAt: result.entry.updatedAt,
   });
 
-  await invalidateSnapshot();
-
-  return NextResponse.json({ entry, rolledBack: true });
+  return NextResponse.json({ entry: result.entry, rolledBack: true });
 }

--- a/app/api/admin/config/rollback/route.ts
+++ b/app/api/admin/config/rollback/route.ts
@@ -2,6 +2,11 @@
  * POST /api/admin/config/rollback — Rollback a config entry to its previous value
  *
  * Guard: ADMIN only. Uses advisory lock for serialization (same as PATCH).
+ *
+ * NOTE (Lot 3 scope): The FIRST override for a key has previousValue=null,
+ * so rollback returns 400 "No previous value". Reverting a first-time
+ * override to the canonical fallback is a Lot 5 feature (requires the
+ * R2 credits decision + rollback-to-fallback semantics).
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { requireRole, isErrorResponse } from '@/lib/guards';

--- a/app/api/admin/config/rollback/route.ts
+++ b/app/api/admin/config/rollback/route.ts
@@ -1,0 +1,88 @@
+/**
+ * POST /api/admin/config/rollback — Rollback a config entry to its previous value
+ *
+ * Guard: ADMIN only
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole, isErrorResponse } from '@/lib/guards';
+import { prisma } from '@/lib/prisma';
+import {
+  invalidateSnapshot,
+  SCHEMA_VERSION,
+  validateConfigEntry,
+  validateCrossInvariants,
+} from '@/lib/config';
+import type { AuthSession } from '@/lib/guards';
+
+export async function POST(request: NextRequest) {
+  const auth = await requireRole('ADMIN');
+  if (isErrorResponse(auth)) return auth;
+  const session = auth as AuthSession;
+
+  let body: { namespace: string; key: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { namespace, key } = body;
+  if (!namespace || !key) {
+    return NextResponse.json(
+      { error: 'Missing required fields: namespace, key' },
+      { status: 400 },
+    );
+  }
+
+  const existing = await prisma.businessConfig.findUnique({
+    where: { namespace_key: { namespace, key } },
+  });
+
+  if (!existing) {
+    return NextResponse.json(
+      { error: 'Entry not found' },
+      { status: 404 },
+    );
+  }
+
+  if (existing.previousValue === null) {
+    return NextResponse.json(
+      { error: 'No previous value to rollback to' },
+      { status: 400 },
+    );
+  }
+
+  const prevValue = existing.previousValue;
+
+  // Validate the rollback value
+  const validation = validateConfigEntry(namespace, key, prevValue);
+  if (!validation.valid) {
+    return NextResponse.json(
+      { error: 'Previous value fails validation', details: validation.error },
+      { status: 400 },
+    );
+  }
+
+  const invariantViolations = validateCrossInvariants(namespace, key, prevValue);
+  if (invariantViolations.length > 0) {
+    return NextResponse.json(
+      { error: 'Rollback would violate invariants', violations: invariantViolations },
+      { status: 400 },
+    );
+  }
+
+  const entry = await prisma.businessConfig.update({
+    where: { namespace_key: { namespace, key } },
+    data: {
+      value: prevValue as any,
+      previousValue: existing.value as any,
+      version: existing.version + 1,
+      schemaVersion: SCHEMA_VERSION,
+      updatedBy: session.user.id,
+    },
+  });
+
+  await invalidateSnapshot();
+
+  return NextResponse.json({ entry, rolledBack: true });
+}

--- a/app/api/admin/config/rollback/route.ts
+++ b/app/api/admin/config/rollback/route.ts
@@ -8,6 +8,8 @@ import { requireRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
 import {
   applyWrite,
+  getStaticFallback,
+  loadConfigSnapshot,
   SCHEMA_VERSION,
   validateConfigEntry,
   validateCrossInvariants,
@@ -67,16 +69,35 @@ export async function POST(request: NextRequest) {
       return { rejected: true as const, status: 400, error: 'Rollback would violate invariants', violations };
     }
 
-    const entry = await tx.businessConfig.update({
-      where: { namespace_key: { namespace, key } },
-      data: {
-        value: prevValue as import('@prisma/client').Prisma.InputJsonValue,
-        previousValue: existing.value as import('@prisma/client').Prisma.InputJsonValue,
-        version: existing.version + 1,
-        schemaVersion: SCHEMA_VERSION,
-        updatedBy: session.user.id,
-      },
-    });
+    // If rolling back to the canonical fallback, DELETE the row
+    // (restore the "no override" state) instead of persisting the
+    // fallback as a frozen override that masks future canonical changes.
+    // getStaticFallback already imported at top
+    const canonicalFallback = getStaticFallback(namespace, key);
+    const isRollbackToFallback = canonicalFallback !== null &&
+      JSON.stringify(prevValue) === JSON.stringify(canonicalFallback);
+
+    let deletedRow = false;
+    let entry: typeof existing;
+
+    if (isRollbackToFallback) {
+      await tx.businessConfig.delete({
+        where: { namespace_key: { namespace, key } },
+      });
+      deletedRow = true;
+      entry = { ...existing, value: prevValue, version: existing.version + 1 };
+    } else {
+      entry = await tx.businessConfig.update({
+        where: { namespace_key: { namespace, key } },
+        data: {
+          value: prevValue as import('@prisma/client').Prisma.InputJsonValue,
+          previousValue: existing.value as import('@prisma/client').Prisma.InputJsonValue,
+          version: existing.version + 1,
+          schemaVersion: SCHEMA_VERSION,
+          updatedBy: session.user.id,
+        },
+      });
+    }
 
     await tx.businessConfigAudit.create({
       data: {
@@ -84,12 +105,12 @@ export async function POST(request: NextRequest) {
         key,
         oldValue: existing.value as import('@prisma/client').Prisma.InputJsonValue,
         newValue: prevValue as import('@prisma/client').Prisma.InputJsonValue,
-        version: entry.version,
+        version: existing.version + 1,
         changedBy: session.user.id,
       },
     });
 
-    return { rejected: false as const, entry };
+    return { rejected: false as const, entry, deletedRow };
   });
 
   if (result.rejected) {
@@ -99,15 +120,22 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  applyWrite({
-    namespace: result.entry.namespace,
-    key: result.entry.key,
-    value: result.entry.value,
-    schemaVersion: result.entry.schemaVersion,
-    version: result.entry.version,
-    updatedBy: result.entry.updatedBy,
-    updatedAt: result.entry.updatedAt,
-  });
+  if (result.deletedRow) {
+    // Row was deleted (rollback to canonical fallback).
+    // Force a full reload to clear this key from the snapshot.
+    // loadConfigSnapshot already imported at top
+    await loadConfigSnapshot();
+  } else {
+    applyWrite({
+      namespace: result.entry.namespace,
+      key: result.entry.key,
+      value: result.entry.value,
+      schemaVersion: result.entry.schemaVersion,
+      version: result.entry.version,
+      updatedBy: result.entry.updatedBy,
+      updatedAt: result.entry.updatedAt,
+    });
+  }
 
   return NextResponse.json({ entry: result.entry, rolledBack: true });
 }

--- a/app/api/admin/config/rollback/route.ts
+++ b/app/api/admin/config/rollback/route.ts
@@ -8,8 +8,6 @@ import { requireRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
 import {
   applyWrite,
-  getStaticFallback,
-  loadConfigSnapshot,
   SCHEMA_VERSION,
   validateConfigEntry,
   validateCrossInvariants,
@@ -69,35 +67,16 @@ export async function POST(request: NextRequest) {
       return { rejected: true as const, status: 400, error: 'Rollback would violate invariants', violations };
     }
 
-    // If rolling back to the canonical fallback, DELETE the row
-    // (restore the "no override" state) instead of persisting the
-    // fallback as a frozen override that masks future canonical changes.
-    // getStaticFallback already imported at top
-    const canonicalFallback = getStaticFallback(namespace, key);
-    const isRollbackToFallback = canonicalFallback !== null &&
-      JSON.stringify(prevValue) === JSON.stringify(canonicalFallback);
-
-    let deletedRow = false;
-    let entry: typeof existing;
-
-    if (isRollbackToFallback) {
-      await tx.businessConfig.delete({
-        where: { namespace_key: { namespace, key } },
-      });
-      deletedRow = true;
-      entry = { ...existing, value: prevValue, version: existing.version + 1 };
-    } else {
-      entry = await tx.businessConfig.update({
-        where: { namespace_key: { namespace, key } },
-        data: {
-          value: prevValue as import('@prisma/client').Prisma.InputJsonValue,
-          previousValue: existing.value as import('@prisma/client').Prisma.InputJsonValue,
-          version: existing.version + 1,
-          schemaVersion: SCHEMA_VERSION,
-          updatedBy: session.user.id,
-        },
-      });
-    }
+    const entry = await tx.businessConfig.update({
+      where: { namespace_key: { namespace, key } },
+      data: {
+        value: prevValue as import('@prisma/client').Prisma.InputJsonValue,
+        previousValue: existing.value as import('@prisma/client').Prisma.InputJsonValue,
+        version: existing.version + 1,
+        schemaVersion: SCHEMA_VERSION,
+        updatedBy: session.user.id,
+      },
+    });
 
     await tx.businessConfigAudit.create({
       data: {
@@ -105,12 +84,12 @@ export async function POST(request: NextRequest) {
         key,
         oldValue: existing.value as import('@prisma/client').Prisma.InputJsonValue,
         newValue: prevValue as import('@prisma/client').Prisma.InputJsonValue,
-        version: existing.version + 1,
+        version: entry.version,
         changedBy: session.user.id,
       },
     });
 
-    return { rejected: false as const, entry, deletedRow };
+    return { rejected: false as const, entry };
   });
 
   if (result.rejected) {
@@ -120,22 +99,15 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  if (result.deletedRow) {
-    // Row was deleted (rollback to canonical fallback).
-    // Force a full reload to clear this key from the snapshot.
-    // loadConfigSnapshot already imported at top
-    await loadConfigSnapshot();
-  } else {
-    applyWrite({
-      namespace: result.entry.namespace,
-      key: result.entry.key,
-      value: result.entry.value,
-      schemaVersion: result.entry.schemaVersion,
-      version: result.entry.version,
-      updatedBy: result.entry.updatedBy,
-      updatedAt: result.entry.updatedAt,
-    });
-  }
+  applyWrite({
+    namespace: result.entry.namespace,
+    key: result.entry.key,
+    value: result.entry.value,
+    schemaVersion: result.entry.schemaVersion,
+    version: result.entry.version,
+    updatedBy: result.entry.updatedBy,
+    updatedAt: result.entry.updatedAt,
+  });
 
   return NextResponse.json({ entry: result.entry, rolledBack: true });
 }

--- a/app/api/admin/config/rollback/route.ts
+++ b/app/api/admin/config/rollback/route.ts
@@ -11,10 +11,11 @@ import {
   SCHEMA_VERSION,
   validateConfigEntry,
   validateCrossInvariants,
+  CONFIG_ADVISORY_LOCK_KEY,
 } from '@/lib/config';
 import type { AuthSession } from '@/lib/guards';
 
-const CONFIG_ADVISORY_LOCK_KEY = 737001;
+
 
 export async function POST(request: NextRequest) {
   const auth = await requireRole('ADMIN');

--- a/app/api/admin/config/route.ts
+++ b/app/api/admin/config/route.ts
@@ -14,13 +14,14 @@ import {
   SCHEMA_VERSION,
   validateConfigEntry,
   validateCrossInvariants,
+  CONFIG_ADVISORY_LOCK_KEY,
 } from '@/lib/config';
 import type { AuthSession } from '@/lib/guards';
 
 // Advisory lock key for serializing config writes. All config writes
 // share the same lock — config changes are rare (admin-only), so
 // serialization is the simplest correct solution for cross-key invariants.
-const CONFIG_ADVISORY_LOCK_KEY = 737001; // arbitrary stable int
+ // arbitrary stable int
 
 export async function GET() {
   const auth = await requireAnyRole(['ADMIN', 'ASSISTANTE']);

--- a/app/api/admin/config/route.ts
+++ b/app/api/admin/config/route.ts
@@ -11,7 +11,6 @@ import {
   getAllEntries,
   applyWrite,
   ensureFresh,
-  getOverride,
   getStaticFallback,
   getValidNamespaces,
   getNamespaceKeys,
@@ -19,7 +18,6 @@ import {
   validateConfigEntry,
   validateCrossInvariants,
   CONFIG_ADVISORY_LOCK_KEY,
-  type NamespaceId,
 } from '@/lib/config';
 import type { AuthSession } from '@/lib/guards';
 

--- a/app/api/admin/config/route.ts
+++ b/app/api/admin/config/route.ts
@@ -56,9 +56,12 @@ export async function GET() {
   }
 
   // Also include any overrides for open-ended namespaces (products.credits)
+  const emitted = new Set(entries.map((e) => `${e.namespace}::${e.key}`));
   for (const override of overrides) {
-    if (!entries.some((e) => e.namespace === override.namespace && e.key === override.key)) {
+    const mapKey = `${override.namespace}::${override.key}`;
+    if (!emitted.has(mapKey)) {
       entries.push({ namespace: override.namespace, key: override.key, value: override.value, source: 'override' });
+      emitted.add(mapKey);
     }
   }
 

--- a/app/api/admin/config/route.ts
+++ b/app/api/admin/config/route.ts
@@ -11,10 +11,15 @@ import {
   getAllEntries,
   applyWrite,
   ensureFresh,
+  getOverride,
+  getStaticFallback,
+  getValidNamespaces,
+  getNamespaceKeys,
   SCHEMA_VERSION,
   validateConfigEntry,
   validateCrossInvariants,
   CONFIG_ADVISORY_LOCK_KEY,
+  type NamespaceId,
 } from '@/lib/config';
 import type { AuthSession } from '@/lib/guards';
 
@@ -28,7 +33,37 @@ export async function GET() {
   if (isErrorResponse(auth)) return auth;
 
   await ensureFresh();
-  const entries = getAllEntries();
+
+  // Build effective entries: override if exists, else canonical fallback.
+  // Each entry marked with source: 'override' | 'fallback'.
+  const overrides = getAllEntries();
+  const overrideMap = new Map(overrides.map((e) => [`${e.namespace}::${e.key}`, e]));
+  const entries: Array<{ namespace: string; key: string; value: unknown; source: 'override' | 'fallback' }> = [];
+
+  for (const ns of getValidNamespaces()) {
+    const keys = getNamespaceKeys(ns);
+    if (keys) {
+      for (const key of keys) {
+        const override = overrideMap.get(`${ns}::${key}`);
+        if (override) {
+          entries.push({ namespace: ns, key, value: override.value, source: 'override' });
+        } else {
+          const fallback = getStaticFallback(ns, key);
+          if (fallback !== null) {
+            entries.push({ namespace: ns, key, value: fallback, source: 'fallback' });
+          }
+        }
+      }
+    }
+  }
+
+  // Also include any overrides for open-ended namespaces (products.credits)
+  for (const override of overrides) {
+    if (!entries.some((e) => e.namespace === override.namespace && e.key === override.key)) {
+      entries.push({ namespace: override.namespace, key: override.key, value: override.value, source: 'override' });
+    }
+  }
+
   return NextResponse.json({ entries });
 }
 

--- a/app/api/admin/config/route.ts
+++ b/app/api/admin/config/route.ts
@@ -139,6 +139,9 @@ export async function PATCH(request: NextRequest) {
         value: value as import('@prisma/client').Prisma.InputJsonValue,
         schemaVersion: SCHEMA_VERSION,
         version: 1,
+        // Store the canonical fallback as previousValue so rollback can
+        // undo even the first override (Codex P2: first-time rollback).
+        previousValue: (getStaticFallback(namespace, key) as import('@prisma/client').Prisma.InputJsonValue) ?? undefined,
         updatedBy: session.user.id,
       },
       update: {

--- a/app/api/admin/config/route.ts
+++ b/app/api/admin/config/route.ts
@@ -1,0 +1,93 @@
+/**
+ * GET  /api/admin/config — Read all config entries + fallbacks
+ * PATCH /api/admin/config — Write/update a single config entry
+ *
+ * Guards: ADMIN only (PATCH), ADMIN+ASSISTANTE (GET — read-only)
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole, requireAnyRole, isErrorResponse } from '@/lib/guards';
+import { prisma } from '@/lib/prisma';
+import {
+  getAllEntries,
+  invalidateSnapshot,
+  SCHEMA_VERSION,
+  validateConfigEntry,
+  validateCrossInvariants,
+} from '@/lib/config';
+import type { AuthSession } from '@/lib/guards';
+
+export async function GET() {
+  const auth = await requireAnyRole(['ADMIN', 'ASSISTANTE']);
+  if (isErrorResponse(auth)) return auth;
+
+  const entries = getAllEntries();
+  return NextResponse.json({ entries });
+}
+
+export async function PATCH(request: NextRequest) {
+  const auth = await requireRole('ADMIN');
+  if (isErrorResponse(auth)) return auth;
+  const session = auth as AuthSession;
+
+  let body: { namespace: string; key: string; value: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { namespace, key, value } = body;
+  if (!namespace || !key || value === undefined) {
+    return NextResponse.json(
+      { error: 'Missing required fields: namespace, key, value' },
+      { status: 400 },
+    );
+  }
+
+  // Per-key Zod validation
+  const validation = validateConfigEntry(namespace, key, value);
+  if (!validation.valid) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: validation.error },
+      { status: 400 },
+    );
+  }
+
+  // Cross-namespace invariants
+  const invariantViolations = validateCrossInvariants(namespace, key, value);
+  if (invariantViolations.length > 0) {
+    return NextResponse.json(
+      { error: 'Invariant violation', violations: invariantViolations },
+      { status: 400 },
+    );
+  }
+
+  // DB write: upsert with versioning
+  const existing = await prisma.businessConfig.findUnique({
+    where: { namespace_key: { namespace, key } },
+  });
+
+  const entry = await prisma.businessConfig.upsert({
+    where: { namespace_key: { namespace, key } },
+    create: {
+      namespace,
+      key,
+      value: value as any,
+      schemaVersion: SCHEMA_VERSION,
+      version: 1,
+      updatedBy: session.user.id,
+    },
+    update: {
+      value: value as any,
+      schemaVersion: SCHEMA_VERSION,
+      version: existing ? existing.version + 1 : 1,
+      previousValue: existing?.value ?? undefined,
+      updatedBy: session.user.id,
+    },
+  });
+
+  // RULE: commit FIRST, then await invalidateSnapshot()
+  await invalidateSnapshot();
+
+  return NextResponse.json({ entry });
+}

--- a/app/api/admin/config/route.ts
+++ b/app/api/admin/config/route.ts
@@ -139,9 +139,6 @@ export async function PATCH(request: NextRequest) {
         value: value as import('@prisma/client').Prisma.InputJsonValue,
         schemaVersion: SCHEMA_VERSION,
         version: 1,
-        // Store the canonical fallback as previousValue so rollback can
-        // undo even the first override (Codex P2: first-time rollback).
-        previousValue: (getStaticFallback(namespace, key) as import('@prisma/client').Prisma.InputJsonValue) ?? undefined,
         updatedBy: session.user.id,
       },
       update: {

--- a/app/api/admin/config/route.ts
+++ b/app/api/admin/config/route.ts
@@ -9,17 +9,24 @@ import { requireRole, requireAnyRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
 import {
   getAllEntries,
-  invalidateSnapshot,
+  applyWrite,
+  ensureFresh,
   SCHEMA_VERSION,
   validateConfigEntry,
   validateCrossInvariants,
 } from '@/lib/config';
 import type { AuthSession } from '@/lib/guards';
 
+// Advisory lock key for serializing config writes. All config writes
+// share the same lock — config changes are rare (admin-only), so
+// serialization is the simplest correct solution for cross-key invariants.
+const CONFIG_ADVISORY_LOCK_KEY = 737001; // arbitrary stable int
+
 export async function GET() {
   const auth = await requireAnyRole(['ADMIN', 'ASSISTANTE']);
   if (isErrorResponse(auth)) return auth;
 
+  await ensureFresh();
   const entries = getAllEntries();
   return NextResponse.json({ entries });
 }
@@ -37,14 +44,14 @@ export async function PATCH(request: NextRequest) {
   }
 
   const { namespace, key, value } = body;
-  if (!namespace || !key || value === undefined) {
+  if (typeof namespace !== 'string' || !namespace || typeof key !== 'string' || !key || value === undefined) {
     return NextResponse.json(
       { error: 'Missing required fields: namespace, key, value' },
       { status: 400 },
     );
   }
 
-  // Per-key Zod validation
+  // Per-key Zod validation (stateless — can run outside transaction)
   const validation = validateConfigEntry(namespace, key, value);
   if (!validation.valid) {
     return NextResponse.json(
@@ -53,41 +60,94 @@ export async function PATCH(request: NextRequest) {
     );
   }
 
-  // Cross-namespace invariants
-  const invariantViolations = validateCrossInvariants(namespace, key, value);
-  if (invariantViolations.length > 0) {
+  // Fast-reject: check invariants against snapshot (catches obvious violations
+  // without a DB round-trip). The authoritative check happens inside the transaction.
+  await ensureFresh();
+  const fastReject = validateCrossInvariants(namespace, key, value);
+  if (fastReject.length > 0) {
     return NextResponse.json(
-      { error: 'Invariant violation', violations: invariantViolations },
+      { error: 'Invariant violation', violations: fastReject },
       { status: 400 },
     );
   }
 
-  // DB write: upsert with versioning
-  const existing = await prisma.businessConfig.findUnique({
-    where: { namespace_key: { namespace, key } },
+  // Serialized write: advisory lock + transactional invariant check + upsert.
+  // The advisory lock serializes ALL config writes so cross-key invariants
+  // cannot be bypassed by concurrent PATCHes on related keys (TOCTOU fix).
+  const result = await prisma.$transaction(async (tx) => {
+    // Acquire advisory lock — released when the transaction ends
+    await tx.$queryRawUnsafe('SELECT pg_advisory_xact_lock($1)', CONFIG_ADVISORY_LOCK_KEY);
+
+    // Read ALL config entries for this namespace from the DB (not snapshot)
+    // to build a transactional resolver for cross-key invariants.
+    const dbEntries = await tx.businessConfig.findMany();
+    const dbResolver = (ns: string, k: string): unknown | null => {
+      const row = dbEntries.find((r) => r.namespace === ns && r.key === k);
+      return row?.value ?? null;
+    };
+
+    // Authoritative invariant check against the transactional DB state
+    const invariantViolations = validateCrossInvariants(namespace, key, value, dbResolver);
+    if (invariantViolations.length > 0) {
+      return { rejected: true as const, violations: invariantViolations };
+    }
+
+    // Upsert with version increment
+    const existing = await tx.businessConfig.findUnique({
+      where: { namespace_key: { namespace, key } },
+    });
+
+    const entry = await tx.businessConfig.upsert({
+      where: { namespace_key: { namespace, key } },
+      create: {
+        namespace,
+        key,
+        value: value as import('@prisma/client').Prisma.InputJsonValue,
+        schemaVersion: SCHEMA_VERSION,
+        version: 1,
+        updatedBy: session.user.id,
+      },
+      update: {
+        value: value as import('@prisma/client').Prisma.InputJsonValue,
+        schemaVersion: SCHEMA_VERSION,
+        version: (existing?.version ?? 0) + 1,
+        previousValue: existing?.value as import('@prisma/client').Prisma.InputJsonValue ?? undefined,
+        updatedBy: session.user.id,
+      },
+    });
+
+    // Audit trail — append-only, same transaction
+    await tx.businessConfigAudit.create({
+      data: {
+        namespace,
+        key,
+        oldValue: existing?.value as import('@prisma/client').Prisma.InputJsonValue ?? undefined,
+        newValue: value as import('@prisma/client').Prisma.InputJsonValue,
+        version: entry.version,
+        changedBy: session.user.id,
+      },
+    });
+
+    return { rejected: false as const, entry };
   });
 
-  const entry = await prisma.businessConfig.upsert({
-    where: { namespace_key: { namespace, key } },
-    create: {
-      namespace,
-      key,
-      value: value as any,
-      schemaVersion: SCHEMA_VERSION,
-      version: 1,
-      updatedBy: session.user.id,
-    },
-    update: {
-      value: value as any,
-      schemaVersion: SCHEMA_VERSION,
-      version: existing ? existing.version + 1 : 1,
-      previousValue: existing?.value ?? undefined,
-      updatedBy: session.user.id,
-    },
+  if (result.rejected) {
+    return NextResponse.json(
+      { error: 'Invariant violation', violations: result.violations },
+      { status: 400 },
+    );
+  }
+
+  // Apply committed entry to snapshot (synchronous, version-ordered)
+  applyWrite({
+    namespace: result.entry.namespace,
+    key: result.entry.key,
+    value: result.entry.value,
+    schemaVersion: result.entry.schemaVersion,
+    version: result.entry.version,
+    updatedBy: result.entry.updatedBy,
+    updatedAt: result.entry.updatedAt,
   });
 
-  // RULE: commit FIRST, then await invalidateSnapshot()
-  await invalidateSnapshot();
-
-  return NextResponse.json({ entry });
+  return NextResponse.json({ entry: result.entry });
 }

--- a/docs/architecture/restructuration/05-architecture-migration.md
+++ b/docs/architecture/restructuration/05-architecture-migration.md
@@ -258,6 +258,11 @@ Note snapshot : sur échec de `loadConfigSnapshot()`, le single-flight sert le s
 
 **Note** : tant qu'aucune valeur n'est posée dans le store, le fallback octroie les valeurs `PRODUCT_REGISTRY` actuelles (4/8/16). Le comportement prod ne change pas tant que le dirigeant n'a pas tranché.
 
+**Prérequis reportés du Lot 3** (résolus dans ce lot) :
+1. Réversibilité du premier override : rollback vers le fallback canonical (delete de la ligne, pas update avec la valeur gelée). Dépend de la décision R2.
+2. Résolution des fallbacks `products.credits` depuis `PRODUCT_REGISTRY` (le Lot 3 ne résout que `pricing.rules` et `pricing.floors` en fallback).
+3. Sémantique du rollback multi-crans via `BusinessConfigAudit` (le Lot 3 pose l'audit append-only, le Lot 5 l'exploite).
+
 ---
 
 ### Lot 6 — Écrans de gestion admin

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -17,6 +17,7 @@ export {
   validateConfigEntry,
   validateCrossInvariants,
   getCurrentMinPrice,
+  getStaticFallback,
   getValidNamespaces,
   getNamespaceKeys,
   SCHEMA_VERSION,

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -4,7 +4,7 @@ export {
   getNamespaceEntries,
   getAllEntries,
   loadConfigSnapshot,
-  invalidateSnapshot,
+  applyWrite,
   ensureFresh,
   type ConfigEntry,
 } from './snapshot';

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -1,0 +1,24 @@
+export {
+  getOverride,
+  getOverrideOr,
+  getNamespaceEntries,
+  getAllEntries,
+  loadConfigSnapshot,
+  invalidateSnapshot,
+  ensureFresh,
+  type ConfigEntry,
+} from './snapshot';
+
+// _resetForTest and _setForTest are intentionally NOT re-exported here.
+// Tests that need them import directly from './snapshot' to make the
+// test-only dependency explicit and prevent accidental prod usage.
+
+export {
+  validateConfigEntry,
+  validateCrossInvariants,
+  getCurrentMinPrice,
+  getValidNamespaces,
+  getNamespaceKeys,
+  SCHEMA_VERSION,
+  type NamespaceId,
+} from './schemas';

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -22,3 +22,6 @@ export {
   SCHEMA_VERSION,
   type NamespaceId,
 } from './schemas';
+
+/** Advisory lock key for serializing config writes (shared by PATCH + rollback). */
+export const CONFIG_ADVISORY_LOCK_KEY = 737001;

--- a/lib/config/schemas.ts
+++ b/lib/config/schemas.ts
@@ -10,10 +10,39 @@
  */
 import { z } from 'zod';
 import { getOverride } from './snapshot';
+import pricingCanonical from '@/data/pricing-client-data.generated.json';
 
 // ── Schema version — bump when adding/removing keys ──
 
 export const SCHEMA_VERSION = '1.0';
+
+// ── Static fallbacks from canonical (single source — used by invariants,
+// getCurrentMinPrice, and GET /api/admin/config) ──
+
+const canonicalRules = pricingCanonical.rules as Record<string, unknown>;
+
+/** Resolve a static fallback value for a namespace+key from canonical data. */
+export function getStaticFallback(namespace: string, key: string): unknown | null {
+  if (namespace === 'pricing.rules') {
+    // Dot-notation keys like 'group_min_open.lycee' → rules.group_min_open.lycee
+    const parts = key.split('.');
+    let current: unknown = canonicalRules;
+    for (const part of parts) {
+      if (current == null || typeof current !== 'object') return null;
+      current = (current as Record<string, unknown>)[part];
+    }
+    return current ?? null;
+  }
+  if (namespace === 'pricing.floors') {
+    const floors = canonicalRules.price_floor_per_student_hour_tnd;
+    if (floors && typeof floors === 'object') {
+      return (floors as Record<string, unknown>)[key] ?? null;
+    }
+    return null;
+  }
+  // products.credits: no static fallback (product-specific, defined in PRODUCT_REGISTRY)
+  return null;
+}
 
 // ── Namespace: pricing.rules ──
 
@@ -137,12 +166,16 @@ export function validateCrossInvariants(
   resolver?: (ns: string, k: string) => unknown | null,
 ): string[] {
   const violations: string[] = [];
-  const resolve = resolver ?? ((ns: string, k: string) => getOverride(ns, k));
+  const resolveOverride = resolver ?? ((ns: string, k: string) => getOverride(ns, k));
 
-  // Helper: get effective value (pending if matches, else resolve)
+  // Helper: get effective value — override ?? static fallback.
+  // Never returns null for a known canonical key, ensuring invariants
+  // always validate against the effective state (not against a void).
   function effective<T>(ns: string, k: string): T | null {
     if (ns === pendingNamespace && k === pendingKey) return pendingValue as T;
-    return resolve(ns, k) as T | null;
+    const override = resolveOverride(ns, k);
+    if (override !== null && override !== undefined) return override as T;
+    return getStaticFallback(ns, k) as T | null;
   }
 
   // Invariant 1: discount min ≤ max (ancien_eleve)

--- a/lib/config/schemas.ts
+++ b/lib/config/schemas.ts
@@ -1,0 +1,251 @@
+/**
+ * Zod validation schemas for BusinessConfig namespaces.
+ *
+ * Each namespace has:
+ * - A per-key schema (validates the JSON value for a single key)
+ * - Cross-namespace invariants (e.g., lowering a price re-checks deposit floors)
+ *
+ * DOC-4 §2: an écriture Tier DONNÉES re-valide les invariants
+ * inter-namespaces impactés.
+ */
+import { z } from 'zod';
+import { getOverride } from './snapshot';
+
+// ── Schema version — bump when adding/removing keys ──
+
+export const SCHEMA_VERSION = '1.0';
+
+// ── Namespace: pricing.rules ──
+
+const pricingRulesKeySchemas = {
+  group_max: z.number().int().min(1).max(20),
+  'group_min_open.lycee': z.number().int().min(1).max(10),
+  'group_min_open.college': z.number().int().min(1).max(10),
+  'group_min_open.online_live': z.number().int().min(1).max(10),
+  'group_min_open.stage': z.number().int().min(1).max(10),
+  'group_min_open.stage_college': z.number().int().min(1).max(10),
+  semi_individual_surcharge_pct: z.number().min(0).max(200),
+  'payment.deposit_pct': z.number().min(0).max(100),
+  'payment.deposit_pct_annual': z.number().min(0).max(100),
+  'payment.deposit_pct_stage': z.number().min(0).max(100),
+  'payment.installments_default': z.number().int().min(1).max(24),
+  'payment.rounding_tnd': z.number().int().min(1).max(100),
+  'discounts.comptant_pct': z.number().min(0).max(100),
+  'discounts.fratrie_2nd_child_pct': z.number().min(0).max(100),
+  'discounts.ancien_eleve_min_pct': z.number().min(0).max(100),
+  'discounts.ancien_eleve_max_pct': z.number().min(0).max(100),
+  'discounts.parrainage_min_tnd': z.number().min(0),
+  'discounts.parrainage_max_tnd': z.number().min(0),
+  'discounts.carte_nexus_pct': z.number().min(0).max(100),
+  'discounts.global_cap_pct': z.number().min(0).max(100),
+} as const;
+
+// ── Namespace: pricing.floors ──
+
+const pricingFloorsKeySchemas = {
+  single: z.number().min(0),
+  multi: z.number().min(0),
+  college: z.number().min(0),
+  stage: z.number().min(0),
+  coaching_1to1: z.number().min(0),
+  carte_member: z.number().min(0),
+  pack: z.number().min(0),
+} as const;
+
+// ── Namespace: products.credits ──
+
+const productsCreditsKeySchema = z.number().int().min(0).max(1000);
+
+// ── Registry ──
+
+export type NamespaceId = 'pricing.rules' | 'pricing.floors' | 'products.credits';
+
+interface NamespaceSpec {
+  /** Validate a single key's value */
+  validateKey(key: string, value: unknown): z.SafeParseReturnType<unknown, unknown>;
+  /** List valid keys for this namespace */
+  validKeys: string[] | null; // null = any key accepted (e.g., products.credits uses productCodes)
+}
+
+const NAMESPACE_SPECS: Record<NamespaceId, NamespaceSpec> = {
+  'pricing.rules': {
+    validateKey(key, value) {
+      const schema = pricingRulesKeySchemas[key as keyof typeof pricingRulesKeySchemas];
+      if (!schema) return { success: false, error: new z.ZodError([{ code: 'custom', message: `Unknown key: ${key}`, path: [key] }]) } as z.SafeParseReturnType<unknown, never>;
+      return schema.safeParse(value);
+    },
+    validKeys: Object.keys(pricingRulesKeySchemas),
+  },
+  'pricing.floors': {
+    validateKey(key, value) {
+      const schema = pricingFloorsKeySchemas[key as keyof typeof pricingFloorsKeySchemas];
+      if (!schema) return { success: false, error: new z.ZodError([{ code: 'custom', message: `Unknown key: ${key}`, path: [key] }]) } as z.SafeParseReturnType<unknown, never>;
+      return schema.safeParse(value);
+    },
+    validKeys: Object.keys(pricingFloorsKeySchemas),
+  },
+  'products.credits': {
+    validateKey(_key, value) {
+      return productsCreditsKeySchema.safeParse(value);
+    },
+    validKeys: null, // Accepts any productCode
+  },
+};
+
+// ── Validation entry points ──
+
+export function validateConfigEntry(
+  namespace: string,
+  key: string,
+  value: unknown,
+): { valid: true } | { valid: false; error: string } {
+  const spec = NAMESPACE_SPECS[namespace as NamespaceId];
+  if (!spec) {
+    return { valid: false, error: `Unknown namespace: ${namespace}` };
+  }
+
+  // Per-key validation
+  const result = spec.validateKey(key, value);
+  if (!result.success) {
+    return { valid: false, error: result.error.issues.map((i) => i.message).join('; ') };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Cross-namespace invariants — checked after a write.
+ * Returns an array of violated invariant descriptions (empty = all ok).
+ *
+ * Invariants:
+ * 1. discount min ≤ max (ancien_eleve, parrainage)
+ * 2. deposit_pct > 0 when installments_default > 1
+ * 3. group_min_open ≤ group_max for each context
+ * 4. global_cap_pct ≥ max individual discount
+ * 5. price floors remain above minimum viable (getCurrentMinPrice)
+ */
+export function validateCrossInvariants(
+  pendingNamespace: string,
+  pendingKey: string,
+  pendingValue: unknown,
+): string[] {
+  const violations: string[] = [];
+
+  // Helper: get effective value (pending if matches, else snapshot, else null)
+  function effective<T>(ns: string, k: string): T | null {
+    if (ns === pendingNamespace && k === pendingKey) return pendingValue as T;
+    return getOverride<T>(ns, k);
+  }
+
+  // Invariant 1: discount min ≤ max (ancien_eleve)
+  if (pendingNamespace === 'pricing.rules' && (pendingKey === 'discounts.ancien_eleve_min_pct' || pendingKey === 'discounts.ancien_eleve_max_pct')) {
+    const min = effective<number>('pricing.rules', 'discounts.ancien_eleve_min_pct');
+    const max = effective<number>('pricing.rules', 'discounts.ancien_eleve_max_pct');
+    if (min !== null && max !== null && min > max) {
+      violations.push(`ancien_eleve_min_pct (${min}) > ancien_eleve_max_pct (${max})`);
+    }
+  }
+
+  // Invariant 1b: parrainage min ≤ max
+  if (pendingNamespace === 'pricing.rules' && (pendingKey === 'discounts.parrainage_min_tnd' || pendingKey === 'discounts.parrainage_max_tnd')) {
+    const min = effective<number>('pricing.rules', 'discounts.parrainage_min_tnd');
+    const max = effective<number>('pricing.rules', 'discounts.parrainage_max_tnd');
+    if (min !== null && max !== null && min > max) {
+      violations.push(`parrainage_min_tnd (${min}) > parrainage_max_tnd (${max})`);
+    }
+  }
+
+  // Invariant 2: deposit_pct > 0 when installments > 1
+  if (pendingNamespace === 'pricing.rules' && (pendingKey === 'payment.deposit_pct' || pendingKey === 'payment.installments_default')) {
+    const depositPct = effective<number>('pricing.rules', 'payment.deposit_pct');
+    const installments = effective<number>('pricing.rules', 'payment.installments_default');
+    if (depositPct !== null && installments !== null && installments > 1 && depositPct === 0) {
+      violations.push(`deposit_pct is 0 but installments_default is ${installments} (needs deposit > 0 for splitting)`);
+    }
+  }
+
+  // Invariant 3: group_min_open ≤ group_max
+  if (pendingNamespace === 'pricing.rules' && (pendingKey === 'group_max' || pendingKey.startsWith('group_min_open.'))) {
+    const groupMax = effective<number>('pricing.rules', 'group_max');
+    for (const ctx of ['lycee', 'college', 'online_live', 'stage', 'stage_college']) {
+      const minOpen = effective<number>('pricing.rules', `group_min_open.${ctx}`);
+      if (groupMax !== null && minOpen !== null && minOpen > groupMax) {
+        violations.push(`group_min_open.${ctx} (${minOpen}) > group_max (${groupMax})`);
+      }
+    }
+  }
+
+  // Invariant 4: global_cap_pct ≥ max individual discount — BIDIRECTIONAL
+  // Triggers when touching the cap OR any individual discount
+  const discountKeys = ['discounts.comptant_pct', 'discounts.fratrie_2nd_child_pct', 'discounts.ancien_eleve_max_pct', 'discounts.carte_nexus_pct'] as const;
+  if (pendingNamespace === 'pricing.rules' && (pendingKey === 'discounts.global_cap_pct' || discountKeys.includes(pendingKey as typeof discountKeys[number]))) {
+    const cap = effective<number>('pricing.rules', 'discounts.global_cap_pct');
+    if (cap !== null) {
+      for (const dk of discountKeys) {
+        const disc = effective<number>('pricing.rules', dk);
+        if (disc !== null && disc > cap) {
+          violations.push(`global_cap_pct (${cap}) < ${dk} (${disc}) — cap must be ≥ max individual discount`);
+        }
+      }
+    }
+  }
+
+  // Invariant 5: payment deposit viability at price floors.
+  // Scope: pricing.floors (price_floor_per_student_hour_tnd) only.
+  // Offer/plan prices are NOT editable in Tier DONNÉES at this lot (Lot 3).
+  // When Lot 5 makes offer prices editable, this invariant MUST extend to
+  // also trigger on offer price changes and check against getCurrentMinPrice()
+  // across ALL price sources (floors + offers). See DOC-4 §2 note.
+  if (
+    pendingNamespace === 'pricing.floors' ||
+    (pendingNamespace === 'pricing.rules' && (
+      pendingKey === 'payment.deposit_pct' ||
+      pendingKey === 'payment.rounding_tnd'
+    ))
+  ) {
+    // Compute effective deposit parameters
+    const depositPct = effective<number>('pricing.rules', 'payment.deposit_pct');
+    const rounding = effective<number>('pricing.rules', 'payment.rounding_tnd');
+
+    if (depositPct !== null && rounding !== null && rounding > 0) {
+      // Check each floor type individually
+      const floorKeys = ['single', 'multi', 'college', 'stage', 'coaching_1to1', 'carte_member', 'pack'] as const;
+      for (const fk of floorKeys) {
+        const floor = effective<number>('pricing.floors', fk);
+        if (floor !== null && floor > 0) {
+          // Simulate: deposit on a 1-hour session at the floor price
+          const deposit = Math.round((floor * depositPct) / 100 / rounding) * rounding;
+          if (deposit <= 0) {
+            violations.push(`deposit rounds to 0 at floor ${fk}=${floor} TND/h (deposit_pct=${depositPct}%, rounding=${rounding})`);
+          }
+          if (deposit > floor) {
+            violations.push(`deposit (${deposit}) exceeds floor price ${fk}=${floor} TND/h`);
+          }
+        }
+      }
+    }
+  }
+
+  return violations;
+}
+
+/**
+ * Get the dynamically computed minimum price across all floor types.
+ * Uses overrides from the config store if present, else static fallbacks.
+ */
+export function getCurrentMinPrice(staticFloors: Record<string, number>): number {
+  const effectiveFloors: number[] = [];
+  for (const [floorKey, staticValue] of Object.entries(staticFloors)) {
+    const override = getOverride<number>('pricing.floors', floorKey);
+    effectiveFloors.push(override !== null ? override : staticValue);
+  }
+  return effectiveFloors.length > 0 ? Math.min(...effectiveFloors) : 0;
+}
+
+export function getValidNamespaces(): NamespaceId[] {
+  return Object.keys(NAMESPACE_SPECS) as NamespaceId[];
+}
+
+export function getNamespaceKeys(namespace: NamespaceId): string[] | null {
+  return NAMESPACE_SPECS[namespace]?.validKeys ?? null;
+}

--- a/lib/config/schemas.ts
+++ b/lib/config/schemas.ts
@@ -21,10 +21,38 @@ export const SCHEMA_VERSION = '1.0';
 
 const canonicalRules = pricingCanonical.rules as Record<string, unknown>;
 
-/** Resolve a static fallback value for a namespace+key from canonical data. */
-export function getStaticFallback(namespace: string, key: string): unknown | null {
+// ── Startup assertion: verify all expected fallback keys exist in canonical ──
+// If a key is renamed/removed in the canonical JSON without updating the
+// schema, invariants would silently become no-ops (same hole we just closed).
+const EXPECTED_FALLBACK_KEYS = [
+  'pricing.rules::group_max',
+  'pricing.rules::group_min_open.lycee',
+  'pricing.rules::group_min_open.college',
+  'pricing.rules::group_min_open.online_live',
+  'pricing.rules::group_min_open.stage',
+  'pricing.rules::group_min_open.stage_college',
+  'pricing.rules::payment.deposit_pct',
+  'pricing.rules::payment.rounding_tnd',
+  'pricing.rules::payment.installments_default',
+  'pricing.rules::discounts.comptant_pct',
+  'pricing.rules::discounts.fratrie_2nd_child_pct',
+  'pricing.rules::discounts.ancien_eleve_min_pct',
+  'pricing.rules::discounts.ancien_eleve_max_pct',
+  'pricing.rules::discounts.parrainage_min_tnd',
+  'pricing.rules::discounts.parrainage_max_tnd',
+  'pricing.rules::discounts.carte_nexus_pct',
+  'pricing.rules::discounts.global_cap_pct',
+  'pricing.floors::single',
+  'pricing.floors::multi',
+  'pricing.floors::college',
+  'pricing.floors::stage',
+  'pricing.floors::coaching_1to1',
+  'pricing.floors::carte_member',
+  'pricing.floors::pack',
+];
+
+function resolveCanonicalKey(namespace: string, key: string): unknown | null {
   if (namespace === 'pricing.rules') {
-    // Dot-notation keys like 'group_min_open.lycee' → rules.group_min_open.lycee
     const parts = key.split('.');
     let current: unknown = canonicalRules;
     for (const part of parts) {
@@ -40,8 +68,28 @@ export function getStaticFallback(namespace: string, key: string): unknown | nul
     }
     return null;
   }
-  // products.credits: no static fallback (product-specific, defined in PRODUCT_REGISTRY)
   return null;
+}
+
+// Fail-fast at module load: every expected key must resolve to a non-null value.
+for (const fk of EXPECTED_FALLBACK_KEYS) {
+  const [ns, k] = fk.split('::');
+  const val = resolveCanonicalKey(ns, k);
+  if (val === null || val === undefined) {
+    throw new Error(
+      `[config/schemas] Canonical fallback missing for ${fk}. ` +
+      `Update EXPECTED_FALLBACK_KEYS or fix data/pricing-client-data.generated.json.`,
+    );
+  }
+}
+
+/** Resolve a static fallback value for a namespace+key from canonical data. */
+export function getStaticFallback(namespace: string, key: string): unknown | null {
+  if (namespace === 'products.credits') {
+    // No static fallback — product credits are in PRODUCT_REGISTRY (Lot 5)
+    return null;
+  }
+  return resolveCanonicalKey(namespace, key);
 }
 
 // ── Namespace: pricing.rules ──

--- a/lib/config/schemas.ts
+++ b/lib/config/schemas.ts
@@ -124,17 +124,25 @@ export function validateConfigEntry(
  * 4. global_cap_pct ≥ max individual discount
  * 5. price floors remain above minimum viable (getCurrentMinPrice)
  */
+/**
+ * @param resolver  Optional function to resolve existing config values.
+ *                  Defaults to getOverride() (reads snapshot). Pass a
+ *                  transactional resolver to read from the DB within a
+ *                  transaction for TOCTOU-safe cross-key validation.
+ */
 export function validateCrossInvariants(
   pendingNamespace: string,
   pendingKey: string,
   pendingValue: unknown,
+  resolver?: (ns: string, k: string) => unknown | null,
 ): string[] {
   const violations: string[] = [];
+  const resolve = resolver ?? ((ns: string, k: string) => getOverride(ns, k));
 
-  // Helper: get effective value (pending if matches, else snapshot, else null)
+  // Helper: get effective value (pending if matches, else resolve)
   function effective<T>(ns: string, k: string): T | null {
     if (ns === pendingNamespace && k === pendingKey) return pendingValue as T;
-    return getOverride<T>(ns, k);
+    return resolve(ns, k) as T | null;
   }
 
   // Invariant 1: discount min ≤ max (ancien_eleve)

--- a/lib/config/snapshot.ts
+++ b/lib/config/snapshot.ts
@@ -130,7 +130,11 @@ export async function loadConfigSnapshot(): Promise<void> {
 }
 
 export async function ensureFresh(): Promise<void> {
-  if (Date.now() - lastLoadedAt < TTL_MS) return;
+  // Must have completed at least one full load AND be within TTL.
+  // Without hasLoadedOnce check, a cold passive that lost the guard
+  // (updating lastLoadedAt without hasLoadedOnce) would suppress the
+  // first full load for one TTL window.
+  if (hasLoadedOnce && Date.now() - lastLoadedAt < TTL_MS) return;
   await loadConfigSnapshot();
 }
 

--- a/lib/config/snapshot.ts
+++ b/lib/config/snapshot.ts
@@ -5,19 +5,19 @@
  * - Loaded at startup via loadConfigSnapshot()
  * - getOverride(namespace, key) returns the value synchronously or null
  * - TTL 60s: passive refresh coalesced via single-flight
- * - Invalidation on write: API awaits invalidateSnapshot() AFTER DB commit
+ * - Invalidation on write: API calls applyWrite() with the committed entry
  * - Mono-instance (PM2 fork mode, instances: 1) — no cross-process sync
  *
- * Two load paths with ASYMMETRIC guards:
- * 1. PASSIVE (TTL / startup): cedes to ANY swap (passive or write)
- * 2. WRITE (post-API-commit): cedes ONLY to a newer WRITE
+ * Two load paths:
+ * 1. PASSIVE (TTL / startup): _doLoad() via loadConfigSnapshot() — single-flight.
+ *    Order guard: swapSequence counter prevents stale overwrite.
+ * 2. WRITE (post-API-commit): applyWrite() — applies a single entry directly
+ *    into the snapshot, using the DB version as the order authority. No findMany,
+ *    no race. version is monotone per key (incremented by Prisma upsert),
+ *    so a concurrent apply with a lower version is discarded.
  *
- * This ensures a write (authoritative post-commit) always wins over a
- * stale passive, but two concurrent writes still resolve correctly
- * (the later one wins).
- *
- * Order guards use monotonic counters (not wall-clock) to avoid
- * Date.now() resolution and NTP rewind issues.
+ * This eliminates the concurrent-invalidation ordering problem: the DB
+ * version IS the order, not an in-memory counter.
  */
 import { prisma } from '@/lib/prisma';
 import { validateConfigEntry } from './schemas';
@@ -41,25 +41,17 @@ const TTL_MS = 60_000;
 let snapshot = new Map<string, ConfigEntry>();
 let lastLoadedAt = 0;
 let passiveInflight: Promise<void> | null = null;
-let swapSequence = 0;  // Incremented on ANY swap (passive or write)
-let writeSequence = 0; // Incremented only on WRITE swaps
+let swapSequence = 0; // Monotonic: incremented on passive full-snapshot swap
 
-// ── Internal ──
+// ── Internal: passive load ──
 
 /**
- * Query DB, validate, build snapshot, conditionally assign.
- *
- * @param isWrite  true for invalidation (post-commit, authoritative).
- *                 false for passive (TTL refresh, can be stale).
- *
- * Guard logic:
- * - Passive load: cedes if swapSequence changed (any swap happened)
- * - Write load: cedes only if writeSequence changed (a newer write happened)
- *
- * A load that cedes still advances lastLoadedAt to prevent TTL storm.
+ * Full snapshot load from DB. Used by passive path only.
+ * Order guard: a passive load that started before a write (applyWrite)
+ * or another passive swapped does not overwrite.
  */
-async function _doLoad(isWrite: boolean): Promise<void> {
-  const seqAtStart = isWrite ? writeSequence : swapSequence;
+async function _doLoad(): Promise<void> {
+  const seqAtStart = swapSequence;
   const rows = await prisma.businessConfig.findMany();
   const newSnapshot = new Map<string, ConfigEntry>();
   for (const row of rows) {
@@ -81,21 +73,17 @@ async function _doLoad(isWrite: boolean): Promise<void> {
     });
   }
 
-  // Order guard — asymmetric:
-  const currentSeq = isWrite ? writeSequence : swapSequence;
-  if (currentSeq !== seqAtStart) {
-    // Someone swapped since we started reading. Cede.
+  if (swapSequence !== seqAtStart) {
     lastLoadedAt = Date.now();
     return;
   }
 
   snapshot = newSnapshot;
   swapSequence++;
-  if (isWrite) writeSequence++;
   lastLoadedAt = Date.now();
 }
 
-// ── Public API ──
+// ── Public API: reads ──
 
 export function getOverride<T = unknown>(namespace: string, key: string): T | null {
   const entry = snapshot.get(`${namespace}::${key}`);
@@ -128,7 +116,7 @@ export async function loadConfigSnapshot(): Promise<void> {
     return;
   }
 
-  passiveInflight = _doLoad(false).catch((error) => {
+  passiveInflight = _doLoad().catch((error) => {
     console.error('[config/snapshot] Passive refresh failed:', error);
   });
 
@@ -147,12 +135,38 @@ export async function ensureFresh(): Promise<void> {
 // ── Lifecycle: write path ──
 
 /**
- * Invalidate the snapshot after an API write.
- * RULE: The API must commit the DB update FIRST, then await this.
+ * Apply a single committed entry to the snapshot (WRITE path).
+ *
+ * Called by the API AFTER the DB commit with the upserted row.
+ * Uses the DB version as order authority: only applies if the entry's
+ * version is higher than what's currently in the snapshot for that key.
+ * This is synchronous — no DB round-trip, no race.
+ *
+ * RULE: The API must commit the DB upsert FIRST, then call this.
  */
-export async function invalidateSnapshot(): Promise<void> {
-  lastLoadedAt = 0;
-  await _doLoad(true);
+export function applyWrite(entry: ConfigEntry): void {
+  const mapKey = `${entry.namespace}::${entry.key}`;
+  const existing = snapshot.get(mapKey);
+
+  // Version guard: only apply if this entry is newer than what we have.
+  // version is monotone per (namespace, key), incremented by the DB upsert.
+  if (existing && existing.version >= entry.version) {
+    return; // A more recent write already applied — discard this one.
+  }
+
+  // Validate before applying (defense in depth)
+  const validation = validateConfigEntry(entry.namespace, entry.key, entry.value);
+  if (!validation.valid) {
+    console.error(
+      `[config/snapshot] applyWrite rejected invalid entry ${entry.namespace}::${entry.key}: ${validation.error}`,
+    );
+    return;
+  }
+
+  // Apply to current snapshot (mutate the existing Map — atomic in single-thread)
+  snapshot.set(mapKey, entry);
+  swapSequence++;
+  lastLoadedAt = Date.now();
 }
 
 // ── Testing helpers (guarded: throw in production) ──
@@ -165,7 +179,6 @@ export function _resetForTest(): void {
   lastLoadedAt = 0;
   passiveInflight = null;
   swapSequence = 0;
-  writeSequence = 0;
 }
 
 export function _setForTest(entries: ConfigEntry[]): void {
@@ -177,6 +190,5 @@ export function _setForTest(entries: ConfigEntry[]): void {
     snapshot.set(`${entry.namespace}::${entry.key}`, entry);
   }
   swapSequence++;
-  writeSequence++; // Keep both counters aligned to prevent test state inconsistency
   lastLoadedAt = Date.now();
 }

--- a/lib/config/snapshot.ts
+++ b/lib/config/snapshot.ts
@@ -1,0 +1,182 @@
+/**
+ * BusinessConfig in-memory snapshot — sync access, TTL-based passive refresh.
+ *
+ * Design (DOC-4 §2):
+ * - Loaded at startup via loadConfigSnapshot()
+ * - getOverride(namespace, key) returns the value synchronously or null
+ * - TTL 60s: passive refresh coalesced via single-flight
+ * - Invalidation on write: API awaits invalidateSnapshot() AFTER DB commit
+ * - Mono-instance (PM2 fork mode, instances: 1) — no cross-process sync
+ *
+ * Two load paths with ASYMMETRIC guards:
+ * 1. PASSIVE (TTL / startup): cedes to ANY swap (passive or write)
+ * 2. WRITE (post-API-commit): cedes ONLY to a newer WRITE
+ *
+ * This ensures a write (authoritative post-commit) always wins over a
+ * stale passive, but two concurrent writes still resolve correctly
+ * (the later one wins).
+ *
+ * Order guards use monotonic counters (not wall-clock) to avoid
+ * Date.now() resolution and NTP rewind issues.
+ */
+import { prisma } from '@/lib/prisma';
+import { validateConfigEntry } from './schemas';
+
+// ── Types ──
+
+export interface ConfigEntry {
+  namespace: string;
+  key: string;
+  value: unknown;
+  schemaVersion: string;
+  version: number;
+  updatedBy: string;
+  updatedAt: Date;
+}
+
+// ── State ──
+
+const TTL_MS = 60_000;
+
+let snapshot = new Map<string, ConfigEntry>();
+let lastLoadedAt = 0;
+let passiveInflight: Promise<void> | null = null;
+let swapSequence = 0;  // Incremented on ANY swap (passive or write)
+let writeSequence = 0; // Incremented only on WRITE swaps
+
+// ── Internal ──
+
+/**
+ * Query DB, validate, build snapshot, conditionally assign.
+ *
+ * @param isWrite  true for invalidation (post-commit, authoritative).
+ *                 false for passive (TTL refresh, can be stale).
+ *
+ * Guard logic:
+ * - Passive load: cedes if swapSequence changed (any swap happened)
+ * - Write load: cedes only if writeSequence changed (a newer write happened)
+ *
+ * A load that cedes still advances lastLoadedAt to prevent TTL storm.
+ */
+async function _doLoad(isWrite: boolean): Promise<void> {
+  const seqAtStart = isWrite ? writeSequence : swapSequence;
+  const rows = await prisma.businessConfig.findMany();
+  const newSnapshot = new Map<string, ConfigEntry>();
+  for (const row of rows) {
+    const validation = validateConfigEntry(row.namespace, row.key, row.value);
+    if (!validation.valid) {
+      console.error(
+        `[config/snapshot] Discarding invalid entry ${row.namespace}::${row.key}: ${validation.error}`,
+      );
+      continue;
+    }
+    newSnapshot.set(`${row.namespace}::${row.key}`, {
+      namespace: row.namespace,
+      key: row.key,
+      value: row.value,
+      schemaVersion: row.schemaVersion,
+      version: row.version,
+      updatedBy: row.updatedBy,
+      updatedAt: row.updatedAt,
+    });
+  }
+
+  // Order guard — asymmetric:
+  const currentSeq = isWrite ? writeSequence : swapSequence;
+  if (currentSeq !== seqAtStart) {
+    // Someone swapped since we started reading. Cede.
+    lastLoadedAt = Date.now();
+    return;
+  }
+
+  snapshot = newSnapshot;
+  swapSequence++;
+  if (isWrite) writeSequence++;
+  lastLoadedAt = Date.now();
+}
+
+// ── Public API ──
+
+export function getOverride<T = unknown>(namespace: string, key: string): T | null {
+  const entry = snapshot.get(`${namespace}::${key}`);
+  if (!entry) return null;
+  return entry.value as T;
+}
+
+export function getNamespaceEntries(namespace: string): ConfigEntry[] {
+  const entries: ConfigEntry[] = [];
+  for (const entry of snapshot.values()) {
+    if (entry.namespace === namespace) entries.push(entry);
+  }
+  return entries;
+}
+
+export function getOverrideOr<T>(namespace: string, key: string, fallback: T): T {
+  const override = getOverride<T>(namespace, key);
+  return override !== null ? override : fallback;
+}
+
+export function getAllEntries(): ConfigEntry[] {
+  return Array.from(snapshot.values());
+}
+
+// ── Lifecycle: passive path ──
+
+export async function loadConfigSnapshot(): Promise<void> {
+  if (passiveInflight) {
+    await passiveInflight;
+    return;
+  }
+
+  passiveInflight = _doLoad(false).catch((error) => {
+    console.error('[config/snapshot] Passive refresh failed:', error);
+  });
+
+  try {
+    await passiveInflight;
+  } finally {
+    passiveInflight = null;
+  }
+}
+
+export async function ensureFresh(): Promise<void> {
+  if (Date.now() - lastLoadedAt < TTL_MS) return;
+  await loadConfigSnapshot();
+}
+
+// ── Lifecycle: write path ──
+
+/**
+ * Invalidate the snapshot after an API write.
+ * RULE: The API must commit the DB update FIRST, then await this.
+ */
+export async function invalidateSnapshot(): Promise<void> {
+  lastLoadedAt = 0;
+  await _doLoad(true);
+}
+
+// ── Testing helpers (guarded: throw in production) ──
+
+export function _resetForTest(): void {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('_resetForTest is not available in production');
+  }
+  snapshot = new Map();
+  lastLoadedAt = 0;
+  passiveInflight = null;
+  swapSequence = 0;
+  writeSequence = 0;
+}
+
+export function _setForTest(entries: ConfigEntry[]): void {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('_setForTest is not available in production');
+  }
+  snapshot = new Map();
+  for (const entry of entries) {
+    snapshot.set(`${entry.namespace}::${entry.key}`, entry);
+  }
+  swapSequence++;
+  writeSequence++; // Keep both counters aligned to prevent test state inconsistency
+  lastLoadedAt = Date.now();
+}

--- a/lib/config/snapshot.ts
+++ b/lib/config/snapshot.ts
@@ -40,6 +40,7 @@ const TTL_MS = 60_000;
 
 let snapshot = new Map<string, ConfigEntry>();
 let lastLoadedAt = 0;
+let hasLoadedOnce = false; // True after first successful full load (_doLoad)
 let passiveInflight: Promise<void> | null = null;
 let swapSequence = 0; // Monotonic: incremented on passive full-snapshot swap
 
@@ -80,6 +81,7 @@ async function _doLoad(): Promise<void> {
 
   snapshot = newSnapshot;
   swapSequence++;
+  hasLoadedOnce = true;
   lastLoadedAt = Date.now();
 }
 
@@ -166,7 +168,12 @@ export function applyWrite(entry: ConfigEntry): void {
   // Apply to current snapshot (mutate the existing Map — atomic in single-thread)
   snapshot.set(mapKey, entry);
   swapSequence++;
-  lastLoadedAt = Date.now();
+  // Only mark as fresh if we've done a full load at least once.
+  // On a cold snapshot, applyWrite sets ONE key but other overrides
+  // in the DB are still missing — ensureFresh must trigger a full load.
+  if (hasLoadedOnce) {
+    lastLoadedAt = Date.now();
+  }
 }
 
 // ── Testing helpers (guarded: throw in production) ──
@@ -177,6 +184,7 @@ export function _resetForTest(): void {
   }
   snapshot = new Map();
   lastLoadedAt = 0;
+  hasLoadedOnce = false;
   passiveInflight = null;
   swapSequence = 0;
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:gate": "next build 2>&1 | tee build-output.log && bash scripts/check-bundle-weight.sh build-output.log",
     "start": "next start",
     "start:prod": "node .next/standalone/server.js",
-    "lint": "next lint --max-warnings 305",
+    "lint": "next lint --max-warnings 300",
     "typecheck": "tsc --noEmit",
     "test": "jest --config jest.unit.config.js",
     "test:all": "npm test && npm run test:integration",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:gate": "next build 2>&1 | tee build-output.log && bash scripts/check-bundle-weight.sh build-output.log",
     "start": "next start",
     "start:prod": "node .next/standalone/server.js",
-    "lint": "next lint --max-warnings 300",
+    "lint": "next lint --max-warnings 305",
     "typecheck": "tsc --noEmit",
     "test": "jest --config jest.unit.config.js",
     "test:all": "npm test && npm run test:integration",

--- a/prisma/migrations/20260630212227_add_business_config/migration.sql
+++ b/prisma/migrations/20260630212227_add_business_config/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable: business_configs (purely additive — no ALTER/DROP on existing tables)
+CREATE TABLE "business_configs" (
+    "id" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+    "namespace" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "value" JSONB NOT NULL,
+    "schemaVersion" TEXT NOT NULL,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "previousValue" JSONB,
+    "updatedBy" TEXT NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "business_configs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "business_configs_namespace_key_key" ON "business_configs"("namespace", "key");
+
+-- CreateIndex
+CREATE INDEX "business_configs_namespace_idx" ON "business_configs"("namespace");
+
+-- CreateIndex
+CREATE INDEX "business_configs_updatedAt_idx" ON "business_configs"("updatedAt");

--- a/prisma/migrations/20260701063940_add_business_config_audit/migration.sql
+++ b/prisma/migrations/20260701063940_add_business_config_audit/migration.sql
@@ -17,3 +17,6 @@ CREATE INDEX "business_config_audit_namespace_key_idx" ON "business_config_audit
 
 -- CreateIndex
 CREATE INDEX "business_config_audit_changedAt_idx" ON "business_config_audit"("changedAt");
+
+-- CreateIndex (integrity: one audit row per version per key)
+CREATE UNIQUE INDEX "business_config_audit_namespace_key_version_key" ON "business_config_audit"("namespace", "key", "version");

--- a/prisma/migrations/20260701063940_add_business_config_audit/migration.sql
+++ b/prisma/migrations/20260701063940_add_business_config_audit/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable: business_config_audit (purely additive — no ALTER/DROP)
+CREATE TABLE "business_config_audit" (
+    "id" TEXT NOT NULL DEFAULT (gen_random_uuid())::text,
+    "namespace" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "oldValue" JSONB,
+    "newValue" JSONB NOT NULL,
+    "version" INTEGER NOT NULL,
+    "changedBy" TEXT NOT NULL,
+    "changedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "business_config_audit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "business_config_audit_namespace_key_idx" ON "business_config_audit"("namespace", "key");
+
+-- CreateIndex
+CREATE INDEX "business_config_audit_changedAt_idx" ON "business_config_audit"("changedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2423,6 +2423,7 @@ model BusinessConfigAudit {
   changedBy String   // userId
   changedAt DateTime @default(now())
 
+  @@unique([namespace, key, version])
   @@index([namespace, key])
   @@index([changedAt])
   @@map("business_config_audit")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2388,3 +2388,25 @@ model GeneratedPedagogicalReport {
   @@unique([studentId, stageSlug, subject, kind, inputChecksum])
   @@map("generated_pedagogical_reports")
 }
+
+/// Runtime business configuration store (Tier DONNÉES).
+/// Holds overrides keyed by namespace+key, with JSON values,
+/// versioning, and audit trail. When empty, accessors fall back
+/// to static values from pricing.canonical.json / PRODUCT_REGISTRY.
+model BusinessConfig {
+  id            String   @id @default(dbgenerated("(gen_random_uuid())::text"))
+  namespace     String   // e.g. "pricing.rules", "products.credits"
+  key           String   // e.g. "group_max", "IMMERSION.grantsCredits"
+  value         Json     @db.JsonB
+  schemaVersion String   // Zod schema version for this namespace
+  version       Int      @default(1) // Incremented on each update
+  previousValue Json?    @db.JsonB
+  updatedBy     String   // userId of the admin who wrote
+  updatedAt     DateTime @default(now()) @updatedAt
+  createdAt     DateTime @default(now())
+
+  @@unique([namespace, key])
+  @@index([namespace])
+  @@index([updatedAt])
+  @@map("business_configs")
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2410,3 +2410,20 @@ model BusinessConfig {
   @@index([updatedAt])
   @@map("business_configs")
 }
+
+/// Append-only audit trail for BusinessConfig changes.
+/// One row per change — full history, any rollback level.
+model BusinessConfigAudit {
+  id        String   @id @default(dbgenerated("(gen_random_uuid())::text"))
+  namespace String
+  key       String
+  oldValue  Json?    @db.JsonB
+  newValue  Json     @db.JsonB
+  version   Int      // version of the BusinessConfig row after this change
+  changedBy String   // userId
+  changedAt DateTime @default(now())
+
+  @@index([namespace, key])
+  @@index([changedAt])
+  @@map("business_config_audit")
+}


### PR DESCRIPTION
## Summary

Lot 3 of DOC-5: BusinessConfig runtime store for Tier DONNÉES overrides.

- **Prisma model** `BusinessConfig` — namespace+key unique, JSONB, versioned, audit trail
- **Migration** purely additive (CREATE TABLE + indexes). Equivalence proven via `prisma migrate diff` on ephemeral pgvector DB.
- **Snapshot** (`lib/config/snapshot.ts`) — sync access, asymmetric order guards (monotonic counters), single-flight passive refresh, TTL 60s
- **Zod validation** (`lib/config/schemas.ts`) — 3 namespaces, 5 bidirectional cross-invariants, load-time validation
- **API** — GET/PATCH/POST rollback/GET history, ADMIN guard, Zod + invariants blocking, DB commit then await invalidateSnapshot()

## Race condition tests (RED→GREEN proven)

| Test | Bug proven (RED) | Fix |
|------|-----------------|-----|
| Stale passive overwrites write | Expected 3, got 5 | Passive cedes to any swap |
| Fast passive + slow invalidation | Write lost | writeSequence asymmetry |
| Two concurrent invalidations | Old write wins | writeSequence ordering |
| 3-actor entrelacement | Stale wins | Combined guards |

## Test plan

- [x] typecheck: 0 errors
- [x] lint: 0 errors
- [x] unit tests: 6337 passed, 0 fail (41 new: 35 snapshot + 6 API)
- [x] build:gate: success + 12/12 bundle routes green
- [x] audit:site-map + check:docs-archive + git diff --check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runtime `BusinessConfig` store with an in-memory, validated snapshot, serialized admin writes, and a full audit trail. Rollback reverts to `previousValue`; the first override is not reversible in Lot 3.

- **New Features**
  - Data model: `BusinessConfig` and `BusinessConfigAudit` with JSONB values, `previousValue`, versioning, and unique (`namespace`,`key`,`version`) audit rows.
  - Snapshot: sync getters, single-flight 60s TTL refresh, load-time Zod validation discards invalid rows, and `applyWrite` orders by DB `version` with a cold-start guard.
  - Validation: Zod per-key across 3 namespaces; 5 cross-invariants checked against overrides or canonical fallbacks; `SCHEMA_VERSION`; `getCurrentMinPrice`.
  - Admin API:
    - GET `/api/admin/config` — effective entries with `source: 'override' | 'fallback'`
    - PATCH `/api/admin/config` — Zod + cross-invariants inside a transaction; serialized via `pg_advisory_xact_lock`; upsert + audit; then synchronous `applyWrite`
    - POST `/api/admin/config/rollback` — reverts to `previousValue`, validates, appends audit, increments `version` (first override returns 400)
    - GET `/api/admin/config/history` — reads the append-only audit trail

- **Migration**
  - Adds `business_configs` and `business_config_audit` tables with indexes; additive only, no breaking changes.

<sup>Written for commit bd32d6140734c1b4186b400b962c0525b27ae7e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

