### PR TITLE
docs(DOC-5): mark Lot 3 delivered + serializeError-cleanup lot

### DIFF
--- a/docs/architecture/restructuration/05-architecture-migration.md
+++ b/docs/architecture/restructuration/05-architecture-migration.md
@@ -523,6 +523,8 @@ Lot 7  [faible]       Extensions assistante (config read + entitlements + R4 + R
   ↓
 Lot 8  [très faible]  Guard widening assistante stages (2 lignes) ←── Lot 7
   ↓
+Lot S  [très faible]  serializeError-cleanup (21 scripts @/ → import relatif + tsconfig scripts/)
+  ↓
 Lot 9  [élevé]        StageBilan → Bilan : double-écriture + backfill
   ↓
 Lot 10 [élevé]        StageBilan → Bilan : bascule lectures


### PR DESCRIPTION
Documentation-only: marks Lot 3 as delivered (SHA 204779734) and adds
serializeError-cleanup (Lot S) to the migration sequence before lots 9-11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark Lot 3 as delivered and insert Lot S (serializeError-cleanup) before Lot 9 in the architecture migration plan. Aligns with DOC-5 to prevent failures in upcoming backfill scripts.

- **Migration**
  - Record Lot 3 delivery (SHA `204779734`).
  - Add Lot S: clean up 21 `scripts/` using `@/` imports (switch to relative paths and set `tsconfig` for scripts) so they run outside Next.js before Lots 9–11.

<sup>Written for commit e5e74b06c044988c544f11107bf1499948eb1af4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

