### PR TITLE
fix(config): load snapshot at startup + invariant deposit variants (Lot 3 followup)

### DIFF
--- a/__tests__/api/admin.config.route.test.ts
+++ b/__tests__/api/admin.config.route.test.ts
@@ -344,14 +344,14 @@ describe('Nominal audit path — PATCH(v1) → PATCH(v2) → ROLLBACK(v3) → PA
       const s = dbState[MK];
       if (!s) return null;
       return { id: MK, namespace: NS, key: KEY, value: s.value,
-        schemaVersion: '1.0', version: s.version, previousValue: s.previousValue,
+        schemaVersion: SCHEMA_VERSION, version: s.version, previousValue: s.previousValue,
         updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date() };
     }
 
     function dbRows() {
       return Object.entries(dbState).map(([mk, s]) => {
         const [ns, key] = mk.split('::');
-        return { id: mk, namespace: ns, key, value: s.value, schemaVersion: '1.0',
+        return { id: mk, namespace: ns, key, value: s.value, schemaVersion: SCHEMA_VERSION,
           version: s.version, previousValue: s.previousValue,
           updatedBy: 'admin', updatedAt: new Date(), createdAt: new Date() };
       });

--- a/docs/architecture/restructuration/05-architecture-migration.md
+++ b/docs/architecture/restructuration/05-architecture-migration.md
@@ -91,7 +91,8 @@ Ordonnée par risque croissant et dépendances.
 | **6** | Écrans de gestion admin (config + entitlements + crons + audit + ARIA) | Moyen | ~15 fichiers nouveaux | Lot 3 |
 | **7** | Extensions assistante (stages CRUD + entitlements read + reservations R4) | Faible | ~5 fichiers modifiés | Lot 6 |
 | **8** | Guard widening assistante stages | Très faible | 2 fichiers modifiés | Lot 7 |
-| **9** | StageBilan → Bilan : double-écriture | Élevé | ~11 fichiers | — |
+| **S** | serializeError-cleanup (scripts @/ → relatif) | Très faible | 21 scripts + tsconfig | — |
+| **9** | StageBilan → Bilan : double-écriture | Élevé | ~11 fichiers | Lot S |
 | **10** | StageBilan → Bilan : bascule + dépréciation | Élevé | ~11 fichiers | Lot 9 |
 | **11** | EamProgress + NsiPracticeProgress → SubjectProgress | Élevé | ~6 fichiers + migration data | — |
 
@@ -504,6 +505,23 @@ SELECT 'NSI orphans',
 
 ---
 
+### Lot S — serializeError-cleanup
+
+**Risque** : très faible (mécanique, aucun changement de logique)
+**Périmètre** : 21 scripts sous `scripts/` qui importent `@/lib/utils/serialize-error` — l'alias `@/` ne résout pas hors Next.js (les scripts tournent via `tsx` directement). Invisible au CI car `tsconfig.json` exclut `scripts/`.
+
+| Action | Fichiers |
+|--------|----------|
+| `@/lib/utils/serialize-error` → `../lib/utils/serialize-error` (import relatif) | 21 scripts |
+| Retirer `"scripts"` de `tsconfig.json > exclude` OU créer `tsconfig.scripts.json` + check dans le gate | 1 config |
+
+**Dépend de** : —
+**Bloque** : Lots 9-11 (migrations data qui exécutent des scripts de backfill)
+**Gate** : gate canonique complet. Les 21 scripts doivent compiler (`tsc --project tsconfig.scripts.json` si tsconfig séparé, ou intégrés au `npx tsc --noEmit` si `"scripts"` retiré de `exclude`).
+**Réversibilité** : `git revert`. Aucun impact runtime.
+
+---
+
 ## Résumé de la séquence
 
 ```
@@ -525,7 +543,7 @@ Lot 8  [très faible]  Guard widening assistante stages (2 lignes) ←── Lot
   ↓
 Lot S  [très faible]  serializeError-cleanup (21 scripts @/ → import relatif + tsconfig scripts/)
   ↓
-Lot 9  [élevé]        StageBilan → Bilan : double-écriture + backfill
+Lot 9  [élevé]        StageBilan → Bilan : double-écriture + backfill ←── Lot S
   ↓
 Lot 10 [élevé]        StageBilan → Bilan : bascule lectures
   ↓

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -11,5 +11,15 @@ export async function register() {
   ) {
     const { validateEnv } = await import('./lib/env-validation');
     validateEnv();
+
+    // Load BusinessConfig snapshot into memory at startup.
+    // Without this, getOverride() returns null for all keys until an
+    // admin triggers ensureFresh() via /api/admin/config — meaning all
+    // DB overrides are invisible after a server restart.
+    // Await ensures the snapshot is populated BEFORE the first request.
+    // loadConfigSnapshot handles errors internally (logs + serves fallbacks),
+    // so this await never throws — but it guarantees deterministic startup.
+    const { loadConfigSnapshot } = await import('./lib/config');
+    await loadConfigSnapshot();
   }
 }

--- a/lib/config/schemas.ts
+++ b/lib/config/schemas.ts
@@ -32,6 +32,8 @@ const EXPECTED_FALLBACK_KEYS = [
   'pricing.rules::group_min_open.stage',
   'pricing.rules::group_min_open.stage_college',
   'pricing.rules::payment.deposit_pct',
+  'pricing.rules::payment.deposit_pct_annual',
+  'pricing.rules::payment.deposit_pct_stage',
   'pricing.rules::payment.rounding_tnd',
   'pricing.rules::payment.installments_default',
   'pricing.rules::discounts.comptant_pct',
@@ -244,12 +246,17 @@ export function validateCrossInvariants(
     }
   }
 
-  // Invariant 2: deposit_pct > 0 when installments > 1
-  if (pendingNamespace === 'pricing.rules' && (pendingKey === 'payment.deposit_pct' || pendingKey === 'payment.installments_default')) {
-    const depositPct = effective<number>('pricing.rules', 'payment.deposit_pct');
+  // Invariant 2: deposit_pct variants > 0 when installments > 1
+  const depositKeys = ['payment.deposit_pct', 'payment.deposit_pct_annual', 'payment.deposit_pct_stage'] as const;
+  if (pendingNamespace === 'pricing.rules' && (depositKeys.includes(pendingKey as typeof depositKeys[number]) || pendingKey === 'payment.installments_default')) {
     const installments = effective<number>('pricing.rules', 'payment.installments_default');
-    if (depositPct !== null && installments !== null && installments > 1 && depositPct === 0) {
-      violations.push(`deposit_pct is 0 but installments_default is ${installments} (needs deposit > 0 for splitting)`);
+    if (installments !== null && installments > 1) {
+      for (const dk of depositKeys) {
+        const depositPct = effective<number>('pricing.rules', dk);
+        if (depositPct !== null && depositPct === 0) {
+          violations.push(`${dk} is 0 but installments_default is ${installments} (needs deposit > 0 for splitting)`);
+        }
+      }
     }
   }
 
@@ -288,27 +295,33 @@ export function validateCrossInvariants(
   if (
     pendingNamespace === 'pricing.floors' ||
     (pendingNamespace === 'pricing.rules' && (
+      // Only generic deposit_pct is checked against hourly floors.
+      // _annual/_stage apply to offer/plan prices (Lot 5 scope).
       pendingKey === 'payment.deposit_pct' ||
       pendingKey === 'payment.rounding_tnd'
     ))
   ) {
-    // Compute effective deposit parameters
-    const depositPct = effective<number>('pricing.rules', 'payment.deposit_pct');
+    // Compute effective deposit parameters — check ALL deposit variants
     const rounding = effective<number>('pricing.rules', 'payment.rounding_tnd');
+    // Only generic deposit_pct checked against hourly floors.
+    // _annual/_stage checked against their respective offer prices in Lot 5.
+    const floorDepositVariants = ['payment.deposit_pct'] as const;
 
-    if (depositPct !== null && rounding !== null && rounding > 0) {
-      // Check each floor type individually
+    if (rounding !== null && rounding > 0) {
       const floorKeys = ['single', 'multi', 'college', 'stage', 'coaching_1to1', 'carte_member', 'pack'] as const;
-      for (const fk of floorKeys) {
-        const floor = effective<number>('pricing.floors', fk);
-        if (floor !== null && floor > 0) {
-          // Simulate: deposit on a 1-hour session at the floor price
-          const deposit = Math.round((floor * depositPct) / 100 / rounding) * rounding;
-          if (deposit <= 0) {
-            violations.push(`deposit rounds to 0 at floor ${fk}=${floor} TND/h (deposit_pct=${depositPct}%, rounding=${rounding})`);
-          }
-          if (deposit > floor) {
-            violations.push(`deposit (${deposit}) exceeds floor price ${fk}=${floor} TND/h`);
+      for (const dpk of floorDepositVariants) {
+        const depositPct = effective<number>('pricing.rules', dpk);
+        if (depositPct === null) continue;
+        for (const fk of floorKeys) {
+          const floor = effective<number>('pricing.floors', fk);
+          if (floor !== null && floor > 0) {
+            const deposit = Math.round((floor * depositPct) / 100 / rounding) * rounding;
+            if (deposit <= 0) {
+              violations.push(`deposit rounds to 0 at floor ${fk}=${floor} TND/h (${dpk}=${depositPct}%, rounding=${rounding})`);
+            }
+            if (deposit > floor) {
+              violations.push(`deposit (${deposit}) exceeds floor price ${fk}=${floor} TND/h (${dpk}=${depositPct}%)`);
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

Post-merge followup for Lot 3 (PR #55). Fixes issues found by reviewers after merge.

**P1 — Snapshot never loaded at startup**: loadConfigSnapshot() was not wired in
instrumentation.ts. After a server restart, all DB overrides were invisible.
Blocks Lot 4 (which wires getOverride into pricing accessors).

**P2 — Deposit invariant incomplete**: only checked deposit_pct, not _annual/_stage.

**P3 — schemaVersion hardcoded** in test mocks → SCHEMA_VERSION constant.

**P2 — DOC-5**: Lot S added to canonical table + detailed section.

## Triage by SHA (all PR#55 comments)

| original_commit_id | Status |
|---|---|
| 039e2c4126 | Pre-fix (P1-a/b resolved in 9e8e9ce) |
| b0ffdb9fcc | Pre-fix (load-time test resolved in bd32d6140) |
| 9e8e9ce2bc | Pre-fix (rollback test resolved in bd32d6140) |
| 49993aac94 | Pre-fix (invariants fallback resolved in 13586cff3) |
| b4144206be, 0fee291b5b, 6790b32ec8 | Pre-fix (reverted in 1dcdaec6f) |
| 13586cff3e | Pre-fix (lint resolved in b4144206b) |
| bd32d6140, 1dcdaec6f | 0 comments |

## Test plan
- [x] typecheck, lint (299/300), 6345 tests, build:gate 12/12, site-map, docs, diff-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load the BusinessConfig snapshot at startup so DB overrides apply on the first request after restarts. Enforce deposit > 0 across all deposit variants when `installments_default > 1`, plus small test and docs updates.

- **Bug Fixes**
  - Startup: await `loadConfigSnapshot()` in `instrumentation.ts/register()`; errors are logged and don’t block startup.
  - Invariants: validate `payment.deposit_pct`, `payment.deposit_pct_annual`, `payment.deposit_pct_stage` when `installments_default > 1`; add `_annual`/`_stage` to `EXPECTED_FALLBACK_KEYS`; keep floor checks scoped to `payment.deposit_pct` only.
  - Tests: use `SCHEMA_VERSION` in admin config route test.
  - Docs: add Lot S and show Lot 9 depends on it.

<sup>Written for commit efe1aa2e58ac3889ad59244efb71b45abd8e5bca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

