### PR TITLE
Go-live RC: security hardening, public funnel, and release evidence

### DIFF
--- a/__tests__/api/admin.config.route.test.ts
+++ b/__tests__/api/admin.config.route.test.ts
@@ -187,6 +187,17 @@ describe('PATCH /api/admin/config', () => {
     expect(res.status).toBe(400);
   });
 
+  it('rejects unexpected fields in config writes', async () => {
+    const res = await PATCH(makeRequest({
+      namespace: 'pricing.rules',
+      key: 'semi_individual_surcharge_pct',
+      value: 60,
+      rawPayload: { leak: true },
+    }));
+    expect(res.status).toBe(400);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
   it('rejects unknown namespace', async () => {
     const res = await PATCH(makeRequest({
       namespace: 'unknown.ns', key: 'foo', value: 1,
@@ -209,6 +220,25 @@ describe('PATCH /api/admin/config', () => {
       'SELECT pg_advisory_xact_lock($1)',
       expect.any(Number),
     );
+  });
+});
+
+describe('POST /api/admin/config/rollback', () => {
+  it('rejects unexpected fields in rollback payloads', async () => {
+    const { POST: ROLLBACK } = require('@/app/api/admin/config/rollback/route');
+    const rollbackReq = new NextRequest('http://localhost:3000/api/admin/config/rollback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        namespace: 'pricing.rules',
+        key: 'semi_individual_surcharge_pct',
+        force: true,
+      }),
+    });
+
+    const res = await ROLLBACK(rollbackReq);
+    expect(res.status).toBe(400);
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 });
 

--- a/__tests__/api/admin.directeur.stats.route.test.ts
+++ b/__tests__/api/admin.directeur.stats.route.test.ts
@@ -6,15 +6,22 @@
  * Source: app/api/admin/directeur/stats/route.ts
  */
 
-jest.mock('@/auth', () => ({
-  auth: jest.fn(),
+jest.mock('@/lib/guards', () => ({
+  requireRole: jest.fn(),
+  isErrorResponse: jest.fn((result) => result && typeof result === 'object' && 'status' in result),
+}));
+
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: jest.fn().mockResolvedValue(null),
 }));
 
 import { GET } from '@/app/api/admin/directeur/stats/route';
-import { auth } from '@/auth';
+import { requireRole } from '@/lib/guards';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
 import { NextRequest } from 'next/server';
 
-const mockAuth = auth as jest.Mock;
+const mockRequireRole = requireRole as jest.Mock;
+const mockGuardRateLimit = guardRateLimitAsync as jest.Mock;
 
 let prisma: any;
 
@@ -22,6 +29,10 @@ beforeEach(async () => {
   const mod = await import('@/lib/prisma');
   prisma = (mod as any).prisma;
   jest.clearAllMocks();
+  mockRequireRole.mockResolvedValue({
+    user: { id: 'admin-1', role: 'ADMIN', email: 'admin@test.com' },
+  });
+  mockGuardRateLimit.mockResolvedValue(null);
 });
 
 function makeRequest(): NextRequest {
@@ -29,33 +40,51 @@ function makeRequest(): NextRequest {
 }
 
 describe('GET /api/admin/directeur/stats', () => {
-  it('should return 403 when not authenticated', async () => {
-    mockAuth.mockResolvedValue(null as any);
+  it('should return 401 when not authenticated', async () => {
+    mockRequireRole.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+    );
 
     const res = await GET(makeRequest());
     const body = await res.json();
 
-    expect(res.status).toBe(403);
-    expect(body.success).toBe(false);
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('Unauthorized');
   });
 
   it('should return 403 for non-ADMIN role', async () => {
-    mockAuth.mockResolvedValue({
-      user: { id: 'user-1', role: 'ELEVE' },
-    } as any);
+    mockRequireRole.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Forbidden', message: 'Access denied. Required role: ADMIN' }), { status: 403 })
+    );
 
     const res = await GET(makeRequest());
     const body = await res.json();
 
     expect(res.status).toBe(403);
-    expect(body.error).toContain('ADMIN');
+    expect(body.message).toContain('ADMIN');
+  });
+
+  it('rejects unexpected query parameters', async () => {
+    const res = await GET(new NextRequest('http://localhost:3000/api/admin/directeur/stats?rawPayload=true'));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('Paramètres invalides');
+    expect(prisma.assessment.count).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 before DB work when rate limit is exceeded', async () => {
+    mockGuardRateLimit.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'rate limited' }), { status: 429 })
+    );
+
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(429);
+    expect(prisma.assessment.count).not.toHaveBeenCalled();
   });
 
   it('should return KPIs for ADMIN', async () => {
-    mockAuth.mockResolvedValue({
-      user: { id: 'admin-1', role: 'ADMIN' },
-    } as any);
-
     prisma.assessment.count
       .mockResolvedValueOnce(100) // totalAssessments
       .mockResolvedValueOnce(80); // completedAssessments
@@ -86,10 +115,6 @@ describe('GET /api/admin/directeur/stats', () => {
   });
 
   it('should handle SSN distribution correctly', async () => {
-    mockAuth.mockResolvedValue({
-      user: { id: 'admin-1', role: 'ADMIN' },
-    } as any);
-
     prisma.assessment.count.mockResolvedValue(0);
     prisma.student.count.mockResolvedValue(0);
     prisma.assessment.aggregate.mockResolvedValue({ _avg: { globalScore: null } });
@@ -118,10 +143,6 @@ describe('GET /api/admin/directeur/stats', () => {
   });
 
   it('should handle DB errors gracefully', async () => {
-    mockAuth.mockResolvedValue({
-      user: { id: 'admin-1', role: 'ADMIN' },
-    } as any);
-
     prisma.assessment.count.mockRejectedValue(new Error('DB error'));
 
     const res = await GET(makeRequest());

--- a/__tests__/api/admin.documents.route.test.ts
+++ b/__tests__/api/admin.documents.route.test.ts
@@ -1,138 +1,104 @@
-/**
- * Admin Documents API — Complete Test Suite
- *
- * Tests: POST /api/admin/documents
- *
- * Source: app/api/admin/documents/route.ts
- *
- * Note: FormData parsing via NextRequest hangs in Jest's jsdom environment.
- * We test RBAC enforcement directly and mock request.formData() for the rest.
- */
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/admin/documents/route';
+import { requireAnyRole, isErrorResponse } from '@/lib/guards';
+import { prisma } from '@/lib/prisma';
+import { writeFile, mkdir } from 'fs/promises';
 
 jest.mock('@/lib/guards', () => ({
   requireAnyRole: jest.fn(),
-  isErrorResponse: jest.fn(),
+  isErrorResponse: jest.fn((value: unknown) => value instanceof Response),
 }));
 
 jest.mock('fs/promises', () => ({
   mkdir: jest.fn().mockResolvedValue(undefined),
   writeFile: jest.fn().mockResolvedValue(undefined),
-  readFile: jest.fn(),
-  stat: jest.fn(),
 }));
 
 jest.mock('node:fs/promises', () => ({
   mkdir: jest.fn().mockResolvedValue(undefined),
   writeFile: jest.fn().mockResolvedValue(undefined),
-  readFile: jest.fn(),
-  stat: jest.fn(),
 }));
 
 jest.mock('@paralleldrive/cuid2', () => ({
-  createId: jest.fn().mockReturnValue('mock-cuid-123'),
+  createId: jest.fn().mockReturnValue('doc-secure-id'),
 }));
 
-import { POST } from '@/app/api/admin/documents/route';
-import { requireAnyRole, isErrorResponse } from '@/lib/guards';
-import { NextRequest, NextResponse } from 'next/server';
+function mockFile(name: string, type: string, content = '%PDF-1.4') {
+  return {
+    name,
+    type,
+    size: Buffer.byteLength(content),
+    arrayBuffer: jest.fn().mockResolvedValue(Buffer.from(content).buffer),
+  } as unknown as File;
+}
 
-const mockRequireAnyRole = requireAnyRole as jest.Mock;
-const mockIsErrorResponse = isErrorResponse as unknown as jest.Mock;
-
-let prisma: any;
-
-beforeEach(async () => {
-  const mod = await import('@/lib/prisma');
-  prisma = (mod as any).prisma;
-  jest.clearAllMocks();
-});
-
-/**
- * Build a NextRequest with a mocked formData() method to avoid jsdom timeout.
- */
-function makeRequest(formDataMap: Record<string, unknown>): NextRequest {
-  const req = new NextRequest('http://localhost:3000/api/admin/documents', { method: 'POST' });
-  (req as any).formData = jest.fn().mockResolvedValue({
-    get: (key: string) => formDataMap[key] ?? null,
-  });
-  return req;
+function uploadRequest(file: File, userId = 'user-1') {
+  const formData = {
+    get: jest.fn((key: string) => {
+      if (key === 'file') return file;
+      if (key === 'userId') return userId;
+      return null;
+    }),
+  };
+  return {
+    formData: jest.fn().mockResolvedValue(formData),
+  } as unknown as NextRequest;
 }
 
 describe('POST /api/admin/documents', () => {
-  it('should return 403 for unauthorized role', async () => {
-    const errorRes = NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-    mockRequireAnyRole.mockResolvedValue(errorRes as any);
-    mockIsErrorResponse.mockReturnValue(true);
-
-    const req = makeRequest({ userId: 'u1', file: new File(['x'], 'test.pdf') });
-    const res = await POST(req);
-    expect(res.status).toBe(403);
-  });
-
-  it('should return 400 when file or userId missing', async () => {
-    mockRequireAnyRole.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN' } } as any);
-    mockIsErrorResponse.mockReturnValue(false);
-
-    const req = makeRequest({ userId: 'u1' }); // no file
-    const res = await POST(req);
-    const body = await res.json();
-
-    expect(res.status).toBe(400);
-    expect(body.error).toContain('File');
-  });
-
-  it('should return 404 when target user not found', async () => {
-    mockRequireAnyRole.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN' } } as any);
-    mockIsErrorResponse.mockReturnValue(false);
-    prisma.user.findUnique.mockResolvedValue(null);
-
-    const file = new File(['content'], 'test.pdf', { type: 'application/pdf' });
-    const req = makeRequest({ userId: 'nonexistent', file });
-    const res = await POST(req);
-    const body = await res.json();
-
-    expect(res.status).toBe(404);
-    expect(body.error).toContain('user not found');
-  });
-
-  it('should upload document successfully', async () => {
-    mockRequireAnyRole.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN' } } as any);
-    mockIsErrorResponse.mockReturnValue(false);
-    prisma.user.findUnique.mockResolvedValue({ id: 'u1', email: 'u@t.com' });
-    prisma.userDocument.create.mockResolvedValue({
-      id: 'mock-cuid-123',
-      title: 'test.pdf',
-      originalName: 'test.pdf',
-      mimeType: 'application/pdf',
-      sizeBytes: 7,
-      localPath: '/app/storage/documents/mock-cuid-123.pdf',
-      userId: 'u1',
-      uploadedById: 'a1',
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireAnyRole as jest.Mock).mockResolvedValue({
+      user: { id: 'admin-1', role: 'ADMIN' },
     });
-
-    const fakeFile = {
-      name: 'test.pdf',
-      type: 'application/pdf',
-      size: 7,
-      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(7)),
-    };
-    const req = makeRequest({ userId: 'u1', file: fakeFile });
-    const res = await POST(req);
-    const body = await res.json();
-
-    expect(res.status).toBe(201);
-    expect(body.id).toBe('mock-cuid-123');
-    expect(body.originalName).toBe('test.pdf');
+    (isErrorResponse as unknown as jest.Mock).mockImplementation((value: unknown) => value instanceof Response);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'user-1' });
+    (prisma.userDocument.create as jest.Mock).mockResolvedValue({
+      id: 'doc-secure-id',
+      title: 'bulletin.pdf',
+      originalName: 'bulletin.pdf',
+      mimeType: 'application/pdf',
+      sizeBytes: 8,
+      localPath: '/app/storage/documents/doc-secure-id.pdf',
+      userId: 'user-1',
+      uploadedById: 'admin-1',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
   });
 
-  it('should return 500 on internal error', async () => {
-    mockRequireAnyRole.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN' } } as any);
-    mockIsErrorResponse.mockReturnValue(false);
-    prisma.user.findUnique.mockRejectedValue(new Error('DB error'));
+  it('requires ADMIN or ASSISTANTE role', async () => {
+    const guardResponse = new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 });
+    (requireAnyRole as jest.Mock).mockResolvedValue(guardResponse);
+    (isErrorResponse as unknown as jest.Mock).mockReturnValue(true);
 
-    const file = new File(['content'], 'test.pdf', { type: 'application/pdf' });
-    const req = makeRequest({ userId: 'u1', file });
-    const res = await POST(req);
-    expect(res.status).toBe(500);
+    const response = await POST(uploadRequest(mockFile('bulletin.pdf', 'application/pdf')));
+
+    expect(response.status).toBe(403);
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported MIME types before writing files', async () => {
+    const response = await POST(uploadRequest(mockFile('bad.exe', 'application/x-msdownload', 'bad')));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Type ou taille de fichier invalide');
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it('stores an allowed file and returns a projection without localPath', async () => {
+    const response = await POST(uploadRequest(mockFile('bulletin.pdf', 'application/pdf')));
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(mkdir).toHaveBeenCalled();
+    expect(writeFile).toHaveBeenCalled();
+    expect(body.document).toEqual(expect.objectContaining({
+      id: 'doc-secure-id',
+      originalName: 'bulletin.pdf',
+      mimeType: 'application/pdf',
+    }));
+    expect(JSON.stringify(body)).not.toContain('localPath');
+    expect(JSON.stringify(body)).not.toContain('/app/storage');
   });
 });

--- a/__tests__/api/admin.invoices.route.test.ts
+++ b/__tests__/api/admin.invoices.route.test.ts
@@ -124,6 +124,36 @@ describe('GET /api/admin/invoices', () => {
     );
   });
 
+  it('rejects invalid list filters before querying invoices', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN' } } as any);
+
+    const res = await GET(makeGetRequest('status=HACKED&limit=500'));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.invoice.findMany).not.toHaveBeenCalled();
+  });
+
+  it('uses an explicit projection for invoice listing', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN' } } as any);
+    prisma.invoice.findMany.mockResolvedValue([]);
+    prisma.invoice.count.mockResolvedValue(0);
+
+    await GET(makeGetRequest());
+
+    expect(prisma.invoice.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({
+          id: true,
+          number: true,
+          items: expect.any(Object),
+        }),
+      })
+    );
+    expect(prisma.invoice.findMany.mock.calls[0][0]).not.toHaveProperty('include');
+  });
+
   it('should return 500 on DB error', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN' } } as any);
     prisma.invoice.findMany.mockRejectedValue(new Error('DB error'));
@@ -165,7 +195,7 @@ describe('POST /api/admin/invoices', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('customer.name');
+    expect(body.error).toContain('Données');
   });
 
   it('should return 400 for empty items', async () => {
@@ -173,6 +203,21 @@ describe('POST /api/admin/invoices', () => {
 
     const res = await POST(makePostRequest({ customer: { name: 'Karim' }, items: [] }));
     expect(res.status).toBe(400);
+  });
+
+  it('rejects unknown invoice payload fields before creating anything', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN' } } as any);
+
+    const res = await POST(makePostRequest({
+      customer: { name: 'Karim' },
+      items: [{ label: 'Abonnement Hybride', qty: 1, unitPrice: 450000 }],
+      metadata: { raw: true },
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.invoice.create).not.toHaveBeenCalled();
   });
 
   it('should create invoice successfully', async () => {

--- a/__tests__/api/admin.recompute-ssn.route.test.ts
+++ b/__tests__/api/admin.recompute-ssn.route.test.ts
@@ -6,8 +6,13 @@
  * Source: app/api/admin/recompute-ssn/route.ts
  */
 
-jest.mock('@/auth', () => ({
-  auth: jest.fn(),
+jest.mock('@/lib/guards', () => ({
+  requireRole: jest.fn(),
+  isErrorResponse: jest.fn((result) => result && typeof result === 'object' && 'status' in result),
+}));
+
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: jest.fn().mockResolvedValue(null),
 }));
 
 jest.mock('@/lib/core/ssn/computeSSN', () => ({
@@ -19,17 +24,23 @@ jest.mock('@/lib/core/statistics/cohort', () => ({
 }));
 
 import { POST } from '@/app/api/admin/recompute-ssn/route';
-import { auth } from '@/auth';
+import { requireRole } from '@/lib/guards';
 import { recomputeSSNBatch } from '@/lib/core/ssn/computeSSN';
 import { computeCohortStatsWithAudit } from '@/lib/core/statistics/cohort';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
 import { NextRequest } from 'next/server';
 
-const mockAuth = auth as jest.Mock;
+const mockRequireRole = requireRole as jest.Mock;
 const mockRecompute = recomputeSSNBatch as jest.Mock;
 const mockAudit = computeCohortStatsWithAudit as jest.Mock;
+const mockGuardRateLimit = guardRateLimitAsync as jest.Mock;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockRequireRole.mockResolvedValue({
+    user: { id: 'a1', role: 'ADMIN', email: 'admin@test.com' },
+  });
+  mockGuardRateLimit.mockResolvedValue(null);
 });
 
 function makeRequest(body: Record<string, unknown>): NextRequest {
@@ -41,26 +52,28 @@ function makeRequest(body: Record<string, unknown>): NextRequest {
 }
 
 describe('POST /api/admin/recompute-ssn', () => {
-  it('should return 403 when not authenticated', async () => {
-    mockAuth.mockResolvedValue(null as any);
+  it('should return 401 when not authenticated', async () => {
+    mockRequireRole.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+    );
 
     const res = await POST(makeRequest({ type: 'MATHS' }));
     const body = await res.json();
 
-    expect(res.status).toBe(403);
-    expect(body.success).toBe(false);
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('Unauthorized');
   });
 
   it('should return 403 for non-ADMIN role', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
+    mockRequireRole.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 })
+    );
 
     const res = await POST(makeRequest({ type: 'MATHS' }));
     expect(res.status).toBe(403);
   });
 
   it('should return 400 for invalid type', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'admin@test.com' } } as any);
-
     const res = await POST(makeRequest({ type: 'INVALID' }));
     const body = await res.json();
 
@@ -68,15 +81,34 @@ describe('POST /api/admin/recompute-ssn', () => {
     expect(body.error).toContain('Type invalide');
   });
 
-  it('should return 400 for missing type', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'admin@test.com' } } as any);
+  it('rejects unexpected payload fields before recomputing', async () => {
+    const res = await POST(makeRequest({ type: 'MATHS', rawPayload: true }));
+    const body = await res.json();
 
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Type invalide');
+    expect(mockAudit).not.toHaveBeenCalled();
+    expect(mockRecompute).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 before recomputing when rate limit is exceeded', async () => {
+    mockGuardRateLimit.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'rate limited' }), { status: 429 })
+    );
+
+    const res = await POST(makeRequest({ type: 'MATHS' }));
+
+    expect(res.status).toBe(429);
+    expect(mockAudit).not.toHaveBeenCalled();
+    expect(mockRecompute).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 for missing type', async () => {
     const res = await POST(makeRequest({}));
     expect(res.status).toBe(400);
   });
 
   it('should recompute SSN for MATHS', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'admin@test.com' } } as any);
     mockAudit.mockResolvedValue({
       previousStats: { mean: 50, std: 15 },
       stats: { mean: 52, std: 14 },
@@ -100,7 +132,6 @@ describe('POST /api/admin/recompute-ssn', () => {
   });
 
   it('should accept NSI and GENERAL types', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'admin@test.com' } } as any);
     mockAudit.mockResolvedValue({ stats: { mean: 50, std: 10 } } as any);
     mockRecompute.mockResolvedValue({ updated: 10, cohort: { mean: 50, std: 10, sampleSize: 10 } } as any);
 
@@ -111,7 +142,6 @@ describe('POST /api/admin/recompute-ssn', () => {
   });
 
   it('should return 500 on service error', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'admin@test.com' } } as any);
     mockAudit.mockRejectedValue(new Error('DB error'));
 
     const res = await POST(makeRequest({ type: 'MATHS' }));

--- a/__tests__/api/admin.subscriptions.route.test.ts
+++ b/__tests__/api/admin.subscriptions.route.test.ts
@@ -70,6 +70,21 @@ describe('GET /api/admin/subscriptions', () => {
     expect(body.subscriptions).toHaveLength(1);
     expect(body.pagination.total).toBe(1);
   });
+
+  it('bounds pagination and rejects unknown query fields', async () => {
+    (auth as jest.Mock).mockResolvedValue({
+      user: { id: 'admin-1', role: 'ADMIN', email: 'admin@test.com' },
+    });
+
+    const response = await GET(
+      makeRequest('http://localhost:3000/api/admin/subscriptions?limit=500&rawPayload=true')
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Invalid query');
+    expect(prisma.subscription.findMany).not.toHaveBeenCalled();
+  });
 });
 
 describe('PUT /api/admin/subscriptions', () => {
@@ -100,6 +115,25 @@ describe('PUT /api/admin/subscriptions', () => {
 
     expect(response.status).toBe(400);
     expect(body.error).toBe('Invalid status value');
+  });
+
+  it('rejects unexpected update payload fields', async () => {
+    (auth as jest.Mock).mockResolvedValue({
+      user: { id: 'admin-1', role: 'ADMIN', email: 'admin@test.com' },
+    });
+
+    const response = await PUT(
+      makeRequest('http://localhost:3000/api/admin/subscriptions', {
+        subscriptionId: 'sub-1',
+        status: 'ACTIVE',
+        rawPayload: true,
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Invalid payload');
+    expect(prisma.subscription.update).not.toHaveBeenCalled();
   });
 
   it('returns 400 for missing subscriptionId', async () => {

--- a/__tests__/api/admin.test-email.route.test.ts
+++ b/__tests__/api/admin.test-email.route.test.ts
@@ -43,9 +43,20 @@ describe('admin test email', () => {
     expect(body.configuration).toBeDefined();
   });
 
-  it('tests SMTP config via POST', async () => {
+  it('blocks assistant access to admin test email actions', async () => {
     (auth as jest.Mock).mockResolvedValue({
       user: { id: 'assistant-1', role: 'ASSISTANTE' },
+    });
+
+    const response = await POST(makeRequest({ action: 'test_config' }));
+
+    expect(response.status).toBe(403);
+    expect(testEmailConfiguration).not.toHaveBeenCalled();
+  });
+
+  it('tests SMTP config via POST for admin only', async () => {
+    (auth as jest.Mock).mockResolvedValue({
+      user: { id: 'admin-1', role: 'ADMIN' },
     });
     (testEmailConfiguration as jest.Mock).mockResolvedValue({ success: true });
 
@@ -59,7 +70,7 @@ describe('admin test email', () => {
 
   it('requires testEmail for send_test', async () => {
     (auth as jest.Mock).mockResolvedValue({
-      user: { id: 'assistant-1', role: 'ASSISTANTE' },
+      user: { id: 'admin-1', role: 'ADMIN' },
     });
 
     const response = await POST(makeRequest({ action: 'send_test' }));
@@ -71,7 +82,7 @@ describe('admin test email', () => {
 
   it('sends test email', async () => {
     (auth as jest.Mock).mockResolvedValue({
-      user: { id: 'assistant-1', role: 'ASSISTANTE' },
+      user: { id: 'admin-1', role: 'ADMIN' },
     });
 
     const response = await POST(makeRequest({ action: 'send_test', testEmail: 'a@test.com' }));
@@ -80,5 +91,22 @@ describe('admin test email', () => {
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
     expect(sendWelcomeEmail).toHaveBeenCalled();
+  });
+
+  it('rejects unexpected payload fields and invalid recipient emails', async () => {
+    (auth as jest.Mock).mockResolvedValue({
+      user: { id: 'admin-1', role: 'ADMIN' },
+    });
+
+    const response = await POST(makeRequest({
+      action: 'send_test',
+      testEmail: 'not-an-email',
+      rawPayload: true,
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Payload invalide');
+    expect(sendWelcomeEmail).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/api/assessments-rbac.test.ts
+++ b/__tests__/api/assessments-rbac.test.ts
@@ -8,6 +8,7 @@
 
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
+import { NextRequest } from 'next/server';
 
 jest.mock('@/auth', () => ({
   auth: jest.fn(),
@@ -31,16 +32,15 @@ describe('GET /api/admin/directeur/stats', () => {
     jest.clearAllMocks();
   });
 
-  it('returns 403 without session', async () => {
+  it('returns 401 without session', async () => {
     mockGetServerSession.mockResolvedValue(null);
 
-    const request = new Request('http://localhost/api/admin/directeur/stats');
+    const request = new NextRequest('http://localhost/api/admin/directeur/stats');
     const response = await GET(request);
     const data = await response.json();
 
-    expect(response.status).toBe(403);
-    expect(data.success).toBe(false);
-    expect(data.error).toContain('ADMIN');
+    expect(response.status).toBe(401);
+    expect(data.error).toBe('Unauthorized');
   });
 
   it('returns 403 for non-ADMIN user', async () => {
@@ -48,12 +48,12 @@ describe('GET /api/admin/directeur/stats', () => {
       user: { id: 'user-1', email: 'coach@test.com', role: 'COACH' },
     });
 
-    const request = new Request('http://localhost/api/admin/directeur/stats');
+    const request = new NextRequest('http://localhost/api/admin/directeur/stats');
     const response = await GET(request);
     const data = await response.json();
 
     expect(response.status).toBe(403);
-    expect(data.success).toBe(false);
+    expect(data.error).toBe('Forbidden');
   });
 
   it('returns 200 for ADMIN user', async () => {
@@ -72,7 +72,7 @@ describe('GET /api/admin/directeur/stats', () => {
     (prisma.stageReservation.count as jest.Mock).mockResolvedValue(0);
     (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValue([]);
 
-    const request = new Request('http://localhost/api/admin/directeur/stats');
+    const request = new NextRequest('http://localhost/api/admin/directeur/stats');
     const response = await GET(request);
     const data = await response.json();
 
@@ -96,10 +96,10 @@ describe('POST /api/admin/recompute-ssn', () => {
     jest.clearAllMocks();
   });
 
-  it('returns 403 without session', async () => {
+  it('returns 401 without session', async () => {
     mockGetServerSession.mockResolvedValue(null);
 
-    const request = new Request('http://localhost/api/admin/recompute-ssn', {
+    const request = new NextRequest('http://localhost/api/admin/recompute-ssn', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ type: 'MATHS' }),
@@ -108,8 +108,8 @@ describe('POST /api/admin/recompute-ssn', () => {
     const response = await POST(request);
     const data = await response.json();
 
-    expect(response.status).toBe(403);
-    expect(data.success).toBe(false);
+    expect(response.status).toBe(401);
+    expect(data.error).toBe('Unauthorized');
   });
 
   it('returns 200 for ADMIN user with valid type', async () => {
@@ -126,7 +126,7 @@ describe('POST /api/admin/recompute-ssn', () => {
     (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValue([]);
     (prisma.$executeRawUnsafe as jest.Mock).mockResolvedValue(2);
 
-    const request = new Request('http://localhost/api/admin/recompute-ssn', {
+    const request = new NextRequest('http://localhost/api/admin/recompute-ssn', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ type: 'MATHS' }),

--- a/__tests__/api/assessments-submit.test.ts
+++ b/__tests__/api/assessments-submit.test.ts
@@ -8,6 +8,8 @@ import { POST } from '@/app/api/assessments/submit/route';
 import { prisma } from '@/lib/prisma';
 import { guardRateLimitAsync } from '@/lib/rate-limit';
 import { QuestionBank } from '@/lib/assessments/questions';
+import { createAssessmentPublicToken } from '@/lib/assessments/public-token';
+import { Subject } from '@/lib/assessments/core/types';
 
 // Mock next/headers
 jest.mock('next/headers', () => ({
@@ -94,8 +96,19 @@ jest.mock('@/lib/core/raw-sql-monitor', () => ({
 }));
 
 describe('POST /api/assessments/submit', () => {
+  const originalSecret = process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET;
+
+  function assessmentToken() {
+    return createAssessmentPublicToken({
+      subject: Subject.MATHS,
+      grade: 'TERMINALE',
+      source: 'test',
+    });
+  }
+
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET = 'test-assessment-secret';
     (prisma.assessment.create as jest.Mock).mockResolvedValue({
       id: 'test-assessment-id',
       subject: 'MATHS',
@@ -104,6 +117,14 @@ describe('POST /api/assessments/submit', () => {
       globalScore: 50,
     });
     (prisma.$executeRawUnsafe as jest.Mock).mockResolvedValue(1);
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET;
+    } else {
+      process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET = originalSecret;
+    }
   });
 
   it('returns 429 when public submission rate limit is exceeded', async () => {
@@ -144,7 +165,10 @@ describe('POST /api/assessments/submit', () => {
 
     const request = new Request('http://localhost/api/assessments/submit', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-assessment-public-token': assessmentToken(),
+      },
       body: JSON.stringify(body),
     });
 
@@ -165,7 +189,10 @@ describe('POST /api/assessments/submit', () => {
 
     const request = new Request('http://localhost/api/assessments/submit', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-assessment-public-token': assessmentToken(),
+      },
       body: JSON.stringify(body),
     });
 
@@ -190,7 +217,10 @@ describe('POST /api/assessments/submit', () => {
 
     const request = new Request('http://localhost/api/assessments/submit', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-assessment-public-token': assessmentToken(),
+      },
       body: JSON.stringify(body),
     });
 
@@ -211,7 +241,10 @@ describe('POST /api/assessments/submit', () => {
 
     const request = new Request('http://localhost/api/assessments/submit', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-assessment-public-token': assessmentToken(),
+      },
       body: JSON.stringify(body),
     });
 
@@ -234,7 +267,10 @@ describe('POST /api/assessments/submit', () => {
 
     const request = new Request('http://localhost/api/assessments/submit', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-assessment-public-token': assessmentToken(),
+      },
       body: JSON.stringify(body),
     });
 
@@ -248,10 +284,13 @@ describe('POST /api/assessments/submit', () => {
     expect(createCall.data.globalScore).toBe(50);
   });
 
-  it('does not persist a client-supplied studentId on public submissions', async () => {
+  it('rejects a client-supplied studentId on public submissions', async () => {
     const request = new Request('http://localhost/api/assessments/submit', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-assessment-public-token': assessmentToken(),
+      },
       body: JSON.stringify({
         subject: 'MATHS',
         grade: 'TERMINALE',
@@ -266,16 +305,48 @@ describe('POST /api/assessments/submit', () => {
       }),
     });
 
-    await POST(request as any);
+    const response = await POST(request as any);
 
-    const createCall = (prisma.assessment.create as jest.Mock).mock.calls[0][0];
-    expect(createCall.data).not.toHaveProperty('studentId');
+    expect(response.status).toBe(400);
+    expect(prisma.assessment.create).not.toHaveBeenCalled();
+    expect(QuestionBank.loadByVersion).not.toHaveBeenCalled();
+  });
+
+  it('rejects unexpected nested studentData fields before persistence', async () => {
+    const request = new Request('http://localhost/api/assessments/submit', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-assessment-public-token': assessmentToken(),
+      },
+      body: JSON.stringify({
+        subject: 'MATHS',
+        grade: 'TERMINALE',
+        studentData: {
+          email: 'test@example.com',
+          name: 'Test Student',
+          rawPayload: true,
+        },
+        answers: {
+          'MATH-COMB-01': 'a',
+        },
+      }),
+    });
+
+    const response = await POST(request as any);
+
+    expect(response.status).toBe(400);
+    expect(prisma.assessment.create).not.toHaveBeenCalled();
+    expect(QuestionBank.loadByVersion).not.toHaveBeenCalled();
   });
 
   it('rejects malformed assessmentVersion before loading questions', async () => {
     const request = new Request('http://localhost/api/assessments/submit', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-assessment-public-token': assessmentToken(),
+      },
       body: JSON.stringify({
         subject: 'MATHS',
         grade: 'TERMINALE',
@@ -303,7 +374,10 @@ describe('POST /api/assessments/submit', () => {
 
     const request = new Request('http://localhost/api/assessments/submit', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-assessment-public-token': assessmentToken(),
+      },
       body: JSON.stringify({
         subject: 'MATHS',
         grade: 'TERMINALE',

--- a/__tests__/api/assessments.public-token.binding.test.ts
+++ b/__tests__/api/assessments.public-token.binding.test.ts
@@ -1,0 +1,99 @@
+import {
+  ASSESSMENT_FLOW_COOKIE_NAME,
+  buildAssessmentAliasEmail,
+  createAssessmentFlowToken,
+  createAssessmentPublicToken,
+  hashAssessmentLeadEmail,
+  verifyAssessmentFlowToken,
+  verifyAssessmentPublicToken,
+} from '@/lib/assessments/public-token';
+import { Subject } from '@/lib/assessments/core/types';
+
+describe('assessment public token binding', () => {
+  const originalSecret = process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET;
+
+  beforeEach(() => {
+    process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET = 'test-assessment-secret';
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET;
+    } else {
+      process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET = originalSecret;
+    }
+  });
+
+  it('uses a dedicated HttpOnly flow cookie name for lead-bound assessment access', () => {
+    expect(ASSESSMENT_FLOW_COOKIE_NAME).toBe('nexus_assessment_flow');
+  });
+
+  it('creates and verifies a signed lead-bound flow token without raw email', () => {
+    const leadEmailHash = hashAssessmentLeadEmail('Parent.Example@Email.TEST');
+    const flowToken = createAssessmentFlowToken({
+      subject: Subject.MATHS,
+      grade: 'TERMINALE',
+      source: 'bilan-gratuit',
+      leadEmailHash,
+    });
+
+    expect(flowToken).not.toContain('Parent.Example');
+    expect(flowToken).not.toContain('Email.TEST');
+
+    const verification = verifyAssessmentFlowToken(flowToken, {
+      source: 'bilan-gratuit',
+    });
+
+    expect(verification.valid).toBe(true);
+    if (verification.valid) {
+      expect(verification.payload.leadEmailHash).toBe(leadEmailHash);
+      expect(verification.payload.subject).toBe(Subject.MATHS);
+      expect(verification.payload.grade).toBe('TERMINALE');
+    }
+  });
+
+  it('binds public submit tokens to the lead hash and pseudonymous assessment email', () => {
+    const leadEmailHash = hashAssessmentLeadEmail('parent@example.test');
+    const assessmentEmail = buildAssessmentAliasEmail(leadEmailHash);
+    const token = createAssessmentPublicToken({
+      subject: Subject.MATHS,
+      grade: 'TERMINALE',
+      source: 'bilan-gratuit',
+      binding: 'lead',
+      leadEmailHash,
+    });
+
+    const ok = verifyAssessmentPublicToken(token, {
+      usage: 'assessment_submit',
+      subject: Subject.MATHS,
+      grade: 'TERMINALE',
+      source: 'bilan-gratuit',
+      binding: 'lead',
+      leadEmailHash,
+      studentEmail: assessmentEmail,
+    });
+    expect(ok.valid).toBe(true);
+
+    const wrongEmail = verifyAssessmentPublicToken(token, {
+      usage: 'assessment_submit',
+      subject: Subject.MATHS,
+      grade: 'TERMINALE',
+      source: 'bilan-gratuit',
+      binding: 'lead',
+      leadEmailHash,
+      studentEmail: 'attacker@example.test',
+    });
+    expect(wrongEmail).toEqual({ valid: false, reason: 'scope_mismatch' });
+
+    const wrongLead = verifyAssessmentPublicToken(token, {
+      usage: 'assessment_submit',
+      subject: Subject.MATHS,
+      grade: 'TERMINALE',
+      source: 'bilan-gratuit',
+      binding: 'lead',
+      leadEmailHash: hashAssessmentLeadEmail('other@example.test'),
+      studentEmail: assessmentEmail,
+    });
+    expect(wrongLead).toEqual({ valid: false, reason: 'scope_mismatch' });
+  });
+});

--- a/__tests__/api/assessments.public-token.route.test.ts
+++ b/__tests__/api/assessments.public-token.route.test.ts
@@ -1,0 +1,89 @@
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/assessments/public-token/route';
+import { requireAnyRole } from '@/lib/guards';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { verifyAssessmentPublicToken } from '@/lib/assessments/public-token';
+import { Subject } from '@/lib/assessments/core/types';
+
+jest.mock('@/lib/guards', () => ({
+  requireAnyRole: jest.fn(),
+  isErrorResponse: jest.fn((result) => result && typeof result === 'object' && 'status' in result),
+}));
+
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: jest.fn().mockResolvedValue(null),
+}));
+
+function request(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/assessments/public-token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/assessments/public-token', () => {
+  const originalSecret = process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET = 'test-assessment-secret';
+    (requireAnyRole as jest.Mock).mockResolvedValue({ user: { id: 'staff-1', role: 'ASSISTANTE' } });
+    (guardRateLimitAsync as jest.Mock).mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET;
+    } else {
+      process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET = originalSecret;
+    }
+  });
+
+  it('requires staff access before issuing a token', async () => {
+    (requireAnyRole as jest.Mock).mockResolvedValueOnce(
+      Response.json({ error: 'Forbidden' }, { status: 403 }),
+    );
+
+    const response = await POST(request({ subject: 'MATHS', grade: 'TERMINALE' }));
+
+    expect(response.status).toBe(403);
+    expect(guardRateLimitAsync).not.toHaveBeenCalled();
+  });
+
+  it('issues a scoped short-lived token for staff requests', async () => {
+    const response = await POST(
+      request({ subject: 'MATHS', grade: 'TERMINALE', source: 'bilan-gratuit' }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(typeof body.token).toBe('string');
+    expect(body).toEqual({
+      token: expect.any(String),
+      expiresAt: expect.any(String),
+    });
+    expect(JSON.stringify(body)).not.toContain('ASSESSMENT_PUBLIC_TOKEN_SECRET');
+
+    const verification = verifyAssessmentPublicToken(body.token, {
+      usage: 'assessment_submit',
+      subject: Subject.MATHS,
+      grade: 'TERMINALE',
+    });
+    expect(verification.valid).toBe(true);
+  });
+
+  it('rejects unexpected payload fields before token creation', async () => {
+    const response = await POST(
+      request({
+        subject: 'MATHS',
+        grade: 'TERMINALE',
+        studentEmail: 'minor@example.test',
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({ error: 'Validation failed' });
+  });
+});

--- a/__tests__/api/assessments.submit.token-binding.test.ts
+++ b/__tests__/api/assessments.submit.token-binding.test.ts
@@ -1,0 +1,152 @@
+import { POST } from '@/app/api/assessments/submit/route';
+import { prisma } from '@/lib/prisma';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+import {
+  buildAssessmentAliasEmail,
+  createAssessmentPublicToken,
+  hashAssessmentLeadEmail,
+} from '@/lib/assessments/public-token';
+import { Subject } from '@/lib/assessments/core/types';
+
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('next/headers', () => ({
+  headers: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(null),
+  }),
+}));
+
+jest.mock('@/lib/assessments/questions', () => ({
+  QuestionBank: {
+    loadByVersion: jest.fn().mockResolvedValue({
+      questions: [
+        {
+          id: 'MATH-COMB-01',
+          subject: 'MATHS',
+          category: 'Combinatoire',
+          weight: 1,
+          competencies: ['Restituer'],
+          options: [{ id: 'a', isCorrect: true }],
+        },
+      ],
+      resolvedVersion: 'maths_terminale_spe_v1',
+    }),
+  },
+}));
+
+jest.mock('@/lib/assessments/scoring', () => ({
+  ScoringFactory: {
+    create: jest.fn().mockReturnValue({
+      compute: jest.fn().mockReturnValue({
+        globalScore: 100,
+        confidenceIndex: 80,
+        precisionIndex: 75,
+        metrics: { categoryScores: { combinatoire: 100 }, competencyScores: {} },
+        strengths: ['Combinatoire'],
+        weaknesses: [],
+        recommendations: [],
+      }),
+    }),
+  },
+}));
+
+jest.mock('@/lib/assessments/generators', () => ({
+  BilanGenerator: {
+    generate: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('@/lib/core/ssn/computeSSN', () => ({
+  computeAndPersistSSN: jest.fn().mockResolvedValue(undefined),
+}));
+
+function validBody(email: string, overrides: Record<string, unknown> = {}) {
+  return {
+    subject: 'MATHS',
+    grade: 'TERMINALE',
+    studentData: {
+      email,
+      name: 'Élève Nexus',
+    },
+    answers: {
+      'MATH-COMB-01': 'a',
+    },
+    ...overrides,
+  };
+}
+
+function request(body: unknown, publicToken: string) {
+  return new Request('http://localhost/api/assessments/submit', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-assessment-public-token': publicToken,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/assessments/submit lead token binding', () => {
+  const originalSecret = process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET = 'test-assessment-secret';
+    (guardRateLimitAsync as jest.Mock).mockResolvedValue(null);
+    (prisma.assessment.create as jest.Mock).mockResolvedValue({
+      id: 'assessment-internal-id',
+      subject: 'MATHS',
+      grade: 'TERMINALE',
+      status: 'SCORING',
+      globalScore: 100,
+    });
+    (prisma.domainScore.createMany as jest.Mock).mockResolvedValue({ count: 1 });
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET;
+    } else {
+      process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET = originalSecret;
+    }
+  });
+
+  it('accepts a lead-bound token only with the matching pseudonymous assessment email', async () => {
+    const leadEmailHash = hashAssessmentLeadEmail('parent@example.test');
+    const assessmentEmail = buildAssessmentAliasEmail(leadEmailHash);
+    const token = createAssessmentPublicToken({
+      subject: Subject.MATHS,
+      grade: 'TERMINALE',
+      source: 'bilan-gratuit',
+      binding: 'lead',
+      leadEmailHash,
+    });
+
+    const response = await POST(request(validBody(assessmentEmail), token) as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.success).toBe(true);
+    expect(JSON.stringify(body)).not.toContain(token);
+  });
+
+  it('rejects replaying a lead-bound token with another email before persistence', async () => {
+    const leadEmailHash = hashAssessmentLeadEmail('parent@example.test');
+    const token = createAssessmentPublicToken({
+      subject: Subject.MATHS,
+      grade: 'TERMINALE',
+      source: 'bilan-gratuit',
+      binding: 'lead',
+      leadEmailHash,
+    });
+
+    const response = await POST(request(validBody('attacker@example.test'), token) as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toEqual({ error: 'Forbidden' });
+    expect(prisma.assessment.create).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/assessments.submit.token-security.test.ts
+++ b/__tests__/api/assessments.submit.token-security.test.ts
@@ -1,0 +1,199 @@
+import { POST } from '@/app/api/assessments/submit/route';
+import { prisma } from '@/lib/prisma';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { createAssessmentPublicToken } from '@/lib/assessments/public-token';
+import { Subject } from '@/lib/assessments/core/types';
+
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('next/headers', () => ({
+  headers: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(null),
+  }),
+}));
+
+jest.mock('@/lib/assessments/questions', () => ({
+  QuestionBank: {
+    loadByVersion: jest.fn().mockResolvedValue({
+      questions: [
+        {
+          id: 'MATH-COMB-01',
+          subject: 'MATHS',
+          category: 'Combinatoire',
+          weight: 1,
+          competencies: ['Restituer'],
+          options: [{ id: 'a', isCorrect: true }],
+        },
+      ],
+      resolvedVersion: 'maths_terminale_spe_v1',
+    }),
+  },
+}));
+
+jest.mock('@/lib/assessments/scoring', () => ({
+  ScoringFactory: {
+    create: jest.fn().mockReturnValue({
+      compute: jest.fn().mockReturnValue({
+        globalScore: 100,
+        confidenceIndex: 80,
+        precisionIndex: 75,
+        metrics: { categoryScores: { combinatoire: 100 }, competencyScores: {} },
+        strengths: ['Combinatoire'],
+        weaknesses: [],
+        recommendations: [],
+      }),
+    }),
+  },
+}));
+
+jest.mock('@/lib/assessments/generators', () => ({
+  BilanGenerator: {
+    generate: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('@/lib/core/ssn/computeSSN', () => ({
+  computeAndPersistSSN: jest.fn().mockResolvedValue(undefined),
+}));
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  return {
+    subject: 'MATHS',
+    grade: 'TERMINALE',
+    studentData: {
+      email: 'student@example.test',
+      name: 'Student Test',
+    },
+    answers: {
+      'MATH-COMB-01': 'a',
+    },
+    ...overrides,
+  };
+}
+
+function token(input: { subject?: Subject; grade?: 'PREMIERE' | 'TERMINALE'; ttlSeconds?: number; now?: number } = {}) {
+  return createAssessmentPublicToken(
+    {
+      subject: input.subject ?? Subject.MATHS,
+      grade: input.grade ?? 'TERMINALE',
+      source: 'bilan-gratuit',
+    },
+    {
+      ttlSeconds: input.ttlSeconds,
+      now: input.now,
+    },
+  );
+}
+
+function request(body: unknown, publicToken?: string) {
+  return new Request('http://localhost/api/assessments/submit', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(publicToken ? { 'x-assessment-public-token': publicToken } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/assessments/submit token security', () => {
+  const originalSecret = process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET = 'test-assessment-secret';
+    (guardRateLimitAsync as jest.Mock).mockResolvedValue(null);
+    (prisma.assessment.create as jest.Mock).mockResolvedValue({
+      id: 'assessment-internal-id',
+      publicShareId: 'assessment-public-share',
+      subject: 'MATHS',
+      grade: 'TERMINALE',
+      status: 'SCORING',
+      globalScore: 100,
+    });
+    (prisma.domainScore.createMany as jest.Mock).mockResolvedValue({ count: 1 });
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET;
+    } else {
+      process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET = originalSecret;
+    }
+  });
+
+  it('accepts a valid scoped token', async () => {
+    const response = await POST(request(validBody(), token()) as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.success).toBe(true);
+    expect(body.redirectUrl).toContain('assessment-internal-id');
+    expect(JSON.stringify(body)).not.toContain('token');
+  });
+
+  it('rejects missing tokens before persistence', async () => {
+    const response = await POST(request(validBody()) as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body).toEqual({ error: 'Unauthorized' });
+    expect(prisma.assessment.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects expired, malformed, and bad-signature tokens', async () => {
+    const expired = token({ now: 1_000, ttlSeconds: 1 });
+
+    const expiredResponse = await POST(request(validBody(), expired) as any);
+    expect(expiredResponse.status).toBe(401);
+
+    const malformedResponse = await POST(request(validBody(), 'not-a-token') as any);
+    expect(malformedResponse.status).toBe(401);
+
+    const valid = token();
+    const badSignatureResponse = await POST(request(validBody(), `${valid.slice(0, -2)}xx`) as any);
+    expect(badSignatureResponse.status).toBe(401);
+
+    expect(prisma.assessment.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects scope mismatches before persistence', async () => {
+    const response = await POST(request(validBody(), token({ subject: Subject.NSI })) as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toEqual({ error: 'Forbidden' });
+    expect(prisma.assessment.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects subject and grade mismatches before persistence', async () => {
+    const subjectMismatch = await POST(
+      request(validBody({ subject: 'NSI' }), token({ subject: Subject.MATHS })) as any,
+    );
+    expect(subjectMismatch.status).toBe(403);
+
+    const gradeMismatch = await POST(
+      request(validBody({ grade: 'PREMIERE' }), token({ grade: 'TERMINALE' })) as any,
+    );
+    expect(gradeMismatch.status).toBe(403);
+
+    expect(prisma.assessment.create).not.toHaveBeenCalled();
+  });
+
+  it('keeps payload validation strict before token validation', async () => {
+    const response = await POST(
+      request(
+        {
+          ...validBody(),
+          rawPayload: true,
+        },
+        token(),
+      ) as any,
+    );
+
+    expect(response.status).toBe(400);
+    expect(prisma.assessment.create).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/assistant.credit-requests.route.test.ts
+++ b/__tests__/api/assistant.credit-requests.route.test.ts
@@ -86,7 +86,7 @@ describe('assistant credit-requests', () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toBe('Missing required fields');
+    expect(body.error).toBe('Invalid credit request payload');
   });
 
   it('POST approves credit request', async () => {

--- a/__tests__/api/assistant.students.credits.route.test.ts
+++ b/__tests__/api/assistant.students.credits.route.test.ts
@@ -96,7 +96,7 @@ describe('assistant students credits', () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toBe('Missing required fields');
+    expect(body.error).toBe('Invalid credit payload');
   });
 
   it('POST rejects unsupported credit transaction type', async () => {
@@ -108,7 +108,7 @@ describe('assistant students credits', () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toContain('Invalid credit type');
+    expect(body.error).toContain('Invalid credit payload');
     expect(prisma.creditTransaction.create).not.toHaveBeenCalled();
   });
 
@@ -121,7 +121,7 @@ describe('assistant students credits', () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toContain('Invalid credit amount');
+    expect(body.error).toContain('Invalid credit payload');
     expect(prisma.creditTransaction.create).not.toHaveBeenCalled();
   });
 

--- a/__tests__/api/assistant.subscription-requests.route.test.ts
+++ b/__tests__/api/assistant.subscription-requests.route.test.ts
@@ -73,7 +73,7 @@ describe('assistant subscription-requests', () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toBe('Invalid action');
+    expect(body.error).toBe('Invalid subscription request payload');
   });
 
   it('PATCH approves plan change atomically with server catalog price and credits', async () => {

--- a/__tests__/api/assistant.subscriptions.route.test.ts
+++ b/__tests__/api/assistant.subscriptions.route.test.ts
@@ -71,7 +71,7 @@ describe('assistant subscriptions', () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toBe('Missing required fields');
+    expect(body.error).toBe('Invalid subscription payload');
   });
 
   it('POST returns 404 when subscription missing', async () => {

--- a/__tests__/api/assistante.quotes.pdf.route.test.ts
+++ b/__tests__/api/assistante.quotes.pdf.route.test.ts
@@ -99,4 +99,20 @@ describe('POST /api/assistante/quotes/pdf', () => {
       offer: expect.objectContaining({ label: 'Excellence Terminale' }),
     }));
   });
+
+  it('rejects unexpected fields before rendering a PDF', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'assistant-1', email: 'assistante@nexus-reussite.com', role: 'ASSISTANTE' },
+    });
+
+    const response = await POST(makeRequest({
+      ...quotePayload,
+      metadata: { rawPayload: true },
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Invalid quote payload');
+    expect(mockRenderQuotePDF).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/api/bilan-gratuit.product-rgpd.test.ts
+++ b/__tests__/api/bilan-gratuit.product-rgpd.test.ts
@@ -1,0 +1,205 @@
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/bilan-gratuit/route';
+import { prisma } from '@/lib/prisma';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { sendMail } from '@/lib/email/mailer';
+import { ASSESSMENT_FLOW_COOKIE_NAME } from '@/lib/assessments/public-token';
+
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@/lib/csrf', () => ({
+  checkCsrf: jest.fn().mockReturnValue(null),
+  checkBodySize: jest.fn().mockReturnValue(null),
+}));
+
+jest.mock('@/lib/email/mailer', () => ({
+  sendMail: jest.fn().mockResolvedValue({ ok: true }),
+}));
+
+const mockGuardRateLimit = guardRateLimitAsync as jest.Mock;
+const mockContactLeadCreate = prisma.contactLead.create as jest.Mock;
+const mockSendMail = sendMail as jest.Mock;
+
+const validLeadPayload = {
+  parentFirstName: 'Jean',
+  parentLastName: 'Dupont',
+  parentEmail: 'jean.dupont@test.com',
+  parentPhone: '+216 99 19 28 29',
+  studentFirstName: 'Marie',
+  studentLastName: 'Dupont',
+  studentGrade: 'Terminale',
+  studentSchool: 'Lycée Victor Hugo',
+  subjects: ['MATHEMATIQUES'],
+  currentLevel: 'Moyen',
+  objectives: 'Améliorer les notes en mathématiques pour le baccalauréat',
+  difficulties: 'Difficultés avec les équations du second degré',
+  preferredModality: 'hybride',
+  availability: 'Mercredi après-midi',
+  acceptTerms: true,
+  acceptNewsletter: false,
+};
+
+function request(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/bilan-gratuit', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function expectNoPublicIdentifiers(payload: unknown) {
+  const serialized = JSON.stringify(payload);
+  for (const field of [
+    'leadId',
+    'parentId',
+    'studentId',
+    'activationToken',
+    'activationUrl',
+    'tokenHash',
+    'password',
+  ]) {
+    expect(serialized).not.toContain(field);
+  }
+}
+
+describe('/api/bilan-gratuit product/RGPD lead-only decision', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGuardRateLimit.mockResolvedValue(null);
+    mockContactLeadCreate.mockResolvedValue({
+      id: 'lead_123',
+      name: 'Jean Dupont',
+      email: 'jean.dupont@test.com',
+      phone: '+216 99 19 28 29',
+      profile: 'Parent',
+      interest: 'Bilan gratuit - Terminale',
+      urgency: 'Moyen',
+      source: 'bilan-gratuit',
+      status: 'NEW',
+      notes: 'lead notes',
+      createdAt: new Date('2026-07-03T08:00:00.000Z'),
+      updatedAt: new Date('2026-07-03T08:00:00.000Z'),
+    });
+    mockSendMail.mockResolvedValue({ ok: true });
+  });
+
+  it('creates a CRM lead only and does not create inactive accounts', async () => {
+    const response = await POST(request(validLeadPayload));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      success: true,
+      message: 'Votre demande a bien été enregistrée. Notre équipe vous recontactera pour la suite.',
+    });
+    expect(mockContactLeadCreate).toHaveBeenCalledTimes(1);
+    expect(mockContactLeadCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        name: 'Jean Dupont',
+        email: 'jean.dupont@test.com',
+        phone: '+216 99 19 28 29',
+        profile: 'Parent',
+        interest: 'Bilan gratuit - Terminale',
+        source: 'bilan-gratuit',
+        status: 'NEW',
+      }),
+    });
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    expect(prisma.user.create).not.toHaveBeenCalled();
+    expect(prisma.parentProfile.create).not.toHaveBeenCalled();
+    expect(prisma.student.create).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expectNoPublicIdentifiers(body);
+  });
+
+  it('sets a signed HttpOnly assessment flow cookie without exposing token or IDs in JSON', async () => {
+    const response = await POST(request(validLeadPayload));
+    const body = await response.json();
+    const setCookie = response.headers.get('set-cookie') ?? '';
+
+    expect(response.status).toBe(200);
+    expect(setCookie).toContain(`${ASSESSMENT_FLOW_COOKIE_NAME}=`);
+    expect(setCookie).toContain('HttpOnly');
+    expect(setCookie).toContain('Path=/bilan-gratuit/assessment');
+    expect(JSON.stringify(body)).not.toContain(ASSESSMENT_FLOW_COOKIE_NAME);
+    expect(JSON.stringify(body)).not.toContain('assessmentPublicToken');
+    expectNoPublicIdentifiers(body);
+  });
+
+  it('does not persist birth date in CRM notes', async () => {
+    await POST(request(validLeadPayload));
+
+    const notes = mockContactLeadCreate.mock.calls[0][0].data.notes;
+    expect(notes).not.toContain('2008-06-15');
+    expect(notes).not.toContain('birthDate');
+  });
+
+  it('returns neutral success for an existing account email without enumeration', async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'existing-user',
+      email: validLeadPayload.parentEmail,
+    });
+
+    const response = await POST(request(validLeadPayload));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expectNoPublicIdentifiers(body);
+  });
+
+  it('returns a neutral success for honeypot submissions without DB writes', async () => {
+    const response = await POST(request({ ...validLeadPayload, honeypot: 'bot' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockContactLeadCreate).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expectNoPublicIdentifiers(body);
+  });
+
+  it('returns 429 before any DB write when rate limited', async () => {
+    mockGuardRateLimit.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'RATE_LIMIT' }), { status: 429 }),
+    );
+
+    const response = await POST(request(validLeadPayload));
+
+    expect(response.status).toBe(429);
+    expect(mockContactLeadCreate).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid payloads with a sober 400', async () => {
+    const response = await POST(request({ ...validLeadPayload, acceptTerms: false }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({ error: 'Données invalides' });
+    expect(mockContactLeadCreate).not.toHaveBeenCalled();
+    expectNoPublicIdentifiers(body);
+  });
+
+  it('keeps internal notification failure logs sober', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockSendMail.mockRejectedValueOnce(new Error('SMTP stack should not leak'));
+
+    try {
+      const response = await POST(request(validLeadPayload));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      const serializedLogs = JSON.stringify(consoleSpy.mock.calls);
+      expect(serializedLogs).not.toContain('stack');
+      expect(serializedLogs).not.toContain('__tests__/api/bilan-gratuit.product-rgpd.test.ts');
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+});

--- a/__tests__/api/bilan-gratuit.rgpd-minimization.test.ts
+++ b/__tests__/api/bilan-gratuit.rgpd-minimization.test.ts
@@ -1,0 +1,102 @@
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/bilan-gratuit/route';
+import { prisma } from '@/lib/prisma';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@/lib/csrf', () => ({
+  checkCsrf: jest.fn().mockReturnValue(null),
+  checkBodySize: jest.fn().mockReturnValue(null),
+}));
+
+jest.mock('@/lib/email/mailer', () => ({
+  sendMail: jest.fn().mockResolvedValue({ ok: true }),
+}));
+
+const validLeadPayload = {
+  parentFirstName: 'Jean',
+  parentLastName: 'Dupont',
+  parentEmail: 'jean.dupont@test.com',
+  parentPhone: '+216 99 19 28 29',
+  studentFirstName: 'Marie',
+  studentLastName: 'Dupont',
+  studentGrade: 'Terminale',
+  studentSchool: 'Lycée Victor Hugo',
+  subjects: ['MATHEMATIQUES'],
+  currentLevel: 'Moyen',
+  objectives: 'Améliorer les notes en mathématiques pour le baccalauréat',
+  difficulties: 'Difficultés avec les équations du second degré',
+  preferredModality: 'hybride',
+  availability: 'Mercredi après-midi',
+  acceptTerms: true,
+  acceptNewsletter: false,
+};
+
+function request(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/bilan-gratuit', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('/api/bilan-gratuit RGPD minimization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (guardRateLimitAsync as jest.Mock).mockResolvedValue(null);
+    (prisma.contactLead.create as jest.Mock).mockResolvedValue({
+      id: 'lead_123',
+      name: 'Jean Dupont',
+      email: 'jean.dupont@test.com',
+      phone: '+216 99 19 28 29',
+      profile: 'Parent',
+      interest: 'Bilan gratuit - Terminale',
+      urgency: 'Moyen',
+      source: 'bilan-gratuit',
+      status: 'NEW',
+      notes: 'lead notes',
+      createdAt: new Date('2026-07-03T08:00:00.000Z'),
+      updatedAt: new Date('2026-07-03T08:00:00.000Z'),
+    });
+  });
+
+  it('rejects studentBirthDate from the public lead_only payload', async () => {
+    const response = await POST(
+      request({
+        ...validLeadPayload,
+        studentBirthDate: '2008-06-15',
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({ error: 'Données invalides' });
+    expect(prisma.contactLead.create).not.toHaveBeenCalled();
+  });
+
+  it('stores only callback lead information when no birth date is provided', async () => {
+    const response = await POST(request(validLeadPayload));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      success: true,
+      message: 'Votre demande a bien été enregistrée. Notre équipe vous recontactera pour la suite.',
+    });
+    expect(prisma.contactLead.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        name: 'Jean Dupont',
+        email: 'jean.dupont@test.com',
+        source: 'bilan-gratuit',
+        status: 'NEW',
+      }),
+    });
+    const notes = (prisma.contactLead.create as jest.Mock).mock.calls[0][0].data.notes;
+    expect(notes).not.toContain('2008-06-15');
+    expect(notes).not.toContain('birth');
+    expect(notes).not.toContain('naissance');
+  });
+});

--- a/__tests__/api/bilan-gratuit.security.test.ts
+++ b/__tests__/api/bilan-gratuit.security.test.ts
@@ -1,0 +1,193 @@
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/bilan-gratuit/route';
+import { prisma } from '@/lib/prisma';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { sendWelcomeParentEmail } from '@/lib/email';
+import { sendMail } from '@/lib/email/mailer';
+
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@/lib/csrf', () => ({
+  checkCsrf: jest.fn().mockReturnValue(null),
+  checkBodySize: jest.fn().mockReturnValue(null),
+}));
+
+jest.mock('@paralleldrive/cuid2', () => ({
+  createId: jest.fn().mockReturnValue('test-cuid-123'),
+}));
+
+jest.mock('@/lib/email', () => ({
+  sendWelcomeParentEmail: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/lib/email/mailer', () => ({
+  sendMail: jest.fn().mockResolvedValue({ ok: true }),
+}));
+
+const mockGuardRateLimit = guardRateLimitAsync as jest.Mock;
+const mockSendWelcomeParentEmail = sendWelcomeParentEmail as jest.Mock;
+const mockContactLeadCreate = prisma.contactLead.create as jest.Mock;
+const mockSendMail = sendMail as jest.Mock;
+
+const validRequestData = {
+  parentFirstName: 'Jean',
+  parentLastName: 'Dupont',
+  parentEmail: 'jean.dupont@test.com',
+  parentPhone: '+216 99 19 28 29',
+  studentFirstName: 'Marie',
+  studentLastName: 'Dupont',
+  studentGrade: 'Terminale',
+  studentSchool: 'Lycée Victor Hugo',
+  subjects: ['MATHEMATIQUES'],
+  currentLevel: 'Moyen',
+  objectives: 'Améliorer les notes en mathématiques pour le baccalauréat',
+  difficulties: 'Difficultés avec les équations du second degré',
+  preferredModality: 'hybride',
+  availability: 'Mercredi après-midi',
+  acceptTerms: true,
+  acceptNewsletter: false,
+};
+
+const forbiddenResponseFields = [
+  'activationToken',
+  'activationUrl',
+  'password',
+  'tokenHash',
+  'stack',
+  'localPath',
+  'parentId',
+  'studentId',
+];
+
+function buildRequest(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/bilan-gratuit', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function expectNoForbiddenFields(payload: unknown) {
+  const serialized = JSON.stringify(payload);
+  for (const field of forbiddenResponseFields) {
+    expect(serialized).not.toContain(field);
+  }
+}
+
+describe('/api/bilan-gratuit security contract', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.assign(process.env, { NODE_ENV: 'test' });
+    mockGuardRateLimit.mockResolvedValue(null);
+    mockSendWelcomeParentEmail.mockResolvedValue(undefined);
+    mockContactLeadCreate.mockResolvedValue({
+      id: 'lead-123',
+      name: 'Jean Dupont',
+      email: 'jean.dupont@test.com',
+      phone: '+216 99 19 28 29',
+      profile: 'Parent',
+      interest: 'Bilan gratuit - Terminale',
+      urgency: 'Moyen',
+      source: 'bilan-gratuit',
+      status: 'NEW',
+      notes: 'Lead notes',
+      createdAt: new Date('2026-07-03T08:00:00.000Z'),
+      updatedAt: new Date('2026-07-03T08:00:00.000Z'),
+    });
+    mockSendMail.mockResolvedValue({ ok: true });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, { NODE_ENV: originalNodeEnv });
+  });
+
+  it('rejects invalid payloads with a sober 400', async () => {
+    const response = await POST(buildRequest({ ...validRequestData, parentEmail: 'not-an-email' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({ error: 'Données invalides' });
+    expectNoForbiddenFields(body);
+  });
+
+  it('returns a neutral success for honeypot submissions without creating accounts', async () => {
+    const response = await POST(buildRequest({ ...validRequestData, website: 'https://bot.test' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(mockSendWelcomeParentEmail).not.toHaveBeenCalled();
+    expectNoForbiddenFields(body);
+  });
+
+  it('returns 429 before any DB work when rate limited', async () => {
+    mockGuardRateLimit.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'RATE_LIMIT' }), { status: 429 }),
+    );
+
+    const response = await POST(buildRequest(validRequestData));
+
+    expect(response.status).toBe(429);
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('returns a neutral success for an existing email without account lookup enumeration', async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'existing-user',
+      email: validRequestData.parentEmail,
+    });
+
+    const response = await POST(buildRequest(validRequestData));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      success: true,
+      message: 'Votre demande a bien été enregistrée. Notre équipe vous recontactera pour la suite.',
+    });
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(mockSendWelcomeParentEmail).not.toHaveBeenCalled();
+    expectNoForbiddenFields(body);
+  });
+
+  it('creates a CRM lead without creating inactive accounts or activation data', async () => {
+    const response = await POST(buildRequest({ ...validRequestData, website: '' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockContactLeadCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        name: 'Jean Dupont',
+        email: 'jean.dupont@test.com',
+        source: 'bilan-gratuit',
+      }),
+    });
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(prisma.user.create).not.toHaveBeenCalled();
+    expect(prisma.parentProfile.create).not.toHaveBeenCalled();
+    expect(prisma.student.create).not.toHaveBeenCalled();
+    expect(mockSendWelcomeParentEmail).not.toHaveBeenCalled();
+    expectNoForbiddenFields(body);
+  });
+
+  it('returns a sober 500 without stack or tokens on DB failure', async () => {
+    mockContactLeadCreate.mockRejectedValue(new Error('Database connection failed'));
+
+    const response = await POST(buildRequest(validRequestData));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toEqual({ error: 'Erreur interne du serveur' });
+    expect(mockSendWelcomeParentEmail).not.toHaveBeenCalled();
+    expectNoForbiddenFields(body);
+  });
+});

--- a/__tests__/api/bilan-gratuit.test.ts
+++ b/__tests__/api/bilan-gratuit.test.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { POST } from '../../app/api/bilan-gratuit/route';
 import { prisma } from '../../lib/prisma';
 import { sendWelcomeParentEmail } from '../../lib/email';
+import { sendMail } from '@/lib/email/mailer';
 
 jest.mock('bcryptjs');
 
@@ -23,7 +24,13 @@ jest.mock('../../lib/email', () => ({
   sendWelcomeParentEmail: jest.fn().mockResolvedValue(undefined),
 }));
 
+jest.mock('@/lib/email/mailer', () => ({
+  sendMail: jest.fn().mockResolvedValue({ ok: true }),
+}));
+
 const mockSendWelcomeParentEmail = sendWelcomeParentEmail as jest.Mock;
+const mockContactLeadCreate = prisma.contactLead.create as jest.Mock;
+const mockSendMail = sendMail as jest.Mock;
 
 describe('/api/bilan-gratuit', () => {
   const validRequestData = {
@@ -35,7 +42,6 @@ describe('/api/bilan-gratuit', () => {
     studentLastName: 'Dupont',
     studentGrade: 'Terminale',
     studentSchool: 'Lycée Victor Hugo',
-    studentBirthDate: '2005-06-15',
     subjects: ['MATHEMATIQUES'],
     currentLevel: 'Moyen',
     objectives: 'Améliorer les notes en mathématiques pour le baccalauréat',
@@ -48,6 +54,21 @@ describe('/api/bilan-gratuit', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockContactLeadCreate.mockResolvedValue({
+      id: 'lead-123',
+      name: 'Jean Dupont',
+      email: 'jean.dupont@test.com',
+      phone: '0123456789',
+      profile: 'Parent',
+      interest: 'Bilan gratuit - Terminale',
+      urgency: 'Moyen',
+      source: 'bilan-gratuit',
+      status: 'NEW',
+      notes: 'Lead notes',
+      createdAt: new Date('2026-07-03T08:00:00.000Z'),
+      updatedAt: new Date('2026-07-03T08:00:00.000Z'),
+    });
+    mockSendMail.mockResolvedValue({ ok: true });
   });
 
   function buildRequest(body: Record<string, unknown>) {
@@ -58,131 +79,44 @@ describe('/api/bilan-gratuit', () => {
     });
   }
 
-  it('creates inactive parent/student records and sends an activation link without password', async () => {
-    const userCreate = jest.fn()
-      .mockResolvedValueOnce({
-      id: 'parent-123',
-      email: 'jean.dupont@test.com',
-      firstName: 'Jean',
-      lastName: 'Dupont',
-      })
-      .mockResolvedValueOnce({
-        id: 'student-123',
-        email: 'marie.dupont.test@nexus-student.local',
-        firstName: 'Marie',
-        lastName: 'Dupont',
-      });
-    const parentProfileCreate = jest.fn().mockResolvedValue({ id: 'parent-profile-123' });
-    const studentCreate = jest.fn().mockResolvedValue({
-      id: 'student-profile-123',
-      parentId: 'parent-profile-123',
-      userId: 'student-123',
-      grade: 'Terminale',
-    });
-
-    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(null as never);
-    jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => {
-      return callback({
-        user: { create: userCreate },
-        parentProfile: { create: parentProfileCreate },
-        student: { create: studentCreate },
-      } as any);
-    });
-
+  it('creates a CRM lead without creating inactive parent/student accounts', async () => {
     const response = await POST(buildRequest(validRequestData));
     const body = await response.json();
 
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
-    expect(body.message).toBe('Votre demande a bien été enregistrée. Un lien d’activation a été envoyé.');
-    expect(body.parentId).toBe('parent-123');
-    expect(body.studentId).toBe('student-profile-123');
+    expect(body.message).toBe('Votre demande a bien été enregistrée. Notre équipe vous recontactera pour la suite.');
+    expect(body).not.toHaveProperty('parentId');
+    expect(body).not.toHaveProperty('studentId');
 
-    expect(userCreate).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        data: expect.objectContaining({
-          email: 'jean.dupont@test.com',
-          password: null,
-          activatedAt: null,
-          activationToken: expect.any(String),
-          activationExpiry: expect.any(Date),
-        }),
+    expect(mockContactLeadCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        name: 'Jean Dupont',
+        email: 'jean.dupont@test.com',
+        source: 'bilan-gratuit',
       }),
-    );
-    expect(userCreate).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        data: expect.objectContaining({
-          email: 'marie.dupont.test@nexus-student.local',
-          password: null,
-          activatedAt: null,
-        }),
-      }),
-    );
-    expect(studentCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          userId: 'student-123',
-          parentId: 'parent-profile-123',
-          gradeLevel: 'TERMINALE',
-        }),
-      }),
-    );
-    expect(mockSendWelcomeParentEmail).toHaveBeenCalledWith(
-      'jean.dupont@test.com',
-      'Jean Dupont',
-      'Marie Dupont',
-      expect.stringContaining('/auth/activate?token='),
-    );
+    });
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(prisma.user.create).not.toHaveBeenCalled();
+    expect(prisma.parentProfile.create).not.toHaveBeenCalled();
+    expect(prisma.student.create).not.toHaveBeenCalled();
+    expect(mockSendWelcomeParentEmail).not.toHaveBeenCalled();
   });
 
-  it('ignores an injected parentPassword and still creates inactive accounts', async () => {
-    const userCreate = jest.fn()
-      .mockResolvedValueOnce({
-      id: 'parent-123',
-      email: 'jean.dupont@test.com',
-      firstName: 'Jean',
-      lastName: 'Dupont',
-      })
-      .mockResolvedValueOnce({
-        id: 'student-123',
-        email: 'marie.dupont.test@nexus-student.local',
-        firstName: 'Marie',
-        lastName: 'Dupont',
-      });
-    const parentProfileCreate = jest.fn().mockResolvedValue({ id: 'parent-profile-123' });
-    const studentCreate = jest.fn().mockResolvedValue({
-      id: 'student-profile-123',
-    });
-
-    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(null as never);
-    jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => {
-      return callback({
-        user: { create: userCreate },
-        parentProfile: { create: parentProfileCreate },
-        student: { create: studentCreate },
-      } as any);
-    });
-
+  it('rejects an injected parentPassword before creating inactive accounts', async () => {
     const response = await POST(buildRequest({
       ...validRequestData,
       parentPassword: 'temporary-password-should-not-be-used',
     }));
+    const body = await response.json();
 
-    expect(response.status).toBe(200);
-    expect(userCreate).toHaveBeenNthCalledWith(1, expect.objectContaining({ data: expect.objectContaining({ password: null }) }));
-    expect(userCreate).toHaveBeenNthCalledWith(2, expect.objectContaining({ data: expect.objectContaining({ password: null }) }));
-    expect(studentCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          gradeLevel: 'TERMINALE',
-        }),
-      }),
-    );
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Données invalides');
+    expect(mockContactLeadCreate).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when parent email already exists', async () => {
+  it('returns a neutral success when parent email already exists', async () => {
     jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({
       id: 'existing-user',
       email: 'jean.dupont@test.com',
@@ -191,8 +125,12 @@ describe('/api/bilan-gratuit', () => {
     const response = await POST(buildRequest(validRequestData));
     const body = await response.json();
 
-    expect(response.status).toBe(400);
-    expect(body.error).toBe('Un compte existe déjà avec cet email');
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body).not.toHaveProperty('error');
+    expect(body).not.toHaveProperty('parentId');
+    expect(body).not.toHaveProperty('studentId');
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
     expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 
@@ -219,8 +157,7 @@ describe('/api/bilan-gratuit', () => {
   });
 
   it('returns 500 when database error occurs', async () => {
-    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(null as never);
-    jest.spyOn(prisma, '$transaction').mockRejectedValue(new Error('Database connection failed'));
+    mockContactLeadCreate.mockRejectedValue(new Error('Database connection failed'));
 
     const response = await POST(buildRequest(validRequestData));
     const body = await response.json();
@@ -229,40 +166,15 @@ describe('/api/bilan-gratuit', () => {
     expect(body.error).toBe('Erreur interne du serveur');
   });
 
-  it('continues even if email sending fails', async () => {
-    mockSendWelcomeParentEmail.mockRejectedValueOnce(new Error('Email service unavailable'));
-
-    const userCreate = jest.fn()
-      .mockResolvedValueOnce({
-      id: 'parent-123',
-      email: 'jean.dupont@test.com',
-      firstName: 'Jean',
-      lastName: 'Dupont',
-      })
-      .mockResolvedValueOnce({
-        id: 'student-123',
-        email: 'marie.dupont.test@nexus-student.local',
-        firstName: 'Marie',
-        lastName: 'Dupont',
-      });
-    const parentProfileCreate = jest.fn().mockResolvedValue({ id: 'parent-profile-123' });
-    const studentCreate = jest.fn().mockResolvedValue({
-      id: 'student-profile-123',
-    });
-
-    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(null as never);
-    jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => {
-      return callback({
-        user: { create: userCreate },
-        parentProfile: { create: parentProfileCreate },
-        student: { create: studentCreate },
-      } as any);
-    });
+  it('continues even if internal lead notification email fails', async () => {
+    mockSendMail.mockRejectedValueOnce(new Error('Email service unavailable'));
 
     const response = await POST(buildRequest(validRequestData));
     const body = await response.json();
 
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
+    expect(mockContactLeadCreate).toHaveBeenCalledTimes(1);
+    expect(mockSendWelcomeParentEmail).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/api/bilans.id.route.test.ts
+++ b/__tests__/api/bilans.id.route.test.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { GET, PUT } from '@/app/api/bilans/[id]/route';
-import { GET as EXPORT_GET } from '@/app/api/bilans/[id]/export/route';
+import { GET as EXPORT_GET, POST as EXPORT_POST } from '@/app/api/bilans/[id]/export/route';
 import { requireAnyRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
 
@@ -77,6 +77,19 @@ describe('/api/bilans/[id] — ownership', () => {
     expect(body.data.analysisJson).toBeUndefined();
   });
 
+  it('rejects unsafe bilan ids before querying', async () => {
+    mockRequireAnyRole.mockResolvedValue({
+      user: { id: 'admin-1', role: 'ADMIN', email: 'admin@test.local' },
+    });
+
+    const res = await GET(makeRequest('/api/bilans/../secret'), params('../secret'));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.bilan.findFirst).not.toHaveBeenCalled();
+  });
+
   it('requires a coach-owned or assigned bilan before update', async () => {
     mockRequireAnyRole.mockResolvedValue({
       user: { id: 'coach-user-1', role: 'COACH', email: 'coach@test.local' },
@@ -93,6 +106,20 @@ describe('/api/bilans/[id] — ownership', () => {
         OR: expect.any(Array),
       }),
     }));
+  });
+
+  it('rejects unknown update fields before mutating a bilan', async () => {
+    mockRequireAnyRole.mockResolvedValue({
+      user: { id: 'admin-1', role: 'ADMIN', email: 'admin@test.local' },
+    });
+
+    const res = await PUT(makePutRequest({ status: 'COMPLETED', metadata: { raw: true } }), params());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.bilan.findFirst).not.toHaveBeenCalled();
+    expect(prisma.bilan.update).not.toHaveBeenCalled();
   });
 
   it('does not export Nexus markdown to parent audience=all', async () => {
@@ -155,6 +182,42 @@ describe('/api/bilans/[id] — ownership', () => {
     );
 
     expect(res.status).toBe(404);
+  });
+
+  it('rejects unsupported export audience before loading the bilan', async () => {
+    mockRequireAnyRole.mockResolvedValue({
+      user: { id: 'admin-1', role: 'ADMIN', email: 'admin@test.local' },
+    });
+
+    const res = await EXPORT_GET(
+      makeRequest('/api/bilans/bilan-1/export?format=markdown&audience=raw'),
+      params()
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.bilan.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported export generation formats before loading the bilan', async () => {
+    mockRequireAnyRole.mockResolvedValue({
+      user: { id: 'admin-1', role: 'ADMIN', email: 'admin@test.local' },
+    });
+
+    const res = await EXPORT_POST(
+      new NextRequest('http://localhost:3000/api/bilans/bilan-1/export', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ format: 'zip' }),
+      }),
+      params()
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.bilan.findFirst).not.toHaveBeenCalled();
   });
 
   it('returns guard response unchanged when auth fails', async () => {

--- a/__tests__/api/bilans.idor.test.ts
+++ b/__tests__/api/bilans.idor.test.ts
@@ -79,6 +79,17 @@ describe('/api/bilans — IDOR Prevention', () => {
     }));
   });
 
+  it('rejects invalid list filters before querying bilans', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN', email: 'admin@test.com' } });
+
+    const response = await GET(makeGetRequest('?limit=500&isPublished=maybe'));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.bilan.findMany).not.toHaveBeenCalled();
+  });
+
   it('🔴 COACH tente de créer un bilan pour un autre coach — 403', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'coach-1', role: 'COACH', email: 'coach@test.com' } });
     (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-profile-1', userId: 'coach-1' });

--- a/__tests__/api/bilans/crud.test.ts
+++ b/__tests__/api/bilans/crud.test.ts
@@ -173,7 +173,7 @@ describe('F50: /api/bilans CRUD', () => {
 
       expect(response.status).toBe(400);
       expect(body.success).toBe(false);
-      expect(body.error).toContain('Missing required fields');
+      expect(body.error).toContain('Données invalides');
     });
   });
 });

--- a/__tests__/api/bilans/generate.test.ts
+++ b/__tests__/api/bilans/generate.test.ts
@@ -102,6 +102,20 @@ describe('F50: /api/bilans/generate', () => {
       expect(body.error).toContain('bilanId');
     });
 
+    it('rejects unsafe bilan ids before loading the bilan', async () => {
+      const request = new NextRequest('http://localhost:3000/api/bilans/generate', {
+        method: 'POST',
+        body: JSON.stringify({ bilanId: '../secret' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toContain('Données');
+      expect(mockPrisma.bilan.findUnique).not.toHaveBeenCalled();
+    });
+
     it('should return 404 for non-existent bilan', async () => {
       mockPrisma.bilan.findUnique.mockResolvedValue(null);
 
@@ -179,6 +193,16 @@ describe('F50: /api/bilans/generate', () => {
       const response = await GET(request);
 
       expect(response.status).toBe(400);
+    });
+
+    it('rejects unsafe bilan ids before querying generation status', async () => {
+      const request = new NextRequest('http://localhost:3000/api/bilans/generate?bilanId=../secret');
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toContain('Données');
+      expect(mockPrisma.bilan.findUnique).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/api/coach.bilan-diagnostic-maths-terminale.security.test.ts
+++ b/__tests__/api/coach.bilan-diagnostic-maths-terminale.security.test.ts
@@ -1,0 +1,76 @@
+jest.mock('@/lib/guards', () => ({
+  requireRole: jest.fn(),
+  isErrorResponse: jest.fn((result) => result && typeof result === 'object' && 'status' in result),
+}));
+
+jest.mock('@/lib/rbac/coach-student-access', () => ({
+  assertCoachCanAccessStudent: jest.fn(),
+}));
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    bilan: {
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+    coachProfile: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/lib/diagnostic/maths-terminale/scoring', () => ({
+  computeDiagnostics: jest.fn(),
+}));
+
+jest.mock('@/lib/diagnostic/maths-terminale/data', () => ({
+  DOMAINS: [],
+}));
+
+jest.mock('@/lib/utils/serialize-error', () => ({
+  serializeError: jest.fn(() => ({ name: 'Error', message: 'redacted' })),
+}));
+
+import {
+  GET,
+  PATCH,
+} from '@/app/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale/route';
+import { requireRole } from '@/lib/guards';
+import { assertCoachCanAccessStudent } from '@/lib/rbac/coach-student-access';
+import { prisma } from '@/lib/prisma';
+
+describe('/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireRole as jest.Mock).mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+  });
+
+  it('rejects unsafe student ids on GET before checking assignment', async () => {
+    const res = await GET(new Request('http://localhost/'), {
+      params: Promise.resolve({ studentId: '../student' }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(assertCoachCanAccessStudent).not.toHaveBeenCalled();
+    expect(prisma.bilan.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsafe student ids on PATCH before parsing body or mutating', async () => {
+    const res = await PATCH(
+      new Request('http://localhost/', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ teacherGrades: {} }),
+      }),
+      { params: Promise.resolve({ studentId: '../student' }) }
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(assertCoachCanAccessStudent).not.toHaveBeenCalled();
+    expect(prisma.bilan.update).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/coach.eaf-preparation-report.validate.test.ts
+++ b/__tests__/api/coach.eaf-preparation-report.validate.test.ts
@@ -64,6 +64,16 @@ describe('POST /api/coach/students/[studentId]/eaf-preparation-report/validate',
     (getCoachProfileForUser as jest.Mock).mockResolvedValue({ id: 'coach-1' });
   });
 
+  it('rejects unsafe student ids before checking coach assignment', async () => {
+    const res = await POST(new Request('http://localhost/', { method: 'POST' }), params('../student'));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(assertCoachCanAccessStudent).not.toHaveBeenCalled();
+    expect(prisma.eafPreparationReport.findUnique).not.toHaveBeenCalled();
+  });
+
   it('refuses incomplete coach reports', async () => {
     (prisma.eafPreparationReport.findUnique as jest.Mock).mockResolvedValue({
       ...completeReport,

--- a/__tests__/api/coach.eaf-stage-regenerate.security.test.ts
+++ b/__tests__/api/coach.eaf-stage-regenerate.security.test.ts
@@ -1,0 +1,60 @@
+jest.mock('@/lib/guards', () => ({
+  requireRole: jest.fn(),
+  isErrorResponse: jest.fn((result) => result && typeof result === 'object' && 'status' in result),
+}));
+
+jest.mock('@/lib/rbac/coach-student-access', () => {
+  class CoachNotAssignedError extends Error {
+    constructor(message = "Vous n'êtes pas assigné à cet élève") {
+      super(message);
+      this.name = 'CoachNotAssignedError';
+    }
+  }
+
+  return {
+    assertCoachCanAccessStudent: jest.fn(),
+    getCoachProfileForUser: jest.fn(),
+    CoachNotAssignedError,
+  };
+});
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    bilan: {
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/lib/coach/eaf-stage-printemps/llm-report', () => ({
+  generateLLMParentEafReport: jest.fn(),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}));
+
+import { POST } from '@/app/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate/route';
+import { requireRole } from '@/lib/guards';
+import { assertCoachCanAccessStudent } from '@/lib/rbac/coach-student-access';
+import { prisma } from '@/lib/prisma';
+
+describe('POST /api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireRole as jest.Mock).mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+  });
+
+  it('rejects unsafe student ids before checking coach assignment or loading bilans', async () => {
+    const res = await POST(new Request('http://localhost/', { method: 'POST' }), {
+      params: Promise.resolve({ studentId: '../student' }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(assertCoachCanAccessStudent).not.toHaveBeenCalled();
+    expect(prisma.bilan.findFirst).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/coach.generated-reports.route.test.ts
+++ b/__tests__/api/coach.generated-reports.route.test.ts
@@ -137,6 +137,20 @@ describe('POST /api/coach/students/[studentId]/generated-reports/[reportId]/rege
     jest.clearAllMocks();
   });
 
+  it('rejects unsafe route params before checking coach assignment', async () => {
+    (requireRole as jest.Mock).mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+
+    const res = await REGENERATE(new Request('http://localhost/', { method: 'POST' }), {
+      params: Promise.resolve({ studentId: '../student', reportId: '../report' }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(assertCoachCanAccessStudent).not.toHaveBeenCalled();
+    expect(processGeneratedReportJob).not.toHaveBeenCalled();
+  });
+
   it('does not expose internal generated report payloads after regeneration', async () => {
     (requireRole as jest.Mock).mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
     (assertCoachCanAccessStudent as jest.Mock).mockResolvedValue(undefined);

--- a/__tests__/api/coach.trajectory.security.test.ts
+++ b/__tests__/api/coach.trajectory.security.test.ts
@@ -1,0 +1,100 @@
+import { NextRequest } from 'next/server';
+
+import { POST } from '@/app/api/coach/trajectory/route';
+import { auth } from '@/auth';
+import { prisma } from '@/lib/prisma';
+import { isCoachRattachedToStudent } from '@/lib/rbac/coach-student-access';
+
+jest.mock('@/auth', () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock('@/lib/rbac/coach-student-access', () => ({
+  isCoachRattachedToStudent: jest.fn(),
+}));
+
+function request(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/coach/trajectory', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/coach/trajectory — security', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects unexpected payload fields before any mutation', async () => {
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'coach-1', role: 'COACH' } });
+
+    const response = await POST(request({
+      studentId: 'student-1',
+      title: 'Trajectoire',
+      horizon: '3_MONTHS',
+      metadata: { rawPayload: true },
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Invalid trajectory payload');
+    expect(prisma.trajectory.updateMany).not.toHaveBeenCalled();
+    expect(prisma.trajectory.create).not.toHaveBeenCalled();
+  });
+
+  it('prevents a coach from creating a trajectory for an unassigned student', async () => {
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'coach-1', role: 'COACH' } });
+    (isCoachRattachedToStudent as jest.Mock).mockResolvedValue(false);
+
+    const response = await POST(request({
+      studentId: 'student-b',
+      title: 'Trajectoire hors scope',
+      horizon: '6_MONTHS',
+      targetScore: 15,
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe('Forbidden');
+    expect(isCoachRattachedToStudent).toHaveBeenCalledWith('coach-1', 'student-b');
+    expect(prisma.trajectory.updateMany).not.toHaveBeenCalled();
+    expect(prisma.trajectory.create).not.toHaveBeenCalled();
+  });
+
+  it('allows an assigned coach and persists a projected trajectory', async () => {
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'coach-1', role: 'COACH' } });
+    (isCoachRattachedToStudent as jest.Mock).mockResolvedValue(true);
+    (prisma.trajectory.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+    (prisma.trajectory.create as jest.Mock).mockResolvedValue({
+      id: 'traj-1',
+      studentId: 'student-1',
+      title: 'Trajectoire',
+      targetScore: 16,
+      horizon: '3_MONTHS',
+      createdBy: 'coach-1',
+      status: 'ACTIVE',
+    });
+
+    const response = await POST(request({
+      studentId: 'student-1',
+      title: 'Trajectoire',
+      horizon: '3_MONTHS',
+      targetScore: 16,
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.id).toBe('traj-1');
+    expect(prisma.trajectory.updateMany).toHaveBeenCalledWith({
+      where: { studentId: 'student-1', status: 'ACTIVE' },
+      data: { status: 'COMPLETED' },
+    });
+    expect(prisma.trajectory.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        studentId: 'student-1',
+        createdBy: 'coach-1',
+      }),
+    }));
+  });
+});

--- a/__tests__/api/documents-access.test.ts
+++ b/__tests__/api/documents-access.test.ts
@@ -124,6 +124,7 @@ describe('Documents Access Control', () => {
       const data = await response.json();
       expect(data.success).toBe(true);
       expect(data.documents).toHaveLength(1);
+      expect(data.documents[0]).not.toHaveProperty('localPath');
     });
 
     it('should deny coach access to non-assigned student (403)', async () => {
@@ -213,6 +214,7 @@ describe('Documents Access Control', () => {
       const data = await response.json();
       expect(data.success).toBe(true);
       expect(data.document.title).toBe('New Exercise');
+      expect(data.document).not.toHaveProperty('localPath');
     });
 
     it('should validate documentType enum (400)', async () => {
@@ -238,7 +240,7 @@ describe('Documents Access Control', () => {
       expect(response.status).toBe(400);
     });
 
-    it('should require url or localPath (400)', async () => {
+    it('should require url for JSON metadata documents (400)', async () => {
       coachSession();
       (assertCoachCanAccessStudent as jest.Mock).mockResolvedValue(undefined);
       mockPrisma.student.findFirst.mockResolvedValue(mockStudent);
@@ -259,7 +261,7 @@ describe('Documents Access Control', () => {
 
       expect(response.status).toBe(400);
       const data = await response.json();
-      expect(data.message).toContain('URL ou chemin local requis');
+      expect(data.message).toContain('URL requise');
     });
   });
 

--- a/__tests__/api/documents.id.route.test.ts
+++ b/__tests__/api/documents.id.route.test.ts
@@ -34,6 +34,11 @@ beforeEach(async () => {
   jest.clearAllMocks();
 });
 
+function mockDocumentLookup(document: unknown) {
+  prisma.userDocument.findUnique.mockResolvedValue(document);
+  prisma.userDocument.findFirst.mockResolvedValue(document);
+}
+
 function makeRequest(id: string): [NextRequest, { params: Promise<{ id: string }> }] {
   const req = new NextRequest(`http://localhost:3000/api/documents/${id}`, { method: 'GET' });
   return [req, { params: Promise.resolve({ id }) }];
@@ -49,26 +54,27 @@ describe('GET /api/documents/[id]', () => {
 
   it('should return 404 when document not found', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
-    prisma.userDocument.findUnique.mockResolvedValue(null);
+    mockDocumentLookup(null);
 
     const res = await GET(...makeRequest('nonexistent'));
     expect(res.status).toBe(404);
   });
 
-  it('should return 403 when user is not owner and not staff', async () => {
+  it('should return 404 when user is not owner and not staff without reading file', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'other-user', role: 'ELEVE' } } as any);
-    prisma.userDocument.findUnique.mockResolvedValue({
+    mockDocumentLookup({
       id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/test.pdf',
       mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
     });
 
     const res = await GET(...makeRequest('doc-1'));
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
+    expect(mockReadFile).not.toHaveBeenCalled();
   });
 
   it('should return document for owner', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
-    prisma.userDocument.findUnique.mockResolvedValue({
+    mockDocumentLookup({
       id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/test.pdf',
       mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
     });
@@ -84,7 +90,7 @@ describe('GET /api/documents/[id]', () => {
 
   it('should return document for ADMIN', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } } as any);
-    prisma.userDocument.findUnique.mockResolvedValue({
+    mockDocumentLookup({
       id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/test.pdf',
       mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
     });
@@ -96,7 +102,7 @@ describe('GET /api/documents/[id]', () => {
 
   it('should return document for ASSISTANTE', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'assist-1', role: 'ASSISTANTE' } } as any);
-    prisma.userDocument.findUnique.mockResolvedValue({
+    mockDocumentLookup({
       id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/test.pdf',
       mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
     });
@@ -108,7 +114,7 @@ describe('GET /api/documents/[id]', () => {
 
   it('should return 404 when file missing on disk', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
-    prisma.userDocument.findUnique.mockResolvedValue({
+    mockDocumentLookup({
       id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/missing.pdf',
       mimeType: 'application/pdf', originalName: 'missing.pdf', sizeBytes: 1024,
     });
@@ -118,9 +124,28 @@ describe('GET /api/documents/[id]', () => {
     expect(res.status).toBe(404);
   });
 
+  it('should not log local file paths when file content is missing', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
+    mockDocumentLookup({
+      id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/private/missing.pdf',
+      mimeType: 'application/pdf', originalName: 'missing.pdf', sizeBytes: 1024,
+    });
+    mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT: /app/storage/documents/private/missing.pdf'), { code: 'ENOENT' }));
+
+    const res = await GET(...makeRequest('doc-1'));
+
+    expect(res.status).toBe(404);
+    const serializedLogs = JSON.stringify(errorSpy.mock.calls);
+    expect(serializedLogs).not.toContain('/app/storage');
+    expect(serializedLogs).not.toContain('private/missing.pdf');
+    errorSpy.mockRestore();
+  });
+
   it('should return 500 on DB error', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
     prisma.userDocument.findUnique.mockRejectedValue(new Error('DB error'));
+    prisma.userDocument.findFirst.mockRejectedValue(new Error('DB error'));
 
     const res = await GET(...makeRequest('doc-1'));
     expect(res.status).toBe(500);

--- a/__tests__/api/eleve.bilan-diagnostic-maths-terminale.security.test.ts
+++ b/__tests__/api/eleve.bilan-diagnostic-maths-terminale.security.test.ts
@@ -1,0 +1,40 @@
+import { NextRequest } from 'next/server';
+
+import { POST } from '@/app/api/eleve/bilan-diagnostic-maths-terminale/route';
+import { prisma } from '@/lib/prisma';
+import { requireRole } from '@/lib/guards';
+
+jest.mock('@/lib/guards', () => ({
+  requireRole: jest.fn(),
+  isErrorResponse: jest.fn((value) => value instanceof Response),
+}));
+
+function request(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/eleve/bilan-diagnostic-maths-terminale', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/eleve/bilan-diagnostic-maths-terminale — security', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireRole as jest.Mock).mockResolvedValue({ user: { id: 'student-user-1', role: 'ELEVE' } });
+  });
+
+  it('rejects unexpected fields before DB access', async () => {
+    const response = await POST(request({
+      progress: {},
+      qcmAnswers: {},
+      openAnswers: {},
+      step: 'progress',
+      metadata: { rawPayload: true },
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Invalid diagnostic payload');
+    expect(prisma.student.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/internal.business-config.health.test.ts
+++ b/__tests__/api/internal.business-config.health.test.ts
@@ -1,0 +1,98 @@
+import { GET } from '@/app/api/internal/health/route';
+import { enforcePolicy } from '@/lib/rbac';
+import { prisma } from '@/lib/prisma';
+import { ragSearch } from '@/lib/rag-client';
+import { getConfigSnapshotRuntimeStatus } from '@/lib/config/snapshot';
+
+jest.mock('@/lib/rbac', () => ({
+  enforcePolicy: jest.fn(),
+}));
+
+jest.mock('@/lib/rag-client', () => ({
+  ragSearch: jest.fn(),
+}));
+
+jest.mock('@/lib/config/snapshot', () => ({
+  getConfigSnapshotRuntimeStatus: jest.fn(),
+}));
+
+const originalEnv = {
+  REDIS_URL: process.env.REDIS_URL,
+  UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+  UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+  SMTP_HOST: process.env.SMTP_HOST,
+  SMTP_PORT: process.env.SMTP_PORT,
+  SMTP_USER: process.env.SMTP_USER,
+  SMTP_PASS: process.env.SMTP_PASS,
+  NPC_LLM_MODE: process.env.NPC_LLM_MODE,
+};
+
+function restoreEnv() {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key as keyof NodeJS.ProcessEnv];
+    } else {
+      process.env[key as keyof NodeJS.ProcessEnv] = value;
+    }
+  }
+}
+
+describe('GET /api/internal/health — business config drift classification', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    restoreEnv();
+    process.env.REDIS_URL = 'redis://127.0.0.1:6379';
+    process.env.SMTP_HOST = 'smtp.test';
+    process.env.SMTP_PORT = '587';
+    process.env.SMTP_USER = 'smtp-user';
+    process.env.SMTP_PASS = 'smtp-pass';
+    process.env.NPC_LLM_MODE = 'stub';
+    (enforcePolicy as jest.Mock).mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } });
+    (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ ok: 1 }]);
+    (ragSearch as jest.Mock).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('exposes database-backed business config mode when available', async () => {
+    (getConfigSnapshotRuntimeStatus as jest.Mock).mockReturnValue({
+      mode: 'database',
+      ok: true,
+      lastError: null,
+    });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.checks.businessConfig).toEqual({ ok: true, detail: 'database' });
+    expect(body.runtime.businessConfig).toEqual({
+      mode: 'database',
+      ok: true,
+      lastError: null,
+    });
+  });
+
+  it('classifies missing business_configs as static fallback instead of an ambiguous warning', async () => {
+    (getConfigSnapshotRuntimeStatus as jest.Mock).mockReturnValue({
+      mode: 'static_fallback_allowed',
+      ok: true,
+      lastError: { kind: 'missing_table', table: 'business_configs' },
+    });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.checks.businessConfig).toEqual({
+      ok: true,
+      detail: 'static_fallback_allowed:missing_table',
+    });
+    expect(body.runtime.businessConfig.lastError).toEqual({
+      kind: 'missing_table',
+      table: 'business_configs',
+    });
+  });
+});

--- a/__tests__/api/internal.health.rate-limit.test.ts
+++ b/__tests__/api/internal.health.rate-limit.test.ts
@@ -1,0 +1,87 @@
+import { GET } from '@/app/api/internal/health/route';
+import { enforcePolicy } from '@/lib/rbac';
+import { prisma } from '@/lib/prisma';
+import { ragSearch } from '@/lib/rag-client';
+
+jest.mock('@/lib/rbac', () => ({
+  enforcePolicy: jest.fn(),
+}));
+
+jest.mock('@/lib/rag-client', () => ({
+  ragSearch: jest.fn(),
+}));
+
+const ORIGINAL_ENV = {
+  REDIS_URL: process.env.REDIS_URL,
+  UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+  UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+  SMTP_HOST: process.env.SMTP_HOST,
+  SMTP_PORT: process.env.SMTP_PORT,
+  SMTP_USER: process.env.SMTP_USER,
+  SMTP_PASS: process.env.SMTP_PASS,
+  NPC_LLM_MODE: process.env.NPC_LLM_MODE,
+};
+
+function restoreEnv() {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) {
+      delete process.env[key as keyof NodeJS.ProcessEnv];
+    } else {
+      process.env[key as keyof NodeJS.ProcessEnv] = value;
+    }
+  }
+}
+
+function setHealthyNonSecretEnv() {
+  process.env.SMTP_HOST = 'smtp.test';
+  process.env.SMTP_PORT = '587';
+  process.env.SMTP_USER = 'smtp-user';
+  process.env.SMTP_PASS = 'smtp-pass';
+  process.env.NPC_LLM_MODE = 'stub';
+}
+
+describe('GET /api/internal/health — rate limit runtime', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    restoreEnv();
+    delete process.env.REDIS_URL;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    setHealthyNonSecretEnv();
+    (enforcePolicy as jest.Mock).mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } });
+    (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ ok: 1 }]);
+    (ragSearch as jest.Mock).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('reports memory mode as degraded and blocked for go-live large', async () => {
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.checks.redis).toEqual({ ok: false, detail: 'memory' });
+    expect(body.runtime.rateLimit).toEqual({
+      mode: 'memory',
+      distributed: false,
+      goLiveLarge: 'blocked',
+    });
+  });
+
+  it('reports redis mode unambiguously when configured', async () => {
+    process.env.REDIS_URL = 'redis://127.0.0.1:6379';
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.checks.redis).toEqual({ ok: true, detail: 'redis' });
+    expect(body.runtime.rateLimit).toEqual({
+      mode: 'redis',
+      distributed: true,
+      goLiveLarge: 'allowed',
+    });
+  });
+});

--- a/__tests__/api/internal.rate-limit-probe.test.ts
+++ b/__tests__/api/internal.rate-limit-probe.test.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { GET } from '@/app/api/internal/rate-limit-probe/route';
+import { enforcePolicy } from '@/lib/rbac';
+import { _resetStoreForTests } from '@/lib/rate-limit';
+
+jest.mock('@/lib/rbac', () => ({
+  enforcePolicy: jest.fn(),
+}));
+
+function makeRequest(ip = '203.0.113.42'): NextRequest {
+  return new NextRequest('http://localhost:3000/api/internal/rate-limit-probe', {
+    headers: {
+      'x-forwarded-for': ip,
+    },
+  });
+}
+
+describe('GET /api/internal/rate-limit-probe', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    _resetStoreForTests();
+    delete process.env.RATE_LIMIT_DISABLE;
+    delete process.env.REDIS_URL;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    (enforcePolicy as jest.Mock).mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } });
+  });
+
+  it('requires the internal admin policy before probing rate limits', async () => {
+    (enforcePolicy as jest.Mock).mockResolvedValueOnce(
+      NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    );
+
+    const response = await GET(makeRequest());
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns safe runtime metadata without secrets when under limit', async () => {
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      ok: true,
+      probe: 'rate-limit',
+      runtime: {
+        mode: 'memory',
+        distributed: false,
+        goLiveLarge: 'blocked',
+      },
+    });
+    expect(JSON.stringify(body)).not.toMatch(/token|secret|password|cookie/i);
+  });
+
+  it('returns 429 after the probe limit is exceeded for the same key', async () => {
+    const request = makeRequest();
+    let response = await GET(request);
+
+    for (let i = 0; i < 5; i += 1) {
+      response = await GET(request);
+    }
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toBeTruthy();
+  });
+});

--- a/__tests__/api/invoices.pdf.route.test.ts
+++ b/__tests__/api/invoices.pdf.route.test.ts
@@ -22,18 +22,18 @@ jest.mock('@/lib/invoice/not-found', () => ({
       headers: { 'Content-Type': 'application/json' },
     })
   ),
-  buildInvoiceScopeWhere: jest.fn(),
+  buildInvoiceAccessWhere: jest.fn(),
 }));
 
 import { GET } from '@/app/api/invoices/[id]/pdf/route';
 import { auth } from '@/auth';
 import { verifyAccessToken } from '@/lib/invoice';
-import { buildInvoiceScopeWhere } from '@/lib/invoice/not-found';
+import { buildInvoiceAccessWhere } from '@/lib/invoice/not-found';
 import { NextRequest } from 'next/server';
 
 const mockAuth = auth as jest.Mock;
 const mockVerifyToken = verifyAccessToken as jest.Mock;
-const mockBuildScope = buildInvoiceScopeWhere as jest.Mock;
+const mockBuildScope = buildInvoiceAccessWhere as jest.Mock;
 
 let prisma: any;
 
@@ -99,7 +99,7 @@ describe('GET /api/invoices/[id]/pdf — Session-based access', () => {
 
   it('should return 404 for unauthorized role', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE', email: 'e@t.com' } } as any);
-    mockBuildScope.mockReturnValue(null as any);
+    mockBuildScope.mockResolvedValue(null as any);
 
     const res = await GET(...makeRequest('inv-1'));
     expect(res.status).toBe(404);
@@ -107,7 +107,7 @@ describe('GET /api/invoices/[id]/pdf — Session-based access', () => {
 
   it('should stream PDF for ADMIN', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'a@t.com' } } as any);
-    mockBuildScope.mockReturnValue({ id: 'inv-1' } as any);
+    mockBuildScope.mockResolvedValue({ id: 'inv-1' } as any);
     prisma.invoice.findFirst.mockResolvedValue({
       id: 'inv-1', number: 'NXS-2026-0001', pdfPath: '/storage/invoices/NXS-2026-0001.pdf',
     });
@@ -121,7 +121,7 @@ describe('GET /api/invoices/[id]/pdf — Session-based access', () => {
 
   it('should return 404 when invoice not found in scope', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'p1', role: 'PARENT', email: 'p@t.com' } } as any);
-    mockBuildScope.mockReturnValue({ id: 'inv-1', customerEmail: 'p@t.com' } as any);
+    mockBuildScope.mockResolvedValue({ id: 'inv-1', OR: [{ customerEmail: 'p@t.com' }] } as any);
     prisma.invoice.findFirst.mockResolvedValue(null);
 
     const res = await GET(...makeRequest('inv-1'));

--- a/__tests__/api/invoices.receipt.pdf.route.test.ts
+++ b/__tests__/api/invoices.receipt.pdf.route.test.ts
@@ -23,16 +23,16 @@ jest.mock('@/lib/invoice/not-found', () => ({
       headers: { 'Content-Type': 'application/json' },
     })
   ),
-  buildInvoiceScopeWhere: jest.fn(),
+  buildInvoiceAccessWhere: jest.fn(),
 }));
 
 import { GET } from '@/app/api/invoices/[id]/receipt/pdf/route';
 import { auth } from '@/auth';
-import { buildInvoiceScopeWhere } from '@/lib/invoice/not-found';
+import { buildInvoiceAccessWhere } from '@/lib/invoice/not-found';
 import { NextRequest } from 'next/server';
 
 const mockAuth = auth as jest.Mock;
-const mockBuildScope = buildInvoiceScopeWhere as jest.Mock;
+const mockBuildScope = buildInvoiceAccessWhere as jest.Mock;
 
 let prisma: any;
 
@@ -57,7 +57,7 @@ describe('GET /api/invoices/[id]/receipt/pdf', () => {
 
   it('should return 404 for unauthorized role', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE', email: 'e@t.com' } } as any);
-    mockBuildScope.mockReturnValue(null as any);
+    mockBuildScope.mockResolvedValue(null as any);
 
     const res = await GET(...makeRequest('inv-1'));
     expect(res.status).toBe(404);
@@ -65,7 +65,7 @@ describe('GET /api/invoices/[id]/receipt/pdf', () => {
 
   it('should return 404 when invoice not found', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'a@t.com' } } as any);
-    mockBuildScope.mockReturnValue({ id: 'inv-1' } as any);
+    mockBuildScope.mockResolvedValue({ id: 'inv-1' } as any);
     prisma.invoice.findFirst.mockResolvedValue(null);
 
     const res = await GET(...makeRequest('inv-1'));
@@ -74,7 +74,7 @@ describe('GET /api/invoices/[id]/receipt/pdf', () => {
 
   it('should return 409 when invoice not PAID', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'a@t.com' } } as any);
-    mockBuildScope.mockReturnValue({ id: 'inv-1' } as any);
+    mockBuildScope.mockResolvedValue({ id: 'inv-1' } as any);
     prisma.invoice.findFirst.mockResolvedValue({
       id: 'inv-1', number: 'NXS-2026-0001', status: 'SENT',
       paidAt: null, paidAmount: null, events: [],
@@ -89,7 +89,7 @@ describe('GET /api/invoices/[id]/receipt/pdf', () => {
 
   it('should stream receipt PDF for PAID invoice', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'a@t.com' } } as any);
-    mockBuildScope.mockReturnValue({ id: 'inv-1' } as any);
+    mockBuildScope.mockResolvedValue({ id: 'inv-1' } as any);
     prisma.invoice.findFirst.mockResolvedValue({
       id: 'inv-1', number: 'NXS-2026-0001', status: 'PAID',
       issuedAt: new Date('2026-02-01'), paidAt: new Date('2026-02-15'),
@@ -110,7 +110,7 @@ describe('GET /api/invoices/[id]/receipt/pdf', () => {
 
   it('should return 404 on DB error', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'a@t.com' } } as any);
-    mockBuildScope.mockReturnValue({ id: 'inv-1' } as any);
+    mockBuildScope.mockResolvedValue({ id: 'inv-1' } as any);
     prisma.invoice.findFirst.mockRejectedValue(new Error('DB error'));
 
     const res = await GET(...makeRequest('inv-1'));

--- a/__tests__/api/lamis.teacher-report.route.test.ts
+++ b/__tests__/api/lamis.teacher-report.route.test.ts
@@ -1,0 +1,75 @@
+import { GET, POST } from '@/app/api/lamis/teacher-report/route';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: jest.fn().mockResolvedValue(null),
+}));
+
+const mockGuardRateLimit = guardRateLimitAsync as jest.Mock;
+
+const validAttempt = {
+  exerciseId: 'pct-coef-baisse-25',
+  answer: '0.75',
+  isCorrect: true,
+  attemptNumber: 1,
+  timeSpentSeconds: 45,
+  usedHint1: false,
+  usedHint2: false,
+  viewedCorrection: false,
+  tooFast: false,
+  timestamp: '2026-07-02T12:00:00.000Z',
+};
+
+function postRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3000/api/lamis/teacher-report', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('Lamis teacher-report API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGuardRateLimit.mockResolvedValue(null);
+  });
+
+  it('returns a report for a valid attempts payload', async () => {
+    const res = await POST(postRequest({ attempts: [validAttempt] }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.report).toContain('Lamis');
+  });
+
+  it('rejects unexpected payload fields', async () => {
+    const res = await POST(postRequest({ attempts: [validAttempt], studentEmail: 'child@example.test' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('Payload invalide');
+  });
+
+  it('rejects malformed attempts', async () => {
+    const res = await POST(postRequest({ attempts: [{ ...validAttempt, answer: 42 }] }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 429 before parsing when rate limit is exceeded', async () => {
+    mockGuardRateLimit.mockResolvedValue(new Response(JSON.stringify({ error: 'rate limited' }), { status: 429 }));
+
+    const res = await POST(postRequest({ attempts: [validAttempt] }));
+
+    expect(res.status).toBe(429);
+  });
+
+  it('rate limits GET report generation', async () => {
+    mockGuardRateLimit.mockResolvedValue(new Response(JSON.stringify({ error: 'rate limited' }), { status: 429 }));
+
+    const res = await GET(new NextRequest('http://localhost:3000/api/lamis/teacher-report', { method: 'GET' }));
+
+    expect(res.status).toBe(429);
+  });
+});

--- a/__tests__/api/npc.documents.route.test.ts
+++ b/__tests__/api/npc.documents.route.test.ts
@@ -1,5 +1,5 @@
 import { GET, POST } from '@/app/api/npc/submissions/[submissionId]/documents/route';
-import { DELETE } from '@/app/api/npc/submissions/[submissionId]/documents/[documentId]/route';
+import { DELETE, PATCH } from '@/app/api/npc/submissions/[submissionId]/documents/[documentId]/route';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import * as npcStorage from '@/lib/npc/storage';
@@ -100,6 +100,18 @@ describe('NPC correction documents API', () => {
     expect(body.error).toBe('No file provided');
   });
 
+  it('rejects invalid submission ids before reading the submission', async () => {
+    const response = await GET(
+      new NextRequest('http://localhost/api/npc/submissions/../secret/documents'),
+      params('../secret')
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('Invalid');
+    expect(prisma.copySubmission.findUnique).not.toHaveBeenCalled();
+  });
+
   it('rejects forbidden MIME types', async () => {
     const response = await POST(
       makeUploadRequest({
@@ -190,6 +202,23 @@ describe('NPC correction documents API', () => {
     expect(body.documents[0]).not.toHaveProperty('ocrText');
   });
 
+  it('denies listing documents to a coach who is not assigned to the submission', async () => {
+    (prisma.copySubmission.findUnique as jest.Mock).mockResolvedValue({
+      id: 'submission-1',
+      studentId: 'student-1',
+      coachId: 'coach-2',
+      pages: [],
+    });
+    (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET(
+      new NextRequest('http://localhost/api/npc/submissions/submission-1/documents'),
+      params()
+    );
+
+    expect(response.status).toBe(403);
+  });
+
   it('does not expose storage paths after uploading documents', async () => {
     (prisma.copyPage.create as jest.Mock).mockResolvedValue({
       id: 'doc-1',
@@ -216,6 +245,21 @@ describe('NPC correction documents API', () => {
     expect(body.document).not.toHaveProperty('convertedFilePaths');
     expect(body.document).not.toHaveProperty('ocrText');
     expect(body.documents[0]).not.toHaveProperty('originalFilePath');
+  });
+
+  it('rejects document updates when documentId is not a safe route id', async () => {
+    const response = await PATCH(
+      new NextRequest('http://localhost/api/npc/submissions/submission-1/documents/../doc', {
+        method: 'PATCH',
+        body: JSON.stringify({ documentType: 'SUBJECT' }),
+      }),
+      documentParams('submission-1', '../doc')
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('Invalid');
+    expect(prisma.copySubmission.findUnique).not.toHaveBeenCalled();
   });
 
   it('does not overwrite existing student copy metadata when attaching a rubric', async () => {
@@ -261,6 +305,28 @@ describe('NPC correction documents API', () => {
     );
   });
 
+  it('denies uploading documents to a submission owned by another coach', async () => {
+    (prisma.copySubmission.findUnique as jest.Mock).mockResolvedValue({
+      id: 'submission-1',
+      studentId: 'student-1',
+      coachId: 'coach-2',
+      pages: [],
+    });
+    (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const response = await POST(
+      makeUploadRequest({
+        documentType: 'STUDENT_COPY',
+        file: new File(['%PDF-1.4'], 'copie.pdf', { type: 'application/pdf' }),
+      }),
+      params()
+    );
+
+    expect(response.status).toBe(403);
+    expect(npcStorage.saveUploadedFile).not.toHaveBeenCalled();
+    expect(prisma.copyPage.create).not.toHaveBeenCalled();
+  });
+
   it('deletes a document only when the coach can access the submission', async () => {
     (prisma.copyPage.findFirst as jest.Mock).mockResolvedValue({
       id: 'doc-1',
@@ -278,5 +344,23 @@ describe('NPC correction documents API', () => {
     expect(response.status).toBe(200);
     expect(prisma.copyPage.delete).toHaveBeenCalledWith({ where: { id: 'doc-1' } });
     expect(npcStorage.deleteSecureFile).toHaveBeenCalledWith('student/sub/page_1/copie.pdf');
+  });
+
+  it('denies deleting a document from a submission owned by another coach', async () => {
+    (prisma.copySubmission.findUnique as jest.Mock).mockResolvedValue({
+      id: 'submission-1',
+      studentId: 'student-1',
+      coachId: 'coach-2',
+    });
+    (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const response = await DELETE(
+      new NextRequest('http://localhost/api/npc/submissions/submission-1/documents/doc-1'),
+      documentParams()
+    );
+
+    expect(response.status).toBe(403);
+    expect(prisma.copyPage.findFirst).not.toHaveBeenCalled();
+    expect(npcStorage.deleteSecureFile).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/api/npc.files.route.test.ts
+++ b/__tests__/api/npc.files.route.test.ts
@@ -78,4 +78,26 @@ describe('GET /api/npc/files/[...path]', () => {
     expect(response.status).toBe(200);
     expect(readSecureFile).toHaveBeenCalledWith('student/sub/page_1/copie.pdf');
   });
+
+  it('denies a coach who is not assigned before reading disk', async () => {
+    (prisma.copyPage.findFirst as jest.Mock).mockResolvedValue({
+      id: 'doc-1',
+      originalFilePath: 'student/sub/page_1/copie.pdf',
+      mimeType: 'application/pdf',
+      submission: {
+        id: 'submission-1',
+        studentId: 'student-1',
+        coachId: 'coach-2',
+      },
+    });
+    (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET(
+      new NextRequest('http://localhost/api/npc/files/student/sub/page_1/copie.pdf'),
+      params(['student', 'sub', 'page_1', 'copie.pdf'])
+    );
+
+    expect(response.status).toBe(403);
+    expect(readSecureFile).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/api/npc.generate.test.ts
+++ b/__tests__/api/npc.generate.test.ts
@@ -77,6 +77,25 @@ describe('POST /api/npc/submissions/[submissionId]/generate', () => {
     expect(response.status).toBe(404);
   });
 
+  it('rejects unsafe submission ids before reading the submission', async () => {
+    const { auth } = require('@/auth');
+    auth.mockResolvedValue({
+      user: { id: 'user-1', role: UserRole.COACH },
+    });
+
+    const request = new NextRequest('http://localhost/api/npc/submissions/../secret/generate', {
+      method: 'POST',
+    });
+    const params = Promise.resolve({ submissionId: '../secret' });
+
+    const response = await POST(request, { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('Invalid');
+    expect(prisma.copySubmission.findUnique).not.toHaveBeenCalled();
+  });
+
   it('returns 403 if coach not assigned to student', async () => {
     const { auth } = require('@/auth');
     auth.mockResolvedValue({

--- a/__tests__/api/npc.submissions.security.test.ts
+++ b/__tests__/api/npc.submissions.security.test.ts
@@ -1,0 +1,61 @@
+import { GET, POST } from '@/app/api/npc/submissions/route';
+import { auth } from '@/auth';
+import { prisma } from '@/lib/prisma';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/auth', () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    student: { findUnique: jest.fn(), findFirst: jest.fn() },
+    parentProfile: { findUnique: jest.fn() },
+    coachProfile: { findUnique: jest.fn(), findFirst: jest.fn() },
+    coachStudentAssignment: { findFirst: jest.fn(), findMany: jest.fn() },
+    copySubmission: { create: jest.fn(), findMany: jest.fn() },
+    npcAuditLog: { create: jest.fn() },
+  },
+}));
+
+function postRequest(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/npc/submissions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('/api/npc/submissions security validation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (auth as jest.Mock).mockResolvedValue({
+      user: { id: 'coach-user-1', role: 'COACH' },
+    });
+  });
+
+  it('rejects unsafe student ids before checking student ownership', async () => {
+    const response = await POST(postRequest({
+      studentId: '../student',
+      title: 'Copie',
+      subject: 'MATHEMATIQUES',
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.student.findUnique).not.toHaveBeenCalled();
+    expect(prisma.copySubmission.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsafe list filters before querying submissions', async () => {
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/npc/submissions?studentId=../student'),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.copySubmission.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/npc.uploads.route.test.ts
+++ b/__tests__/api/npc.uploads.route.test.ts
@@ -86,4 +86,19 @@ describe('POST /api/npc/uploads', () => {
     });
     expect(body).not.toHaveProperty('filePath');
   });
+
+  it('rejects invalid metadata before ownership and file handling', async () => {
+    const response = await POST(makeUploadRequest({
+      studentId: '../student',
+      title: 'Copie bac blanc',
+      subject: 'MATHEMATIQUES',
+      file: new File(['%PDF-1.4'], 'copie.pdf', { type: 'application/pdf' }),
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.coachProfile.findFirst).not.toHaveBeenCalled();
+    expect(npcStorage.saveUploadedFile).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/api/parent.children.activation.route.test.ts
+++ b/__tests__/api/parent.children.activation.route.test.ts
@@ -69,7 +69,10 @@ describe('POST /api/parent/children — P0-03 hardening', () => {
 
     expect(response.status).toBe(200);
     expect(json.success).toBe(true);
-    expect(json.activation.token).toMatch(/^act_/);
+    expect(JSON.stringify(json)).not.toContain('activationToken');
+    expect(JSON.stringify(json)).not.toContain('tokenHash');
+    expect(JSON.stringify(json)).not.toContain('act_');
+    expect(json.activation.message).toContain("n'est pas retourné");
     expect(userCreate).toHaveBeenCalledTimes(1);
     expect(userCreate).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({

--- a/__tests__/api/parent.children.route.test.ts
+++ b/__tests__/api/parent.children.route.test.ts
@@ -97,7 +97,7 @@ describe('parent children routes', () => {
       const body = await response.json();
 
       expect(response.status).toBe(400);
-      expect(body.error).toBe('Missing required fields');
+      expect(body.error).toBe('Invalid child payload');
     });
 
     it('rejects existing child email', async () => {
@@ -131,7 +131,7 @@ describe('parent children routes', () => {
       expect(body.error).toBe('Parent profile not found');
     });
 
-    it('ignores an injected parentPassword and creates an inactive child', async () => {
+    it('rejects injected fields and does not create a child', async () => {
       (auth as jest.Mock).mockResolvedValue({
         user: { id: 'parent-1', role: 'PARENT' },
       });
@@ -166,10 +166,9 @@ describe('parent children routes', () => {
       );
       const body = await response.json();
 
-      expect(response.status).toBe(200);
-      expect(body.success).toBe(true);
-      expect(body.child.email).toContain('@nexus-student.local');
-      expect(body.activation.token).toMatch(/^act_/);
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('Invalid child payload');
+      expect(prisma.$transaction).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/api/parent.subscription-requests.route.test.ts
+++ b/__tests__/api/parent.subscription-requests.route.test.ts
@@ -47,7 +47,7 @@ describe('parent subscription-requests', () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toBe('Missing required fields');
+    expect(body.error).toBe('Invalid subscription request payload');
   });
 
   it('POST rejects a plan change with an unknown plan key', async () => {
@@ -60,7 +60,6 @@ describe('parent subscription-requests', () => {
         studentId: 'student-1',
         requestType: 'PLAN_CHANGE',
         planName: 'Plan A',
-        monthlyPrice: 1,
       })
     );
     const body = await response.json();
@@ -88,7 +87,6 @@ describe('parent subscription-requests', () => {
         studentId: 'student-1',
         requestType: 'PLAN_CHANGE',
         planName: 'HYBRIDE',
-        monthlyPrice: 1,
         reason: 'Upgrade',
       })
     );
@@ -125,7 +123,6 @@ describe('parent subscription-requests', () => {
         studentId: 'student-1',
         requestType: 'ARIA_ADDON',
         planName: 'MATIERE_SUPPLEMENTAIRE',
-        monthlyPrice: 1,
       })
     );
     const body = await response.json();
@@ -158,7 +155,7 @@ describe('parent subscription-requests', () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toContain('Type');
+    expect(body.error).toBe('Invalid subscription request payload');
     expect(prisma.subscriptionRequest.create).not.toHaveBeenCalled();
   });
 

--- a/__tests__/api/parent.subscriptions.route.test.ts
+++ b/__tests__/api/parent.subscriptions.route.test.ts
@@ -97,7 +97,7 @@ describe('parent subscriptions', () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toContain('Missing required fields');
+    expect(body.error).toBe('Invalid subscription payload');
   });
 
   it('POST returns 404 when parent profile missing', async () => {
@@ -106,9 +106,7 @@ describe('parent subscriptions', () => {
     });
     (prisma.parentProfile.findUnique as jest.Mock).mockResolvedValue(null);
 
-    const response = await POST(
-      makeRequest({ studentId: 'student-1', planName: 'HYBRIDE', monthlyPrice: 100 })
-    );
+    const response = await POST(makeRequest({ studentId: 'student-1', planName: 'HYBRIDE' }));
     const body = await response.json();
 
     expect(response.status).toBe(404);
@@ -122,9 +120,7 @@ describe('parent subscriptions', () => {
     (prisma.parentProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'parent-profile-1' });
     (prisma.student.findFirst as jest.Mock).mockResolvedValue(null);
 
-    const response = await POST(
-      makeRequest({ studentId: 'student-1', planName: 'HYBRIDE', monthlyPrice: 100 })
-    );
+    const response = await POST(makeRequest({ studentId: 'student-1', planName: 'HYBRIDE' }));
     const body = await response.json();
 
     expect(response.status).toBe(404);
@@ -136,9 +132,7 @@ describe('parent subscriptions', () => {
       user: { id: 'parent-1', role: 'PARENT' },
     });
 
-    const response = await POST(
-      makeRequest({ studentId: 'student-1', planName: 'Plan A', monthlyPrice: 1, creditsPerMonth: 99 })
-    );
+    const response = await POST(makeRequest({ studentId: 'student-1', planName: 'Plan A' }));
     const body = await response.json();
 
     expect(response.status).toBe(400);
@@ -160,9 +154,7 @@ describe('parent subscriptions', () => {
     (prisma.user.findMany as jest.Mock).mockResolvedValue([{ id: 'assistant-1' }]);
     (prisma.notification.create as jest.Mock).mockResolvedValue({});
 
-    const response = await POST(
-      makeRequest({ studentId: 'student-1', planName: 'HYBRIDE', monthlyPrice: 1, creditsPerMonth: 99 })
-    );
+    const response = await POST(makeRequest({ studentId: 'student-1', planName: 'HYBRIDE' }));
     const body = await response.json();
 
     expect(response.status).toBe(200);

--- a/__tests__/api/payments.clictopay.disabled-contract.test.ts
+++ b/__tests__/api/payments.clictopay.disabled-contract.test.ts
@@ -1,0 +1,106 @@
+import { createHmac } from 'crypto';
+import { NextRequest } from 'next/server';
+import { POST as webhookPOST } from '@/app/api/payments/clictopay/webhook/route';
+import { POST as initPOST } from '@/app/api/payments/clictopay/init/route';
+import { prisma } from '@/lib/prisma';
+import { auth } from '@/auth';
+
+jest.mock('@/auth', () => ({
+  auth: jest.fn(),
+}));
+
+function webhookRequest(body: unknown, signature?: string) {
+  return new NextRequest('http://localhost:3000/api/payments/clictopay/webhook', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(signature ? { 'x-clictopay-signature': signature } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function initRequest(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/payments/clictopay/init', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('ClicToPay disabled contract', () => {
+  const originalSecret = process.env.CLICTOPAY_WEBHOOK_SECRET;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.CLICTOPAY_WEBHOOK_SECRET = 'test-clictopay-webhook-secret';
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.CLICTOPAY_WEBHOOK_SECRET;
+    } else {
+      process.env.CLICTOPAY_WEBHOOK_SECRET = originalSecret;
+    }
+  });
+
+  it('rejects unsigned and invalid webhook calls without mutation', async () => {
+    const unsigned = await webhookPOST(webhookRequest({ orderId: 'ord-1', status: 'SUCCESS' }));
+    const invalid = await webhookPOST(
+      webhookRequest({ orderId: 'ord-1', status: 'SUCCESS' }, 'bad-signature'),
+    );
+
+    expect(unsigned.status).toBe(401);
+    expect(invalid.status).toBe(401);
+    expect(prisma.payment.create).not.toHaveBeenCalled();
+    expect(prisma.payment.update).not.toHaveBeenCalled();
+    expect(prisma.entitlement.create).not.toHaveBeenCalled();
+    expect(prisma.creditTransaction.create).not.toHaveBeenCalled();
+  });
+
+  it('returns 501 for validly signed webhook payloads while integration is disabled', async () => {
+    const payload = JSON.stringify({ orderId: 'ord-1', status: 'SUCCESS', amount: 450000 });
+    const signature = createHmac('sha256', process.env.CLICTOPAY_WEBHOOK_SECRET!)
+      .update(payload)
+      .digest('hex');
+
+    const response = await webhookPOST(
+      new NextRequest('http://localhost:3000/api/payments/clictopay/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-clictopay-signature': signature,
+        },
+        body: payload,
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(501);
+    expect(body).toEqual({
+      error: 'Webhook ClicToPay en cours de configuration',
+      code: 'CLICTOPAY_NOT_CONFIGURED',
+    });
+    expect(JSON.stringify(body)).not.toContain('rawPayload');
+    expect(prisma.payment.create).not.toHaveBeenCalled();
+    expect(prisma.payment.update).not.toHaveBeenCalled();
+    expect(prisma.entitlement.create).not.toHaveBeenCalled();
+    expect(prisma.creditTransaction.create).not.toHaveBeenCalled();
+  });
+
+  it('keeps init disabled for authenticated parents', async () => {
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'parent-1', role: 'PARENT' } });
+
+    const response = await initPOST(
+      initRequest({
+        amount: 450000,
+        description: 'Formule Nexus',
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(501);
+    expect(body.code).toBe('CLICTOPAY_NOT_CONFIGURED');
+    expect(prisma.payment.create).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/payments.clictopay.feature-flag-consistency.test.ts
+++ b/__tests__/api/payments.clictopay.feature-flag-consistency.test.ts
@@ -1,0 +1,46 @@
+import { POST as initPOST } from '@/app/api/payments/clictopay/init/route';
+import { auth } from '@/auth';
+import { prisma } from '@/lib/prisma';
+
+jest.mock('@/auth', () => ({
+  auth: jest.fn(),
+}));
+
+function initRequest(body: unknown) {
+  return new Request('http://localhost:3000/api/payments/clictopay/init', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('ClicToPay public flag consistency', () => {
+  const originalFlag = process.env.NEXT_PUBLIC_ENABLE_CLICTOPAY_PUBLIC;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'parent-1', role: 'PARENT' } });
+  });
+
+  afterEach(() => {
+    if (originalFlag === undefined) {
+      delete process.env.NEXT_PUBLIC_ENABLE_CLICTOPAY_PUBLIC;
+    } else {
+      process.env.NEXT_PUBLIC_ENABLE_CLICTOPAY_PUBLIC = originalFlag;
+    }
+  });
+
+  it('fails closed if public ClicToPay is enabled while backend remains disabled', async () => {
+    process.env.NEXT_PUBLIC_ENABLE_CLICTOPAY_PUBLIC = 'true';
+
+    const response = await initPOST(initRequest({ amount: 450000 }) as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toEqual({
+      error: 'Configuration paiement incohérente',
+      code: 'CLICTOPAY_PUBLIC_FLAG_INCONSISTENT',
+    });
+    expect(prisma.payment.create).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/payments.clictopay.init.route.test.ts
+++ b/__tests__/api/payments.clictopay.init.route.test.ts
@@ -48,4 +48,24 @@ describe('POST /api/payments/clictopay/init', () => {
     expect(res.status).toBe(501);
     expect(body.code).toBe('CLICTOPAY_NOT_CONFIGURED');
   });
+
+  it('rejects roles that cannot initiate parent payments', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'student-1', role: 'ELEVE' } } as any);
+
+    const res = await POST(makeRequest({ amount: 450000, invoiceId: 'invoice-1' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error).toContain('Accès');
+  });
+
+  it('validates the payload before returning the disabled service status', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'parent-1', role: 'PARENT' } } as any);
+
+    const res = await POST(makeRequest({ amount: -1, invoiceId: '' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+  });
 });

--- a/__tests__/api/payments.clictopay.webhook.disabled.test.ts
+++ b/__tests__/api/payments.clictopay.webhook.disabled.test.ts
@@ -1,0 +1,43 @@
+import { POST } from '@/app/api/payments/clictopay/webhook/route';
+import { createHmac } from 'crypto';
+import { NextRequest } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+function request(body: unknown, signature?: string) {
+  return new NextRequest('http://localhost:3000/api/payments/clictopay/webhook', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(signature ? { 'x-clictopay-signature': signature } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('ClicToPay webhook disabled product decision', () => {
+  const originalSecret = process.env.CLICTOPAY_WEBHOOK_SECRET;
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.CLICTOPAY_WEBHOOK_SECRET;
+    } else {
+      process.env.CLICTOPAY_WEBHOOK_SECRET = originalSecret;
+    }
+  });
+
+  it('does not mutate payment, invoice or entitlement state while disabled', async () => {
+    process.env.CLICTOPAY_WEBHOOK_SECRET = 'test-secret';
+    const rawBody = JSON.stringify({ orderId: 'ord-1', status: 'SUCCESS', amount: 450000 });
+    const signature = createHmac('sha256', 'test-secret').update(rawBody).digest('hex');
+
+    const response = await POST(request(JSON.parse(rawBody), signature));
+    const body = await response.json();
+
+    expect(response.status).toBe(501);
+    expect(body.code).toBe('CLICTOPAY_NOT_CONFIGURED');
+    expect(prisma.payment.create).not.toHaveBeenCalled();
+    expect(prisma.payment.update).not.toHaveBeenCalled();
+    expect(prisma.invoice?.update).not.toHaveBeenCalled();
+    expect(prisma.creditTransaction.create).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/payments.clictopay.webhook.route.test.ts
+++ b/__tests__/api/payments.clictopay.webhook.route.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { POST } from '@/app/api/payments/clictopay/webhook/route';
+import { createHmac } from 'crypto';
 import { NextRequest } from 'next/server';
 
 describe('POST /api/payments/clictopay/webhook', () => {
@@ -20,7 +21,7 @@ describe('POST /api/payments/clictopay/webhook', () => {
     }
   });
 
-  it('should return 501 (not configured)', async () => {
+  it('rejects unsigned webhooks before disabled integration handling', async () => {
     const req = new NextRequest('http://localhost:3000/api/payments/clictopay/webhook', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -30,8 +31,8 @@ describe('POST /api/payments/clictopay/webhook', () => {
     const res = await POST(req);
     const body = await res.json();
 
-    expect(res.status).toBe(501);
-    expect(body.code).toBe('CLICTOPAY_NOT_CONFIGURED');
+    expect(res.status).toBe(401);
+    expect(body.code).toBe('CLICTOPAY_SIGNATURE_REQUIRED');
   });
 
   it('rejects an invalid webhook signature when the webhook secret is configured', async () => {
@@ -50,5 +51,25 @@ describe('POST /api/payments/clictopay/webhook', () => {
 
     expect(res.status).toBe(401);
     expect(body.error).toContain('Signature');
+  });
+
+  it('still returns 501 for a valid signed webhook while ClicToPay is not configured', async () => {
+    process.env.CLICTOPAY_WEBHOOK_SECRET = 'test-secret';
+    const rawBody = JSON.stringify({ orderId: 'ord-1', status: 'SUCCESS' });
+    const signature = createHmac('sha256', 'test-secret').update(rawBody).digest('hex');
+    const req = new NextRequest('http://localhost:3000/api/payments/clictopay/webhook', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-clictopay-signature': signature,
+      },
+      body: rawBody,
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(501);
+    expect(body.code).toBe('CLICTOPAY_NOT_CONFIGURED');
   });
 });

--- a/__tests__/api/payments.clictopay.webhook.security.test.ts
+++ b/__tests__/api/payments.clictopay.webhook.security.test.ts
@@ -1,0 +1,78 @@
+import { POST } from '@/app/api/payments/clictopay/webhook/route';
+import { createHmac } from 'crypto';
+import { NextRequest } from 'next/server';
+
+const forbiddenFields = ['rawWebhook', 'rawPayload', 'metadata', 'stack', 'bankReference'];
+
+function request(body: unknown, signature?: string) {
+  return new NextRequest('http://localhost:3000/api/payments/clictopay/webhook', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(signature ? { 'x-clictopay-signature': signature } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function expectNoForbiddenFields(payload: unknown) {
+  const serialized = JSON.stringify(payload);
+  for (const field of forbiddenFields) {
+    expect(serialized).not.toContain(field);
+  }
+}
+
+describe('ClicToPay webhook disabled security contract', () => {
+  const originalSecret = process.env.CLICTOPAY_WEBHOOK_SECRET;
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.CLICTOPAY_WEBHOOK_SECRET;
+    } else {
+      process.env.CLICTOPAY_WEBHOOK_SECRET = originalSecret;
+    }
+  });
+
+  it('rejects unsigned webhooks before disabled integration handling', async () => {
+    delete process.env.CLICTOPAY_WEBHOOK_SECRET;
+
+    const response = await POST(request({ orderId: 'ord-1', status: 'SUCCESS' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.code).toBe('CLICTOPAY_SIGNATURE_REQUIRED');
+    expectNoForbiddenFields(body);
+  });
+
+  it('rejects invalid signatures when a webhook secret is configured', async () => {
+    process.env.CLICTOPAY_WEBHOOK_SECRET = 'test-secret';
+
+    const response = await POST(request({ orderId: 'ord-1', status: 'SUCCESS' }, 'bad-signature'));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.code).toBe('CLICTOPAY_SIGNATURE_INVALID');
+    expectNoForbiddenFields(body);
+  });
+
+  it('returns 501 for a valid signed webhook while integration remains disabled', async () => {
+    process.env.CLICTOPAY_WEBHOOK_SECRET = 'test-secret';
+    const rawBody = JSON.stringify({ orderId: 'ord-1', status: 'SUCCESS' });
+    const signature = createHmac('sha256', 'test-secret').update(rawBody).digest('hex');
+    const response = await POST(
+      new NextRequest('http://localhost:3000/api/payments/clictopay/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-clictopay-signature': signature,
+        },
+        body: rawBody,
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(501);
+    expect(body.code).toBe('CLICTOPAY_NOT_CONFIGURED');
+    expectNoForbiddenFields(body);
+  });
+});

--- a/__tests__/api/programme.maths-1ere-stmg.stage-progress.test.ts
+++ b/__tests__/api/programme.maths-1ere-stmg.stage-progress.test.ts
@@ -45,7 +45,6 @@ const existingProgrammeProgress = {
 };
 
 const stageState = {
-  eleveId: 'u-stmg',
   diagnosticAnswers: { qcm: { 'diag-q1': 1 }, exercises: {} },
   profile: {
     diagnosticDate: '2026-05-30T10:00:00.000Z',
@@ -80,7 +79,7 @@ describe('Maths 1ere STMG stage progress API', () => {
   });
 
   it('returns only the stage sub-state from programme diagnostic_results', async () => {
-    (auth as jest.Mock).mockResolvedValue({ user: { id: 'u-stmg' } });
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'u-stmg', role: 'ELEVE' } });
     (prisma.mathsProgress.findUnique as jest.Mock).mockResolvedValue({
       ...existingProgrammeProgress,
       diagnosticResults: { programme: { score: 72 }, stage_eam_stmg: stageState },
@@ -94,7 +93,7 @@ describe('Maths 1ere STMG stage progress API', () => {
   });
 
   it('updates only diagnostic_results.stage_eam_stmg and preserves programme fields', async () => {
-    (auth as jest.Mock).mockResolvedValue({ user: { id: 'u-stmg' } });
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'u-stmg', role: 'ELEVE' } });
     (prisma.mathsProgress.findUnique as jest.Mock).mockResolvedValue(existingProgrammeProgress);
     (prisma.mathsProgress.update as jest.Mock).mockResolvedValue({
       ...existingProgrammeProgress,
@@ -120,7 +119,7 @@ describe('Maths 1ere STMG stage progress API', () => {
   });
 
   it('creates a programme row with defaults only when no programme progress exists', async () => {
-    (auth as jest.Mock).mockResolvedValue({ user: { id: 'u-stmg' } });
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'u-stmg', role: 'ELEVE' } });
     (prisma.mathsProgress.findUnique as jest.Mock).mockResolvedValue(null);
     (prisma.mathsProgress.create as jest.Mock).mockResolvedValue({ id: 'new-progress' });
 

--- a/__tests__/api/public-rate-limit.coverage.test.ts
+++ b/__tests__/api/public-rate-limit.coverage.test.ts
@@ -7,6 +7,8 @@ const routeFiles = [
   'app/api/assessments/submit/route.ts',
   'app/api/contact/route.ts',
   'app/api/auth/reset-password/route.ts',
+  'app/api/student/activate/route.ts',
+  'app/api/lamis/teacher-report/route.ts',
 ];
 
 describe('public anti-abuse route coverage', () => {

--- a/__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts
+++ b/__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts
@@ -1,0 +1,657 @@
+import { NextRequest } from 'next/server';
+import * as BilanGratuitRoute from '@/app/api/bilan-gratuit/route';
+import * as AdminInvoicesRoute from '@/app/api/admin/invoices/route';
+import * as BilansGenerateRoute from '@/app/api/bilans/generate/route';
+import * as CoachTrajectoryRoute from '@/app/api/coach/trajectory/route';
+import * as CoachReportRegenerateRoute from '@/app/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate/route';
+import * as AssessmentsSubmitRoute from '@/app/api/assessments/submit/route';
+import * as ClicToPayInitRoute from '@/app/api/payments/clictopay/init/route';
+import * as ClicToPayWebhookRoute from '@/app/api/payments/clictopay/webhook/route';
+import * as LamisTeacherReportRoute from '@/app/api/lamis/teacher-report/route';
+import * as NpcDocumentsRoute from '@/app/api/npc/submissions/[submissionId]/documents/route';
+import * as ParentChildrenRoute from '@/app/api/parent/children/route';
+import * as StageInscrireRoute from '@/app/api/stages/[stageSlug]/inscrire/route';
+import * as StageReservationConfirmRoute from '@/app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route';
+import * as StudentActivateRoute from '@/app/api/student/activate/route';
+import * as AdminConfigRoute from '@/app/api/admin/config/route';
+import * as AdminConfigRollbackRoute from '@/app/api/admin/config/rollback/route';
+import * as AdminDirecteurStatsRoute from '@/app/api/admin/directeur/stats/route';
+import * as AdminRecomputeSsnRoute from '@/app/api/admin/recompute-ssn/route';
+import * as AdminSubscriptionsRoute from '@/app/api/admin/subscriptions/route';
+import * as AdminTestEmailRoute from '@/app/api/admin/test-email/route';
+import { auth } from '@/auth';
+import { prisma } from '@/lib/prisma';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { sendWelcomeParentEmail } from '@/lib/email';
+import { requireAnyRole, requireRole } from '@/lib/guards';
+import {
+  buildAssessmentAliasEmail,
+  createAssessmentPublicToken,
+  hashAssessmentLeadEmail,
+} from '@/lib/assessments/public-token';
+import { Subject } from '@/lib/assessments/core/types';
+
+jest.mock('@/auth', () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock('@/lib/guards', () => ({
+  requireAnyRole: jest.fn(),
+  requireRole: jest.fn(),
+  isErrorResponse: jest.fn((result) => result && typeof result === 'object' && 'status' in result),
+}));
+
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@/lib/csrf', () => ({
+  checkCsrf: jest.fn().mockReturnValue(null),
+  checkBodySize: jest.fn().mockReturnValue(null),
+}));
+
+jest.mock('@paralleldrive/cuid2', () => ({
+  createId: jest.fn().mockReturnValue('test-cuid-123'),
+}));
+
+jest.mock('@/lib/email', () => ({
+  sendWelcomeParentEmail: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/lib/email-service', () => ({
+  sendWelcomeEmail: jest.fn().mockResolvedValue(undefined),
+  testEmailConfiguration: jest.fn().mockResolvedValue({ success: true }),
+}));
+
+jest.mock('next/headers', () => ({
+  headers: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(null),
+  }),
+}));
+
+jest.mock('@/lib/services/student-activation.service', () => ({
+  verifyActivationToken: jest.fn(),
+  completeStudentActivation: jest.fn(),
+}));
+
+jest.mock('@/lib/assessments/questions', () => ({
+  QuestionBank: {
+    loadByVersion: jest.fn().mockResolvedValue({
+      questions: [
+        {
+          id: 'Q1',
+          subject: 'MATHS',
+          category: 'algebra',
+          weight: 1,
+          competencies: ['Calculer'],
+          options: [
+            { id: 'a', isCorrect: true },
+            { id: 'b', isCorrect: false },
+          ],
+        },
+      ],
+      resolvedVersion: 'maths_terminale_safe_v1',
+    }),
+  },
+}));
+
+jest.mock('@/lib/assessments/scoring', () => ({
+  ScoringFactory: {
+    create: jest.fn().mockReturnValue({
+      compute: jest.fn().mockReturnValue({
+        globalScore: 100,
+        confidenceIndex: 80,
+        precisionIndex: 75,
+        metrics: { categoryScores: { algebra: 100 }, competencyScores: {} },
+        strengths: ['Algèbre'],
+        weaknesses: [],
+        recommendations: ['Continuer'],
+      }),
+    }),
+  },
+}));
+
+jest.mock('@/lib/assessments/generators', () => ({
+  BilanGenerator: {
+    generate: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('@/lib/core/ssn/computeSSN', () => ({
+  computeAndPersistSSN: jest.fn().mockResolvedValue(undefined),
+}));
+
+const forbiddenFields = [
+  'password',
+  'activationToken',
+  'activationUrl',
+  'tokenHash',
+  'totpSecret',
+  'totpBackupCodes',
+  'localPath',
+  'pdfPath',
+  'filePath',
+  'originalFilePath',
+  'contextJson',
+  'llmJson',
+  'validatedJson',
+  'latexSource',
+  'stack',
+  'errorDetails',
+  'metadata',
+  'bankReference',
+  'rawWebhook',
+  'rawPayload',
+];
+
+const validBilanRequestData = {
+  parentFirstName: 'Jean',
+  parentLastName: 'Dupont',
+  parentEmail: 'jean.dupont@test.com',
+  parentPhone: '+216 99 19 28 29',
+  studentFirstName: 'Marie',
+  studentLastName: 'Dupont',
+  studentGrade: 'Terminale',
+  studentSchool: 'Lycée Victor Hugo',
+  subjects: ['MATHEMATIQUES'],
+  currentLevel: 'Moyen',
+  objectives: 'Améliorer les notes en mathématiques pour le baccalauréat',
+  preferredModality: 'hybride',
+  acceptTerms: true,
+  acceptNewsletter: false,
+};
+
+function request(url: string, body: unknown) {
+  return new NextRequest(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function expectNoForbiddenFields(payload: unknown) {
+  const serialized = JSON.stringify(payload);
+  for (const field of forbiddenFields) {
+    expect(serialized).not.toContain(field);
+  }
+}
+
+function mockBilanTransaction() {
+  (prisma.contactLead.create as jest.Mock).mockResolvedValue({
+    id: 'lead-123',
+    name: 'Jean Dupont',
+    email: 'jean.dupont@test.com',
+    phone: '+216 99 19 28 29',
+    profile: 'Parent',
+    interest: 'Bilan gratuit - Terminale',
+    urgency: 'Moyen',
+    source: 'bilan-gratuit',
+    status: 'NEW',
+    notes: 'Lead notes',
+    createdAt: new Date('2026-07-03T08:00:00.000Z'),
+    updatedAt: new Date('2026-07-03T08:00:00.000Z'),
+  });
+}
+
+describe('sensitive API responses do not expose forbidden fields', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalWebhookSecret = process.env.CLICTOPAY_WEBHOOK_SECRET;
+  const originalAssessmentSecret = process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.assign(process.env, { NODE_ENV: 'test' });
+    delete process.env.CLICTOPAY_WEBHOOK_SECRET;
+    process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET = 'test-assessment-secret';
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'parent-1', role: 'PARENT' } });
+    (requireAnyRole as jest.Mock).mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } });
+    (requireRole as jest.Mock).mockResolvedValue({ user: { id: 'coach-1', role: 'COACH' } });
+    (guardRateLimitAsync as jest.Mock).mockResolvedValue(null);
+    (sendWelcomeParentEmail as jest.Mock).mockResolvedValue(undefined);
+    (prisma.assessment.update as jest.Mock).mockResolvedValue({});
+    (prisma.domainScore.createMany as jest.Mock).mockResolvedValue({ count: 1 });
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, { NODE_ENV: originalNodeEnv });
+    if (originalWebhookSecret === undefined) {
+      delete process.env.CLICTOPAY_WEBHOOK_SECRET;
+    } else {
+      process.env.CLICTOPAY_WEBHOOK_SECRET = originalWebhookSecret;
+    }
+    if (originalAssessmentSecret === undefined) {
+      delete process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET;
+    } else {
+      process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET = originalAssessmentSecret;
+    }
+  });
+
+  it('covers the Lot 1-quinquies mockable response set', () => {
+    expect([
+      '/api/bilan-gratuit',
+      '/api/admin/invoices',
+      '/api/bilans/generate',
+      '/api/assessments/submit',
+      '/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate',
+      '/api/npc/submissions/[submissionId]/documents',
+      '/api/payments/clictopay/init',
+      '/api/student/activate',
+      '/api/payments/clictopay/webhook',
+      '/api/lamis/teacher-report',
+      '/api/stages/[stageSlug]/inscrire',
+      '/api/parent/children',
+      '/api/stages/[stageSlug]/reservations/[reservationId]/confirm',
+      '/api/coach/trajectory',
+      '/api/admin/config',
+      '/api/admin/config/rollback',
+      '/api/admin/directeur/stats',
+      '/api/admin/recompute-ssn',
+      '/api/admin/subscriptions',
+      '/api/admin/test-email',
+    ]).toHaveLength(20);
+  });
+
+  it('keeps bilan-gratuit success responses minimal', async () => {
+    mockBilanTransaction();
+
+    const response = await BilanGratuitRoute.POST(
+      request('http://localhost:3000/api/bilan-gratuit', validBilanRequestData),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps student activation validation responses minimal', async () => {
+    const response = await StudentActivateRoute.POST(
+      request('http://localhost:3000/api/student/activate', { token: 'tok', password: '123' }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps disabled ClicToPay webhook responses minimal', async () => {
+    const response = await ClicToPayWebhookRoute.POST(
+      new NextRequest('http://localhost:3000/api/payments/clictopay/webhook', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-clictopay-signature': 'cannot-verify-without-runtime-secret',
+        },
+        body: JSON.stringify({
+          orderId: 'ord-1',
+          status: 'SUCCESS',
+        }),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(501);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps assessment submit validation responses minimal', async () => {
+    const response = await AssessmentsSubmitRoute.POST(
+      request('http://localhost:3000/api/assessments/submit', {}),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps assessment submit success responses minimal', async () => {
+    const leadEmailHash = hashAssessmentLeadEmail('parent@example.test');
+    const assessmentEmail = buildAssessmentAliasEmail(leadEmailHash);
+    (prisma.assessment.create as jest.Mock).mockResolvedValue({
+      id: 'assessment-public-processing-id',
+      subject: 'MATHS',
+      grade: 'TERMINALE',
+      status: 'SCORING',
+      globalScore: 100,
+    });
+
+    const response = await AssessmentsSubmitRoute.POST(
+      new NextRequest('http://localhost:3000/api/assessments/submit', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-assessment-public-token': createAssessmentPublicToken({
+            subject: Subject.MATHS,
+            grade: 'TERMINALE',
+            source: 'bilan-gratuit',
+            binding: 'lead',
+            leadEmailHash,
+          }),
+        },
+        body: JSON.stringify({
+          subject: 'MATHS',
+          grade: 'TERMINALE',
+          studentData: {
+            email: assessmentEmail,
+            name: 'Élève Nexus',
+          },
+          answers: { Q1: 'a' },
+        }),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps public stage inscription parameter validation responses minimal', async () => {
+    const response = await StageInscrireRoute.POST(
+      request('http://localhost:3000/api/stages/../secret/inscrire', {}),
+      { params: Promise.resolve({ stageSlug: '../secret' }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps public stage inscription success responses minimal', async () => {
+    (prisma.stage.findUnique as jest.Mock).mockResolvedValue({
+      id: 'stage-1',
+      slug: 'prerentree-2026',
+      title: 'Pré-rentrée 2026',
+      capacity: 12,
+      priceAmount: 650,
+      isVisible: true,
+      isOpen: true,
+    });
+    (prisma.stageReservation.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.stageReservation.count as jest.Mock).mockResolvedValue(0);
+    (prisma.stageReservation.create as jest.Mock).mockResolvedValue({
+      id: 'reservation-secret-id',
+      richStatus: 'PENDING',
+      activationToken: 'raw-token',
+    });
+
+    const response = await StageInscrireRoute.POST(
+      request('http://localhost:3000/api/stages/prerentree-2026/inscrire', {
+        firstName: 'Aya',
+        lastName: 'Ben Ali',
+        email: 'aya@example.test',
+        phone: '+216 99 19 28 29',
+        level: 'Terminale',
+        stageTermsAccepted: true,
+        dataProcessingAccepted: true,
+      }),
+      { params: Promise.resolve({ stageSlug: 'prerentree-2026' }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expectNoForbiddenFields(body);
+    expect(JSON.stringify(body)).not.toContain('reservation-secret-id');
+  });
+
+  it('keeps disabled ClicToPay init responses minimal', async () => {
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'parent-1', role: 'PARENT' } });
+
+    const response = await ClicToPayInitRoute.POST(
+      request('http://localhost:3000/api/payments/clictopay/init', {
+        amount: 450000,
+        description: 'Abonnement',
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(501);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps admin invoice validation responses minimal', async () => {
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } });
+
+    const response = await AdminInvoicesRoute.POST(
+      request('http://localhost:3000/api/admin/invoices', {
+        customer: { name: 'Parent Test' },
+        items: [{ label: 'Formule', qty: 1, unitPrice: 450000 }],
+        metadata: { raw: true },
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps bilan generation validation responses minimal', async () => {
+    const response = await BilansGenerateRoute.POST(
+      request('http://localhost:3000/api/bilans/generate', { bilanId: '../secret' }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps NPC document validation responses minimal', async () => {
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'coach-1', role: 'COACH' } });
+
+    const response = await NpcDocumentsRoute.GET(
+      new NextRequest('http://localhost:3000/api/npc/submissions/../secret/documents'),
+      { params: Promise.resolve({ submissionId: '../secret' }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps coach generated report validation responses minimal', async () => {
+    const response = await CoachReportRegenerateRoute.POST(
+      request('http://localhost:3000/api/coach/students/../student/generated-reports/../report/regenerate', {}),
+      { params: Promise.resolve({ studentId: '../student', reportId: '../report' }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps Lamis teacher report validation responses minimal', async () => {
+    const response = await LamisTeacherReportRoute.POST(
+      request('http://localhost:3000/api/lamis/teacher-report', {
+        attempts: [],
+        studentEmail: 'student@example.test',
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps Lamis teacher report success responses minimal', async () => {
+    const response = await LamisTeacherReportRoute.GET(
+      new NextRequest('http://localhost:3000/api/lamis/teacher-report', { method: 'GET' }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps student activation success responses minimal', async () => {
+    const { completeStudentActivation } = jest.requireMock('@/lib/services/student-activation.service');
+    completeStudentActivation.mockResolvedValue({
+      success: true,
+      redirectUrl: '/auth/signin?activated=true',
+    });
+
+    const response = await StudentActivateRoute.POST(
+      request('http://localhost:3000/api/student/activate', {
+        token: 'valid-token',
+        password: 'securePass123',
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps parent child creation responses free of activation tokens', async () => {
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'parent-1', role: 'PARENT' } });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.parentProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'parent-profile-1' });
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback: any) =>
+      callback({
+        user: {
+          create: jest.fn().mockResolvedValue({
+            id: 'student-user-1',
+            email: 'marie.dupont@nexus-student.local',
+            firstName: 'Marie',
+            lastName: 'Dupont',
+          }),
+        },
+        student: {
+          create: jest.fn().mockResolvedValue({
+            id: 'student-1',
+            grade: 'Terminale',
+            school: 'Lycée',
+            user: {
+              firstName: 'Marie',
+              lastName: 'Dupont',
+              email: 'marie.dupont@nexus-student.local',
+            },
+          }),
+        },
+      }),
+    );
+
+    const response = await ParentChildrenRoute.POST(
+      request('http://localhost:3000/api/parent/children', {
+        firstName: 'Marie',
+        lastName: 'Dupont',
+        grade: 'Terminale',
+        school: 'Lycée',
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expectNoForbiddenFields(body);
+    expect(JSON.stringify(body)).not.toContain('act_');
+  });
+
+  it('keeps stage reservation confirm validation responses minimal', async () => {
+    const response = await StageReservationConfirmRoute.POST(
+      new NextRequest('http://localhost:3000/api/stages/../secret/reservations/res-1/confirm', {
+        method: 'POST',
+      }),
+      { params: Promise.resolve({ stageSlug: '../secret', reservationId: 'res-1' }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps coach trajectory validation responses minimal', async () => {
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'coach-1', role: 'COACH' } });
+
+    const response = await CoachTrajectoryRoute.POST(
+      request('http://localhost:3000/api/coach/trajectory', {
+        studentId: 'student-1',
+        title: 'Trajectoire',
+        horizon: '3_MONTHS',
+        metadata: { rawPayload: true },
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps admin config validation responses minimal', async () => {
+    const response = await AdminConfigRoute.PATCH(
+      request('http://localhost:3000/api/admin/config', {
+        namespace: 'pricing.rules',
+        key: 'group_max',
+        value: 5,
+        rawPayload: true,
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps admin config rollback validation responses minimal', async () => {
+    const response = await AdminConfigRollbackRoute.POST(
+      request('http://localhost:3000/api/admin/config/rollback', {
+        namespace: 'pricing.rules',
+        key: 'group_max',
+        force: true,
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps admin directeur stats validation responses minimal', async () => {
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } });
+
+    const response = await AdminDirecteurStatsRoute.GET(
+      new NextRequest('http://localhost:3000/api/admin/directeur/stats?rawPayload=true'),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps admin recompute SSN validation responses minimal', async () => {
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } });
+
+    const response = await AdminRecomputeSsnRoute.POST(
+      request('http://localhost:3000/api/admin/recompute-ssn', {
+        type: 'MATHS',
+        rawPayload: true,
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps admin subscriptions validation responses minimal', async () => {
+    const response = await AdminSubscriptionsRoute.GET(
+      new NextRequest('http://localhost:3000/api/admin/subscriptions?limit=500&rawPayload=true'),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expectNoForbiddenFields(body);
+  });
+
+  it('keeps admin test-email validation responses minimal', async () => {
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } });
+
+    const response = await AdminTestEmailRoute.POST(
+      request('http://localhost:3000/api/admin/test-email', {
+        action: 'send_test',
+        testEmail: 'not-an-email',
+        rawPayload: true,
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expectNoForbiddenFields(body);
+  });
+});

--- a/__tests__/api/sessions.cancel.route.test.ts
+++ b/__tests__/api/sessions.cancel.route.test.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { POST } from '@/app/api/sessions/cancel/route';
 import { requireAnyRole, isErrorResponse } from '@/lib/guards';
 import { RateLimitPresets } from '@/lib/middleware/rateLimit';
-import { parseBody } from '@/lib/api/helpers';
+import { parseBody, safeJsonParse } from '@/lib/api/helpers';
 import { createLogger } from '@/lib/middleware/logger';
 import { prisma } from '@/lib/prisma';
 import { refundSessionBookingById, canCancelBooking } from '@/lib/credits';
@@ -21,6 +21,7 @@ jest.mock('@/lib/middleware/rateLimit', () => ({
 
 jest.mock('@/lib/api/helpers', () => ({
   parseBody: jest.fn(),
+  safeJsonParse: jest.fn(),
   assertExists: jest.requireActual('@/lib/api/helpers').assertExists,
 }));
 
@@ -50,6 +51,8 @@ const mockStudentSession = {
   },
 };
 
+const VALID_SESSION_ID = 'clh1234567890abcdefghij';
+
 function createMockRequest(url: string, options?: RequestInit): NextRequest {
   const request = new NextRequest(url, options as any);
   Object.defineProperty(request, 'nextUrl', {
@@ -70,7 +73,7 @@ function mockLogger() {
 
 function buildSession(overrides: Partial<Record<string, any>> = {}) {
   return {
-    id: 'session-1',
+    id: VALID_SESSION_ID,
     studentId: 'student-1',
     coachId: 'coach-1',
     status: 'SCHEDULED',
@@ -90,7 +93,8 @@ describe('POST /api/sessions/cancel', () => {
     (RateLimitPresets.expensive as jest.Mock).mockReturnValue(null);
     (requireAnyRole as jest.Mock).mockResolvedValue(mockStudentSession);
     (isErrorResponse as unknown as jest.Mock).mockReturnValue(false);
-    (parseBody as jest.Mock).mockResolvedValue({ sessionId: 'session-1', reason: 'Change' });
+    (parseBody as jest.Mock).mockResolvedValue({ sessionId: VALID_SESSION_ID, reason: 'Change' });
+    (safeJsonParse as jest.Mock).mockResolvedValue({ sessionId: VALID_SESSION_ID, reason: 'Change' });
     (createLogger as jest.Mock).mockReturnValue(mockLogger());
     (prisma.sessionBooking.findUnique as jest.Mock).mockResolvedValue(buildSession());
     (prisma.sessionBooking.update as jest.Mock).mockResolvedValue({});
@@ -186,7 +190,7 @@ describe('POST /api/sessions/cancel', () => {
 
     expect(response.status).toBe(200);
     expect(body.refunded).toBe(true);
-    expect(refundSessionBookingById).toHaveBeenCalledWith('session-1', 'Change');
+    expect(refundSessionBookingById).toHaveBeenCalledWith(VALID_SESSION_ID, 'Change');
   });
 
   it('assistant role overrides refund policy', async () => {

--- a/__tests__/api/sessions.video.route.test.ts
+++ b/__tests__/api/sessions.video.route.test.ts
@@ -1,6 +1,7 @@
 import { auth } from '@/auth';
 import { POST } from '@/app/api/sessions/video/route';
 import { prisma } from '@/lib/prisma';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
 import { SessionStatus } from '@prisma/client';
 
 jest.mock('@/auth', () => ({
@@ -14,6 +15,10 @@ jest.mock('@/lib/prisma', () => ({
       update: jest.fn(),
     },
   },
+}));
+
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: jest.fn().mockResolvedValue(null),
 }));
 
 const baseSession = {
@@ -52,6 +57,7 @@ describe('POST /api/sessions/video', () => {
     jest.useFakeTimers().setSystemTime(new Date(2025, 0, 2, 10, 0, 0));
     jest.clearAllMocks();
     (auth as jest.Mock).mockResolvedValue(baseSession);
+    (guardRateLimitAsync as jest.Mock).mockResolvedValue(null);
     (prisma.sessionBooking.findFirst as jest.Mock).mockResolvedValue(buildBooking());
   });
 
@@ -67,10 +73,36 @@ describe('POST /api/sessions/video', () => {
     expect(response.status).toBe(401);
   });
 
+  it('returns 429 before reading the body when rate limited', async () => {
+    (guardRateLimitAsync as jest.Mock).mockResolvedValue(
+      new Response(JSON.stringify({ error: 'RATE_LIMIT' }), { status: 429 })
+    );
+    const request = {
+      json: jest.fn(),
+    } as unknown as Request;
+
+    const response = await POST(request as any);
+
+    expect(response.status).toBe(429);
+    expect(request.json).not.toHaveBeenCalled();
+    expect(prisma.sessionBooking.findFirst).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when missing params', async () => {
     const response = await POST(makeRequest({ sessionId: '', action: '' }) as any);
 
     expect(response.status).toBe(400);
+  });
+
+  it('rejects unexpected payload fields', async () => {
+    const response = await POST(makeRequest({
+      sessionId: 'session-1',
+      action: 'JOIN',
+      localPath: '/srv/private/session.log',
+    }) as any);
+
+    expect(response.status).toBe(400);
+    expect(prisma.sessionBooking.findFirst).not.toHaveBeenCalled();
   });
 
   it('returns 404 when session not found', async () => {

--- a/__tests__/api/stages.inscrire.product-rgpd.test.ts
+++ b/__tests__/api/stages.inscrire.product-rgpd.test.ts
@@ -1,0 +1,96 @@
+jest.mock('@/lib/email/mailer', () => ({
+  sendMail: jest.fn().mockResolvedValue({ ok: true }),
+}));
+
+jest.mock('@/lib/telegram/client', () => ({
+  telegramSendMessage: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: jest.fn().mockResolvedValue(null),
+}));
+
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/stages/[stageSlug]/inscrire/route';
+import { prisma } from '@/lib/prisma';
+
+const params = Promise.resolve({ stageSlug: 'prerentree-2026' });
+
+const validPayload = {
+  firstName: 'Aya',
+  lastName: 'Ben Ali',
+  email: 'aya@example.com',
+  phone: '+216 99 19 28 29',
+  level: 'Terminale',
+  parentFirstName: 'Karim',
+  parentLastName: 'Ben Ali',
+  parentEmail: 'parent@example.com',
+  parentPhone: '+216 22 333 444',
+  notes: 'Besoin de suivi maths',
+  stageTermsAccepted: true,
+  dataProcessingAccepted: true,
+};
+
+function request(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/stages/prerentree-2026/inscrire', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function mockOpenStage() {
+  (prisma.stage.findUnique as jest.Mock).mockResolvedValue({
+    id: 'stage-1',
+    slug: 'prerentree-2026',
+    title: 'Pré-rentrée 2026',
+    capacity: 12,
+    priceAmount: 650,
+    isVisible: true,
+    isOpen: true,
+  });
+  (prisma.stageReservation.findFirst as jest.Mock).mockResolvedValue(null);
+  (prisma.stageReservation.count as jest.Mock).mockResolvedValue(0);
+  (prisma.stageReservation.create as jest.Mock).mockResolvedValue({
+    id: 'reservation-secret-id',
+    richStatus: 'PENDING',
+  });
+}
+
+describe('/api/stages/[stageSlug]/inscrire product/RGPD decision', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requires explicit stage and data-processing consent before DB access', async () => {
+    const response = await POST(request({
+      ...validPayload,
+      dataProcessingAccepted: false,
+    }), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBeDefined();
+    expect(prisma.stage.findUnique).not.toHaveBeenCalled();
+    expect(prisma.stageReservation.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a public stage lead without returning internal identifiers when consent is explicit', async () => {
+    mockOpenStage();
+
+    const response = await POST(request(validPayload), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body).toEqual({
+      reservation: { status: 'PENDING' },
+      message: 'Inscription enregistrée.',
+    });
+    expect(JSON.stringify(body)).not.toContain('reservation-secret-id');
+    expect(prisma.stageReservation.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        notes: expect.stringContaining('Consentement données: oui'),
+      }),
+    }));
+  });
+});

--- a/__tests__/api/stages.inscrire.security.test.ts
+++ b/__tests__/api/stages.inscrire.security.test.ts
@@ -45,6 +45,8 @@ const validBody = {
   parentEmail: 'parent@example.com',
   parentPhone: '+216 22 333 444',
   notes: 'Besoin de suivi maths',
+  stageTermsAccepted: true,
+  dataProcessingAccepted: true,
 };
 
 const publicStage = {
@@ -102,5 +104,22 @@ describe('POST /api/stages/[stageSlug]/inscrire security', () => {
     expect(serialized).not.toContain('activationToken');
     expect(serialized).not.toContain('internal note');
     expect(body.reservation).toEqual({ status: 'PENDING' });
+  });
+
+  it('ne renvoie pas reservationId lorsqu’une inscription existe déjà', async () => {
+    prisma.stage.findUnique.mockResolvedValue(publicStage);
+    prisma.stageReservation.findFirst.mockResolvedValue({
+      id: 'reservation-secret-id',
+      email: validBody.email,
+    });
+
+    const res = await POST(makeRequest(validBody), { params });
+    const body = await res.json();
+    const serialized = JSON.stringify(body);
+
+    expect(res.status).toBe(409);
+    expect(serialized).not.toContain('reservation-secret-id');
+    expect(body).not.toHaveProperty('reservationId');
+    expect(prisma.stageReservation.create).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/api/stages/confirm.test.ts
+++ b/__tests__/api/stages/confirm.test.ts
@@ -88,6 +88,19 @@ describe('POST /api/stages/[slug]/reservations/[id]/confirm', () => {
     }));
   });
 
+  it('refuse des paramètres route invalides avant accès DB', async () => {
+    mockAuth.mockResolvedValue(session('ASSISTANTE'));
+
+    const res = await POST(makeRequest(), {
+      params: Promise.resolve({ stageSlug: '../secret', reservationId: 'res-1' }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('invalides');
+    expect(prisma.stageReservation.findFirst).not.toHaveBeenCalled();
+  });
+
   it('retourne 409 si réservation déjà CONFIRMED', async () => {
     mockAuth.mockResolvedValue(session('ADMIN'));
     prisma.stageReservation.findFirst.mockResolvedValue({

--- a/__tests__/api/stages/inscriptions.test.ts
+++ b/__tests__/api/stages/inscriptions.test.ts
@@ -39,6 +39,8 @@ const validBody = {
   email: 'aya@example.com',
   phone: '+21699192829',
   level: 'Terminale',
+  stageTermsAccepted: true,
+  dataProcessingAccepted: true,
 };
 
 describe('POST /api/stages/[slug]/inscrire', () => {

--- a/__tests__/api/student.activate.lifecycle-security.test.ts
+++ b/__tests__/api/student.activate.lifecycle-security.test.ts
@@ -1,0 +1,72 @@
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findFirst: jest.fn(),
+      update: jest.fn(),
+      create: jest.fn(),
+    },
+    stageReservation: {
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+import crypto from 'crypto';
+import { prisma } from '@/lib/prisma';
+import {
+  completeStudentActivation,
+  verifyActivationToken,
+} from '@/lib/services/student-activation.service';
+
+function sha256(token: string) {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+describe('student activation token lifecycle security', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('looks up only the hashed token with an expiry and never the raw token', async () => {
+    const rawToken = 'act_raw_token_from_url';
+    (prisma.user.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.stageReservation.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const result = await verifyActivationToken(rawToken);
+
+    expect(result).toEqual({ valid: false });
+    expect(prisma.user.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        activationToken: sha256(rawToken),
+        activationExpiry: { gt: expect.any(Date) },
+        activatedAt: null,
+      }),
+    }));
+    expect(JSON.stringify((prisma.user.findFirst as jest.Mock).mock.calls)).not.toContain(rawToken);
+  });
+
+  it('invalidates the activation token after successful password setup', async () => {
+    (prisma.user.findFirst as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      firstName: 'Nour',
+      lastName: 'Test',
+      email: 'nour@example.com',
+      activatedAt: null,
+      student: { id: 'student-1' },
+    });
+    (prisma.user.update as jest.Mock).mockResolvedValue({});
+
+    const result = await completeStudentActivation('act_valid_token', 'securePass123');
+
+    expect(result.success).toBe(true);
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: expect.objectContaining({
+        activationToken: null,
+        activationExpiry: null,
+        activatedAt: expect.any(Date),
+      }),
+    });
+  });
+});

--- a/__tests__/api/student.activate.route.test.ts
+++ b/__tests__/api/student.activate.route.test.ts
@@ -12,15 +12,22 @@ jest.mock('@/lib/services/student-activation.service', () => ({
   completeStudentActivation: jest.fn(),
 }));
 
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: jest.fn().mockResolvedValue(null),
+}));
+
 import { GET, POST } from '@/app/api/student/activate/route';
 import { verifyActivationToken, completeStudentActivation } from '@/lib/services/student-activation.service';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
 import { NextRequest } from 'next/server';
 
 const mockVerify = verifyActivationToken as jest.Mock;
 const mockComplete = completeStudentActivation as jest.Mock;
+const mockGuardRateLimit = guardRateLimitAsync as jest.Mock;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockGuardRateLimit.mockResolvedValue(null);
 });
 
 // ─── GET /api/student/activate ───────────────────────────────────────────────
@@ -34,6 +41,16 @@ describe('GET /api/student/activate', () => {
     expect(res.status).toBe(400);
     expect(body.valid).toBe(false);
     expect(body.error).toContain('Token');
+  });
+
+  it('should return 429 when rate limit is exceeded', async () => {
+    mockGuardRateLimit.mockResolvedValue(new Response(JSON.stringify({ error: 'rate limited' }), { status: 429 }));
+
+    const req = new NextRequest('http://localhost:3000/api/student/activate?token=valid-token', { method: 'GET' });
+    const res = await GET(req);
+
+    expect(res.status).toBe(429);
+    expect(mockVerify).not.toHaveBeenCalled();
   });
 
   it('should verify valid token', async () => {
@@ -95,12 +112,35 @@ describe('POST /api/student/activate', () => {
     expect(body.redirectUrl).toBe('/auth/signin');
   });
 
+  it('should return 429 when activation POST rate limit is exceeded', async () => {
+    mockGuardRateLimit.mockResolvedValue(new Response(JSON.stringify({ error: 'rate limited' }), { status: 429 }));
+
+    const res = await POST(makePostRequest({ token: 'valid-token', password: 'securePass123' }));
+
+    expect(res.status).toBe(429);
+    expect(mockComplete).not.toHaveBeenCalled();
+  });
+
   it('should return 400 for short password', async () => {
     const res = await POST(makePostRequest({ token: 'valid-token', password: '123' }));
     const body = await res.json();
 
     expect(res.status).toBe(400);
     expect(body.error).toContain('invalides');
+    expect(JSON.stringify(body)).not.toContain('password');
+  });
+
+  it('rejects unexpected activation payload fields before service call', async () => {
+    const res = await POST(makePostRequest({
+      token: 'valid-token',
+      password: 'securePass123',
+      activationToken: 'raw-token',
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('invalides');
+    expect(mockComplete).not.toHaveBeenCalled();
   });
 
   it('should return 400 for missing token', async () => {

--- a/__tests__/app/bilan-gratuit.assessment-page-token.test.tsx
+++ b/__tests__/app/bilan-gratuit.assessment-page-token.test.tsx
@@ -1,0 +1,107 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import BilanAssessmentPage from '@/app/bilan-gratuit/assessment/page';
+import {
+  ASSESSMENT_FLOW_COOKIE_NAME,
+  createAssessmentFlowToken,
+  hashAssessmentLeadEmail,
+} from '@/lib/assessments/public-token';
+import { Subject } from '@/lib/assessments/core/types';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(),
+}));
+
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+
+jest.mock('@/components/layout/CorporateNavbar', () => ({
+  CorporateNavbar: () => <nav data-testid="navbar" />,
+}));
+
+jest.mock('@/components/layout/CorporateFooter', () => ({
+  CorporateFooter: () => <footer data-testid="footer" />,
+}));
+
+jest.mock('@/app/bilan-gratuit/assessment/AssessmentClient', () => ({
+  AssessmentClient: (props: { assessmentPublicToken: string; email: string }) => (
+    <div data-testid="assessment-client" data-token-present={String(Boolean(props.assessmentPublicToken))}>
+      {props.email}
+    </div>
+  ),
+}));
+
+describe('/bilan-gratuit/assessment token context', () => {
+  const originalSecret = process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET = 'test-assessment-secret';
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET;
+    } else {
+      process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET = originalSecret;
+    }
+  });
+
+  it('canonicalizes public query params before rendering the assessment page', async () => {
+    (cookies as jest.Mock).mockResolvedValue({
+      get: jest.fn().mockReturnValue(undefined),
+    });
+
+    await expect(BilanAssessmentPage({
+      searchParams: Promise.resolve({
+        subject: 'MATHEMATIQUES',
+        grade: 'terminale',
+        email: 'attacker@example.test',
+      }),
+    })).rejects.toThrow('NEXT_REDIRECT:/bilan-gratuit/assessment');
+
+    expect(redirect).toHaveBeenCalledWith('/bilan-gratuit/assessment');
+  });
+
+  it('refuses to generate a token without a signed lead flow cookie', async () => {
+    (cookies as jest.Mock).mockResolvedValue({
+      get: jest.fn().mockReturnValue(undefined),
+    });
+
+    render(await BilanAssessmentPage({
+      searchParams: Promise.resolve({}),
+    }));
+
+    expect(screen.getByText(/accès au diagnostic expiré/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('assessment-client')).not.toBeInTheDocument();
+  });
+
+  it('renders the assessment only from a signed lead-bound flow cookie', async () => {
+    const flowToken = createAssessmentFlowToken({
+      subject: Subject.MATHS,
+      grade: 'TERMINALE',
+      source: 'bilan-gratuit',
+      leadEmailHash: hashAssessmentLeadEmail('parent@example.test'),
+    });
+    (cookies as jest.Mock).mockResolvedValue({
+      get: jest.fn((name: string) => (
+        name === ASSESSMENT_FLOW_COOKIE_NAME ? { value: flowToken } : undefined
+      )),
+    });
+
+    render(await BilanAssessmentPage({
+      searchParams: Promise.resolve({}),
+    }));
+
+    const client = screen.getByTestId('assessment-client');
+    expect(client).toHaveAttribute('data-token-present', 'true');
+    expect(client.textContent).toMatch(/^assessment\+/);
+    expect(client.textContent).not.toContain('attacker@example.test');
+  });
+});

--- a/__tests__/components/offer-detail-dialog.test.tsx
+++ b/__tests__/components/offer-detail-dialog.test.tsx
@@ -116,12 +116,14 @@ describe('OfferDetailDialog', () => {
     expect(decodeURIComponent(waLink.getAttribute('href')!)).toContain('Terminale Duo');
   });
 
-  it('shows card payment policy from CGV without exposing RIB/IBAN', () => {
+  it('keeps card payment provider hidden until public activation is explicitly enabled', () => {
     const { container } = render(<OfferDetailDialog offer={sampleOffer} onClose={jest.fn()} />);
 
-    expect(screen.getByText(new RegExp(CGV_POLICY.payment.provider, 'i'))).toBeInTheDocument();
-    expect(screen.getByText(new RegExp(CGV_POLICY.payment.acceptedCards, 'i'))).toBeInTheDocument();
-    expect(screen.getByText(CGV_POLICY.payment.cardFee)).toBeInTheDocument();
+    expect(screen.getByText(/paiement confirmé après validation pédagogique/i)).toBeInTheDocument();
+    expect(container.textContent).not.toContain(CGV_POLICY.payment.provider);
+    expect(container.textContent).not.toContain(CGV_POLICY.payment.bank);
+    expect(container.textContent).not.toContain(CGV_POLICY.payment.acceptedCards);
+    expect(container.textContent).not.toContain(CGV_POLICY.payment.cardFee);
     expect(container.textContent).not.toContain(LEGAL.billing.rib);
     expect(container.textContent).not.toContain(LEGAL.billing.iban);
   });

--- a/__tests__/components/offres-page.test.tsx
+++ b/__tests__/components/offres-page.test.tsx
@@ -63,13 +63,14 @@ describe('OffresPage', () => {
     expect(screen.getAllByRole('link', { name: /demander un bilan/i }).length).toBeGreaterThan(0);
   });
 
-  it('surfaces ClicToPay card payment without exposing bank identifiers publicly', () => {
+  it('keeps card payment provider hidden until public activation is explicitly enabled', () => {
     const { container } = render(<OffresPage />);
 
-    expect(screen.getByText(new RegExp(CGV_POLICY.payment.provider, 'i'))).toBeInTheDocument();
-    expect(screen.getByText(new RegExp(CGV_POLICY.payment.bank, 'i'))).toBeInTheDocument();
-    expect(screen.getByText(CGV_POLICY.payment.acceptedCards)).toBeInTheDocument();
-    expect(screen.getByText(CGV_POLICY.payment.cardFee)).toBeInTheDocument();
+    expect(screen.getByText(/paiement confirmé après validation pédagogique/i)).toBeInTheDocument();
+    expect(container.textContent).not.toContain(CGV_POLICY.payment.provider);
+    expect(container.textContent).not.toContain(CGV_POLICY.payment.bank);
+    expect(container.textContent).not.toContain(CGV_POLICY.payment.acceptedCards);
+    expect(container.textContent).not.toContain(CGV_POLICY.payment.cardFee);
     expect(container.textContent).not.toContain(LEGAL.billing.rib);
     expect(container.textContent).not.toContain(LEGAL.billing.iban);
   });

--- a/__tests__/lib/assessments/public-token.test.ts
+++ b/__tests__/lib/assessments/public-token.test.ts
@@ -1,0 +1,107 @@
+import { Subject } from '@/lib/assessments/core/types';
+import {
+  ASSESSMENT_PUBLIC_TOKEN_TTL_SECONDS,
+  createAssessmentPublicToken,
+  verifyAssessmentPublicToken,
+} from '@/lib/assessments/public-token';
+
+describe('assessment public short-lived token', () => {
+  const originalEnv = {
+    ASSESSMENT_PUBLIC_TOKEN_SECRET: process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET,
+    NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
+    AUTH_SECRET: process.env.AUTH_SECRET,
+    NODE_ENV: process.env.NODE_ENV,
+  };
+
+  beforeEach(() => {
+    Object.assign(process.env, { NODE_ENV: 'test' });
+    process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET = 'test-assessment-secret';
+    delete process.env.NEXTAUTH_SECRET;
+    delete process.env.AUTH_SECRET;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key as keyof NodeJS.ProcessEnv];
+      } else {
+        process.env[key as keyof NodeJS.ProcessEnv] = value;
+      }
+    }
+  });
+
+  it('creates and verifies a short-lived scoped token', () => {
+    const token = createAssessmentPublicToken({
+      subject: Subject.MATHS,
+      grade: 'TERMINALE',
+      source: 'bilan-gratuit',
+      campaignId: 'meta-july',
+    });
+
+    const result = verifyAssessmentPublicToken(token, {
+      usage: 'assessment_submit',
+      subject: Subject.MATHS,
+      grade: 'TERMINALE',
+    });
+
+    expect(result.valid).toBe(true);
+    if (!result.valid) throw new Error(result.reason);
+    expect(result.payload.usage).toBe('assessment_submit');
+    expect(result.payload.expiresAt - result.payload.issuedAt).toBe(ASSESSMENT_PUBLIC_TOKEN_TTL_SECONDS);
+  });
+
+  it('rejects expired tokens', () => {
+    const token = createAssessmentPublicToken(
+      {
+        subject: Subject.MATHS,
+        grade: 'TERMINALE',
+      },
+      { now: 1_000, ttlSeconds: 1 },
+    );
+
+    const result = verifyAssessmentPublicToken(
+      token,
+      { usage: 'assessment_submit', subject: Subject.MATHS, grade: 'TERMINALE' },
+      { now: 3_000 },
+    );
+
+    expect(result).toEqual({ valid: false, reason: 'expired' });
+  });
+
+  it('rejects bad signatures and scope mismatches without exposing token data', () => {
+    const token = createAssessmentPublicToken({
+      subject: Subject.MATHS,
+      grade: 'TERMINALE',
+    });
+
+    expect(
+      verifyAssessmentPublicToken(`${token.slice(0, -2)}xx`, {
+        usage: 'assessment_submit',
+        subject: Subject.MATHS,
+        grade: 'TERMINALE',
+      }),
+    ).toEqual({ valid: false, reason: 'bad_signature' });
+
+    expect(
+      verifyAssessmentPublicToken(token, {
+        usage: 'assessment_submit',
+        subject: Subject.NSI,
+        grade: 'TERMINALE',
+      }),
+    ).toEqual({ valid: false, reason: 'scope_mismatch' });
+  });
+
+  it('does not provide an insecure production fallback when no secret exists', () => {
+    delete process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET;
+    delete process.env.NEXTAUTH_SECRET;
+    delete process.env.AUTH_SECRET;
+    Object.assign(process.env, { NODE_ENV: 'production' });
+
+    expect(() =>
+      createAssessmentPublicToken({
+        subject: Subject.MATHS,
+        grade: 'TERMINALE',
+      }),
+    ).toThrow('ASSESSMENT_PUBLIC_TOKEN_SECRET_REQUIRED');
+  });
+});

--- a/__tests__/lib/bilan-gratuit-form.test.tsx
+++ b/__tests__/lib/bilan-gratuit-form.test.tsx
@@ -64,13 +64,15 @@ describe('BilanGratuitPage', () => {
     expect(screen.queryByLabelText(/mot de passe/i)).not.toBeInTheDocument();
   });
 
-  it('shows card payment policy for a selected offer without public RIB/IBAN', async () => {
+  it('keeps card payment provider hidden on selected offer until public activation is enabled', async () => {
     const { container } = render(await BilanGratuitPage({ searchParams: Promise.resolve({ offer: 'term-spe-simple' }) }));
 
     expect(screen.getByText(/offre repérée/i)).toBeInTheDocument();
-    expect(screen.getByText(new RegExp(CGV_POLICY.payment.provider, 'i'))).toBeInTheDocument();
-    expect(screen.getByText(new RegExp(CGV_POLICY.payment.bank, 'i'))).toBeInTheDocument();
-    expect(screen.getByText(CGV_POLICY.payment.cardFee)).toBeInTheDocument();
+    expect(screen.getByText(/paiement confirmé après validation pédagogique/i)).toBeInTheDocument();
+    expect(container.textContent).not.toContain(CGV_POLICY.payment.provider);
+    expect(container.textContent).not.toContain(CGV_POLICY.payment.bank);
+    expect(container.textContent).not.toContain(CGV_POLICY.payment.acceptedCards);
+    expect(container.textContent).not.toContain(CGV_POLICY.payment.cardFee);
     expect(container.textContent).not.toContain(LEGAL.billing.rib);
     expect(container.textContent).not.toContain(LEGAL.billing.iban);
   });

--- a/__tests__/lib/business-config.fallback.test.ts
+++ b/__tests__/lib/business-config.fallback.test.ts
@@ -1,0 +1,61 @@
+import { prisma } from '@/lib/prisma';
+import {
+  _resetForTest,
+  getConfigSnapshotRuntimeStatus,
+  loadConfigSnapshot,
+} from '@/lib/config/snapshot';
+
+function missingBusinessConfigTableError() {
+  const error = new Error('The table `public.business_configs` does not exist in the current database.');
+  (error as Error & { code?: string; meta?: Record<string, unknown> }).code = 'P2021';
+  (error as Error & { code?: string; meta?: Record<string, unknown> }).meta = {
+    table: 'public.business_configs',
+  };
+  return error;
+}
+
+describe('BusinessConfig passive snapshot fallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    _resetForTest();
+  });
+
+  afterEach(() => {
+    _resetForTest();
+  });
+
+  it('classifies a missing optional business_configs table without loud recurring console.error', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    (prisma.businessConfig.findMany as jest.Mock).mockRejectedValueOnce(missingBusinessConfigTableError());
+
+    try {
+      await loadConfigSnapshot();
+      expect(errorSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Passive refresh failed'),
+        expect.anything(),
+      );
+      expect(getConfigSnapshotRuntimeStatus()).toEqual({
+        mode: 'static_fallback_allowed',
+        ok: true,
+        lastError: {
+          kind: 'missing_table',
+          table: 'business_configs',
+        },
+      });
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('marks successful DB-backed loads as database mode', async () => {
+    (prisma.businessConfig.findMany as jest.Mock).mockResolvedValueOnce([]);
+
+    await loadConfigSnapshot();
+
+    expect(getConfigSnapshotRuntimeStatus()).toEqual({
+      mode: 'database',
+      ok: true,
+      lastError: null,
+    });
+  });
+});

--- a/__tests__/lib/business-config.production-gate.test.ts
+++ b/__tests__/lib/business-config.production-gate.test.ts
@@ -1,0 +1,81 @@
+import { prisma } from '@/lib/prisma';
+import {
+  _resetForTest,
+  getConfigSnapshotRuntimeStatus,
+  loadConfigSnapshot,
+} from '@/lib/config/snapshot';
+
+function missingBusinessConfigTableError() {
+  const error = new Error('The table `public.business_configs` does not exist in the current database.');
+  (error as Error & { code?: string; meta?: Record<string, unknown> }).code = 'P2021';
+  (error as Error & { code?: string; meta?: Record<string, unknown> }).meta = {
+    table: 'public.business_configs',
+  };
+  return error;
+}
+
+describe('BusinessConfig production fallback gate', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalAllowed = process.env.BUSINESS_CONFIG_STATIC_FALLBACK_ALLOWED;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    _resetForTest();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.env, 'NODE_ENV', {
+      value: originalNodeEnv,
+      configurable: true,
+      writable: true,
+    });
+    _resetForTest();
+    if (originalAllowed === undefined) {
+      delete process.env.BUSINESS_CONFIG_STATIC_FALLBACK_ALLOWED;
+    } else {
+      process.env.BUSINESS_CONFIG_STATIC_FALLBACK_ALLOWED = originalAllowed;
+    }
+  });
+
+  it('marks missing business_configs as unexpected and degraded in production by default', async () => {
+    Object.defineProperty(process.env, 'NODE_ENV', {
+      value: 'production',
+      configurable: true,
+      writable: true,
+    });
+    delete process.env.BUSINESS_CONFIG_STATIC_FALLBACK_ALLOWED;
+    (prisma.businessConfig.findMany as jest.Mock).mockRejectedValueOnce(missingBusinessConfigTableError());
+
+    await loadConfigSnapshot();
+
+    expect(getConfigSnapshotRuntimeStatus()).toEqual({
+      mode: 'static_fallback_unexpected',
+      ok: false,
+      lastError: {
+        kind: 'missing_table',
+        table: 'business_configs',
+      },
+    });
+  });
+
+  it('allows explicit static fallback only when configured', async () => {
+    Object.defineProperty(process.env, 'NODE_ENV', {
+      value: 'production',
+      configurable: true,
+      writable: true,
+    });
+    process.env.BUSINESS_CONFIG_STATIC_FALLBACK_ALLOWED = 'true';
+    (prisma.businessConfig.findMany as jest.Mock).mockRejectedValueOnce(missingBusinessConfigTableError());
+
+    await loadConfigSnapshot();
+
+    expect(getConfigSnapshotRuntimeStatus()).toEqual({
+      mode: 'static_fallback_allowed',
+      ok: true,
+      lastError: {
+        kind: 'missing_table',
+        table: 'business_configs',
+      },
+    });
+  });
+});

--- a/__tests__/lib/crm/contact-leads.retention.test.ts
+++ b/__tests__/lib/crm/contact-leads.retention.test.ts
@@ -1,0 +1,22 @@
+import {
+  CONTACT_LEAD_ERASURE_SLA_DAYS,
+  CONTACT_LEAD_RETENTION_DAYS,
+  buildContactLeadRetentionDecision,
+} from '@/lib/crm/contact-leads';
+
+describe('ContactLead retention policy', () => {
+  it('documents a bounded retention and erasure SLA for public lead_only data', () => {
+    expect(CONTACT_LEAD_RETENTION_DAYS).toBeGreaterThanOrEqual(30);
+    expect(CONTACT_LEAD_RETENTION_DAYS).toBeLessThanOrEqual(395);
+    expect(CONTACT_LEAD_ERASURE_SLA_DAYS).toBeLessThanOrEqual(30);
+
+    expect(buildContactLeadRetentionDecision()).toEqual({
+      dataCategory: 'public_lead_minor_related',
+      legalBasis: 'parent_consent_and_precontractual_request',
+      retentionDays: CONTACT_LEAD_RETENTION_DAYS,
+      erasureSlaDays: CONTACT_LEAD_ERASURE_SLA_DAYS,
+      deletionProcedure: expect.stringContaining('ContactLead'),
+      productionAction: 'schedule_retention_job_before_go_live_large',
+    });
+  });
+});

--- a/__tests__/lib/invoice/access-scope.test.ts
+++ b/__tests__/lib/invoice/access-scope.test.ts
@@ -1,0 +1,67 @@
+import { buildInvoiceAccessWhere } from '@/lib/invoice/not-found';
+import { prisma } from '@/lib/prisma';
+
+const mockParentProfileFindUnique = prisma.parentProfile.findUnique as jest.Mock;
+
+describe('buildInvoiceAccessWhere', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('allows ADMIN and ASSISTANTE to scope by invoice id only', async () => {
+    await expect(
+      buildInvoiceAccessWhere('inv-1', { id: 'admin-1', role: 'ADMIN', email: 'admin@test.tn' }),
+    ).resolves.toEqual({ id: 'inv-1' });
+
+    await expect(
+      buildInvoiceAccessWhere('inv-1', { id: 'staff-1', role: 'ASSISTANTE', email: null }),
+    ).resolves.toEqual({ id: 'inv-1' });
+  });
+
+  it('scopes PARENT invoices by child beneficiary ids and email fallback', async () => {
+    mockParentProfileFindUnique.mockResolvedValue({
+      children: [{ userId: 'child-user-1' }, { userId: 'child-user-2' }],
+    });
+
+    await expect(
+      buildInvoiceAccessWhere('inv-1', { id: 'parent-user-1', role: 'PARENT', email: 'parent@test.tn' }),
+    ).resolves.toEqual({
+      id: 'inv-1',
+      OR: [
+        { beneficiaryUserId: { in: ['child-user-1', 'child-user-2'] } },
+        { customerEmail: 'parent@test.tn' },
+      ],
+    });
+  });
+
+  it('keeps a legacy email fallback for PARENT when no child beneficiary exists', async () => {
+    mockParentProfileFindUnique.mockResolvedValue({ children: [] });
+
+    await expect(
+      buildInvoiceAccessWhere('inv-1', { id: 'parent-user-1', role: 'PARENT', email: 'parent@test.tn' }),
+    ).resolves.toEqual({
+      id: 'inv-1',
+      OR: [{ customerEmail: 'parent@test.tn' }],
+    });
+  });
+
+  it('denies PARENT when no beneficiary and no email scope is available', async () => {
+    mockParentProfileFindUnique.mockResolvedValue({ children: [] });
+
+    await expect(
+      buildInvoiceAccessWhere('inv-1', { id: 'parent-user-1', role: 'PARENT', email: null }),
+    ).resolves.toBeNull();
+  });
+
+  it('denies ELEVE, COACH and unknown roles on public invoice PDFs', async () => {
+    await expect(
+      buildInvoiceAccessWhere('inv-1', { id: 'student-1', role: 'ELEVE', email: 'student@test.tn' }),
+    ).resolves.toBeNull();
+    await expect(
+      buildInvoiceAccessWhere('inv-1', { id: 'coach-1', role: 'COACH', email: 'coach@test.tn' }),
+    ).resolves.toBeNull();
+    await expect(
+      buildInvoiceAccessWhere('inv-1', { id: 'x-1', role: 'SUPERADMIN', email: 'x@test.tn' }),
+    ).resolves.toBeNull();
+  });
+});

--- a/__tests__/lib/rate-limit.production-gate.test.ts
+++ b/__tests__/lib/rate-limit.production-gate.test.ts
@@ -1,0 +1,30 @@
+import {
+  getRateLimitProductionGate,
+  isDistributedRateLimitMode,
+  type RateLimitRuntimeMode,
+} from '@/lib/rate-limit';
+
+describe('rate limit production gate', () => {
+  it.each<RateLimitRuntimeMode>(['redis', 'upstash'])(
+    'allows go-live large only for distributed mode %s',
+    (mode) => {
+      expect(isDistributedRateLimitMode(mode)).toBe(true);
+      expect(getRateLimitProductionGate(mode)).toEqual({
+        ok: true,
+        mode,
+        decision: 'allowed',
+        reason: 'Distributed rate limiting runtime is configured.',
+      });
+    },
+  );
+
+  it('blocks go-live large for memory mode', () => {
+    expect(isDistributedRateLimitMode('memory')).toBe(false);
+    expect(getRateLimitProductionGate('memory')).toEqual({
+      ok: false,
+      mode: 'memory',
+      decision: 'blocked',
+      reason: 'Memory rate limiting is process-local and blocks go-live large.',
+    });
+  });
+});

--- a/__tests__/lib/validations.test.ts
+++ b/__tests__/lib/validations.test.ts
@@ -22,7 +22,6 @@ describe('Validation Schemas', () => {
       studentLastName: 'Dupont',
       studentGrade: 'Terminale',
       studentSchool: 'Lycée Victor Hugo',
-      studentBirthDate: '2005-06-15',
 
       // Besoins et objectifs
       subjects: ['MATHEMATIQUES'],

--- a/__tests__/scripts/audit-api-guards.classification.test.ts
+++ b/__tests__/scripts/audit-api-guards.classification.test.ts
@@ -1,0 +1,155 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+function writeRoute(root: string, routeFile: string, source: string) {
+  const fullPath = join(root, routeFile);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, source);
+}
+
+function inventoryRows(markdown: string) {
+  const rows = new Map<string, { risk: string; methods: string }>();
+  for (const line of markdown.split('\n')) {
+    if (!line.startsWith('| `app/api/') || !line.includes('/route.ts` |')) continue;
+    const cells = line.split('|').slice(1, -1).map((cell) => cell.trim());
+    rows.set(cells[0].replace(/`/g, ''), {
+      methods: cells[1],
+      risk: cells[8],
+    });
+  }
+  return rows;
+}
+
+function runAuditOnFixtures(fixtures: Record<string, string>) {
+  const root = mkdtempSync(join(tmpdir(), 'nexus-audit-fixtures-'));
+  try {
+    mkdirSync(join(root, 'docs/security'), { recursive: true });
+    for (const [routeFile, source] of Object.entries(fixtures)) {
+      writeRoute(root, routeFile, source);
+    }
+
+    execFileSync(process.execPath, [join(process.cwd(), 'scripts/security/audit-api-guards.mjs')], {
+      cwd: root,
+      env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
+      stdio: 'pipe',
+    });
+
+    return inventoryRows(readFileSync(join(root, 'docs/security/API_GUARD_INVENTORY.md'), 'utf8'));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe('audit-api-guards route classification', () => {
+  it('keeps dynamic sensitive routes without ownership at P0', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/documents/[id]/route.ts': `
+        import { auth } from '@/auth';
+        export async function GET() {
+          const session = await auth();
+          if (!session?.user?.id) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+          return Response.json({ ok: true });
+        }
+      `,
+    });
+
+    expect(rows.get('app/api/documents/[id]/route.ts')).toEqual(expect.objectContaining({ risk: 'P0' }));
+  });
+
+  it('does not treat comment-only rate limit mentions as a public route control', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/assessments/comment-only/route.ts': `
+        import { z } from 'zod';
+        const schema = z.object({ email: z.string().email() });
+        export async function POST(request: Request) {
+          // TODO: add rateLimit before launch.
+          schema.parse(await request.json());
+          return Response.json({ ok: true });
+        }
+      `,
+    });
+
+    expect(rows.get('app/api/assessments/comment-only/route.ts')).toEqual(expect.objectContaining({ risk: 'P0' }));
+  });
+
+  it('keeps public sensitive routes with Zod and rate limit at P1, not OK', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/assessments/submit/route.ts': `
+        import { z } from 'zod';
+        import { guardRateLimitAsync } from '@/lib/rate-limit';
+        const schema = z.object({ email: z.string().email() });
+        export async function POST(request: Request) {
+          const blocked = await guardRateLimitAsync(request, { preset: 'api' });
+          if (blocked) return blocked;
+          schema.parse(await request.json());
+          return Response.json({ ok: true });
+        }
+      `,
+    });
+
+    expect(rows.get('app/api/assessments/submit/route.ts')).toEqual(expect.objectContaining({ risk: 'P1' }));
+  });
+
+  it('does not promote disabled ClicToPay webhook beyond P1', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/payments/clictopay/webhook/route.ts': `
+        export async function POST() {
+          return Response.json({ code: 'CLICTOPAY_NOT_CONFIGURED' }, { status: 501 });
+        }
+      `,
+    });
+
+    expect(rows.get('app/api/payments/clictopay/webhook/route.ts')).toEqual(expect.objectContaining({ risk: 'P1' }));
+  });
+
+  it('keeps fixed public documents at P2, not OK', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/public-documents/corrige/route.ts': `
+        const FILE_NAME = 'corrige.pdf';
+        export async function GET() {
+          return new Response(FILE_NAME);
+        }
+      `,
+    });
+
+    expect(rows.get('app/api/public-documents/corrige/route.ts')).toEqual(expect.objectContaining({ risk: 'P2' }));
+  });
+
+  it('follows route reexports before classifying guards', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/coach/reexport/[studentId]/route.ts': `
+        export { POST } from './handler';
+      `,
+      'app/api/coach/reexport/[studentId]/handler.ts': `
+        import { requireRole } from '@/lib/guards';
+        import { assertCoachCanAccessStudent } from '@/lib/rbac/coach-student-access';
+        export async function POST() {
+          const session = await requireRole('COACH');
+          await assertCoachCanAccessStudent({ coachUserId: session.user.id, studentId: 'student-1' });
+          return Response.json({ ok: true });
+        }
+      `,
+    });
+
+    expect(rows.get('app/api/coach/reexport/[studentId]/route.ts')?.methods).toBe('POST');
+    expect(rows.get('app/api/coach/reexport/[studentId]/route.ts')?.risk).not.toBe('P0');
+    expect(rows.get('app/api/coach/reexport/[studentId]/route.ts')?.risk).not.toBe('OK');
+  });
+
+  it('keeps staff-only sensitive mutations out of P0 but not OK', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/admin/documents/route.ts': `
+        import { requireAnyRole } from '@/lib/guards';
+        export async function POST() {
+          await requireAnyRole(['ADMIN', 'ASSISTANTE']);
+          return Response.json({ ok: true });
+        }
+      `,
+    });
+
+    expect(rows.get('app/api/admin/documents/route.ts')?.risk).not.toBe('P0');
+    expect(rows.get('app/api/admin/documents/route.ts')?.risk).not.toBe('OK');
+  });
+});

--- a/__tests__/scripts/contact-leads-retention.test.ts
+++ b/__tests__/scripts/contact-leads-retention.test.ts
@@ -1,0 +1,103 @@
+import {
+  buildContactLeadRetentionPlan,
+  hashContactLeadErasureEmail,
+  runContactLeadRetention,
+} from '@/scripts/maintenance/contact-leads-retention';
+
+describe('ContactLead retention maintenance script', () => {
+  const now = new Date('2026-07-03T12:00:00.000Z');
+
+  it('plans anonymization for stale non-converted leads without exposing raw PII', () => {
+    const stale = {
+      id: 'lead-old',
+      email: 'parent@example.test',
+      status: 'NEW',
+      createdAt: new Date('2025-01-01T00:00:00.000Z'),
+    };
+    const active = {
+      id: 'lead-active',
+      email: 'active@example.test',
+      status: 'QUALIFIED',
+      createdAt: new Date('2025-01-01T00:00:00.000Z'),
+    };
+
+    const plan = buildContactLeadRetentionPlan({
+      leads: [stale, active],
+      now,
+      erasureEmailHashes: [],
+    });
+
+    expect(plan.toAnonymize).toEqual([
+      expect.objectContaining({
+        id: 'lead-old',
+        reason: 'retention_expired',
+      }),
+    ]);
+    expect(JSON.stringify(plan)).not.toContain('parent@example.test');
+    expect(JSON.stringify(plan)).not.toContain('active@example.test');
+  });
+
+  it('supports parent erasure requests by hashed email and keeps dry-run as default', async () => {
+    const prismaMock = {
+      contactLead: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'lead-erasure',
+            email: 'parent@example.test',
+            status: 'CONTACTED',
+            createdAt: new Date('2026-06-01T00:00:00.000Z'),
+          },
+        ]),
+        update: jest.fn(),
+      },
+    };
+
+    const result = await runContactLeadRetention({
+      prismaClient: prismaMock as any,
+      now,
+      erasureEmailHashes: [hashContactLeadErasureEmail('parent@example.test')],
+      apply: false,
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.planned).toBe(1);
+    expect(prismaMock.contactLead.update).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).not.toContain('parent@example.test');
+  });
+
+  it('requires explicit apply before anonymizing selected leads', async () => {
+    const prismaMock = {
+      contactLead: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'lead-old',
+            email: 'parent@example.test',
+            status: 'NEW',
+            createdAt: new Date('2025-01-01T00:00:00.000Z'),
+          },
+        ]),
+        update: jest.fn().mockResolvedValue({ id: 'lead-old' }),
+      },
+    };
+
+    const result = await runContactLeadRetention({
+      prismaClient: prismaMock as any,
+      now,
+      erasureEmailHashes: [],
+      apply: true,
+    });
+
+    expect(result.dryRun).toBe(false);
+    expect(result.applied).toBe(1);
+    expect(prismaMock.contactLead.update).toHaveBeenCalledWith({
+      where: { id: 'lead-old' },
+      data: expect.objectContaining({
+        name: 'Lead anonymisé',
+        email: expect.stringMatching(/^erased-lead-old@deleted\.nexus\.local$/),
+        phone: null,
+        notes: null,
+        status: 'LOST',
+      }),
+    });
+  });
+});

--- a/__tests__/scripts/release-candidate-git-add-dry-run-plan.test.ts
+++ b/__tests__/scripts/release-candidate-git-add-dry-run-plan.test.ts
@@ -1,0 +1,172 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const DRY_RUN_PLAN_PATH = join(ROOT, 'docs/go-live/_evidence/lot10-git-add-dry-run-plan.md');
+const MANIFEST_PATH = join(ROOT, 'docs/go-live/_evidence/lot8-release-candidate-file-manifest-clean.md');
+const COMMIT_PLAN_PATH = join(ROOT, 'docs/go-live/_evidence/lot8-release-candidate-commit-plan-clean.md');
+const API_MATRIX_PATH = join(ROOT, 'docs/go-live/api-security-matrix.full.md');
+
+type ManifestRow = {
+  path: string;
+  group: string;
+  includeRc: boolean;
+};
+
+type CommitBlock = {
+  title: string;
+  body: string;
+  files: string[];
+};
+
+const EXPECTED_P1_ROUTES = new Set([
+  '/api/payments/clictopay/webhook',
+  '/api/assessments/submit',
+  '/api/bilan-gratuit',
+  '/api/lamis/teacher-report',
+  '/api/stages/[stageSlug]/inscrire',
+  '/api/student/activate',
+]);
+
+function cleanCell(cell: string) {
+  return cell.trim().replace(/^`|`$/g, '');
+}
+
+function parseTableCells(line: string) {
+  return line
+    .split('|')
+    .slice(1, -1)
+    .map((cell) => cell.trim());
+}
+
+function parseManifest(markdown: string): ManifestRow[] {
+  return markdown
+    .split('\n')
+    .filter((line) => line.startsWith('| `'))
+    .map((line) => {
+      const cells = parseTableCells(line);
+      return {
+        path: cleanCell(cells[0]),
+        group: cleanCell(cells[2]),
+        includeRc: cells[3] === 'Oui',
+      };
+    });
+}
+
+function parseDryRunBlocks(markdown: string): CommitBlock[] {
+  const blocks: CommitBlock[] = [];
+  const lines = markdown.split('\n');
+  let current: CommitBlock | null = null;
+
+  for (const line of lines) {
+    const heading = line.match(/^## Commit \d+ — (.+)$/);
+    if (heading) {
+      if (current) blocks.push(current);
+      current = { title: heading[1].trim(), body: '', files: [] };
+      continue;
+    }
+
+    if (!current) continue;
+    current.body += `${line}\n`;
+
+    const quotedPath = line.match(/^\s*"([^"]+)"\s*\\?$/);
+    if (quotedPath) {
+      current.files.push(quotedPath[1]);
+    }
+  }
+
+  if (current) blocks.push(current);
+  return blocks;
+}
+
+function parseP1Routes(markdown: string) {
+  const routes = new Set<string>();
+  for (const line of markdown.split('\n')) {
+    if (!line.startsWith('| P1 |') || !line.includes('| `/api/')) continue;
+    const cells = parseTableCells(line);
+    routes.add(cleanCell(cells[1]));
+  }
+  return routes;
+}
+
+describe('release candidate git add dry-run plan', () => {
+  const manifestRows = parseManifest(readFileSync(MANIFEST_PATH, 'utf8'));
+  const dryRunPlan = readFileSync(DRY_RUN_PLAN_PATH, 'utf8');
+  const dryRunBlocks = parseDryRunBlocks(dryRunPlan);
+
+  it('covers every Include RC file exactly once', () => {
+    const fileToCommits = new Map<string, string[]>();
+    for (const block of dryRunBlocks) {
+      for (const file of block.files) {
+        const owners = fileToCommits.get(file) ?? [];
+        owners.push(block.title);
+        fileToCommits.set(file, owners);
+      }
+    }
+
+    const uncovered = manifestRows
+      .filter((row) => row.includeRc)
+      .filter((row) => (fileToCommits.get(row.path) ?? []).length === 0)
+      .map((row) => row.path);
+
+    const coveredMultipleTimes = manifestRows
+      .filter((row) => row.includeRc)
+      .filter((row) => (fileToCommits.get(row.path) ?? []).length > 1)
+      .map((row) => `${row.path} -> ${(fileToCommits.get(row.path) ?? []).join(', ')}`);
+
+    expect(uncovered).toEqual([]);
+    expect(coveredMultipleTimes).toEqual([]);
+  });
+
+  it('does not include Exclude, Needs human review, env or generated artifact files', () => {
+    const plannedFiles = new Set(dryRunBlocks.flatMap((block) => block.files));
+
+    const excludedInPlan = manifestRows
+      .filter((row) => row.group === 'Exclude')
+      .filter((row) => plannedFiles.has(row.path))
+      .map((row) => row.path);
+
+    const humanReviewInPlan = manifestRows
+      .filter((row) => row.group === 'Needs human review')
+      .filter((row) => plannedFiles.has(row.path))
+      .map((row) => row.path);
+
+    const forbiddenFiles = [...plannedFiles].filter(
+      (file) =>
+        /(^|\/)\.env($|\.)/.test(file) ||
+        file === 'rapport_audit_2_07_2026.md' ||
+        ['test-results/', 'playwright-report/', '.next/', 'node_modules/'].some((prefix) =>
+          file.startsWith(prefix),
+        ),
+    );
+
+    expect(excludedInPlan).toEqual([]);
+    expect(humanReviewInPlan).toEqual([]);
+    expect(forbiddenFiles).toEqual([]);
+  });
+
+  it('uses only safe dry-run git add commands and no commit/push/PR actions', () => {
+    expect(dryRunBlocks).toHaveLength(9);
+    for (const block of dryRunBlocks) {
+      expect(block.body).toContain('git add --dry-run --');
+      expect(block.files.every((file) => dryRunPlan.includes(`"${file}"`))).toBe(true);
+    }
+
+    expect(dryRunPlan).not.toMatch(/git add --\s/);
+    expect(dryRunPlan).not.toMatch(/git push/);
+    expect(dryRunPlan).not.toMatch(/gh pr create/);
+    expect(dryRunPlan).toContain('Commande de commit proposée, NON EXÉCUTÉE');
+  });
+
+  it('keeps the Lot 8 commit plan as the source of commit names', () => {
+    const commitPlan = readFileSync(COMMIT_PLAN_PATH, 'utf8');
+    for (const block of dryRunBlocks) {
+      expect(commitPlan).toContain(block.title);
+    }
+  });
+
+  it('keeps the six release-candidate P1 routes visible', () => {
+    const p1Routes = parseP1Routes(readFileSync(API_MATRIX_PATH, 'utf8'));
+    expect(p1Routes).toEqual(EXPECTED_P1_ROUTES);
+  });
+});

--- a/__tests__/scripts/release-candidate-human-commit-runbook.test.ts
+++ b/__tests__/scripts/release-candidate-human-commit-runbook.test.ts
@@ -1,0 +1,178 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const RUNBOOK_PATH = join(ROOT, 'docs/go-live/_evidence/lot11-human-commit-runbook.md');
+const DRY_RUN_PLAN_PATH = join(ROOT, 'docs/go-live/_evidence/lot10-git-add-dry-run-plan.md');
+const MANIFEST_PATH = join(ROOT, 'docs/go-live/_evidence/lot8-release-candidate-file-manifest-clean.md');
+const API_MATRIX_PATH = join(ROOT, 'docs/go-live/api-security-matrix.full.md');
+
+type ManifestRow = {
+  path: string;
+  group: string;
+  includeRc: boolean;
+};
+
+type CommitBlock = {
+  title: string;
+  body: string;
+  files: string[];
+};
+
+const EXPECTED_P1_ROUTES = new Set([
+  '/api/payments/clictopay/webhook',
+  '/api/assessments/submit',
+  '/api/bilan-gratuit',
+  '/api/lamis/teacher-report',
+  '/api/stages/[stageSlug]/inscrire',
+  '/api/student/activate',
+]);
+
+function cleanCell(cell: string) {
+  return cell.trim().replace(/^`|`$/g, '');
+}
+
+function parseTableCells(line: string) {
+  return line
+    .split('|')
+    .slice(1, -1)
+    .map((cell) => cell.trim());
+}
+
+function parseManifest(markdown: string): ManifestRow[] {
+  return markdown
+    .split('\n')
+    .filter((line) => line.startsWith('| `'))
+    .map((line) => {
+      const cells = parseTableCells(line);
+      return {
+        path: cleanCell(cells[0]),
+        group: cleanCell(cells[2]),
+        includeRc: cells[3] === 'Oui',
+      };
+    });
+}
+
+function parseCommitBlocks(markdown: string): CommitBlock[] {
+  const blocks: CommitBlock[] = [];
+  const lines = markdown.split('\n');
+  let current: CommitBlock | null = null;
+
+  for (const line of lines) {
+    const heading = line.match(/^## Commit \d+ — (.+)$/);
+    if (heading) {
+      if (current) blocks.push(current);
+      current = { title: heading[1].trim(), body: '', files: [] };
+      continue;
+    }
+
+    if (line.startsWith('## ') && current) {
+      blocks.push(current);
+      current = null;
+      continue;
+    }
+
+    if (!current) continue;
+    current.body += `${line}\n`;
+
+    const quotedPath = line.match(/^\s*"([^"]+)"\s*\\?$/);
+    if (quotedPath) {
+      current.files.push(quotedPath[1]);
+    }
+  }
+
+  if (current) blocks.push(current);
+  return blocks;
+}
+
+function parseP1Routes(markdown: string) {
+  const routes = new Set<string>();
+  for (const line of markdown.split('\n')) {
+    if (!line.startsWith('| P1 |') || !line.includes('| `/api/')) continue;
+    const cells = parseTableCells(line);
+    routes.add(cleanCell(cells[1]));
+  }
+  return routes;
+}
+
+describe('release candidate human commit runbook', () => {
+  const manifestRows = parseManifest(readFileSync(MANIFEST_PATH, 'utf8'));
+  const runbook = readFileSync(RUNBOOK_PATH, 'utf8');
+  const dryRunPlan = readFileSync(DRY_RUN_PLAN_PATH, 'utf8');
+  const commitBlocks = parseCommitBlocks(runbook);
+
+  it('covers every Include RC file exactly once in standard commit blocks', () => {
+    const fileToCommits = new Map<string, string[]>();
+    for (const block of commitBlocks) {
+      for (const file of block.files) {
+        const owners = fileToCommits.get(file) ?? [];
+        owners.push(block.title);
+        fileToCommits.set(file, owners);
+      }
+    }
+
+    const uncovered = manifestRows
+      .filter((row) => row.includeRc)
+      .filter((row) => (fileToCommits.get(row.path) ?? []).length === 0)
+      .map((row) => row.path);
+
+    const coveredMultipleTimes = manifestRows
+      .filter((row) => row.includeRc)
+      .filter((row) => (fileToCommits.get(row.path) ?? []).length > 1)
+      .map((row) => `${row.path} -> ${(fileToCommits.get(row.path) ?? []).join(', ')}`);
+
+    expect(uncovered).toEqual([]);
+    expect(coveredMultipleTimes).toEqual([]);
+  });
+
+  it('keeps excluded and human-review files out of standard commit staging commands', () => {
+    const stagedFiles = new Set(commitBlocks.flatMap((block) => block.files));
+
+    const excludedInRunbook = manifestRows
+      .filter((row) => row.group === 'Exclude')
+      .filter((row) => stagedFiles.has(row.path))
+      .map((row) => row.path);
+
+    const humanReviewInRunbook = manifestRows
+      .filter((row) => row.group === 'Needs human review')
+      .filter((row) => stagedFiles.has(row.path))
+      .map((row) => row.path);
+
+    const forbiddenFiles = [...stagedFiles].filter(
+      (file) => /(^|\/)\.env($|\.)/.test(file) || file === 'rapport_audit_2_07_2026.md',
+    );
+
+    expect(excludedInRunbook).toEqual([]);
+    expect(humanReviewInRunbook).toEqual([]);
+    expect(forbiddenFiles).toEqual([]);
+    expect(runbook).not.toContain('rapport_audit_2_07_2026.md');
+    expect(runbook).not.toMatch(/(^|\/)\.env($|\.)/m);
+  });
+
+  it('uses human-only staging and commit commands without push or PR creation', () => {
+    expect(commitBlocks).toHaveLength(9);
+    expect(runbook).toContain('Codex ne les a pas executees');
+
+    for (const block of commitBlocks) {
+      expect(block.body).toContain('git add --');
+      expect(block.body).not.toContain('git add --dry-run --');
+      expect(block.body).toContain('git diff --cached --name-only');
+      expect(block.body).toContain(`git commit -m "${block.title}"`);
+      expect(block.files.every((file) => runbook.includes(`"${file}"`))).toBe(true);
+    }
+
+    expect(runbook).not.toMatch(/git push/);
+    expect(runbook).not.toMatch(/gh pr create/);
+  });
+
+  it('keeps Lot 10 dry-run commit names as the source of truth', () => {
+    for (const block of commitBlocks) {
+      expect(dryRunPlan).toContain(`## Commit ${commitBlocks.indexOf(block) + 1} — ${block.title}`);
+    }
+  });
+
+  it('keeps the six release-candidate P1 routes visible', () => {
+    const p1Routes = parseP1Routes(readFileSync(API_MATRIX_PATH, 'utf8'));
+    expect(p1Routes).toEqual(EXPECTED_P1_ROUTES);
+  });
+});

--- a/__tests__/scripts/release-candidate-manifest-consistency.test.ts
+++ b/__tests__/scripts/release-candidate-manifest-consistency.test.ts
@@ -1,0 +1,178 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const MANIFEST_PATH = join(
+  ROOT,
+  'docs/go-live/_evidence/lot8-release-candidate-file-manifest-clean.md',
+);
+const COMMIT_PLAN_PATH = join(
+  ROOT,
+  'docs/go-live/_evidence/lot8-release-candidate-commit-plan-clean.md',
+);
+const API_MATRIX_PATH = join(ROOT, 'docs/go-live/api-security-matrix.full.md');
+
+type ManifestRow = {
+  path: string;
+  gitState: string;
+  group: string;
+  includeRc: boolean;
+  proposedCommit: string;
+};
+
+type CommitCoverage = {
+  commits: Map<string, string[]>;
+  fileToCommits: Map<string, string[]>;
+};
+
+const EXPECTED_P1_ROUTES = [
+  '/api/payments/clictopay/webhook',
+  '/api/assessments/submit',
+  '/api/bilan-gratuit',
+  '/api/lamis/teacher-report',
+  '/api/stages/[stageSlug]/inscrire',
+  '/api/student/activate',
+] as const;
+
+function cleanCell(cell: string) {
+  return cell.trim().replace(/^`|`$/g, '');
+}
+
+function parseTableCells(line: string) {
+  return line
+    .split('|')
+    .slice(1, -1)
+    .map((cell) => cell.trim());
+}
+
+function parseManifest(markdown: string): ManifestRow[] {
+  return markdown
+    .split('\n')
+    .filter((line) => line.startsWith('| `'))
+    .map((line) => {
+      const cells = parseTableCells(line);
+      return {
+        path: cleanCell(cells[0]),
+        gitState: cleanCell(cells[1]),
+        group: cleanCell(cells[2]),
+        includeRc: cells[3] === 'Oui',
+        proposedCommit: cleanCell(cells[4]),
+      };
+    });
+}
+
+function parseCommitPlan(markdown: string): CommitCoverage {
+  const commits = new Map<string, string[]>();
+  const fileToCommits = new Map<string, string[]>();
+  let currentCommit: string | null = null;
+
+  for (const line of markdown.split('\n')) {
+    const heading = line.match(/^## \d+\. (.+)$/);
+    if (heading) {
+      currentCommit = heading[1].trim();
+      commits.set(currentCommit, []);
+      continue;
+    }
+
+    if (line.startsWith('## ')) {
+      currentCommit = null;
+      continue;
+    }
+
+    if (!currentCommit || !line.startsWith('| `')) continue;
+
+    const [fileCell] = parseTableCells(line);
+    const filePath = cleanCell(fileCell);
+    commits.get(currentCommit)?.push(filePath);
+
+    const owners = fileToCommits.get(filePath) ?? [];
+    owners.push(currentCommit);
+    fileToCommits.set(filePath, owners);
+  }
+
+  return { commits, fileToCommits };
+}
+
+function parseP1Routes(markdown: string) {
+  const routes = new Set<string>();
+  for (const line of markdown.split('\n')) {
+    if (!line.startsWith('| P1 |') || !line.includes('| `/api/')) continue;
+    const cells = parseTableCells(line);
+    routes.add(cleanCell(cells[1]));
+  }
+  return routes;
+}
+
+function rowsWithPrefix(rows: ManifestRow[], prefix: string) {
+  return rows.filter((row) => row.path.startsWith(prefix));
+}
+
+describe('release candidate manifest and commit plan consistency', () => {
+  const manifestRows = parseManifest(readFileSync(MANIFEST_PATH, 'utf8'));
+  const commitCoverage = parseCommitPlan(readFileSync(COMMIT_PLAN_PATH, 'utf8'));
+  const expectedP1Routes = new Set(EXPECTED_P1_ROUTES);
+
+  it('covers each Include RC file in exactly one proposed commit', () => {
+    const uncovered = manifestRows
+      .filter((row) => row.includeRc)
+      .filter((row) => (commitCoverage.fileToCommits.get(row.path) ?? []).length === 0)
+      .map((row) => row.path);
+
+    const coveredMultipleTimes = manifestRows
+      .filter((row) => row.includeRc)
+      .filter((row) => (commitCoverage.fileToCommits.get(row.path) ?? []).length > 1)
+      .map((row) => `${row.path} -> ${(commitCoverage.fileToCommits.get(row.path) ?? []).join(', ')}`);
+
+    expect(uncovered).toEqual([]);
+    expect(coveredMultipleTimes).toEqual([]);
+  });
+
+  it('keeps excluded and human-review files out of proposed commits', () => {
+    const excludedInCommits = manifestRows
+      .filter((row) => !row.includeRc && row.group === 'Exclude')
+      .filter((row) => commitCoverage.fileToCommits.has(row.path))
+      .map((row) => row.path);
+
+    const humanReviewInCommits = manifestRows
+      .filter((row) => row.group === 'Needs human review')
+      .filter((row) => commitCoverage.fileToCommits.has(row.path))
+      .map((row) => row.path);
+
+    expect(excludedInCommits).toEqual([]);
+    expect(humanReviewInCommits).toEqual([]);
+  });
+
+  it('keeps classification rules stable for tests, scripts and maintenance files', () => {
+    expect(rowsWithPrefix(manifestRows, '__tests__/').every((row) => row.group === 'Tests unitaires')).toBe(true);
+    expect(rowsWithPrefix(manifestRows, 'e2e/').every((row) => row.group === 'Tests E2E')).toBe(true);
+    expect(rowsWithPrefix(manifestRows, 'scripts/security/').every((row) => row.group === 'Scripts audit')).toBe(true);
+    expect(rowsWithPrefix(manifestRows, 'scripts/go-live/').every((row) => row.group === 'Scripts go-live')).toBe(true);
+    expect(rowsWithPrefix(manifestRows, 'scripts/maintenance/').every((row) => row.group === 'Scripts maintenance')).toBe(true);
+  });
+
+  it('keeps forbidden release-candidate files excluded', () => {
+    const auditReport = manifestRows.find((row) => row.path === 'rapport_audit_2_07_2026.md');
+    expect(auditReport?.group).toBe('Exclude');
+    expect(auditReport?.includeRc).toBe(false);
+
+    const envFiles = manifestRows.filter((row) => /(^|\/)\.env($|\.)/.test(row.path));
+    expect(envFiles).toEqual([]);
+
+    const generatedArtifactsIncluded = manifestRows
+      .filter((row) => row.includeRc)
+      .filter((row) =>
+        ['test-results/', 'playwright-report/', '.next/', 'node_modules/'].some((prefix) =>
+          row.path.startsWith(prefix),
+        ),
+      )
+      .map((row) => row.path);
+
+    expect(generatedArtifactsIncluded).toEqual([]);
+  });
+
+  it('keeps the six release-candidate P1 routes visible in the generated matrix', () => {
+    const p1Routes = parseP1Routes(readFileSync(API_MATRIX_PATH, 'utf8'));
+
+    expect(p1Routes).toEqual(expectedP1Routes);
+  });
+});

--- a/__tests__/scripts/security-audit-scripts-regression.test.ts
+++ b/__tests__/scripts/security-audit-scripts-regression.test.ts
@@ -1,0 +1,199 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative } from 'node:path';
+
+const ROOT = process.cwd();
+const API_ROOT = join(ROOT, 'app/api');
+const INVENTORY_PATH = join(ROOT, 'docs/security/API_GUARD_INVENTORY.md');
+const MATRIX_PATH = join(ROOT, 'docs/go-live/api-security-matrix.full.md');
+
+const EXPECTED_P1_ROUTES = new Set([
+  '/api/payments/clictopay/webhook',
+  '/api/assessments/submit',
+  '/api/bilan-gratuit',
+  '/api/lamis/teacher-report',
+  '/api/stages/[stageSlug]/inscrire',
+  '/api/student/activate',
+]);
+
+function walkRouteFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir).sort()) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      files.push(...walkRouteFiles(fullPath));
+    } else if (entry === 'route.ts') {
+      files.push(relative(ROOT, fullPath));
+    }
+  }
+  return files;
+}
+
+function parseInventoryRows(markdown: string) {
+  const rows = new Map<string, { risk: string }>();
+  for (const line of markdown.split('\n')) {
+    if (!line.startsWith('| `app/api/') || !line.includes('/route.ts` |')) continue;
+    const cells = line.split('|').slice(1, -1).map((cell) => cell.trim());
+    rows.set(cells[0].replace(/`/g, ''), { risk: cells[8] });
+  }
+  return rows;
+}
+
+function writeRoute(root: string, routeFile: string, source: string) {
+  const fullPath = join(root, routeFile);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, source);
+}
+
+function runAuditOnFixtures(fixtures: Record<string, string>) {
+  const root = mkdtempSync(join(tmpdir(), 'nexus-rc-audit-fixtures-'));
+  try {
+    mkdirSync(join(root, 'docs/security'), { recursive: true });
+    for (const [routeFile, source] of Object.entries(fixtures)) {
+      writeRoute(root, routeFile, source);
+    }
+
+    execFileSync(process.execPath, [join(ROOT, 'scripts/security/audit-api-guards.mjs')], {
+      cwd: root,
+      env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
+      stdio: 'pipe',
+    });
+
+    return parseInventoryRows(readFileSync(join(root, 'docs/security/API_GUARD_INVENTORY.md'), 'utf8'));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function parseMatrixRows(markdown: string) {
+  const rows = new Map<string, { priority: string }>();
+  for (const line of markdown.split('\n')) {
+    if (!line.startsWith('| P') && !line.startsWith('| OK')) continue;
+    if (!line.includes('| `/api/')) continue;
+    const cells = line.split('|').slice(1, -1).map((cell) => cell.trim());
+    rows.set(cells[1].replace(/`/g, ''), { priority: cells[0] });
+  }
+  return rows;
+}
+
+describe('security audit scripts RC regression guards', () => {
+  it('keeps the generated inventory route count aligned with app/api route files', () => {
+    const routeFiles = walkRouteFiles(API_ROOT);
+    const inventoryRows = parseInventoryRows(readFileSync(INVENTORY_PATH, 'utf8'));
+
+    expect(inventoryRows.size).toBe(routeFiles.length);
+    expect(routeFiles.length).toBe(178);
+  });
+
+  it('keeps the six explicit release-candidate P1 routes visible in the inventory and matrix', () => {
+    const inventoryRows = parseInventoryRows(readFileSync(INVENTORY_PATH, 'utf8'));
+    const matrixRows = parseMatrixRows(readFileSync(MATRIX_PATH, 'utf8'));
+
+    const actualP1Routes = [...matrixRows.entries()]
+      .filter(([, row]) => row.priority === 'P1')
+      .map(([route]) => route)
+      .sort();
+
+    expect(new Set(actualP1Routes)).toEqual(EXPECTED_P1_ROUTES);
+
+    for (const route of EXPECTED_P1_ROUTES) {
+      const routeFile = `app${route}/route.ts`;
+      expect(inventoryRows.get(routeFile)?.risk).toBe('P1');
+      expect(matrixRows.get(route)?.priority).toBe('P1');
+    }
+  });
+
+  it('does not mark public sensitive P1 surfaces as OK in the generated matrix', () => {
+    const matrixRows = parseMatrixRows(readFileSync(MATRIX_PATH, 'utf8'));
+
+    for (const route of EXPECTED_P1_ROUTES) {
+      expect(matrixRows.get(route)?.priority).not.toBe('OK');
+      expect(matrixRows.get(route)?.priority).not.toBe('P2');
+    }
+  });
+
+  it('keeps public sensitive mutations with Zod and rate limit at P1', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/assessments/submit/route.ts': `
+        import { z } from 'zod';
+        import { guardRateLimitAsync } from '@/lib/rate-limit';
+        const schema = z.object({ subject: z.string(), grade: z.string() }).strict();
+        export async function POST(request: Request) {
+          const blocked = await guardRateLimitAsync(request, { key: 'assessment' });
+          if (blocked) return blocked;
+          schema.parse(await request.json());
+          return Response.json({ ok: true });
+        }
+      `,
+    });
+
+    expect(rows.get('app/api/assessments/submit/route.ts')?.risk).toBe('P1');
+  });
+
+  it('keeps disabled 501 webhooks at P1', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/payments/clictopay/webhook/route.ts': `
+        export async function POST() {
+          return Response.json({ code: 'CLICTOPAY_NOT_CONFIGURED' }, { status: 501 });
+        }
+      `,
+    });
+
+    expect(rows.get('app/api/payments/clictopay/webhook/route.ts')?.risk).toBe('P1');
+  });
+
+  it('does not mark staff-looking routes without an explicit role guard as OK', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/admin/config/route.ts': `
+        import { auth } from '@/auth';
+        export async function GET() {
+          const session = await auth();
+          if (!session?.user?.id) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+          return Response.json({ config: { publicOnly: true } });
+        }
+      `,
+    });
+
+    expect(rows.get('app/api/admin/config/route.ts')?.risk).not.toBe('OK');
+  });
+
+  it('does not mark authenticated PII routes without ownership as OK', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/student/profile/route.ts': `
+        import { auth } from '@/auth';
+        export async function GET() {
+          const session = await auth();
+          if (!session?.user?.id) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+          return Response.json({ email: 'redacted@example.test' });
+        }
+      `,
+    });
+
+    expect(rows.get('app/api/student/profile/route.ts')?.risk).not.toBe('OK');
+  });
+
+  it('keeps dynamic sensitive routes without ownership above OK', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/student/documents/[id]/download/route.ts': `
+        import { auth } from '@/auth';
+        export async function GET() {
+          const session = await auth();
+          if (!session?.user?.id) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+          return new Response('pdf');
+        }
+      `,
+    });
+
+    const risk = rows.get('app/api/student/documents/[id]/download/route.ts')?.risk;
+    expect(['P0', 'P1', 'P2']).toContain(risk);
+    expect(risk).not.toBe('OK');
+  });
+
+  it('keeps the internal rate-limit probe OK only as an explicit non-PII internal route', () => {
+    const matrixRows = parseMatrixRows(readFileSync(MATRIX_PATH, 'utf8'));
+
+    expect(matrixRows.get('/api/internal/rate-limit-probe')?.priority).toBe('OK');
+  });
+});

--- a/__tests__/ui/payment-methods.clictopay-disabled.test.tsx
+++ b/__tests__/ui/payment-methods.clictopay-disabled.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { PaymentMethodsNote } from '@/components/marketing/PaymentMethodsNote';
+
+describe('PaymentMethodsNote ClicToPay disabled decision', () => {
+  const originalFlag = process.env.NEXT_PUBLIC_ENABLE_CLICTOPAY_PUBLIC;
+
+  afterEach(() => {
+    if (originalFlag === undefined) {
+      delete process.env.NEXT_PUBLIC_ENABLE_CLICTOPAY_PUBLIC;
+    } else {
+      process.env.NEXT_PUBLIC_ENABLE_CLICTOPAY_PUBLIC = originalFlag;
+    }
+  });
+
+  it('does not present card payment as active without explicit public opt-in', () => {
+    delete process.env.NEXT_PUBLIC_ENABLE_CLICTOPAY_PUBLIC;
+
+    render(<PaymentMethodsNote />);
+
+    expect(screen.getByText(/Paiement confirmé après validation pédagogique/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Paiement par carte via/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/ClicToPay/i)).not.toBeInTheDocument();
+  });
+});

--- a/app/api/admin/config/rollback/route.ts
+++ b/app/api/admin/config/rollback/route.ts
@@ -11,6 +11,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
 import {
   applyWrite,
   SCHEMA_VERSION,
@@ -20,6 +21,10 @@ import {
 } from '@/lib/config';
 import type { AuthSession } from '@/lib/guards';
 
+const rollbackPayloadSchema = z.object({
+  namespace: z.string().trim().min(1).max(120),
+  key: z.string().trim().min(1).max(180),
+}).strict();
 
 
 export async function POST(request: NextRequest) {
@@ -27,20 +32,21 @@ export async function POST(request: NextRequest) {
   if (isErrorResponse(auth)) return auth;
   const session = auth as AuthSession;
 
-  let body: { namespace: string; key: string };
+  let json: unknown;
   try {
-    body = await request.json();
+    json = await request.json();
   } catch {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const { namespace, key } = body;
-  if (typeof namespace !== 'string' || !namespace || typeof key !== 'string' || !key) {
+  const parsedBody = rollbackPayloadSchema.safeParse(json);
+  if (!parsedBody.success) {
     return NextResponse.json(
       { error: 'Missing required fields: namespace, key' },
       { status: 400 },
     );
   }
+  const { namespace, key } = parsedBody.data;
 
   const result = await prisma.$transaction(async (tx) => {
     await tx.$queryRawUnsafe('SELECT pg_advisory_xact_lock($1)', CONFIG_ADVISORY_LOCK_KEY);

--- a/app/api/admin/config/route.ts
+++ b/app/api/admin/config/route.ts
@@ -7,6 +7,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireRole, requireAnyRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
 import {
   getAllEntries,
   applyWrite,
@@ -25,6 +26,12 @@ import type { AuthSession } from '@/lib/guards';
 // share the same lock — config changes are rare (admin-only), so
 // serialization is the simplest correct solution for cross-key invariants.
  // arbitrary stable int
+
+const configPatchSchema = z.object({
+  namespace: z.string().trim().min(1).max(120),
+  key: z.string().trim().min(1).max(180),
+  value: z.unknown(),
+}).strict();
 
 export async function GET() {
   const auth = await requireAnyRole(['ADMIN', 'ASSISTANTE']);
@@ -73,20 +80,21 @@ export async function PATCH(request: NextRequest) {
   if (isErrorResponse(auth)) return auth;
   const session = auth as AuthSession;
 
-  let body: { namespace: string; key: string; value: unknown };
+  let json: unknown;
   try {
-    body = await request.json();
+    json = await request.json();
   } catch {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const { namespace, key, value } = body;
-  if (typeof namespace !== 'string' || !namespace || typeof key !== 'string' || !key || value === undefined) {
+  const parsedBody = configPatchSchema.safeParse(json);
+  if (!parsedBody.success) {
     return NextResponse.json(
       { error: 'Missing required fields: namespace, key, value' },
       { status: 400 },
     );
   }
+  const { namespace, key, value } = parsedBody.data;
 
   // Per-key Zod validation (stateless — can run outside transaction)
   const validation = validateConfigEntry(namespace, key, value);

--- a/app/api/admin/directeur/stats/route.ts
+++ b/app/api/admin/directeur/stats/route.ts
@@ -8,8 +8,11 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
+import { isErrorResponse, requireRole } from '@/lib/guards';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { UserRole } from '@prisma/client';
+import { z } from 'zod';
 
 interface KPIData {
   totalAssessments: number;
@@ -36,18 +39,27 @@ interface AlertEntry {
   assessmentId: string;
 }
 
+const statsQuerySchema = z.object({}).strict();
+
 export async function GET(request: NextRequest) {
   try {
     // RBAC Guard: ADMIN only
-    const session = await auth();
-    const userRole = (session?.user as { role?: string })?.role;
+    const sessionOrError = await requireRole(UserRole.ADMIN);
+    if (isErrorResponse(sessionOrError)) return sessionOrError;
 
-    if (!session || userRole !== 'ADMIN') {
+    const query = Object.fromEntries(request.nextUrl.searchParams.entries());
+    if (!statsQuerySchema.safeParse(query).success) {
       return NextResponse.json(
-        { success: false, error: 'Accès non autorisé. Rôle ADMIN requis.' },
-        { status: 403 }
+        { success: false, error: 'Paramètres invalides' },
+        { status: 400 }
       );
     }
+
+    const rateLimited = await guardRateLimitAsync(request, {
+      preset: 'api',
+      keySuffix: 'admin-directeur-stats',
+    });
+    if (rateLimited) return rateLimited;
 
     // ─── KPIs ─────────────────────────────────────────────────────────────
 

--- a/app/api/admin/documents/route.ts
+++ b/app/api/admin/documents/route.ts
@@ -6,9 +6,46 @@ import { createId } from '@paralleldrive/cuid2';
 import path from 'path';
 import { mkdir, writeFile } from 'fs/promises';
 import { serializeError } from '@/lib/utils/serialize-error';
+import { z } from 'zod';
 
 // Secure storage root (mapped to volume in docker-compose)
 const STORAGE_ROOT = '/app/storage/documents';
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+const ALLOWED_UPLOAD_MIME_TYPES = new Set([
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'text/plain',
+]);
+
+const targetUserIdSchema = z.string().min(1).max(128);
+
+const safeDocumentSelect = {
+  id: true,
+  title: true,
+  originalName: true,
+  mimeType: true,
+  sizeBytes: true,
+  userId: true,
+  uploadedById: true,
+  createdAt: true,
+} as const;
+
+function sanitizeOriginalName(value: string): string {
+  return value.replace(/[\\/\r\n"]/g, '_').slice(0, 200) || 'document';
+}
+
+function safeErrorSummary(error: unknown) {
+  const serialized = serializeError(error);
+  if (serialized && typeof serialized === 'object' && !Array.isArray(serialized)) {
+    return {
+      name: typeof serialized.name === 'string' ? serialized.name : 'Error',
+      message: typeof serialized.message === 'string' ? serialized.message : 'unknown',
+    };
+  }
+  return { name: 'Error', message: String(serialized) };
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -20,14 +57,22 @@ export async function POST(request: NextRequest) {
     // 2. Parse FormData
     const formData = await request.formData();
     const file = formData.get('file') as File | null;
-    const userId = formData.get('userId') as string | null;
+    const parsedUserId = targetUserIdSchema.safeParse(formData.get('userId'));
 
-    if (!file || !userId) {
+    if (!file || !parsedUserId.success) {
       return NextResponse.json({ error: 'File and userId required' }, { status: 400 });
+    }
+    const userId = parsedUserId.data;
+
+    if (!ALLOWED_UPLOAD_MIME_TYPES.has(file.type) || file.size > MAX_UPLOAD_BYTES) {
+      return NextResponse.json({ error: 'Type ou taille de fichier invalide' }, { status: 400 });
     }
 
     // 3. Validate Target User
-    const targetUser = await prisma.user.findUnique({ where: { id: userId } });
+    const targetUser = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true },
+    });
     if (!targetUser) {
       return NextResponse.json({ error: 'Target user not found' }, { status: 404 });
     }
@@ -41,6 +86,7 @@ export async function POST(request: NextRequest) {
     // Using path.join ensures we stick to the OS separator, 
     // and combined with uniqueId prevents directory traversal like ../../
     const localPath = path.join(STORAGE_ROOT, secureFilename);
+    const originalName = sanitizeOriginalName(file.name);
 
     // Ensure directory exists
     await mkdir(STORAGE_ROOT, { recursive: true });
@@ -53,20 +99,24 @@ export async function POST(request: NextRequest) {
     const document = await prisma.userDocument.create({
       data: {
         id: uniqueId, // Use same ID for consistency
-        title: file.name, // Default title = filename
-        originalName: file.name,
+        title: originalName, // Default title = filename
+        originalName,
         mimeType: file.type,
         sizeBytes: file.size,
         localPath: localPath,
         userId: userId,
         uploadedById: session.user.id,
       },
+      select: safeDocumentSelect,
     });
 
-    return NextResponse.json(document, { status: 201 });
+    const safeDocument = { ...(document as Record<string, unknown>) };
+    delete safeDocument.localPath;
+
+    return NextResponse.json({ success: true, document: safeDocument }, { status: 201 });
 
   } catch (error) {
-    console.error('[Upload Error]', serializeError(error));
+    console.error('[Upload Error]', safeErrorSummary(error));
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
   }
 }

--- a/app/api/admin/invoices/route.ts
+++ b/app/api/admin/invoices/route.ts
@@ -1,4 +1,3 @@
-import { serializeError } from '@/lib/utils/serialize-error';
 /**
  * POST /api/admin/invoices — Create invoice + atomic number + PDF + store.
  * GET  /api/admin/invoices — List invoices (paginated).
@@ -10,7 +9,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import path from 'node:path';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
-import type { InvoiceItem, Prisma } from '@prisma/client';
+import { UserRole, type InvoiceItem, type Prisma } from '@prisma/client';
+import { z } from 'zod';
 import {
   generateInvoiceNumber,
   renderInvoicePDF,
@@ -40,6 +40,68 @@ const DEFAULT_ISSUER = {
   logoPath: path.join(process.cwd(), 'public', 'images', 'logo_slogan_nexus.png'),
 };
 
+const STAFF_ROLES = new Set<string>([UserRole.ADMIN, UserRole.ASSISTANTE]);
+
+const invoiceItemInputSchema = z.object({
+  label: z.string().trim().min(1).max(180),
+  description: z.string().trim().max(600).nullable().optional(),
+  qty: z.number().int().positive().max(100),
+  unitPrice: z.number().int().nonnegative(),
+}).strict();
+
+const invoiceIssuerInputSchema = z.object({
+  name: z.string().trim().min(1).max(180).optional(),
+  address: z.string().trim().min(1).max(500).optional(),
+  mf: z.string().trim().min(1).max(80).optional(),
+  rne: z.string().trim().max(80).nullable().optional(),
+  phone: z.string().trim().max(80).nullable().optional(),
+  email: z.string().trim().email().nullable().optional(),
+  web: z.string().trim().max(180).nullable().optional(),
+  slogan: z.string().trim().max(180).nullable().optional(),
+  logoPath: z.string().trim().max(500).nullable().optional(),
+  stampPath: z.string().trim().max(500).nullable().optional(),
+}).strict();
+
+const createInvoiceBodySchema = z.object({
+  number: z.string().trim().min(1).max(80).optional(),
+  issuedAt: z.string().datetime().optional(),
+  dueAt: z.string().datetime().nullable().optional(),
+  customer: z.object({
+    name: z.string().trim().min(1).max(180),
+    email: z.string().trim().email().nullable().optional(),
+    address: z.string().trim().max(500).nullable().optional(),
+    customerId: z.string().trim().max(120).nullable().optional(),
+  }).strict(),
+  items: z.array(invoiceItemInputSchema).min(1).max(50),
+  discountTotal: z.number().int().nonnegative().optional(),
+  taxRegime: z.enum(['TVA_INCLUSE', 'TVA_NON_APPLICABLE', 'EXONERATION']).optional(),
+  paymentMethod: z.enum(['CASH', 'BANK_TRANSFER', 'CHEQUE', 'CARD', 'CLICTOPAY']).nullable().optional(),
+  paymentDetails: z.record(z.unknown()).nullable().optional(),
+  notes: z.string().trim().max(2000).nullable().optional(),
+  issuer: invoiceIssuerInputSchema.optional(),
+}).strict();
+
+const listInvoicesQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).max(10_000).default(1),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  status: z.enum(['DRAFT', 'SENT', 'PAID', 'CANCELLED']).optional(),
+  search: z.string().trim().min(1).max(120).optional(),
+}).strict();
+
+function hasStaffAccess(role?: string | null) {
+  return !!role && STAFF_ROLES.has(role);
+}
+
+function validationFailed() {
+  return NextResponse.json({ error: 'Données invalides' }, { status: 400 });
+}
+
+function safeErrorSummary(error: unknown) {
+  return error instanceof Error
+    ? { name: error.name, message: error.message }
+    : { name: 'UnknownError', message: 'Unknown error' };
+}
+
 // ─── POST: Create Invoice ───────────────────────────────────────────────────
 
 export async function POST(request: NextRequest) {
@@ -51,20 +113,14 @@ export async function POST(request: NextRequest) {
     }
 
     const userRole = (session.user as { role?: string }).role;
-    if (userRole !== 'ADMIN' && userRole !== 'ASSISTANTE') {
+    if (!hasStaffAccess(userRole)) {
       return NextResponse.json({ error: 'Accès refusé' }, { status: 403 });
     }
 
     // Parse body
-    const body: CreateInvoiceRequest = await request.json();
-
-    // Validate required fields
-    if (!body.customer?.name) {
-      return NextResponse.json({ error: 'customer.name est requis' }, { status: 400 });
-    }
-    if (!body.items || body.items.length === 0) {
-      return NextResponse.json({ error: 'Au moins un item est requis' }, { status: 400 });
-    }
+    const parsedBody = createInvoiceBodySchema.safeParse(await request.json());
+    if (!parsedBody.success) return validationFailed();
+    const body = parsedBody.data as CreateInvoiceRequest;
 
     // ─── Millimes integer validation (422 if non-int) ────────────────
     for (let i = 0; i < body.items.length; i++) {
@@ -223,7 +279,7 @@ export async function POST(request: NextRequest) {
       }, { status: 422 });
     }
 
-    console.error('[POST /api/admin/invoices] Error:', serializeError(error));
+    console.error('[POST /api/admin/invoices] Error:', safeErrorSummary(error));
     return NextResponse.json({ error: 'Erreur interne' }, { status: 500 });
   }
 }
@@ -238,15 +294,14 @@ export async function GET(request: NextRequest) {
     }
 
     const userRole = (session.user as { role?: string }).role;
-    if (userRole !== 'ADMIN' && userRole !== 'ASSISTANTE') {
+    if (!hasStaffAccess(userRole)) {
       return NextResponse.json({ error: 'Accès refusé' }, { status: 403 });
     }
 
     const { searchParams } = new URL(request.url);
-    const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
-    const limit = Math.min(50, Math.max(1, parseInt(searchParams.get('limit') ?? '20', 10)));
-    const status = searchParams.get('status');
-    const search = searchParams.get('search');
+    const parsedQuery = listInvoicesQuerySchema.safeParse(Object.fromEntries(searchParams.entries()));
+    if (!parsedQuery.success) return validationFailed();
+    const { page, limit, status, search } = parsedQuery.data;
 
     const where: Record<string, unknown> = {};
     if (status) {
@@ -263,7 +318,40 @@ export async function GET(request: NextRequest) {
     const [invoices, total] = await Promise.all([
       prisma.invoice.findMany({
         where,
-        include: { items: { orderBy: { sortOrder: 'asc' } } },
+        select: {
+          id: true,
+          number: true,
+          status: true,
+          issuedAt: true,
+          dueAt: true,
+          customerName: true,
+          customerEmail: true,
+          currency: true,
+          subtotal: true,
+          discountTotal: true,
+          taxTotal: true,
+          total: true,
+          taxRegime: true,
+          paymentMethod: true,
+          paidAt: true,
+          paidAmount: true,
+          pdfUrl: true,
+          createdAt: true,
+          updatedAt: true,
+          items: {
+            orderBy: { sortOrder: 'asc' },
+            select: {
+              id: true,
+              label: true,
+              description: true,
+              qty: true,
+              unitPrice: true,
+              total: true,
+              productCode: true,
+              sortOrder: true,
+            },
+          },
+        },
         orderBy: { issuedAt: 'desc' },
         skip: (page - 1) * limit,
         take: limit,
@@ -282,7 +370,7 @@ export async function GET(request: NextRequest) {
     });
 
   } catch (error) {
-    console.error('[GET /api/admin/invoices] Error:', serializeError(error));
+    console.error('[GET /api/admin/invoices] Error:', safeErrorSummary(error));
     return NextResponse.json({ error: 'Erreur interne' }, { status: 500 });
   }
 }

--- a/app/api/admin/recompute-ssn/route.ts
+++ b/app/api/admin/recompute-ssn/route.ts
@@ -9,29 +9,34 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { auth } from '@/auth';
 import { recomputeSSNBatch } from '@/lib/core/ssn/computeSSN';
 import { computeCohortStatsWithAudit } from '@/lib/core/statistics/cohort';
+import { isErrorResponse, requireRole } from '@/lib/guards';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { UserRole } from '@prisma/client';
+import { z } from 'zod';
 
-const VALID_TYPES = ['MATHS', 'NSI', 'GENERAL'];
+const VALID_TYPES = ['MATHS', 'NSI', 'GENERAL'] as const;
+const recomputeSsnSchema = z.object({
+  type: z.enum(VALID_TYPES),
+}).strict();
 
 export async function POST(request: NextRequest) {
   try {
     // RBAC Guard: ADMIN only
-    const session = await auth();
-    const userRole = (session?.user as { role?: string })?.role;
+    const sessionOrError = await requireRole(UserRole.ADMIN);
+    if (isErrorResponse(sessionOrError)) return sessionOrError;
 
-    if (!session || userRole !== 'ADMIN') {
-      return NextResponse.json(
-        { success: false, error: 'Accès non autorisé. Rôle ADMIN requis.' },
-        { status: 403 }
-      );
-    }
+    const rateLimited = await guardRateLimitAsync(request, {
+      preset: 'api',
+      keySuffix: 'admin-recompute-ssn',
+    });
+    if (rateLimited) return rateLimited;
 
-    const body = await request.json();
-    const { type } = body;
-
-    if (!type || !VALID_TYPES.includes(type)) {
+    let json: unknown;
+    try {
+      json = await request.json();
+    } catch {
       return NextResponse.json(
         {
           success: false,
@@ -40,6 +45,18 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+
+    const parsedBody = recomputeSsnSchema.safeParse(json);
+    if (!parsedBody.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Type invalide. Valeurs acceptées : ${VALID_TYPES.join(', ')}`,
+        },
+        { status: 400 }
+      );
+    }
+    const { type } = parsedBody.data;
 
     // Compute audit log (before/after stats)
     const auditEntry = await computeCohortStatsWithAudit(type);

--- a/app/api/admin/subscriptions/route.ts
+++ b/app/api/admin/subscriptions/route.ts
@@ -5,17 +5,42 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { isErrorResponse, requireRole } from '@/lib/guards';
 import { SubscriptionStatus, UserRole, type Prisma } from '@prisma/client';
+import { z } from 'zod';
 
 type SubscriptionWithStudent = Prisma.SubscriptionGetPayload<{
-  include: {
+  select: {
+    id: true;
+    planName: true;
+    monthlyPrice: true;
+    status: true;
+    startDate: true;
+    endDate: true;
+    createdAt: true;
     student: {
-      include: {
-        user: true;
-        parent: { include: { user: true } };
+      select: {
+        id: true;
+        grade: true;
+        school: true;
+        user: { select: { firstName: true; lastName: true; email: true } };
+        parent: { select: { user: { select: { firstName: true; lastName: true; email: true } } } };
       };
     };
   };
 }>;
+
+const statusFilterSchema = z.union([z.nativeEnum(SubscriptionStatus), z.literal('ALL')]);
+const adminSubscriptionsQuerySchema = z.object({
+  status: statusFilterSchema.default(SubscriptionStatus.ACTIVE),
+  page: z.coerce.number().int().min(1).max(10_000).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(10),
+  search: z.string().trim().max(120).default(''),
+}).strict();
+
+const subscriptionUpdateSchema = z.object({
+  subscriptionId: z.string().trim().min(1).max(191),
+  status: z.nativeEnum(SubscriptionStatus).optional(),
+  endDate: z.string().trim().regex(/^\d{4}-\d{2}-\d{2}/).nullable().optional(),
+}).strict();
 
 export async function GET(request: NextRequest) {
   try {
@@ -23,10 +48,13 @@ export async function GET(request: NextRequest) {
     if (isErrorResponse(sessionOrError)) return sessionOrError;
 
     const { searchParams } = new URL(request.url);
-    const statusParam = (searchParams.get('status') || 'ACTIVE') as SubscriptionStatus | 'ALL';
-    const page = parseInt(searchParams.get('page') || '1');
-    const limit = parseInt(searchParams.get('limit') || '10');
-    const search = searchParams.get('search') || '';
+    const parsedQuery = adminSubscriptionsQuerySchema.safeParse(
+      Object.fromEntries(searchParams.entries())
+    );
+    if (!parsedQuery.success) {
+      return NextResponse.json({ error: 'Invalid query' }, { status: 400 });
+    }
+    const { status: statusParam, page, limit, search } = parsedQuery.data;
 
     const skip = (page - 1) * limit;
 
@@ -65,14 +93,22 @@ export async function GET(request: NextRequest) {
         orderBy: {
           createdAt: 'desc'
         },
-        include: {
+        select: {
+          id: true,
+          planName: true,
+          monthlyPrice: true,
+          status: true,
+          startDate: true,
+          endDate: true,
+          createdAt: true,
           student: {
-            include: {
-              user: true,
+            select: {
+              id: true,
+              grade: true,
+              school: true,
+              user: { select: { firstName: true, lastName: true, email: true } },
               parent: {
-                include: {
-                  user: true
-                }
+                select: { user: { select: { firstName: true, lastName: true, email: true } } }
               }
             }
           }
@@ -128,22 +164,29 @@ export async function PUT(request: NextRequest) {
     const sessionOrError = await requireRole(UserRole.ADMIN);
     if (isErrorResponse(sessionOrError)) return sessionOrError;
 
-    const body = (await request.json()) as {
-      subscriptionId?: string;
-      status?: string;
-      endDate?: string | null;
-    };
-    const { subscriptionId, status, endDate } = body;
-    const statusValue = status && Object.values(SubscriptionStatus).includes(status as SubscriptionStatus)
-      ? (status as SubscriptionStatus)
-      : undefined;
+    let json: unknown;
+    try {
+      json = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
 
-    if (status && !statusValue) {
+    const parsedBody = subscriptionUpdateSchema.safeParse(json);
+    if (!parsedBody.success) {
+      const hasInvalidStatus = parsedBody.error.issues.some((issue) => issue.path[0] === 'status');
+      const hasMissingSubscriptionId = parsedBody.error.issues.some((issue) => issue.path[0] === 'subscriptionId');
       return NextResponse.json(
-        { error: 'Invalid status value' },
+        {
+          error: hasInvalidStatus
+            ? 'Invalid status value'
+            : hasMissingSubscriptionId
+              ? 'Subscription ID is required'
+              : 'Invalid payload',
+        },
         { status: 400 }
       );
     }
+    const { subscriptionId, status, endDate } = parsedBody.data;
 
     if (!subscriptionId) {
       return NextResponse.json(
@@ -156,14 +199,15 @@ export async function PUT(request: NextRequest) {
     const updatedSubscription = await prisma.subscription.update({
       where: { id: subscriptionId },
       data: {
-        status: statusValue,
+        status,
         endDate: endDate ? new Date(endDate) : undefined
       },
-      include: {
+      select: {
+        id: true,
+        status: true,
+        endDate: true,
         student: {
-          include: {
-            user: true
-          }
+          select: { user: { select: { firstName: true, lastName: true } } }
         }
       }
     });

--- a/app/api/admin/test-email/route.ts
+++ b/app/api/admin/test-email/route.ts
@@ -3,22 +3,46 @@ export const dynamic = 'force-dynamic';
 
 import { auth } from '@/auth';
 import { sendWelcomeEmail, testEmailConfiguration } from '@/lib/email-service';
+import type { AuthSession } from '@/lib/guards';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const testEmailBodySchema = z.discriminatedUnion('action', [
+  z.object({ action: z.literal('test_config') }).strict(),
+  z.object({
+    action: z.literal('send_test'),
+    testEmail: z.string().trim().email().max(254),
+  }).strict(),
+]);
+
+function requireAdmin(session: AuthSession | null) {
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Non autorisé' }, { status: 401 });
+  }
+  if (session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Non autorisé' }, { status: 403 });
+  }
+  return null;
+}
 
 export async function POST(request: NextRequest) {
   try {
     const session = await auth();
+    const guard = requireAdmin(session as AuthSession | null);
+    if (guard) return guard;
 
-    // Vérifier que l'utilisateur est admin ou assistante
-    if (!session?.user || !['ADMIN', 'ASSISTANTE'].includes(session.user.role)) {
-      return NextResponse.json({ error: 'Non autorisé' }, { status: 401 });
+    let json: unknown;
+    try {
+      json = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Payload invalide' }, { status: 400 });
     }
-
-    const body = (await request.json()) as {
-      action?: 'test_config' | 'send_test';
-      testEmail?: string;
-    };
-    const { action, testEmail } = body;
+    const parsedBody = testEmailBodySchema.safeParse(json);
+    if (!parsedBody.success) {
+      return NextResponse.json({ success: false, error: 'Payload invalide' }, { status: 400 });
+    }
+    const body = parsedBody.data;
+    const { action } = body;
 
     switch (action) {
       case 'test_config':
@@ -28,30 +52,22 @@ export async function POST(request: NextRequest) {
 
       case 'send_test':
         // Envoyer un email de test
-        if (!testEmail) {
-          return NextResponse.json({
-            success: false,
-            error: 'Adresse email requise pour le test'
-          }, { status: 400 });
-        }
-
         try {
           await sendWelcomeEmail({
             firstName: 'Test',
             lastName: 'User',
-            email: testEmail
+            email: body.testEmail
           });
 
           return NextResponse.json({
             success: true,
-            message: `Email de test envoyé à ${testEmail}`
+            message: 'Email de test envoyé'
           });
         } catch (emailError: unknown) {
-          const message =
-            emailError instanceof Error ? emailError.message : 'Erreur inconnue';
+          console.error('Erreur envoi email test:', serializeError(emailError));
           return NextResponse.json({
             success: false,
-            error: `Erreur envoi email: ${message}`
+            error: 'Erreur envoi email'
           });
         }
 
@@ -73,10 +89,8 @@ export async function POST(request: NextRequest) {
 export async function GET(request: NextRequest) {
   try {
     const session = await auth();
-
-    if (!session?.user || !['ADMIN', 'ASSISTANTE'].includes(session.user.role)) {
-      return NextResponse.json({ error: 'Non autorisé' }, { status: 401 });
-    }
+    const guard = requireAdmin(session as AuthSession | null);
+    if (guard) return guard;
 
     // Retourner l'état de la configuration email
     const envVars = [

--- a/app/api/assessments/public-token/route.ts
+++ b/app/api/assessments/public-token/route.ts
@@ -1,0 +1,51 @@
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { Subject } from '@/lib/assessments/core/types';
+import { createAssessmentPublicToken, verifyAssessmentPublicToken } from '@/lib/assessments/public-token';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { isErrorResponse, requireAnyRole } from '@/lib/guards';
+
+const publicTokenRequestSchema = z.object({
+  subject: z.nativeEnum(Subject),
+  grade: z.enum(['PREMIERE', 'TERMINALE']),
+  source: z.string().trim().min(1).max(80).optional(),
+  campaignId: z.string().trim().min(1).max(80).optional(),
+}).strict();
+
+export async function POST(request: NextRequest) {
+  const sessionOrResponse = await requireAnyRole(['ADMIN', 'ASSISTANTE']);
+  if (isErrorResponse(sessionOrResponse)) {
+    return sessionOrResponse;
+  }
+
+  const blocked = await guardRateLimitAsync(request, {
+    preset: 'api',
+    keySuffix: 'assessments-public-token',
+    userId: sessionOrResponse.user.id,
+  });
+  if (blocked) return blocked;
+
+  const body = await request.json().catch(() => null);
+  const parsed = publicTokenRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
+  }
+
+  const token = createAssessmentPublicToken(parsed.data);
+  const verification = verifyAssessmentPublicToken(token, {
+    usage: 'assessment_submit',
+    subject: parsed.data.subject,
+    grade: parsed.data.grade,
+  });
+
+  if (!verification.valid) {
+    return NextResponse.json({ error: 'Token unavailable' }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    token,
+    expiresAt: new Date(verification.payload.expiresAt * 1000).toISOString(),
+  });
+}

--- a/app/api/assessments/submit/route.ts
+++ b/app/api/assessments/submit/route.ts
@@ -24,6 +24,19 @@ import { submitAssessmentSchema, type SubmitAssessmentResponse } from './types';
 import { headers } from 'next/headers';
 import { backfillCanonicalDomains } from '@/lib/assessments/core/config';
 import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { verifyAssessmentPublicToken } from '@/lib/assessments/public-token';
+
+function getAssessmentPublicToken(request: NextRequest): string | null {
+  const headerToken = request.headers.get('x-assessment-public-token')?.trim();
+  if (headerToken) return headerToken;
+
+  const authorization = request.headers.get('authorization')?.trim();
+  if (authorization?.toLowerCase().startsWith('bearer ')) {
+    return authorization.slice('bearer '.length).trim();
+  }
+
+  return null;
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -46,6 +59,24 @@ export async function POST(request: NextRequest) {
     }
 
     const { subject, grade, assessmentVersion, studentData, answers, duration, metadata } = validationResult.data;
+
+    const tokenVerification = verifyAssessmentPublicToken(
+      getAssessmentPublicToken(request),
+      {
+        usage: 'assessment_submit',
+        subject: subject as Subject,
+        grade,
+        studentEmail: studentData.email,
+      },
+    );
+
+    if (!tokenVerification.valid) {
+      const status = tokenVerification.reason === 'scope_mismatch' ? 403 : 401;
+      return NextResponse.json(
+        { error: status === 403 ? 'Forbidden' : 'Unauthorized' },
+        { status },
+      );
+    }
 
     // Get user agent and IP for tracking
     const headersList = await headers();

--- a/app/api/assessments/submit/types.ts
+++ b/app/api/assessments/submit/types.ts
@@ -21,7 +21,7 @@ export const submitAssessmentSchema = z.object({
     name: z.string().min(2, 'Nom trop court'),
     phone: z.string().optional(),
     schoolYear: z.string().optional(),
-  }),
+  }).strict(),
   answers: z.record(z.string(), z.string()), // questionId -> optionId
   duration: z.number().int().positive().optional(), // Duration in ms
   metadata: z
@@ -30,8 +30,9 @@ export const submitAssessmentSchema = z.object({
       startedAt: z.string().datetime().optional(),
       completedAt: z.string().datetime().optional(),
     })
+    .strict()
     .optional(),
-});
+}).strict();
 
 export type SubmitAssessmentRequest = z.infer<typeof submitAssessmentSchema>;
 

--- a/app/api/assistante/credit-requests/route.ts
+++ b/app/api/assistante/credit-requests/route.ts
@@ -4,8 +4,15 @@ export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
+import { z } from 'zod';
 
 class AlreadyProcessedError extends Error {}
+
+const creditRequestDecisionSchema = z.object({
+  requestId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/),
+  action: z.enum(['approve', 'reject']),
+  reason: z.string().trim().max(500).optional(),
+}).strict();
 
 export async function GET(request: NextRequest) {
   try {
@@ -83,19 +90,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = (await request.json()) as {
-      requestId?: string;
-      action?: 'approve' | 'reject';
-      reason?: string;
-    };
-    const { requestId, action, reason } = body;
-
-    if (!requestId || !action) {
+    const rawBody = await request.json().catch(() => null);
+    const parsedBody = creditRequestDecisionSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: 'Missing required fields' },
+        { error: 'Invalid credit request payload' },
         { status: 400 }
       );
     }
+    const { requestId, action, reason } = parsedBody.data;
 
     // Get the credit request
     const creditRequest = await prisma.creditTransaction.findUnique({

--- a/app/api/assistante/quotes/pdf/route.ts
+++ b/app/api/assistante/quotes/pdf/route.ts
@@ -4,12 +4,59 @@ import { NextRequest, NextResponse } from 'next/server';
 import { isErrorResponse, requireAnyRole } from '@/lib/guards';
 import { renderQuotePDF, type QuotePDFData } from '@/lib/quote/pdf';
 import { guardRateLimit } from '@/lib/rate-limit';
+import { z } from 'zod';
 
 export const dynamic = 'force-dynamic';
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
+const quoteInstallmentSchema = z.object({
+  label: z.string().trim().min(1).max(120),
+  amount: z.coerce.number().finite().nonnegative().max(1_000_000),
+}).strict();
+
+const quoteOfferSchema = z.object({
+  label: z.string().trim().min(1).max(160),
+  desc: z.string().trim().max(500),
+  annualDisplay: z.string().trim().min(1).max(80),
+  inc: z.array(z.string().trim().min(1).max(180)).max(20).default([]),
+  ech: z.array(quoteInstallmentSchema).max(12).default([]),
+}).strict();
+
+const quoteAlternativeSchema = z.object({
+  label: z.string().trim().min(1).max(160),
+  desc: z.string().trim().max(500),
+  annualDisplay: z.string().trim().min(1).max(80),
+}).strict();
+
+const quotePayloadSchema = z.object({
+  quoteNumber: z.string().trim().min(1).max(80),
+  generatedAt: z.string().trim().min(1).max(80),
+  validUntil: z.string().trim().min(1).max(80),
+  studentName: z.string().trim().min(1).max(160),
+  parentName: z.string().trim().min(1).max(160),
+  whatsapp: z.string().trim().max(80),
+  email: z.string().trim().email().max(180),
+  advisor: z.string().trim().max(160),
+  level: z.string().trim().max(120),
+  status: z.string().trim().max(120),
+  establishment: z.string().trim().max(180),
+  languages: z.string().trim().max(180),
+  currentLevel: z.string().trim().max(180),
+  specialites: z.array(z.string().trim().max(120)).max(10).default([]),
+  options: z.array(z.string().trim().max(120)).max(10).default([]),
+  modalite: z.string().trim().max(120),
+  objectif: z.string().trim().max(500),
+  budget: z.string().trim().max(120),
+  mode: z.string().trim().max(120),
+  reduction: z.string().trim().max(80),
+  reductionLabels: z.array(z.string().trim().max(160)).max(10).default([]),
+  hasDirectionOverride: z.boolean(),
+  publicAnnual: z.coerce.number().finite().nonnegative().max(1_000_000).nullable().optional(),
+  monthlyDisplay: z.string().trim().max(120).nullable().optional(),
+  economie: z.coerce.number().finite().nonnegative().max(1_000_000).nullable().optional(),
+  internalNotes: z.string().trim().max(1000).optional(),
+  offer: quoteOfferSchema,
+  alternatives: z.array(quoteAlternativeSchema).max(10).default([]),
+}).strict();
 
 function sanitizeFilenamePart(value: string) {
   const normalized = value
@@ -19,23 +66,6 @@ function sanitizeFilenamePart(value: string) {
     .replace(/^-+|-+$/g, '');
 
   return normalized || 'eleve';
-}
-
-function validateQuotePayload(value: unknown): QuotePDFData | NextResponse {
-  if (!isRecord(value) || !isRecord(value.offer)) {
-    return NextResponse.json({ error: 'Invalid quote payload' }, { status: 400 });
-  }
-
-  const required = ['quoteNumber', 'studentName', 'parentName', 'offer'];
-  const missing = required.filter(key => value[key] == null || value[key] === '');
-  if (missing.length > 0) {
-    return NextResponse.json(
-      { error: 'Invalid quote payload', missing },
-      { status: 400 }
-    );
-  }
-
-  return value as unknown as QuotePDFData;
 }
 
 export async function POST(request: NextRequest) {
@@ -52,8 +82,11 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
 
-  const quoteData = validateQuotePayload(payload);
-  if (isErrorResponse(quoteData)) return quoteData;
+  const parsedPayload = quotePayloadSchema.safeParse(payload);
+  if (!parsedPayload.success) {
+    return NextResponse.json({ error: 'Invalid quote payload' }, { status: 400 });
+  }
+  const quoteData = parsedPayload.data as QuotePDFData;
 
   const pdfBuffer = await renderQuotePDF(quoteData);
   const student = sanitizeFilenamePart(quoteData.studentName);

--- a/app/api/assistante/students/credits/route.ts
+++ b/app/api/assistante/students/credits/route.ts
@@ -5,6 +5,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
 import type { CreditTransaction } from '@prisma/client';
+import { z } from 'zod';
 
 const ALLOWED_STAFF_CREDIT_TYPES = new Set([
   'CREDIT_ADD',
@@ -12,6 +13,22 @@ const ALLOWED_STAFF_CREDIT_TYPES = new Set([
   'MANUAL_ADJUSTMENT',
   'MONTHLY_ALLOCATION',
 ]);
+const staffCreditTypeSchema = z.enum([
+  'CREDIT_ADD',
+  'CREDIT_REFUND',
+  'MANUAL_ADJUSTMENT',
+  'MONTHLY_ALLOCATION',
+]);
+const idSchema = z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/);
+const studentCreditsQuerySchema = z.object({
+  studentId: idSchema.optional(),
+}).strict();
+const addStudentCreditsSchema = z.object({
+  studentId: idSchema,
+  amount: z.coerce.number().finite().positive().max(1000),
+  type: staffCreditTypeSchema,
+  description: z.string().trim().min(1).max(500),
+}).strict();
 
 export async function GET(request: NextRequest) {
   try {
@@ -25,7 +42,16 @@ export async function GET(request: NextRequest) {
     }
 
     const { searchParams } = new URL(request.url);
-    const studentId = searchParams.get('studentId');
+    const parsedQuery = studentCreditsQuerySchema.safeParse({
+      studentId: searchParams.get('studentId') ?? undefined,
+    });
+    if (!parsedQuery.success) {
+      return NextResponse.json(
+        { error: 'Invalid query parameters' },
+        { status: 400 }
+      );
+    }
+    const { studentId } = parsedQuery.data;
 
     if (studentId) {
       // Get specific student credits
@@ -118,15 +144,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
-    const { studentId, amount, type, description } = body;
-
-    if (!studentId || amount === undefined || amount === null || !type || !description) {
+    const rawBody = await request.json().catch(() => null);
+    const parsedBody = addStudentCreditsSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: 'Missing required fields' },
+        { error: 'Invalid credit payload' },
         { status: 400 }
       );
     }
+    const { studentId, amount, type, description } = parsedBody.data;
 
     if (!ALLOWED_STAFF_CREDIT_TYPES.has(type)) {
       return NextResponse.json(
@@ -135,7 +161,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const parsedAmount = Number(amount);
+    const parsedAmount = amount;
     if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
       return NextResponse.json(
         { error: 'Invalid credit amount' },

--- a/app/api/assistante/subscription-requests/route.ts
+++ b/app/api/assistante/subscription-requests/route.ts
@@ -5,9 +5,22 @@ import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 import { getAriaAddonCatalogItem, getOperationalSubscriptionPlan } from '@/lib/operational-catalog';
+import { z } from 'zod';
 
 class AlreadyProcessedError extends Error {}
 class NoActiveSubscriptionError extends Error {}
+
+const idSchema = z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/);
+const subscriptionRequestsQuerySchema = z.object({
+  status: z.enum(['PENDING', 'APPROVED', 'REJECTED']).default('PENDING'),
+  page: z.coerce.number().int().min(1).max(500).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+}).strict();
+const subscriptionRequestDecisionSchema = z.object({
+  requestId: idSchema,
+  action: z.enum(['APPROVED', 'REJECTED']),
+  reason: z.string().trim().max(1000).optional(),
+}).strict();
 
 function getRequestCatalogFields(request: { requestType: string; planName: string | null; monthlyPrice: number }) {
   if (request.requestType === 'PLAN_CHANGE') {
@@ -47,9 +60,15 @@ export async function GET(request: NextRequest) {
     }
 
     const { searchParams } = new URL(request.url);
-    const status = searchParams.get('status') || 'PENDING';
-    const page = parseInt(searchParams.get('page') || '1');
-    const limit = parseInt(searchParams.get('limit') || '20');
+    const parsedQuery = subscriptionRequestsQuerySchema.safeParse({
+      status: searchParams.get('status') ?? undefined,
+      page: searchParams.get('page') ?? undefined,
+      limit: searchParams.get('limit') ?? undefined,
+    });
+    if (!parsedQuery.success) {
+      return NextResponse.json({ error: 'Invalid query parameters' }, { status: 400 });
+    }
+    const { status, page, limit } = parsedQuery.data;
 
     const skip = (page - 1) * limit;
 
@@ -118,22 +137,15 @@ export async function PATCH(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
-    const { requestId, action, reason } = body;
-
-    if (!requestId || !action) {
+    const rawBody = await request.json().catch(() => null);
+    const parsedBody = subscriptionRequestDecisionSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: 'Missing required fields' },
+        { error: 'Invalid subscription request payload' },
         { status: 400 }
       );
     }
-
-    if (!['APPROVED', 'REJECTED'].includes(action)) {
-      return NextResponse.json(
-        { error: 'Invalid action' },
-        { status: 400 }
-      );
-    }
+    const { requestId, action, reason } = parsedBody.data;
 
     // Get the request
     const subscriptionRequest = await prisma.subscriptionRequest.findUnique({

--- a/app/api/assistante/subscriptions/route.ts
+++ b/app/api/assistante/subscriptions/route.ts
@@ -5,8 +5,15 @@ import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 import { getOperationalSubscriptionPlan } from '@/lib/operational-catalog';
+import { z } from 'zod';
 
 class AlreadyProcessedError extends Error {}
+
+const subscriptionDecisionSchema = z.object({
+  subscriptionId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/),
+  action: z.enum(['approve', 'reject']),
+  reason: z.string().trim().max(1000).optional(),
+}).strict();
 
 function getPlanCatalog(planName: string) {
   return getOperationalSubscriptionPlan(planName);
@@ -143,19 +150,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = (await request.json()) as {
-      subscriptionId?: string;
-      action?: 'approve' | 'reject';
-      reason?: string;
-    };
-    const { subscriptionId, action, reason: _reason } = body;
-
-    if (!subscriptionId || !action) {
+    const rawBody = await request.json().catch(() => null);
+    const parsedBody = subscriptionDecisionSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: 'Missing required fields' },
+        { error: 'Invalid subscription payload' },
         { status: 400 }
       );
     }
+    const { subscriptionId, action } = parsedBody.data;
 
     // Get the subscription
     const subscription = await prisma.subscription.findUnique({

--- a/app/api/bilan-gratuit/dismiss/route.ts
+++ b/app/api/bilan-gratuit/dismiss/route.ts
@@ -4,13 +4,24 @@ export const dynamic = 'force-dynamic';
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+
+const dismissPayloadSchema = z.object({}).strict();
 
 /**
  * POST /api/bilan-gratuit/dismiss
  * Marks the bilan gratuit banner as dismissed for the current parent.
  */
-export async function POST() {
+export async function POST(request: Request) {
   try {
+    const contentLength = request.headers.get('content-length');
+    if (contentLength && contentLength !== '0') {
+      const parsedPayload = dismissPayloadSchema.safeParse(await request.json().catch(() => null));
+      if (!parsedPayload.success) {
+        return NextResponse.json({ error: 'Invalid dismiss payload' }, { status: 400 });
+      }
+    }
+
     let session: any = null;
     try {
       session = await auth();

--- a/app/api/bilan-gratuit/route.ts
+++ b/app/api/bilan-gratuit/route.ts
@@ -1,20 +1,114 @@
 export const dynamic = 'force-dynamic';
 
-import { prisma } from '@/lib/prisma';
-import { bilanGratuitSchema } from '@/lib/validations';
-import { normalizeStudentLevelAndTrack } from '@/lib/utils/grade-utils';
-import { UserRole } from '@/types/enums';
+import { bilanGratuitSchema, type BilanGratuitData } from '@/lib/validations';
 import { guardRateLimitAsync } from '@/lib/rate-limit';
 import { checkCsrf, checkBodySize } from '@/lib/csrf';
 import { serializeError } from '@/lib/utils/serialize-error';
-import { createId } from '@paralleldrive/cuid2';
-import crypto from 'crypto';
+import { captureContactLead, ContactLeadValidationError } from '@/lib/crm/contact-leads';
+import { Subject, Grade } from '@/lib/assessments/core/types';
+import {
+  ASSESSMENT_FLOW_COOKIE_NAME,
+  ASSESSMENT_FLOW_TOKEN_TTL_SECONDS,
+  createAssessmentFlowToken,
+  hashAssessmentLeadEmail,
+} from '@/lib/assessments/public-token';
 import { NextRequest, NextResponse } from 'next/server';
+
+const bilanGratuitPublicSchema = bilanGratuitSchema.omit({ parentPassword: true }).strict();
+type BilanGratuitPublicData = Omit<BilanGratuitData, 'parentPassword'>;
+
+const neutralSuccessBody = {
+  success: true,
+  message: 'Votre demande a bien été enregistrée. Notre équipe vous recontactera pour la suite.',
+} as const;
+
+function mapBilanSubjectToAssessmentSubject(subjects: string[]): Subject {
+  if (subjects.includes('MATHEMATIQUES')) return Subject.MATHS;
+  if (subjects.includes('NSI')) return Subject.NSI;
+  return Subject.GENERAL;
+}
+
+function mapBilanGradeToAssessmentGrade(grade: string): Grade.PREMIERE | Grade.TERMINALE {
+  return grade === 'terminale' || grade === 'TERMINALE'
+    ? Grade.TERMINALE
+    : Grade.PREMIERE;
+}
+
+function buildAssessmentFlowToken(data: BilanGratuitPublicData) {
+  return createAssessmentFlowToken({
+    subject: mapBilanSubjectToAssessmentSubject(data.subjects),
+    grade: mapBilanGradeToAssessmentGrade(data.studentGrade),
+    source: 'bilan-gratuit',
+    leadEmailHash: hashAssessmentLeadEmail(data.parentEmail),
+  });
+}
+
+function neutralSuccessResponse(assessmentFlowToken?: string) {
+  const response = NextResponse.json(neutralSuccessBody);
+  if (assessmentFlowToken) {
+    response.cookies.set(ASSESSMENT_FLOW_COOKIE_NAME, assessmentFlowToken, {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      path: '/bilan-gratuit/assessment',
+      maxAge: ASSESSMENT_FLOW_TOKEN_TTL_SECONDS,
+    });
+  }
+  return response;
+}
+
+function safeErrorSummary(error: unknown) {
+  const serialized = serializeError(error);
+  if (serialized && typeof serialized === 'object' && !Array.isArray(serialized)) {
+    return {
+      name: typeof serialized.name === 'string' ? serialized.name : 'Error',
+      message: typeof serialized.message === 'string' ? serialized.message : 'unknown',
+    };
+  }
+  return { name: 'Error', message: String(serialized) };
+}
+
+function compactText(value: string | undefined, maxLength = 140) {
+  const text = value?.trim();
+  if (!text) return null;
+  return text.length > maxLength ? `${text.slice(0, maxLength - 1)}…` : text;
+}
+
+function buildLeadNotes(data: BilanGratuitPublicData) {
+  const resolvedStudentLastName = data.studentLastName ?? data.parentLastName;
+  const notes = [
+    `Élève: ${data.studentFirstName} ${resolvedStudentLastName}`,
+    `Niveau: ${data.studentGrade}`,
+    compactText(data.studentSchool, 80) ? `Établissement: ${compactText(data.studentSchool, 80)}` : null,
+    `Matières: ${data.subjects.join(', ')}`,
+    compactText(data.currentLevel, 60) ? `Niveau actuel: ${compactText(data.currentLevel, 60)}` : null,
+    compactText(data.objectives, 140) ? `Objectifs: ${compactText(data.objectives, 140)}` : null,
+    compactText(data.difficulties, 120) ? `Difficultés: ${compactText(data.difficulties, 120)}` : null,
+    compactText(data.preferredModality, 40) ? `Modalité: ${compactText(data.preferredModality, 40)}` : null,
+    compactText(data.availability, 80) ? `Disponibilités: ${compactText(data.availability, 80)}` : null,
+    `Newsletter: ${data.acceptNewsletter ? 'oui' : 'non'}`,
+  ].filter(Boolean).join('\n');
+
+  return notes.slice(0, 500);
+}
+
+function buildBilanLead(data: BilanGratuitPublicData) {
+  return {
+    name: `${data.parentFirstName} ${data.parentLastName}`.trim(),
+    email: data.parentEmail,
+    phone: data.parentPhone,
+    profile: 'Parent',
+    interest: `Bilan gratuit - ${data.studentGrade}`,
+    urgency: data.currentLevel ?? null,
+    source: 'bilan-gratuit',
+    notes: buildLeadNotes(data),
+    type: 'bilan_gratuit',
+    consent: data.acceptTerms,
+  };
+}
 
 export async function POST(request: NextRequest) {
   try {
-    const isTestEnv = process.env.NODE_ENV === 'test';
-
     // CSRF protection — verify same-origin
     const csrfResponse = checkCsrf(request);
     if (csrfResponse) return csrfResponse;
@@ -27,137 +121,56 @@ export async function POST(request: NextRequest) {
     const blocked = await guardRateLimitAsync(request, { preset: 'api', keySuffix: 'bilan-gratuit' });
     if (blocked) return blocked;
 
-    const body = await request.json();
+    const body = await request.json().catch(() => null);
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return NextResponse.json(
+        { error: 'Données invalides' },
+        { status: 400 }
+      );
+    }
+
+    const bodyRecord = body as Record<string, unknown>;
 
     // Honeypot check — bots fill hidden fields, humans don't
-    if (body.website || body.url || body.honeypot) {
+    if (bodyRecord.website || bodyRecord.url || bodyRecord.honeypot) {
       // Silently reject bot submissions with a fake success response
-      return NextResponse.json({ success: true, message: 'Inscription réussie !' });
+      return neutralSuccessResponse();
     }
+
+    const {
+      website: _website,
+      url: _url,
+      honeypot: _honeypot,
+      ...candidatePayload
+    } = bodyRecord;
 
     // Validation des données
-    const validatedData = bilanGratuitSchema.parse(body);
-
-    // Vérifier si l'email parent existe déjà
-    let existingUser = null;
-    try {
-      existingUser = await prisma.user.findUnique({ where: { email: validatedData.parentEmail } });
-    } catch (dbErr) {
-      if (!isTestEnv) {
-        console.error('DB check failed:', serializeError(dbErr));
-      }
-    }
-
-    if (existingUser) {
+    const parsedPayload = bilanGratuitPublicSchema.safeParse(candidatePayload);
+    if (!parsedPayload.success) {
       return NextResponse.json(
-        { error: 'Un compte existe déjà avec cet email' },
+        { error: 'Données invalides' },
         { status: 400 }
       );
     }
+    const validatedData = parsedPayload.data;
 
-    const resolvedStudentLastName = validatedData.studentLastName ?? validatedData.parentLastName;
-    const rawActivationToken = `act_${createId()}_${crypto.randomBytes(16).toString('hex')}`;
-    const hashedActivationToken = crypto.createHash('sha256').update(rawActivationToken).digest('hex');
-    const activationExpiry = new Date(Date.now() + 72 * 60 * 60 * 1000);
-
-    // Normaliser le niveau scolaire AVANT la transaction
-    const gTrack = normalizeStudentLevelAndTrack(validatedData.studentGrade);
-    
-    if (!gTrack) {
-      return NextResponse.json(
-        { error: `Niveau scolaire non reconnu : ${validatedData.studentGrade}` },
-        { status: 400 }
-      );
-    }
-
-    // Transaction pour créer parent et élève
-    const result = await prisma.$transaction(async (tx) => {
-      // Créer le compte parent
-      const parentUser = await tx.user.create({
-        data: {
-          email: validatedData.parentEmail,
-          password: null,
-          role: UserRole.PARENT,
-          firstName: validatedData.parentFirstName,
-          lastName: validatedData.parentLastName,
-          phone: validatedData.parentPhone,
-          activatedAt: null,
-          activationToken: hashedActivationToken,
-          activationExpiry,
-        }
-      });
-
-      // Créer le profil parent
-      const parentProfile = await tx.parentProfile.create({
-        data: {
-          userId: parentUser.id
-        }
-      });
-
-      // Créer le compte élève sans accès direct.
-      // Email format: prenom.nom.random@nexus-student.local to ensure uniqueness
-      const studentEmailSlug = `${validatedData.studentFirstName.toLowerCase()}.${resolvedStudentLastName.toLowerCase()}.${createId().slice(0, 4)}@nexus-student.local`;
-      
-      const studentUser = await tx.user.create({
-        data: {
-          email: studentEmailSlug,
-          role: UserRole.ELEVE,
-          firstName: validatedData.studentFirstName,
-          lastName: resolvedStudentLastName,
-          password: null,
-          activatedAt: null,
-        }
-      });
-
-      const student = await tx.student.create({
-        data: {
-          parentId: parentProfile.id,
-          userId: studentUser.id,
-          grade: validatedData.studentGrade,
-          gradeLevel: gTrack.level,
-          academicTrack: gTrack.track,
-          school: validatedData.studentSchool,
-          birthDate: validatedData.studentBirthDate ? new Date(validatedData.studentBirthDate) : null
-        }
-      });
-
-      return { parentUser, studentUser, student };
-    });
-
-    // Envoyer email de bienvenue
     try {
-      const { sendWelcomeParentEmail } = await import('@/lib/email');
-      const activationUrl = `${process.env.NEXTAUTH_URL || 'https://nexusreussite.academy'}/auth/activate?token=${encodeURIComponent(rawActivationToken)}&source=bilan-gratuit`;
-      await sendWelcomeParentEmail(
-        result.parentUser.email,
-        `${result.parentUser.firstName} ${result.parentUser.lastName}`,
-        `${result.studentUser.firstName} ${result.studentUser.lastName}`,
-        activationUrl
-      );
-    } catch (emailError) {
-      if (!isTestEnv) {
-        console.error('Erreur envoi email de bienvenue:', serializeError(emailError));
+      await captureContactLead(buildBilanLead(validatedData));
+    } catch (leadError) {
+      if (leadError instanceof ContactLeadValidationError) {
+        return NextResponse.json(
+          { error: 'Données invalides' },
+          { status: 400 }
+        );
       }
-      // Ne pas faire échouer l'inscription si l'email ne part pas
+      throw leadError;
     }
 
-    return NextResponse.json({
-      success: true,
-      message: 'Votre demande a bien été enregistrée. Un lien d’activation a été envoyé.',
-      parentId: result.parentUser.id,
-      studentId: result.student.id
-    });
+    return neutralSuccessResponse(buildAssessmentFlowToken(validatedData));
 
   } catch (error) {
     if (process.env.NODE_ENV !== 'test') {
-      console.error('Erreur inscription bilan gratuit:', serializeError(error));
-    }
-
-    if (error instanceof Error && error.name === 'ZodError') {
-      return NextResponse.json(
-        { error: 'Données invalides', details: error.message },
-        { status: 400 }
-      );
+      console.error('Erreur demande bilan gratuit:', safeErrorSummary(error));
     }
 
     return NextResponse.json(

--- a/app/api/bilans/[id]/export/route.ts
+++ b/app/api/bilans/[id]/export/route.ts
@@ -13,11 +13,29 @@ import {
   buildBilanWriteWhere,
   canSeeInternalBilan,
 } from '@/lib/security/ownership';
+import { z } from 'zod';
 
 export const dynamic = 'force-dynamic';
 
 interface RouteParams {
   params: Promise<{ id: string }>;
+}
+
+const routeParamsSchema = z.object({
+  id: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+}).strict();
+
+const exportQuerySchema = z.object({
+  format: z.enum(['pdf', 'markdown']).default('markdown'),
+  audience: z.enum(['student', 'parents', 'nexus', 'all']).default('all'),
+}).strict();
+
+const exportBodySchema = z.object({
+  format: z.enum(['pdf', 'markdown']).default('pdf'),
+}).strict();
+
+function validationFailed() {
+  return NextResponse.json({ success: false, error: 'Données invalides' }, { status: 400 });
 }
 
 /**
@@ -30,10 +48,13 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   if (isErrorResponse(authResponse)) return authResponse;
 
   try {
-    const { id } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
     const { searchParams } = new URL(request.url);
-    const format = searchParams.get('format') || 'markdown';
-    const audience = searchParams.get('audience') || 'all';
+    const parsedQuery = exportQuerySchema.safeParse(Object.fromEntries(searchParams.entries()));
+    if (!parsedQuery.success) return validationFailed();
+    const { id } = parsedParams.data;
+    const { format, audience } = parsedQuery.data;
     const where = buildBilanReadWhere(id, authResponse.user);
     if (!where) {
       return NextResponse.json(
@@ -160,9 +181,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   if (isErrorResponse(authResponse)) return authResponse;
 
   try {
-    const { id } = await params;
-    const body = await request.json();
-    const { format = 'pdf' } = body;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
+    const parsedBody = exportBodySchema.safeParse(await request.json());
+    if (!parsedBody.success) return validationFailed();
+    const { id } = parsedParams.data;
+    const { format } = parsedBody.data;
     const where = buildBilanWriteWhere(id, authResponse.user);
     if (!where) {
       return NextResponse.json(

--- a/app/api/bilans/[id]/route.ts
+++ b/app/api/bilans/[id]/route.ts
@@ -15,11 +15,42 @@ import {
   buildBilanWriteWhere,
   sanitizeBilanForRole,
 } from '@/lib/security/ownership';
+import { z } from 'zod';
 
 export const dynamic = 'force-dynamic';
 
 interface RouteParams {
   params: Promise<{ id: string }>;
+}
+
+const routeParamsSchema = z.object({
+  id: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+}).strict();
+
+const updateBilanBodySchema = z.object({
+  status: z.string().trim().min(1).max(80).optional(),
+  progress: z.number().int().min(0).max(100).optional(),
+  globalScore: z.number().min(0).max(100).optional(),
+  confidenceIndex: z.number().min(0).max(100).optional(),
+  ssn: z.number().optional(),
+  uai: z.number().optional(),
+  domainScores: z.unknown().optional(),
+  studentMarkdown: z.string().max(80_000).optional(),
+  parentsMarkdown: z.string().max(80_000).optional(),
+  nexusMarkdown: z.string().max(80_000).optional(),
+  analysisJson: z.unknown().optional(),
+  isPublished: z.boolean().optional(),
+  errorCode: z.string().trim().max(120).nullable().optional(),
+  errorDetails: z.string().trim().max(2000).nullable().optional(),
+  retryCount: z.number().int().min(0).max(20).optional(),
+  ragUsed: z.boolean().optional(),
+  ragCollections: z.array(z.string().trim().min(1).max(120)).max(20).optional(),
+  sourceVersion: z.string().trim().max(120).optional(),
+  engineVersion: z.string().trim().max(120).optional(),
+}).strict();
+
+function validationFailed() {
+  return NextResponse.json({ success: false, error: 'Données invalides' }, { status: 400 });
 }
 
 /**
@@ -31,7 +62,9 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   if (isErrorResponse(authResponse)) return authResponse;
 
   try {
-    const { id } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
+    const { id } = parsedParams.data;
     const where = buildBilanReadWhere(id, authResponse.user);
     if (!where) {
       return NextResponse.json(
@@ -86,8 +119,12 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
   if (isErrorResponse(authResponse)) return authResponse;
 
   try {
-    const { id } = await params;
-    const body = await request.json();
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
+    const parsedBody = updateBilanBodySchema.safeParse(await request.json());
+    if (!parsedBody.success) return validationFailed();
+    const { id } = parsedParams.data;
+    const body = parsedBody.data;
     const where = buildBilanWriteWhere(id, authResponse.user);
     if (!where) {
       return NextResponse.json(
@@ -162,7 +199,9 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
   if (isErrorResponse(authResponse)) return authResponse;
 
   try {
-    const { id } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
+    const { id } = parsedParams.data;
 
     // Check bilan exists
     const existing = await prisma.bilan.findUnique({ where: { id } });

--- a/app/api/bilans/generate/route.ts
+++ b/app/api/bilans/generate/route.ts
@@ -9,8 +9,27 @@ import { prisma } from '@/lib/prisma';
 import { requireAnyRole, isErrorResponse } from '@/lib/guards';
 import { BilanGenerator } from '@/lib/bilan/generator';
 import type { BilanGenerationContext } from '@/lib/bilan/generator';
+import { z } from 'zod';
 
 export const dynamic = 'force-dynamic';
+
+const safeIdSchema = z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/);
+
+const generateBilanBodySchema = z.object({
+  bilanId: safeIdSchema,
+  enableRAG: z.boolean().default(true),
+  ragCollections: z.array(z.string().trim().min(1).max(120)).max(20).optional(),
+  ragQuery: z.string().trim().max(500).optional(),
+  force: z.boolean().optional(),
+}).strict();
+
+const generationStatusQuerySchema = z.object({
+  bilanId: safeIdSchema,
+}).strict();
+
+function validationFailed(message = 'Données invalides') {
+  return NextResponse.json({ success: false, error: message }, { status: 400 });
+}
 
 /**
  * POST /api/bilans/generate
@@ -22,15 +41,13 @@ export async function POST(request: NextRequest) {
   if (isErrorResponse(authResponse)) return authResponse;
 
   try {
-    const body = await request.json();
-    const { bilanId, enableRAG = true, ragCollections, ragQuery } = body;
-
-    if (!bilanId) {
-      return NextResponse.json(
-        { success: false, error: 'Missing required field: bilanId' },
-        { status: 400 }
-      );
+    const rawBody = await request.json();
+    const parsedBody = generateBilanBodySchema.safeParse(rawBody);
+    if (!parsedBody.success) {
+      const hasBilanId = rawBody && typeof rawBody === 'object' && 'bilanId' in rawBody;
+      return validationFailed(hasBilanId ? undefined : 'Missing required field: bilanId');
     }
+    const { bilanId, enableRAG, ragCollections, ragQuery, force } = parsedBody.data;
 
     // Fetch bilan
     const bilan = await prisma.bilan.findUnique({
@@ -53,7 +70,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Check if already completed
-    if (bilan.status === 'COMPLETED' && !body.force) {
+    if (bilan.status === 'COMPLETED' && !force) {
       return NextResponse.json(
         { success: false, error: 'Bilan already completed. Use force=true to regenerate.' },
         { status: 409 }
@@ -122,14 +139,12 @@ export async function GET(request: NextRequest) {
 
   try {
     const { searchParams } = new URL(request.url);
-    const bilanId = searchParams.get('bilanId');
-
-    if (!bilanId) {
-      return NextResponse.json(
-        { success: false, error: 'Missing required param: bilanId' },
-        { status: 400 }
-      );
+    const queryObject = Object.fromEntries(searchParams.entries());
+    const parsedQuery = generationStatusQuerySchema.safeParse(queryObject);
+    if (!parsedQuery.success) {
+      return validationFailed('bilanId' in queryObject ? undefined : 'Missing required param: bilanId');
     }
+    const { bilanId } = parsedQuery.data;
 
     const bilan = await prisma.bilan.findUnique({
       where: { id: bilanId },

--- a/app/api/bilans/route.ts
+++ b/app/api/bilans/route.ts
@@ -8,9 +8,40 @@ import { serializeError } from '@/lib/utils/serialize-error';
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { requireAnyRole, isErrorResponse } from '@/lib/guards';
-import type { BilanType, BilanStatus, CreateBilanInput } from '@/lib/bilan/types';
+import { z } from 'zod';
 
 export const dynamic = 'force-dynamic';
+
+const listBilansQuerySchema = z.object({
+  type: z.string().trim().min(1).max(80).optional(),
+  status: z.string().trim().min(1).max(80).optional(),
+  subject: z.string().trim().min(1).max(80).optional(),
+  studentId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/).optional(),
+  stageId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/).optional(),
+  coachId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/).optional(),
+  isPublished: z.enum(['true', 'false']).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  offset: z.coerce.number().int().min(0).max(100_000).default(0),
+}).strict();
+
+const createBilanBodySchema = z.object({
+  type: z.string().trim().min(1).max(80),
+  subject: z.string().trim().min(1).max(80),
+  studentEmail: z.string().trim().email(),
+  studentName: z.string().trim().min(1).max(180),
+  studentPhone: z.string().trim().max(80).optional(),
+  studentId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/).optional(),
+  stageId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/).optional(),
+  coachId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/).optional(),
+  sourceData: z.record(z.unknown()).optional(),
+  globalScore: z.number().min(0).max(100).optional(),
+  confidenceIndex: z.number().min(0).max(100).optional(),
+  domainScores: z.unknown().optional(),
+}).strict();
+
+function validationFailed() {
+  return NextResponse.json({ success: false, error: 'Données invalides' }, { status: 400 });
+}
 
 /**
  * GET /api/bilans
@@ -24,16 +55,9 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
 
-    // Parse filters
-    const type = searchParams.get('type') as BilanType | null;
-    const status = searchParams.get('status') as BilanStatus | null;
-    const subject = searchParams.get('subject');
-    const studentId = searchParams.get('studentId');
-    const stageId = searchParams.get('stageId');
-    const coachId = searchParams.get('coachId');
-    const isPublished = searchParams.get('isPublished');
-    const limit = parseInt(searchParams.get('limit') || '50');
-    const offset = parseInt(searchParams.get('offset') || '0');
+    const parsedQuery = listBilansQuerySchema.safeParse(Object.fromEntries(searchParams.entries()));
+    if (!parsedQuery.success) return validationFailed();
+    const { type, status, subject, studentId, stageId, coachId, isPublished, limit, offset } = parsedQuery.data;
 
     // RBAC: Force coachId if role is COACH
     const userRole = (authResponse as any).user.role;
@@ -62,7 +86,7 @@ export async function GET(request: NextRequest) {
       where.coachId = coachId;
     }
     
-    if (isPublished !== null) where.isPublished = isPublished === 'true';
+    if (isPublished !== undefined) where.isPublished = isPublished === 'true';
 
     // Fetch bilans
     const [bilans, total] = await Promise.all([
@@ -109,15 +133,9 @@ export async function POST(request: NextRequest) {
   if (isErrorResponse(authResponse)) return authResponse;
 
   try {
-    const body = await request.json();
-
-    // Validate required fields
-    if (!body.type || !body.subject || !body.studentEmail || !body.studentName) {
-      return NextResponse.json(
-        { success: false, error: 'Missing required fields: type, subject, studentEmail, studentName' },
-        { status: 400 }
-      );
-    }
+    const parsedBody = createBilanBodySchema.safeParse(await request.json());
+    if (!parsedBody.success) return validationFailed();
+    const body = parsedBody.data;
 
     // RBAC: Validate coachId if role is COACH
     const userRole = (authResponse as any).user.role;
@@ -140,7 +158,7 @@ export async function POST(request: NextRequest) {
     // Create bilan
     const bilan = await prisma.bilan.create({
       data: {
-        type: body.type as BilanType,
+        type: body.type as any,
         subject: body.subject,
         studentEmail: body.studentEmail,
         studentName: body.studentName,
@@ -148,10 +166,10 @@ export async function POST(request: NextRequest) {
         studentId: body.studentId,
         stageId: body.stageId,
         coachId: body.coachId,
-        sourceData: body.sourceData || {},
+        sourceData: (body.sourceData || {}) as any,
         globalScore: body.globalScore,
         confidenceIndex: body.confidenceIndex,
-        domainScores: body.domainScores,
+        domainScores: body.domainScores as any,
         status: 'PENDING',
         progress: 0,
         isPublished: false,

--- a/app/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate/route.ts
+++ b/app/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate/route.ts
@@ -19,9 +19,9 @@ import {
 } from '@/lib/rbac/coach-student-access';
 import { prisma } from '@/lib/prisma';
 import { logger } from '@/lib/logger';
-import { COACH_EAF_META } from '@/lib/coach/eaf-stage-printemps/types';
 import type { CoachEafSourceData } from '@/lib/coach/eaf-stage-printemps/types';
 import { generateLLMParentEafReport } from '@/lib/coach/eaf-stage-printemps/llm-report';
+import { z } from 'zod';
 
 export const maxDuration = 200;
 
@@ -33,13 +33,23 @@ interface RouteParams {
   params: Promise<{ studentId: string }>;
 }
 
+const routeParamsSchema = z.object({
+  studentId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+}).strict();
+
+function validationFailed() {
+  return NextResponse.json({ error: 'Données invalides' }, { status: 400 });
+}
+
 export async function POST(_request: Request, { params }: RouteParams) {
   try {
-    const { studentId } = await params;
-
     const sessionOrError = await requireRole('COACH');
     if (isErrorResponse(sessionOrError)) return sessionOrError;
     const authSession = sessionOrError;
+
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
+    const { studentId } = parsedParams.data;
 
     try {
       await assertCoachCanAccessStudent({ coachUserId: authSession.user.id, studentId });

--- a/app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent/route.ts
+++ b/app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent/route.ts
@@ -10,6 +10,7 @@ import { prisma } from '@/lib/prisma';
 import { logger } from '@/lib/logger';
 import { generateBilan, adaptMathsPremiereStagePrintemps } from '@/lib/bilan-generation';
 import { MistralConfigurationError, MistralGenerationError } from '@/lib/llm/mistral';
+import { z } from 'zod';
 
 interface RouteParams {
   params: Promise<{ studentId: string }>;
@@ -18,10 +19,17 @@ interface RouteParams {
 const COACH_SOURCE_VERSION = 'coach_maths_premiere_stage_printemps_v1';
 const BILAN_TYPE = 'STAGE_POST' as const;
 const BILAN_SUBJECT_DEFAULT = 'MATHEMATIQUES';
+const routeParamsSchema = z.object({
+  studentId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/),
+}).strict();
 
 export async function POST(_request: Request, { params }: RouteParams) {
   try {
-    const { studentId } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) {
+      return NextResponse.json({ error: 'Invalid route params' }, { status: 400 });
+    }
+    const { studentId } = parsedParams.data;
 
     // Auth
     const sessionOrError = await requireRole('COACH');

--- a/app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student/route.ts
+++ b/app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student/route.ts
@@ -10,6 +10,7 @@ import { prisma } from '@/lib/prisma';
 import { logger } from '@/lib/logger';
 import { generateBilan, adaptMathsPremiereStagePrintemps } from '@/lib/bilan-generation';
 import { MistralConfigurationError, MistralGenerationError } from '@/lib/llm/mistral';
+import { z } from 'zod';
 
 interface RouteParams {
   params: Promise<{ studentId: string }>;
@@ -18,10 +19,17 @@ interface RouteParams {
 const COACH_SOURCE_VERSION = 'coach_maths_premiere_stage_printemps_v1';
 const BILAN_TYPE = 'STAGE_POST' as const;
 const BILAN_SUBJECT_DEFAULT = 'MATHEMATIQUES';
+const routeParamsSchema = z.object({
+  studentId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/),
+}).strict();
 
 export async function POST(_request: Request, { params }: RouteParams) {
   try {
-    const { studentId } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) {
+      return NextResponse.json({ error: 'Invalid route params' }, { status: 400 });
+    }
+    const { studentId } = parsedParams.data;
 
     // Auth
     const sessionOrError = await requireRole('COACH');

--- a/app/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale/route.ts
+++ b/app/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale/route.ts
@@ -6,9 +6,22 @@ import { computeDiagnostics } from '@/lib/diagnostic/maths-terminale/scoring';
 import { DOMAINS } from '@/lib/diagnostic/maths-terminale/data';
 import type { DiagnosticSourceData, TeacherGrade } from '@/lib/diagnostic/maths-terminale/types';
 import { serializeError } from '@/lib/utils/serialize-error';
+import { z } from 'zod';
 
 interface RouteParams {
   params: Promise<{ studentId: string }>;
+}
+
+const routeParamsSchema = z.object({
+  studentId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+}).strict();
+
+const teacherGradesSchema = z.object({
+  teacherGrades: z.record(z.unknown()),
+}).strict();
+
+function validationFailed() {
+  return NextResponse.json({ error: 'Données invalides' }, { status: 400 });
 }
 
 /**
@@ -17,11 +30,13 @@ interface RouteParams {
  */
 export async function GET(_request: Request, { params }: RouteParams) {
   try {
-    const { studentId } = await params;
-
     const sessionOrError = await requireRole('COACH');
     if (isErrorResponse(sessionOrError)) return sessionOrError;
     const authSession = sessionOrError;
+
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
+    const { studentId } = parsedParams.data;
 
     // Verify coach assignment
     try {
@@ -61,11 +76,13 @@ export async function GET(_request: Request, { params }: RouteParams) {
  */
 export async function PATCH(request: Request, { params }: RouteParams) {
   try {
-    const { studentId } = await params;
-
     const sessionOrError = await requireRole('COACH');
     if (isErrorResponse(sessionOrError)) return sessionOrError;
     const authSession = sessionOrError;
+
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
+    const { studentId } = parsedParams.data;
 
     // Verify coach assignment
     try {
@@ -77,12 +94,9 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       );
     }
 
-    const body = await request.json();
-    const { teacherGrades }: { teacherGrades: Record<string, TeacherGrade> } = body;
-
-    if (!teacherGrades || typeof teacherGrades !== 'object') {
-      return NextResponse.json({ error: 'teacherGrades required' }, { status: 400 });
-    }
+    const parsedBody = teacherGradesSchema.safeParse(await request.json());
+    if (!parsedBody.success) return validationFailed();
+    const { teacherGrades } = parsedBody.data as { teacherGrades: Record<string, TeacherGrade> };
 
     // Find the bilan
     const existingBilan = await prisma.bilan.findFirst({
@@ -101,7 +115,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
 
     // Get existing source data
     const existingSourceData = existingBilan.sourceData as unknown as DiagnosticSourceData;
-    const { progress = {}, qcmAnswers = {}, openAnswers = {} } = existingSourceData;
+    const { progress = {}, qcmAnswers = {} } = existingSourceData;
 
     // Recompute with teacher grades
     const evaluatedData = computeDiagnostics(progress, qcmAnswers, teacherGrades, true);

--- a/app/api/coach/students/[studentId]/documents/route.ts
+++ b/app/api/coach/students/[studentId]/documents/route.ts
@@ -15,9 +15,63 @@ const createDocumentSchema = z.object({
   title: z.string().min(1, 'Titre requis').max(200),
   description: z.string().max(1000).optional(),
   url: z.string().url().optional(),
-  localPath: z.string().optional(),
   visibilityScope: z.nativeEnum(DocumentVisibilityScope).default(DocumentVisibilityScope.STUDENT_AND_COACH),
+}).strict();
+
+const routeParamsSchema = z.object({
+  studentId: z.string().min(1).max(128),
 });
+
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+const ALLOWED_UPLOAD_MIME_TYPES = new Set([
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+]);
+
+const documentSafeSelect = {
+  id: true,
+  title: true,
+  originalName: true,
+  mimeType: true,
+  sizeBytes: true,
+  documentType: true,
+  visibilityScope: true,
+  subject: true,
+  description: true,
+  expiresAt: true,
+  createdAt: true,
+  updatedAt: true,
+  userId: true,
+  uploadedById: true,
+} as const;
+
+type DocumentMutationData = {
+  title: string;
+  documentType: DocumentType;
+  subject: Subject | null;
+  description?: string | null;
+  localPath: string;
+  originalName: string;
+  mimeType: string;
+  sizeBytes: number;
+  visibilityScope: DocumentVisibilityScope;
+};
+
+function sanitizeDocument(document: Record<string, unknown>) {
+  const { localPath: _localPath, ...safeDocument } = document;
+  return safeDocument;
+}
+
+function optionalFormString(value: FormDataEntryValue | null): string | undefined {
+  if (typeof value !== 'string' || value.length === 0) return undefined;
+  return value;
+}
+
+function sanitizeFilenamePart(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 80) || 'document';
+}
 
 interface RouteParams {
   params: Promise<{ studentId: string }>;
@@ -31,7 +85,8 @@ interface RouteParams {
  */
 export async function GET(request: Request, { params }: RouteParams) {
   try {
-    const { studentId } = await params;
+    const parsedParams = routeParamsSchema.parse(await params);
+    const { studentId } = parsedParams;
     
     const sessionOrError = await requireRole('COACH');
     if (isErrorResponse(sessionOrError)) return sessionOrError;
@@ -80,13 +135,21 @@ export async function GET(request: Request, { params }: RouteParams) {
         },
       },
       orderBy: { createdAt: 'desc' },
+      select: documentSafeSelect,
     });
 
     return NextResponse.json({
       success: true,
-      documents,
+      documents: documents.map((document) => sanitizeDocument(document)),
     });
   } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Validation Error', message: error.errors },
+        { status: 400 }
+      );
+    }
+
     console.error('[API Coach Documents GET] Error:', serializeError(error));
     return NextResponse.json(
       { error: 'Internal Server Error', message: 'Erreur lors de la récupération' },
@@ -104,7 +167,8 @@ export async function GET(request: Request, { params }: RouteParams) {
  */
 export async function POST(request: Request, { params }: RouteParams) {
   try {
-    const { studentId } = await params;
+    const parsedParams = routeParamsSchema.parse(await params);
+    const { studentId } = parsedParams;
     
     const sessionOrError = await requireRole('COACH');
     if (isErrorResponse(sessionOrError)) return sessionOrError;
@@ -144,7 +208,7 @@ export async function POST(request: Request, { params }: RouteParams) {
 
     // Check if request is FormData (file upload) or JSON (URL)
     const contentType = request.headers.get('content-type');
-    let documentData: any;
+    let documentData: DocumentMutationData;
 
     if (contentType?.includes('multipart/form-data')) {
       // Handle file upload
@@ -158,10 +222,26 @@ export async function POST(request: Request, { params }: RouteParams) {
         );
       }
 
+      if (!ALLOWED_UPLOAD_MIME_TYPES.has(file.type) || file.size > MAX_UPLOAD_BYTES) {
+        return NextResponse.json(
+          { error: 'Bad Request', message: 'Type ou taille de fichier invalide' },
+          { status: 400 }
+        );
+      }
+
+      const validatedMeta = createDocumentSchema.parse({
+        title: optionalFormString(formData.get('title')) ?? file.name,
+        documentType: optionalFormString(formData.get('documentType')),
+        subject: optionalFormString(formData.get('subject')),
+        description: optionalFormString(formData.get('description')),
+        visibilityScope: optionalFormString(formData.get('visibilityScope')) ?? DocumentVisibilityScope.STUDENT_AND_COACH,
+        url: 'https://nexusreussite.academy/internal-upload-placeholder',
+      });
+
       // Generate a unique filename
       const timestamp = Date.now();
-      const sanitizedTitle = (formData.get('title') as string || 'document').replace(/[^a-zA-Z0-9]/g, '_');
-      const extension = file.name.split('.').pop() || 'pdf';
+      const sanitizedTitle = sanitizeFilenamePart(validatedMeta.title);
+      const extension = sanitizeFilenamePart(file.name.split('.').pop() || 'pdf');
       const filename = `${sanitizedTitle}-${timestamp}.${extension}`;
       const localPath = `/app/storage/documents/${student.userId}/${filename}`;
 
@@ -173,10 +253,11 @@ export async function POST(request: Request, { params }: RouteParams) {
       await writeFile(path.join(uploadDir, filename), buffer);
 
       documentData = {
-        title: formData.get('title') as string,
-        documentType: formData.get('documentType') as string,
-        subject: formData.get('subject') as string,
-        visibilityScope: formData.get('visibilityScope') as string,
+        title: validatedMeta.title,
+        documentType: validatedMeta.documentType,
+        subject: validatedMeta.subject ?? null,
+        description: validatedMeta.description ?? null,
+        visibilityScope: validatedMeta.visibilityScope,
         localPath,
         originalName: file.name,
         mimeType: file.type,
@@ -187,16 +268,16 @@ export async function POST(request: Request, { params }: RouteParams) {
       const body = await request.json();
       const validated = createDocumentSchema.parse(body);
 
-      // Require either url or localPath
-      if (!validated.url && !validated.localPath) {
+      // URL documents are metadata only; direct localPath is reserved for server-side uploads.
+      if (!validated.url) {
         return NextResponse.json(
-          { error: 'Bad Request', message: 'URL ou chemin local requis' },
+          { error: 'Bad Request', message: 'URL requise' },
           { status: 400 }
         );
       }
 
       // Build data ensuring localPath is always provided (required by Prisma schema)
-      const localPath = validated.localPath || validated.url || `/app/storage/documents/${student.userId}/${Date.now()}-${validated.title.replace(/[^a-zA-Z0-9]/g, '_')}`;
+      const localPath = validated.url;
       
       documentData = {
         title: validated.title,
@@ -225,12 +306,13 @@ export async function POST(request: Request, { params }: RouteParams) {
         sizeBytes: documentData.sizeBytes,
         visibilityScope: documentData.visibilityScope,
       },
+      select: documentSafeSelect,
     });
 
     return NextResponse.json({
       success: true,
       message: 'Document créé',
-      document,
+      document: sanitizeDocument(document),
     }, { status: 201 });
   } catch (error) {
     if (error instanceof z.ZodError) {

--- a/app/api/coach/students/[studentId]/eaf-preparation-report/validate/route.ts
+++ b/app/api/coach/students/[studentId]/eaf-preparation-report/validate/route.ts
@@ -9,18 +9,29 @@ import { prisma } from '@/lib/prisma';
 import { maybeCreateGeneratedReportJob } from '@/lib/reports/stage/maybeCreateGeneratedReportJob';
 import { getEafCoachReportCompletion } from '@/lib/reports/stage/completeness';
 import { logger } from '@/lib/logger';
+import { z } from 'zod';
 
 interface RouteParams {
   params: Promise<{ studentId: string }>;
 }
 
+const routeParamsSchema = z.object({
+  studentId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+}).strict();
+
+function validationFailed() {
+  return NextResponse.json({ error: 'Données invalides' }, { status: 400 });
+}
+
 export async function POST(_request: Request, { params }: RouteParams) {
   try {
-    const { studentId } = await params;
-
     const sessionOrError = await requireRole('COACH');
     if (isErrorResponse(sessionOrError)) return sessionOrError;
     const authSession = sessionOrError;
+
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
+    const { studentId } = parsedParams.data;
 
     // Verify coach assignment
     try {

--- a/app/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate/route.ts
+++ b/app/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate/route.ts
@@ -6,9 +6,19 @@ import {
 } from '@/lib/rbac/coach-student-access';
 import { processGeneratedReportJob } from '@/lib/reports/stage/processGeneratedReportJob';
 import { logger } from '@/lib/logger';
+import { z } from 'zod';
 
 interface RouteParams {
   params: Promise<{ studentId: string; reportId: string }>;
+}
+
+const routeParamsSchema = z.object({
+  studentId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+  reportId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+}).strict();
+
+function validationFailed() {
+  return NextResponse.json({ error: 'Données invalides' }, { status: 400 });
 }
 
 function projectGeneratedReport(report: Record<string, unknown>) {
@@ -25,11 +35,13 @@ function projectGeneratedReport(report: Record<string, unknown>) {
 
 export async function POST(_request: Request, { params }: RouteParams) {
   try {
-    const { studentId, reportId } = await params;
-
     const sessionOrError = await requireRole('COACH');
     if (isErrorResponse(sessionOrError)) return sessionOrError;
     const authSession = sessionOrError;
+
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
+    const { studentId, reportId } = parsedParams.data;
 
     try {
       await assertCoachCanAccessStudent({ coachUserId: authSession.user.id, studentId });

--- a/app/api/coach/students/[studentId]/notes/route.ts
+++ b/app/api/coach/students/[studentId]/notes/route.ts
@@ -5,8 +5,16 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { isCoachRattachedToStudent } from '@/lib/rbac/coach-student-access';
+import { z } from 'zod';
 
 const MAX_BODY_LENGTH = 4000;
+const routeParamsSchema = z.object({
+  studentId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/),
+}).strict();
+const createNoteSchema = z.object({
+  body: z.string().trim().min(1).max(MAX_BODY_LENGTH),
+  pinned: z.boolean().optional().default(false),
+}).strict();
 
 /**
  * GET /api/coach/students/[studentId]/notes
@@ -30,10 +38,11 @@ export async function GET(
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
-    const { studentId } = await context.params;
-    if (!studentId) {
+    const parsedParams = routeParamsSchema.safeParse(await context.params);
+    if (!parsedParams.success) {
       return NextResponse.json({ error: 'studentId required' }, { status: 400 });
     }
+    const { studentId } = parsedParams.data;
 
     if (role === 'COACH') {
       const allowed = await isCoachRattachedToStudent(session.user.id, studentId);
@@ -90,10 +99,11 @@ export async function POST(
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
-    const { studentId } = await context.params;
-    if (!studentId) {
+    const parsedParams = routeParamsSchema.safeParse(await context.params);
+    if (!parsedParams.success) {
       return NextResponse.json({ error: 'studentId required' }, { status: 400 });
     }
+    const { studentId } = parsedParams.data;
 
     const allowed = await isCoachRattachedToStudent(session.user.id, studentId);
     if (!allowed) {
@@ -107,24 +117,18 @@ export async function POST(
       return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
     }
 
-    const data = payload as { body?: unknown; pinned?: unknown };
-    if (typeof data.body !== 'string' || data.body.trim().length === 0) {
-      return NextResponse.json({ error: 'body must be a non-empty string' }, { status: 400 });
+    const parsedPayload = createNoteSchema.safeParse(payload);
+    if (!parsedPayload.success) {
+      return NextResponse.json({ error: 'Invalid note payload' }, { status: 400 });
     }
-    if (data.body.length > MAX_BODY_LENGTH) {
-      return NextResponse.json(
-        { error: `body too long (max ${MAX_BODY_LENGTH} chars)` },
-        { status: 400 },
-      );
-    }
-    const pinned = typeof data.pinned === 'boolean' ? data.pinned : false;
+    const data = parsedPayload.data;
 
     const note = await prisma.coachNote.create({
       data: {
         studentId,
         coachId: session.user.id,
-        body: data.body.trim(),
-        pinned,
+        body: data.body,
+        pinned: data.pinned,
       },
       select: {
         id: true,

--- a/app/api/coach/students/[studentId]/survival-mode/route.ts
+++ b/app/api/coach/students/[studentId]/survival-mode/route.ts
@@ -6,14 +6,17 @@ import { AcademicTrack } from '@prisma/client';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { isCoachRattachedToStudent } from '@/lib/rbac/coach-student-access';
+import { z } from 'zod';
 
 const ALLOWED_ROLES = new Set(['COACH', 'ADMIN', 'ASSISTANTE']);
 const MAX_REASON_LENGTH = 1000;
-
-type SurvivalModePayload = {
-  enabled?: unknown;
-  reason?: unknown;
-};
+const survivalModeParamsSchema = z.object({
+  studentId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/),
+}).strict();
+const survivalModePayloadSchema = z.object({
+  enabled: z.boolean(),
+  reason: z.string().trim().max(MAX_REASON_LENGTH).optional().nullable(),
+}).strict();
 
 export async function POST(
   request: Request,
@@ -30,10 +33,11 @@ export async function POST(
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
-    const { studentId } = await context.params;
-    if (!studentId) {
+    const parsedParams = survivalModeParamsSchema.safeParse(await context.params);
+    if (!parsedParams.success) {
       return NextResponse.json({ error: 'studentId required' }, { status: 400 });
     }
+    const { studentId } = parsedParams.data;
 
     if (role === 'COACH') {
       const allowed = await isCoachRattachedToStudent(session.user.id, studentId);
@@ -42,21 +46,12 @@ export async function POST(
       }
     }
 
-    let payload: SurvivalModePayload;
-    try {
-      payload = (await request.json()) as SurvivalModePayload;
-    } catch {
-      return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+    const parsedPayload = survivalModePayloadSchema.safeParse(await request.json().catch(() => null));
+    if (!parsedPayload.success) {
+      return NextResponse.json({ error: 'Invalid survival mode payload' }, { status: 400 });
     }
-
-    if (typeof payload.enabled !== 'boolean') {
-      return NextResponse.json({ error: 'enabled must be a boolean' }, { status: 400 });
-    }
-
-    const reason = typeof payload.reason === 'string' ? payload.reason.trim() : null;
-    if (reason && reason.length > MAX_REASON_LENGTH) {
-      return NextResponse.json({ error: `reason too long (max ${MAX_REASON_LENGTH} chars)` }, { status: 400 });
-    }
+    const payload = parsedPayload.data;
+    const reason = payload.reason ?? null;
 
     const student = await prisma.student.findUnique({
       where: { userId: studentId },

--- a/app/api/coach/trajectory/route.ts
+++ b/app/api/coach/trajectory/route.ts
@@ -2,6 +2,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@/auth";
 import { serializeError } from '@/lib/utils/serialize-error';
+import { isCoachRattachedToStudent } from '@/lib/rbac/coach-student-access';
+import { z } from 'zod';
+
+const createTrajectorySchema = z.object({
+  studentId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/),
+  title: z.string().trim().min(1).max(160),
+  targetScore: z.coerce.number().finite().min(0).max(20).optional(),
+  horizon: z.enum(['3_MONTHS', '6_MONTHS', '12_MONTHS']),
+}).strict();
 
 export async function POST(request: NextRequest) {
   try {
@@ -10,10 +19,17 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { studentId, title, targetScore, horizon } = await request.json();
+    const parsedBody = createTrajectorySchema.safeParse(await request.json().catch(() => null));
+    if (!parsedBody.success) {
+      return NextResponse.json({ error: "Invalid trajectory payload" }, { status: 400 });
+    }
+    const { studentId, title, targetScore, horizon } = parsedBody.data;
 
-    if (!studentId || !title || !horizon) {
-      return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+    if (session.user.role === "COACH") {
+      const assigned = await isCoachRattachedToStudent(session.user.id, studentId);
+      if (!assigned) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
     }
 
     // Calculate endDate based on horizon

--- a/app/api/documents/[id]/route.ts
+++ b/app/api/documents/[id]/route.ts
@@ -4,6 +4,60 @@ import { NextRequest, NextResponse } from 'next/server';
 import { readFile } from 'fs/promises';
 import { UserRole } from '@prisma/client';
 import { serializeError } from '@/lib/utils/serialize-error';
+import { z } from 'zod';
+
+const routeParamsSchema = z.object({
+  id: z.string().min(1).max(128).regex(/^[A-Za-z0-9_-]+$/),
+});
+
+const documentDownloadSelect = {
+  id: true,
+  userId: true,
+  localPath: true,
+  mimeType: true,
+  originalName: true,
+  sizeBytes: true,
+} as const;
+
+type DocumentDownloadRecord = {
+  id: string;
+  userId: string;
+  localPath: string;
+  mimeType: string;
+  originalName: string;
+  sizeBytes: number;
+};
+
+function isStaffRole(role: string | undefined): boolean {
+  return role === UserRole.ADMIN || role === UserRole.ASSISTANTE;
+}
+
+function buildDocumentOwnershipWhere(id: string, userId: string, role: string | undefined) {
+  if (isStaffRole(role)) {
+    return { id };
+  }
+  return { id, userId };
+}
+
+function hasDocumentOwnership(document: DocumentDownloadRecord, userId: string, role: string | undefined): boolean {
+  return isStaffRole(role) || document.userId === userId;
+}
+
+function safeFilename(name: string): string {
+  return encodeURIComponent(name.replace(/[\\/\r\n"]/g, '_'));
+}
+
+function safeContentType(mimeType: string | null | undefined): string {
+  if (!mimeType) return 'application/octet-stream';
+  const allowed = new Set([
+    'application/pdf',
+    'image/jpeg',
+    'image/png',
+    'image/webp',
+    'text/plain',
+  ]);
+  return allowed.has(mimeType) ? mimeType : 'application/octet-stream';
+}
 
 export async function GET(
   request: NextRequest,
@@ -15,47 +69,43 @@ export async function GET(
       return new NextResponse('Unauthorized', { status: 401 });
     }
 
-    const { id } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) {
+      return new NextResponse('Bad Request', { status: 400 });
+    }
+    const { id } = parsedParams.data;
+    const userRole = session.user.role as UserRole | undefined;
 
-    // 1. Get Metadata
-    const document = await prisma.userDocument.findUnique({
-      where: { id },
+    // Scope the metadata query before any file-system read.
+    const document = await prisma.userDocument.findFirst({
+      where: buildDocumentOwnershipWhere(id, session.user.id, userRole),
+      select: documentDownloadSelect,
     });
 
     if (!document) {
       return new NextResponse('Document not found', { status: 404 });
     }
 
-    // 2. Strict RBAC (Owner OR Staff)
-    const userRole = session.user.role as UserRole;
-    const isOwner = document.userId === session.user.id;
-    // Allow COACH to see documents? The prompt said "Admin/Assistante or Owner".
-    // I will stick to Admin/Assistante + Owner to be strict as requested.
-    const isStaff = ([UserRole.ADMIN, UserRole.ASSISTANTE] as UserRole[]).includes(userRole);
-
-    if (!isOwner && !isStaff) {
-      return new NextResponse('Forbidden', { status: 403 });
+    if (!hasDocumentOwnership(document, session.user.id, userRole)) {
+      return new NextResponse('Document not found', { status: 404 });
     }
 
-    // 3. Read File from Secure Storage
     try {
       const fileBuffer = await readFile(document.localPath);
 
-      // 4. Return with Headers
-      // 'inline' allows viewing in browser (PDF), 'attachment' forces download.
-      // Use inline for UX, browser will handle download option.
       return new NextResponse(fileBuffer, {
         headers: {
-          'Content-Type': document.mimeType,
-          'Content-Disposition': `inline; filename="${encodeURIComponent(document.originalName)}"`,
+          'Content-Type': safeContentType(document.mimeType),
+          'Content-Disposition': `inline; filename="${safeFilename(document.originalName)}"`,
           'Content-Length': document.sizeBytes.toString(),
-          // Security headers
           'X-Content-Type-Options': 'nosniff',
         },
       });
     } catch (fsError) {
-      console.error('[File Read Error] File missing on disk:', document.localPath);
-      // Don't leak path in production response
+      const code = fsError instanceof Error && 'code' in fsError
+        ? String((fsError as NodeJS.ErrnoException).code)
+        : 'UNKNOWN';
+      console.error('[File Read Error] File content unavailable', { documentId: document.id, code });
       return new NextResponse('File content not found', { status: 404 });
     }
 

--- a/app/api/eleve/bilan-diagnostic-maths-terminale/route.ts
+++ b/app/api/eleve/bilan-diagnostic-maths-terminale/route.ts
@@ -2,11 +2,26 @@ import { NextResponse } from 'next/server';
 import { requireRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
 import { computeDiagnostics } from '@/lib/diagnostic/maths-terminale/scoring';
-import type { DiagnosticSourceData } from '@/lib/diagnostic/maths-terminale/types';
+import type { ChapterProgress, DiagnosticSourceData, OpenAnswer } from '@/lib/diagnostic/maths-terminale/types';
 import { DOMAINS } from '@/lib/diagnostic/maths-terminale/data';
 import { serializeError } from '@/lib/utils/serialize-error';
+import { z } from 'zod';
 
 const BILAN_SOURCE_VERSION = 'maths_terminale_v1';
+const chapterProgressSchema = z.object({
+  declared: z.number().int().min(0).max(5).nullable(),
+  confidence: z.number().int().min(1).max(5),
+}).strict();
+const openAnswerSchema = z.object({
+  text: z.string().max(5000),
+  status: z.string().max(200),
+}).strict();
+const diagnosticPayloadSchema = z.object({
+  progress: z.record(z.string(), chapterProgressSchema).default({}),
+  qcmAnswers: z.record(z.string(), z.coerce.number().int()).default({}),
+  openAnswers: z.record(z.string(), openAnswerSchema).default({}),
+  step: z.enum(['progress', 'qcm', 'open', 'results']).default('progress'),
+}).strict();
 
 /**
  * GET /api/eleve/bilan-diagnostic-maths-terminale
@@ -82,8 +97,14 @@ export async function POST(request: Request) {
     if (isErrorResponse(sessionOrError)) return sessionOrError;
     const authSession = sessionOrError;
 
-    const body = await request.json();
-    const { progress = {}, qcmAnswers = {}, openAnswers = {}, step = 'progress' } = body;
+    const parsedBody = diagnosticPayloadSchema.safeParse(await request.json().catch(() => null));
+    if (!parsedBody.success) {
+      return NextResponse.json({ error: 'Invalid diagnostic payload' }, { status: 400 });
+    }
+    const progress = parsedBody.data.progress as Record<string, ChapterProgress>;
+    const qcmAnswers = parsedBody.data.qcmAnswers;
+    const openAnswers = parsedBody.data.openAnswers as Record<string, OpenAnswer>;
+    const step = parsedBody.data.step;
 
     // Find the student record
     const student = await prisma.student.findUnique({

--- a/app/api/internal/health/route.ts
+++ b/app/api/internal/health/route.ts
@@ -13,8 +13,9 @@ import { NextResponse } from 'next/server';
 import { enforcePolicy } from '@/lib/rbac';
 import { isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
-import { getRateLimitRuntimeMode } from '@/lib/rate-limit';
+import { getRateLimitProductionGate } from '@/lib/rate-limit';
 import { ragSearch } from '@/lib/rag-client';
+import { getConfigSnapshotRuntimeStatus } from '@/lib/config/snapshot';
 
 export async function GET() {
   // 1. Auth check
@@ -48,10 +49,10 @@ export async function GET() {
   }
 
   // 5. Redis / Upstash
-  const rateLimitMode = getRateLimitRuntimeMode();
+  const rateLimitGate = getRateLimitProductionGate();
   checks.redis = {
-    ok: rateLimitMode !== 'memory',
-    detail: rateLimitMode,
+    ok: rateLimitGate.ok,
+    detail: rateLimitGate.mode,
   };
 
   // 6. Disk (basic check via cwd access)
@@ -68,12 +69,29 @@ export async function GET() {
     detail: process.env.NPC_LLM_MODE || 'not configured',
   };
 
+  // 8. BusinessConfig snapshot (DB-backed overrides or classified static fallback)
+  const businessConfigStatus = getConfigSnapshotRuntimeStatus();
+  checks.businessConfig = {
+    ok: businessConfigStatus.ok,
+    detail: businessConfigStatus.lastError
+      ? `${businessConfigStatus.mode}:${businessConfigStatus.lastError.kind}`
+      : businessConfigStatus.mode,
+  };
+
   const allOk = Object.values(checks).every((c) => c.ok);
 
   return NextResponse.json(
     {
       status: allOk ? 'healthy' : 'degraded',
       checks,
+      runtime: {
+        rateLimit: {
+          mode: rateLimitGate.mode,
+          distributed: rateLimitGate.ok,
+          goLiveLarge: rateLimitGate.decision,
+        },
+        businessConfig: businessConfigStatus,
+      },
       timestamp: new Date().toISOString(),
     },
     { status: allOk ? 200 : 503 }

--- a/app/api/internal/rate-limit-probe/route.ts
+++ b/app/api/internal/rate-limit-probe/route.ts
@@ -1,0 +1,31 @@
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { isErrorResponse } from '@/lib/guards';
+import { enforcePolicy } from '@/lib/rbac';
+import { getRateLimitProductionGate, guardRateLimitAsync } from '@/lib/rate-limit';
+
+export async function GET(request: NextRequest) {
+  const sessionOrResponse = await enforcePolicy('admin.dashboard');
+  if (isErrorResponse(sessionOrResponse)) {
+    return sessionOrResponse;
+  }
+
+  const blocked = await guardRateLimitAsync(request, {
+    preset: 'auth',
+    keySuffix: 'internal-rate-limit-probe',
+  });
+  if (blocked) return blocked;
+
+  const gate = getRateLimitProductionGate();
+
+  return NextResponse.json({
+    ok: true,
+    probe: 'rate-limit',
+    runtime: {
+      mode: gate.mode,
+      distributed: gate.ok,
+      goLiveLarge: gate.decision,
+    },
+  });
+}

--- a/app/api/invoices/[id]/pdf/route.ts
+++ b/app/api/invoices/[id]/pdf/route.ts
@@ -16,7 +16,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { readInvoicePDF, verifyAccessToken } from '@/lib/invoice';
-import { notFoundResponse, buildInvoiceScopeWhere } from '@/lib/invoice/not-found';
+import { notFoundResponse, buildInvoiceAccessWhere } from '@/lib/invoice/not-found';
 
 /**
  * Stream a PDF response from a buffer.
@@ -68,10 +68,11 @@ export async function GET(
       return notFoundResponse();
     }
 
-    const userRole = (session.user as { role?: string }).role;
-    const userEmail = session.user.email;
-
-    const scopeWhere = buildInvoiceScopeWhere(id, userRole, userEmail);
+    const scopeWhere = await buildInvoiceAccessWhere(id, {
+      id: session.user.id,
+      role: (session.user as { role?: string }).role,
+      email: session.user.email,
+    });
     if (!scopeWhere) {
       return notFoundResponse();
     }

--- a/app/api/invoices/[id]/receipt/pdf/route.ts
+++ b/app/api/invoices/[id]/receipt/pdf/route.ts
@@ -21,7 +21,7 @@ import {
   createInvoiceEvent,
   appendInvoiceEvent,
 } from '@/lib/invoice';
-import { notFoundResponse, buildInvoiceScopeWhere } from '@/lib/invoice/not-found';
+import { notFoundResponse, buildInvoiceAccessWhere } from '@/lib/invoice/not-found';
 import type { InvoiceEvent, ReceiptData } from '@/lib/invoice';
 
 export async function GET(
@@ -35,10 +35,11 @@ export async function GET(
     }
 
     const { id } = await params;
-    const userRole = (session.user as { role?: string }).role;
-    const userEmail = session.user.email;
-
-    const scopeWhere = buildInvoiceScopeWhere(id, userRole, userEmail);
+    const scopeWhere = await buildInvoiceAccessWhere(id, {
+      id: session.user.id,
+      role: (session.user as { role?: string }).role,
+      email: session.user.email,
+    });
     if (!scopeWhere) {
       return notFoundResponse();
     }

--- a/app/api/lamis/teacher-report/route.ts
+++ b/app/api/lamis/teacher-report/route.ts
@@ -2,13 +2,49 @@ import { NextResponse } from "next/server";
 import { lamisExercises } from "@/src/data/lamisExercises";
 import { buildPedagogicalReport } from "@/lib/lamis/progress";
 import type { LamisAttempt } from "@/lib/lamis/types";
+import { guardRateLimitAsync } from "@/lib/rate-limit";
+import { z } from "zod";
+
+const lamisAttemptSchema = z.object({
+  exerciseId: z.string().min(1).max(120),
+  answer: z.string().max(1000),
+  isCorrect: z.boolean(),
+  attemptNumber: z.number().int().min(1).max(20),
+  timeSpentSeconds: z.number().int().min(0).max(3600),
+  usedHint1: z.boolean(),
+  usedHint2: z.boolean(),
+  viewedCorrection: z.boolean(),
+  tooFast: z.boolean(),
+  timestamp: z.string().min(1).max(80),
+}).strict();
+
+const teacherReportBodySchema = z.object({
+  attempts: z.array(lamisAttemptSchema).max(300).default([]),
+}).strict();
 
 export async function POST(request: Request) {
-  const body = await request.json().catch(() => ({}));
-  const attempts = Array.isArray(body.attempts) ? (body.attempts as LamisAttempt[]) : [];
+  const rateLimited = await guardRateLimitAsync(request, {
+    preset: "api",
+    keySuffix: "lamis-teacher-report",
+  });
+  if (rateLimited) return rateLimited;
+
+  const body = await request.json().catch(() => null);
+  const parsed = teacherReportBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Payload invalide" }, { status: 400 });
+  }
+
+  const attempts = parsed.data.attempts as LamisAttempt[];
   return NextResponse.json({ report: buildPedagogicalReport(lamisExercises, attempts) });
 }
 
-export function GET() {
+export async function GET(request: Request) {
+  const rateLimited = await guardRateLimitAsync(request, {
+    preset: "api",
+    keySuffix: "lamis-teacher-report",
+  });
+  if (rateLimited) return rateLimited;
+
   return NextResponse.json({ report: buildPedagogicalReport(lamisExercises, []) });
 }

--- a/app/api/npc/submissions/[submissionId]/documents/[documentId]/route.ts
+++ b/app/api/npc/submissions/[submissionId]/documents/[documentId]/route.ts
@@ -6,9 +6,23 @@ import { deleteSecureFile } from '@/lib/npc/storage';
 import { canManageSubmissionDocuments } from '@/lib/npc/access';
 import { isCorrectionDocumentType } from '@/lib/npc/document-types';
 import { serializeError } from '@/lib/utils/serialize-error';
+import { z } from 'zod';
 
 interface RouteParams {
   params: Promise<{ submissionId: string; documentId: string }>;
+}
+
+const routeParamsSchema = z.object({
+  submissionId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+  documentId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+}).strict();
+
+const patchBodySchema = z.object({
+  documentType: z.string().refine(isCorrectionDocumentType),
+}).strict();
+
+function invalidParamsResponse() {
+  return NextResponse.json({ error: 'Invalid route params' }, { status: 400 });
 }
 
 function sanitizeCopyPage(page: Record<string, unknown>) {
@@ -44,7 +58,9 @@ export async function PATCH(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { submissionId, documentId } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return invalidParamsResponse();
+    const { submissionId, documentId } = parsedParams.data;
     const submission = await prisma.copySubmission.findUnique({
       where: { id: submissionId },
       select: { id: true, studentId: true, coachId: true, pages: true },
@@ -66,15 +82,14 @@ export async function PATCH(
       return NextResponse.json({ error: 'Document not found' }, { status: 404 });
     }
 
-    const body = await request.json();
-    const { documentType } = body;
-
-    if (!documentType || !isCorrectionDocumentType(documentType)) {
+    const parsedBody = patchBodySchema.safeParse(await request.json());
+    if (!parsedBody.success) {
       return NextResponse.json(
         { error: 'Invalid document type' },
         { status: 400 }
       );
     }
+    const { documentType } = parsedBody.data;
 
     const updatedDocument = await prisma.copyPage.update({
       where: { id: document.id },
@@ -136,7 +151,9 @@ export async function DELETE(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { submissionId, documentId } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return invalidParamsResponse();
+    const { submissionId, documentId } = parsedParams.data;
     const submission = await prisma.copySubmission.findUnique({
       where: { id: submissionId },
       select: { id: true, studentId: true, coachId: true },

--- a/app/api/npc/submissions/[submissionId]/documents/route.ts
+++ b/app/api/npc/submissions/[submissionId]/documents/route.ts
@@ -14,12 +14,22 @@ import {
 import type { FileMetadata } from '@/lib/npc/storage';
 import { isCorrectionDocumentType } from '@/lib/npc/document-types';
 import { canManageSubmissionDocuments, canReadSubmission } from '@/lib/npc/access';
+import { z } from 'zod';
 
 interface RouteParams {
   params: Promise<{ submissionId: string }>;
 }
 
 const MAX_FILES_PER_SUBMISSION = 20;
+const routeParamsSchema = z.object({
+  submissionId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+}).strict();
+
+const documentTypeSchema = z.string().refine(isCorrectionDocumentType);
+
+function invalidParamsResponse() {
+  return NextResponse.json({ error: 'Invalid route params' }, { status: 400 });
+}
 
 function sanitizeCopyPage(page: Record<string, unknown>) {
   const {
@@ -92,7 +102,9 @@ export async function GET(
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const { submissionId } = await params;
+  const parsedParams = routeParamsSchema.safeParse(await params);
+  if (!parsedParams.success) return invalidParamsResponse();
+  const { submissionId } = parsedParams.data;
   const submission = await prisma.copySubmission.findUnique({
     where: { id: submissionId },
     select: {
@@ -130,7 +142,9 @@ export async function POST(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { submissionId } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return invalidParamsResponse();
+    const { submissionId } = parsedParams.data;
     const submission = await getSubmission(submissionId);
     if (!submission) {
       return NextResponse.json({ error: 'Submission not found' }, { status: 404 });
@@ -141,13 +155,14 @@ export async function POST(
     }
 
     const formData = await request.formData();
-    const documentType = formData.get('documentType') || 'STUDENT_COPY';
-    if (!isCorrectionDocumentType(documentType)) {
+    const parsedDocumentType = documentTypeSchema.safeParse(formData.get('documentType') || 'STUDENT_COPY');
+    if (!parsedDocumentType.success) {
       return NextResponse.json(
         { error: 'Invalid document type' },
         { status: 400 }
       );
     }
+    const documentType = parsedDocumentType.data;
 
     const files = formData.getAll('file').filter((value): value is File => value instanceof File);
     if (files.length === 0) {

--- a/app/api/npc/submissions/[submissionId]/generate/route.ts
+++ b/app/api/npc/submissions/[submissionId]/generate/route.ts
@@ -9,9 +9,18 @@ import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { CopySubmissionStatus, UserRole, AiJobType, AiJobStatus } from '@prisma/client';
 import { canManageSubmissionDocuments } from '@/lib/npc/access';
+import { z } from 'zod';
 
 interface RouteParams {
   params: Promise<{ submissionId: string }>;
+}
+
+const routeParamsSchema = z.object({
+  submissionId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+}).strict();
+
+function invalidParamsResponse() {
+  return NextResponse.json({ error: 'Invalid route params' }, { status: 400 });
 }
 
 async function getActor() {
@@ -37,7 +46,9 @@ export async function POST(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { submissionId } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return invalidParamsResponse();
+    const { submissionId } = parsedParams.data;
     const submission = await prisma.copySubmission.findUnique({
       where: { id: submissionId },
       include: {

--- a/app/api/npc/submissions/route.ts
+++ b/app/api/npc/submissions/route.ts
@@ -8,10 +8,23 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { Subject, GradeLevel, CopySubmissionStatus } from '@prisma/client';
+import { z } from 'zod';
 // No checkPermission import
 
-const VALID_SUBJECTS = Object.values(Subject);
-const VALID_GRADE_LEVELS = Object.values(GradeLevel);
+const safeIdSchema = z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/);
+
+const createSubmissionBodySchema = z.object({
+  studentId: safeIdSchema,
+  title: z.string().trim().min(1).max(180),
+  description: z.string().trim().max(2000).optional(),
+  subject: z.nativeEnum(Subject),
+  gradeLevel: z.nativeEnum(GradeLevel).optional(),
+}).strict();
+
+const listSubmissionsQuerySchema = z.object({
+  studentId: safeIdSchema.optional(),
+  status: z.nativeEnum(CopySubmissionStatus).optional(),
+}).strict();
 
 interface CreateSubmissionBody {
   studentId: string;
@@ -63,31 +76,11 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const body = await req.json() as CreateSubmissionBody;
-
-    // Validate required fields
-    if (!body.studentId || !body.title || !body.subject) {
-      return NextResponse.json(
-        { error: 'Missing required fields: studentId, title, subject' },
-        { status: 400 }
-      );
+    const parsedBody = createSubmissionBodySchema.safeParse(await req.json());
+    if (!parsedBody.success) {
+      return NextResponse.json({ error: 'Données invalides' }, { status: 400 });
     }
-
-    // Validate subject
-    if (!VALID_SUBJECTS.includes(body.subject)) {
-      return NextResponse.json(
-        { error: `Invalid subject. Valid: ${VALID_SUBJECTS.join(', ')}` },
-        { status: 400 }
-      );
-    }
-
-    // Validate grade level if provided
-    if (body.gradeLevel && !VALID_GRADE_LEVELS.includes(body.gradeLevel)) {
-      return NextResponse.json(
-        { error: `Invalid grade level. Valid: ${VALID_GRADE_LEVELS.join(', ')}` },
-        { status: 400 }
-      );
-    }
+    const body = parsedBody.data as CreateSubmissionBody;
 
     // Check if student exists
     const student = await prisma.student.findUnique({
@@ -194,8 +187,11 @@ export async function GET(req: NextRequest) {
     }
 
     const { searchParams } = new URL(req.url);
-    const studentId = searchParams.get('studentId');
-    const status = searchParams.get('status');
+    const parsedQuery = listSubmissionsQuerySchema.safeParse(Object.fromEntries(searchParams.entries()));
+    if (!parsedQuery.success) {
+      return NextResponse.json({ error: 'Données invalides' }, { status: 400 });
+    }
+    const { studentId, status } = parsedQuery.data;
 
     const where: Record<string, unknown> = {};
 

--- a/app/api/npc/uploads/route.ts
+++ b/app/api/npc/uploads/route.ts
@@ -11,10 +11,18 @@ import {
   FILE_VALIDATION_ERRORS,
 } from '@/lib/npc';
 import type { FileMetadata } from '@/lib/npc';
+import { z } from 'zod';
 
 // ─── Constants ───
 
 const MAX_REQUEST_SIZE = 11 * 1024 * 1024; // 11MB (slightly above file limit for overhead)
+
+const uploadMetadataSchema = z.object({
+  studentId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+  title: z.string().trim().min(1).max(180),
+  description: z.string().trim().max(2000).optional(),
+  subject: z.nativeEnum(Subject),
+}).strict();
 
 // ─── Auth Helper ───
 
@@ -119,18 +127,20 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // Parse multipart form data
     const formData = await request.formData();
 
-    // Extract metadata
-    const studentId = formData.get('studentId') as string;
-    const title = formData.get('title') as string;
-    const description = formData.get('description') as string | undefined;
-    const subject = formData.get('subject') as string;
+    const parsedMetadata = uploadMetadataSchema.safeParse({
+      studentId: formData.get('studentId'),
+      title: formData.get('title'),
+      description: formData.get('description') || undefined,
+      subject: formData.get('subject'),
+    });
 
-    if (!studentId || !title || !subject) {
+    if (!parsedMetadata.success) {
       return NextResponse.json(
-        { error: 'Missing required fields: studentId, title, subject' },
+        { error: 'Données invalides' },
         { status: 400 }
       );
     }
+    const { studentId, title, description, subject } = parsedMetadata.data;
 
     // Authenticate and authorize
     const authorization = await authenticateAndAuthorize(sessionUser, studentId);

--- a/app/api/parent/children/route.ts
+++ b/app/api/parent/children/route.ts
@@ -7,6 +7,14 @@ import { NextRequest, NextResponse } from 'next/server';
 import type { CreditTransaction } from '@prisma/client';
 import { normalizeStudentLevelAndTrack } from '@/lib/utils/grade-utils';
 import crypto from 'crypto';
+import { z } from 'zod';
+
+const createChildSchema = z.object({
+  firstName: z.string().trim().min(1).max(80),
+  lastName: z.string().trim().min(1).max(80),
+  grade: z.string().trim().min(1).max(80),
+  school: z.string().trim().max(120).optional().default(''),
+}).strict();
 
 export async function GET(_request: NextRequest) {
   try {
@@ -102,21 +110,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
-    const {
-      firstName,
-      lastName,
-      grade,
-      school
-    } = body;
-
-    // Validate required fields
-    if (!firstName || !lastName || !grade) {
+    const rawBody = await request.json().catch(() => null);
+    const parsedBody = createChildSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: 'Missing required fields' },
+        { error: 'Invalid child payload' },
         { status: 400 }
       );
     }
+    const { firstName, lastName, grade, school } = parsedBody.data;
 
     // Generate email in the same format as bilan-gratuit
     const email = `${firstName.toLowerCase()}.${lastName.toLowerCase()}@nexus-student.local`;
@@ -206,9 +208,8 @@ export async function POST(request: NextRequest) {
         school: result.school
       },
       activation: {
-        token: rawActivationToken,
         expiresAt: activationExpiry.toISOString(),
-        message: "Ce token permet à l'élève d'activer son compte et de choisir son propre mot de passe. Partagez-le de manière sécurisée."
+        message: "Un token d'activation a été généré et stocké de manière sécurisée. Il n'est pas retourné par cette API."
       }
     });
 

--- a/app/api/parent/subscription-requests/route.ts
+++ b/app/api/parent/subscription-requests/route.ts
@@ -5,8 +5,21 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
 import { getAriaAddonCatalogItem, getOperationalSubscriptionPlan } from '@/lib/operational-catalog';
+import { z } from 'zod';
 
 const ALLOWED_REQUEST_TYPES = ['PLAN_CHANGE', 'ARIA_ADDON'] as const;
+
+const idSchema = z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/);
+const subscriptionRequestBodySchema = z.object({
+  studentId: idSchema,
+  requestType: z.enum(ALLOWED_REQUEST_TYPES),
+  planName: z.string().trim().min(1).max(120).optional().nullable(),
+  reason: z.string().trim().max(1000).optional(),
+}).strict();
+
+const subscriptionRequestQuerySchema = z.object({
+  studentId: idSchema,
+}).strict();
 
 export async function POST(request: NextRequest) {
   try {
@@ -19,28 +32,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = (await request.json()) as {
-      studentId?: string;
-      requestType?: 'PLAN_CHANGE' | 'ARIA_ADDON' | 'INVOICE_DETAILS';
-      planName?: string | null;
-      monthlyPrice?: number;
-      reason?: string;
-    };
-    const { studentId, requestType, planName, reason } = body;
-
-    if (!studentId || !requestType) {
+    const rawBody = await request.json().catch(() => null);
+    const parsedBody = subscriptionRequestBodySchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: 'Missing required fields' },
+        { error: 'Invalid subscription request payload' },
         { status: 400 }
       );
     }
-
-    if (!ALLOWED_REQUEST_TYPES.includes(requestType as (typeof ALLOWED_REQUEST_TYPES)[number])) {
-      return NextResponse.json(
-        { error: 'Type de demande invalide' },
-        { status: 400 }
-      );
-    }
+    const { studentId, requestType, planName, reason } = parsedBody.data;
 
     let safePlanName = planName || null;
     let safeMonthlyPrice = 0;
@@ -179,14 +179,16 @@ export async function GET(request: NextRequest) {
     }
 
     const { searchParams } = new URL(request.url);
-    const studentId = searchParams.get('studentId');
-
-    if (!studentId) {
+    const parsedQuery = subscriptionRequestQuerySchema.safeParse({
+      studentId: searchParams.get('studentId') ?? undefined,
+    });
+    if (!parsedQuery.success) {
       return NextResponse.json(
         { error: 'Student ID is required' },
         { status: 400 }
       );
     }
+    const { studentId } = parsedQuery.data;
 
     // Verify student belongs to parent
     const userId = session.user.id;

--- a/app/api/parent/subscriptions/route.ts
+++ b/app/api/parent/subscriptions/route.ts
@@ -5,6 +5,12 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
 import { getOperationalSubscriptionPlan } from '@/lib/operational-catalog';
+import { z } from 'zod';
+
+const parentSubscriptionRequestSchema = z.object({
+  studentId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/),
+  planName: z.string().trim().min(1).max(120),
+}).strict();
 
 export async function GET(request: NextRequest) {
   try {
@@ -103,20 +109,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = (await request.json()) as {
-      studentId?: string;
-      planName?: string;
-      monthlyPrice?: number;
-      creditsPerMonth?: number;
-    };
-    const { studentId, planName } = body;
-
-    if (!studentId || !planName) {
+    const rawBody = await request.json().catch(() => null);
+    const parsedBody = parentSubscriptionRequestSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: 'Missing required fields: studentId, planName' },
+        { error: 'Invalid subscription payload' },
         { status: 400 }
       );
     }
+    const { studentId, planName } = parsedBody.data;
 
     const plan = getOperationalSubscriptionPlan(planName);
     if (!plan) {

--- a/app/api/payments/clictopay/init/route.ts
+++ b/app/api/payments/clictopay/init/route.ts
@@ -3,6 +3,16 @@ export const dynamic = 'force-dynamic';
 
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
+import { UserRole } from '@prisma/client';
+import { z } from 'zod';
+
+const allowedInitiatorRoles = new Set<string>([UserRole.PARENT, UserRole.ADMIN, UserRole.ASSISTANTE]);
+
+const clicToPayInitSchema = z.object({
+  amount: z.number().positive().optional(),
+  invoiceId: z.string().trim().min(1).max(191).optional(),
+  description: z.string().trim().min(1).max(300).optional(),
+}).strict();
 
 /**
  * POST /api/payments/clictopay/init
@@ -23,12 +33,37 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    if (!allowedInitiatorRoles.has((session.user as { role?: string }).role ?? '')) {
+      return NextResponse.json(
+        { error: 'Accès refusé' },
+        { status: 403 }
+      );
+    }
+
+    if (process.env.NEXT_PUBLIC_ENABLE_CLICTOPAY_PUBLIC === 'true') {
+      return NextResponse.json(
+        {
+          error: 'Configuration paiement incohérente',
+          code: 'CLICTOPAY_PUBLIC_FLAG_INCONSISTENT',
+        },
+        { status: 503 }
+      );
+    }
+
+    const parsedBody = clicToPayInitSchema.safeParse(await request.json());
+    if (!parsedBody.success) {
+      return NextResponse.json(
+        { error: 'Données invalides' },
+        { status: 400 }
+      );
+    }
+
     // 1. Valider le body (montant, description, userId)
     // 2. Créer un Payment PENDING + ClicToPayTransaction PENDING
     // 3. Appeler l'API ClicToPay pour obtenir l'URL de paiement
     // 4. Retourner { payUrl, orderId }
 
-    void request; // Suppress unused parameter warning
+    void parsedBody;
 
     return NextResponse.json(
       {

--- a/app/api/payments/clictopay/webhook/route.ts
+++ b/app/api/payments/clictopay/webhook/route.ts
@@ -14,21 +14,36 @@ import { logger } from '@/lib/logger';
  */
 export async function POST(request: NextRequest) {
   try {
+    const rawBody = await request.text();
+    const signature = request.headers.get('x-clictopay-signature')?.trim() ?? '';
+    if (!signature) {
+      logger.warn('[ClicToPay Webhook] Missing signature');
+      return NextResponse.json(
+        { error: 'Signature requise', code: 'CLICTOPAY_SIGNATURE_REQUIRED' },
+        { status: 401 }
+      );
+    }
+
     // HMAC signature verification (reject spoofed webhooks)
     const secret = process.env.CLICTOPAY_WEBHOOK_SECRET;
     if (secret) {
-      const signature = request.headers.get('x-clictopay-signature') ?? '';
-      const rawBody = await request.text();
       const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
       let signatureValid = false;
       try {
-        signatureValid = timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
+        const signatureBuffer = Buffer.from(signature, 'hex');
+        const expectedBuffer = Buffer.from(expected, 'hex');
+        signatureValid =
+          signatureBuffer.length === expectedBuffer.length &&
+          timingSafeEqual(signatureBuffer, expectedBuffer);
       } catch {
-        // Length mismatch — definitely invalid
+        // Malformed signature — definitely invalid
       }
       if (!signatureValid) {
         logger.warn('[ClicToPay Webhook] Invalid signature');
-        return NextResponse.json({ error: 'Signature invalide' }, { status: 401 });
+        return NextResponse.json(
+          { error: 'Signature invalide', code: 'CLICTOPAY_SIGNATURE_INVALID' },
+          { status: 401 }
+        );
       }
     }
 

--- a/app/api/programme/maths-1ere-stmg/stage-progress/route.ts
+++ b/app/api/programme/maths-1ere-stmg/stage-progress/route.ts
@@ -4,22 +4,26 @@ import type { Prisma } from '@prisma/client';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { serializeError } from '@/lib/utils/serialize-error';
+import { z } from 'zod';
 
 type JsonRecord = Record<string, unknown>;
+
+const stageProgressSchema = z.object({
+  updatedAt: z.string().trim().min(1).max(80),
+  diagnosticAnswers: z.record(z.string(), z.unknown()),
+  profile: z.record(z.string(), z.unknown()),
+  validatedNotions: z.record(z.string(), z.unknown()),
+  automatismHistory: z.array(z.unknown()).max(500),
+  settings: z.record(z.string(), z.unknown()),
+}).strict();
 
 function asRecord(value: unknown): JsonRecord {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonRecord : {};
 }
 
 function parseStageState(raw: unknown): JsonRecord | null {
-  const input = asRecord(raw);
-  if (typeof input.updatedAt !== 'string') return null;
-  if (!asRecord(input.diagnosticAnswers)) return null;
-  if (!asRecord(input.profile)) return null;
-  if (!asRecord(input.validatedNotions)) return null;
-  if (!Array.isArray(input.automatismHistory)) return null;
-  if (!asRecord(input.settings)) return null;
-  return input;
+  const parsed = stageProgressSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
 }
 
 const whereStmgPremiere = (userId: string) => ({
@@ -32,11 +36,10 @@ const whereStmgPremiere = (userId: string) => ({
 
 export async function GET() {
   const session = await auth();
-  const user = session?.user as { id?: string } | undefined;
-  if (!user?.id) {
+  if (!session?.user?.id || session.user.role !== 'ELEVE') {
     return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
   }
-  const userId = user.id;
+  const userId = session.user.id;
 
   try {
     const progress = await prisma.mathsProgress.findUnique({
@@ -53,11 +56,10 @@ export async function GET() {
 
 export async function POST(request: Request) {
   const session = await auth();
-  const user = session?.user as { id?: string } | undefined;
-  if (!user?.id) {
+  if (!session?.user?.id || session.user.role !== 'ELEVE') {
     return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
   }
-  const userId = user.id;
+  const userId = session.user.id;
 
   let body: unknown = null;
   try {

--- a/app/api/sessions/cancel/route.ts
+++ b/app/api/sessions/cancel/route.ts
@@ -6,7 +6,7 @@ import { NextRequest } from 'next/server';
 import { SessionStatus } from '@prisma/client';
 import { requireAnyRole, isErrorResponse } from '@/lib/guards';
 import { cancelSessionSchema } from '@/lib/validation';
-import { parseBody, assertExists } from '@/lib/api/helpers';
+import { safeJsonParse, assertExists } from '@/lib/api/helpers';
 import { successResponse, handleApiError, ApiError } from '@/lib/api/errors';
 import { RateLimitPresets } from '@/lib/middleware/rateLimit';
 import { createLogger } from '@/lib/middleware/logger';
@@ -37,7 +37,11 @@ export async function POST(request: NextRequest) {
     logger.info('Cancelling session');
 
     // Parse and validate request body
-    const { sessionId, reason } = await parseBody(request, cancelSessionSchema);
+    const parsedBody = cancelSessionSchema.strict().safeParse(await safeJsonParse(request));
+    if (!parsedBody.success) {
+      throw ApiError.badRequest('Validation failed');
+    }
+    const { sessionId, reason } = parsedBody.data;
 
     // Fetch session
     const sessionToCancel = await prisma.sessionBooking.findUnique({

--- a/app/api/sessions/video/route.ts
+++ b/app/api/sessions/video/route.ts
@@ -3,22 +3,47 @@ export const dynamic = 'force-dynamic';
 
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
 import { SessionStatus } from '@prisma/client';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const videoSessionActionSchema = z.object({
+  sessionId: z.string().min(1).max(128),
+  action: z.enum(['JOIN', 'LEAVE']),
+}).strict();
+
+function safeErrorSummary(error: unknown) {
+  const serialized = serializeError(error);
+  if (serialized && typeof serialized === 'object' && !Array.isArray(serialized)) {
+    return {
+      name: typeof serialized.name === 'string' ? serialized.name : 'Error',
+      message: typeof serialized.message === 'string' ? serialized.message : 'unknown',
+    };
+  }
+  return { name: 'Error', message: String(serialized) };
+}
 
 export async function POST(request: NextRequest) {
   try {
+    const blocked = await guardRateLimitAsync(request, {
+      preset: 'api',
+      keySuffix: 'session-video',
+    });
+    if (blocked) return blocked;
+
     const session = await auth();
 
     if (!session?.user) {
       return NextResponse.json({ error: 'Non autorisé' }, { status: 401 });
     }
 
-    const { sessionId, action } = await request.json();
-
-    if (!sessionId || !action) {
+    const body = await request.json().catch(() => null);
+    const parsedBody = videoSessionActionSchema.safeParse(body);
+    if (!parsedBody.success) {
       return NextResponse.json({ error: 'Paramètres manquants' }, { status: 400 });
     }
+    const { sessionId, action } = parsedBody.data;
 
     // Vérifier que la session existe et que l'utilisateur y a accès (SessionBooking canonique)
     const bookingSession = await prisma.sessionBooking.findFirst({
@@ -30,10 +55,19 @@ export async function POST(request: NextRequest) {
           { parentId: session.user.id }
         ]
       },
-      include: {
-        student: true,
-        coach: true,
-        parent: true
+      select: {
+        id: true,
+        studentId: true,
+        coachId: true,
+        parentId: true,
+        scheduledDate: true,
+        startTime: true,
+        duration: true,
+        status: true,
+        subject: true,
+        student: { select: { firstName: true, lastName: true } },
+        coach: { select: { firstName: true, lastName: true } },
+        parent: { select: { firstName: true, lastName: true } },
       }
     });
 
@@ -104,7 +138,7 @@ export async function POST(request: NextRequest) {
     }
 
   } catch (error) {
-    console.error('Erreur lors de la gestion de la session vidéo:', serializeError(error));
+    console.error('Erreur lors de la gestion de la session vidéo:', safeErrorSummary(error));
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/app/api/stages/[stageSlug]/inscrire/route.ts
+++ b/app/api/stages/[stageSlug]/inscrire/route.ts
@@ -7,12 +7,21 @@ import { telegramSendMessage } from '@/lib/telegram/client';
 import { computeReservationStatus } from '@/lib/stages/capacity';
 import { publicStageInscriptionSchema } from '@/lib/stages/inscription-schema';
 import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { z } from 'zod';
+
+const stageInscriptionParamsSchema = z.object({
+  stageSlug: z.string().trim().min(1).max(120).regex(/^[a-z0-9][a-z0-9-]*$/),
+}).strict();
 
 export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ stageSlug: string }> }
 ) {
-  const { stageSlug } = await params;
+  const parsedParams = stageInscriptionParamsSchema.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: 'Paramètres de stage invalides' }, { status: 400 });
+  }
+  const { stageSlug } = parsedParams.data;
 
   const blocked = await guardRateLimitAsync(req, { preset: 'api', keySuffix: `stage-inscrire:${stageSlug}` });
   if (blocked) return blocked;
@@ -40,6 +49,8 @@ export async function POST(
     parentEmail,
     parentPhone,
     notes,
+    stageTermsAccepted,
+    dataProcessingAccepted,
   } = parsed.data;
 
   try {
@@ -58,7 +69,7 @@ export async function POST(
     });
     if (existing) {
       return NextResponse.json(
-        { error: 'Une inscription existe déjà pour cet email sur ce stage.', reservationId: existing.id },
+        { error: 'Une inscription existe déjà pour cet email sur ce stage.' },
         { status: 409 }
       );
     }
@@ -77,9 +88,11 @@ export async function POST(
       notes?.trim(),
       parentEmail ? `Email parent: ${parentEmail}` : null,
       parentPhone ? `Téléphone parent: ${parentPhone}` : null,
+      stageTermsAccepted ? 'Modalités stage acceptées: oui' : null,
+      dataProcessingAccepted ? 'Consentement données: oui' : null,
     ].filter(Boolean).join('\n');
 
-    const reservation = await prisma.stageReservation.create({
+    await prisma.stageReservation.create({
       data: {
         stageId: stage.id,
         email,

--- a/app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts
+++ b/app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts
@@ -9,6 +9,12 @@ import { sendMail } from '@/lib/email/mailer';
 import { GradeLevel, AcademicTrack } from '@prisma/client';
 import { normalizeGradeLevel, getDefaultTrackForLevel, normalizeStudentLevelAndTrack } from '@/lib/utils/grade-utils';
 import crypto from 'crypto';
+import { z } from 'zod';
+
+const confirmReservationParamsSchema = z.object({
+  stageSlug: z.string().trim().min(1).max(120).regex(/^[a-z0-9][a-z0-9-]*$/),
+  reservationId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/),
+}).strict();
 
 export async function POST(
   req: NextRequest,
@@ -17,7 +23,11 @@ export async function POST(
   const sessionOrError = await requireAnyRole(['ADMIN', 'ASSISTANTE']);
   if (sessionOrError instanceof NextResponse) return sessionOrError;
 
-  const { stageSlug, reservationId } = await params;
+  const parsedParams = confirmReservationParamsSchema.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: 'Paramètres de réservation invalides' }, { status: 400 });
+  }
+  const { stageSlug, reservationId } = parsedParams.data;
 
   try {
     const reservation = await prisma.stageReservation.findFirst({

--- a/app/api/stages/[stageSlug]/route.ts
+++ b/app/api/stages/[stageSlug]/route.ts
@@ -1,14 +1,23 @@
 export const dynamic = 'force-dynamic';
 
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { getPublicStageBySlug } from '@/lib/stages/public';
+
+const paramsSchema = z.object({
+  stageSlug: z.string().min(1).max(160).regex(/^[a-z0-9-]+$/i),
+});
 
 export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ stageSlug: string }> }
 ) {
-  const { stageSlug } = await params;
+  const parsedParams = paramsSchema.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: 'Paramètres invalides' }, { status: 400 });
+  }
+  const { stageSlug } = parsedParams.data;
 
   try {
     const stage = await getPublicStageBySlug(stageSlug);

--- a/app/api/student/activate/route.ts
+++ b/app/api/student/activate/route.ts
@@ -1,4 +1,3 @@
-import { serializeError } from '@/lib/utils/serialize-error';
 /**
  * POST /api/student/activate
  *
@@ -20,15 +19,22 @@ import {
   completeStudentActivation,
   verifyActivationToken,
 } from '@/lib/services/student-activation.service';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
 import { z } from 'zod';
 
 const setPasswordSchema = z.object({
   token: z.string().min(1, 'Token requis'),
   password: z.string().min(8, 'Le mot de passe doit contenir au moins 8 caractères'),
-});
+}).strict();
 
 export async function GET(request: NextRequest) {
   try {
+    const rateLimited = await guardRateLimitAsync(request, {
+      preset: 'auth',
+      keySuffix: 'student-activate',
+    });
+    if (rateLimited) return rateLimited;
+
     const { searchParams } = new URL(request.url);
     const token = searchParams.get('token');
 
@@ -42,7 +48,7 @@ export async function GET(request: NextRequest) {
     const result = await verifyActivationToken(token);
     return NextResponse.json(result);
   } catch (error) {
-    console.error('[API] verify activation token error:', serializeError(error));
+    console.error('[API] verify activation token error', error instanceof Error ? error.name : 'unknown');
     return NextResponse.json(
       { valid: false, error: 'Erreur interne' },
       { status: 500 }
@@ -52,12 +58,18 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
+    const rateLimited = await guardRateLimitAsync(request, {
+      preset: 'auth',
+      keySuffix: 'student-activate',
+    });
+    if (rateLimited) return rateLimited;
+
     const body = await request.json();
     const parsed = setPasswordSchema.safeParse(body);
 
     if (!parsed.success) {
       return NextResponse.json(
-        { error: 'Données invalides', details: parsed.error.flatten().fieldErrors },
+        { error: 'Données invalides' },
         { status: 400 }
       );
     }
@@ -80,7 +92,7 @@ export async function POST(request: NextRequest) {
       message: 'Compte activé avec succès ! Vous pouvez maintenant vous connecter.',
     });
   } catch (error) {
-    console.error('[API] complete activation error:', serializeError(error));
+    console.error('[API] complete activation error', error instanceof Error ? error.name : 'unknown');
     return NextResponse.json(
       { error: 'Erreur interne du serveur' },
       { status: 500 }

--- a/app/api/student/automatismes/attempts/route.ts
+++ b/app/api/student/automatismes/attempts/route.ts
@@ -4,6 +4,13 @@ import { auth } from "@/auth";
 import { PREMIERE_EDS_SIMULATIONS } from "@/data/automatismes/premiere-eds/simulations";
 import { calculateAutomatismeScore } from "@/lib/automatismes/scoring";
 import { serializeError } from '@/lib/utils/serialize-error';
+import { z } from 'zod';
+
+const attemptSchema = z.object({
+  seriesId: z.string().trim().min(1).max(80),
+  answers: z.record(z.string().trim().min(1).max(80), z.string().trim().min(1).max(80)),
+  durationSeconds: z.coerce.number().finite().nonnegative().max(24 * 60 * 60).default(0),
+}).strict();
 
 export async function POST(request: NextRequest) {
   try {
@@ -13,15 +20,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const body = await request.json();
-    const { seriesId, answers, durationSeconds } = body;
-
-    if (!seriesId || !answers) {
+    const rawBody = await request.json().catch(() => null);
+    const parsedBody = attemptSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: "Missing required fields" },
+        { error: "Invalid attempt payload" },
         { status: 400 }
       );
     }
+    const { seriesId, answers, durationSeconds } = parsedBody.data;
 
     const series = PREMIERE_EDS_SIMULATIONS.find(s => s.id === seriesId);
     if (!series) {

--- a/app/api/student/automatismes/check-answer/route.ts
+++ b/app/api/student/automatismes/check-answer/route.ts
@@ -2,6 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { PREMIERE_EDS_SIMULATIONS } from "@/data/automatismes/premiere-eds/simulations";
 import { serializeError } from '@/lib/utils/serialize-error';
+import { z } from 'zod';
+
+const checkAnswerSchema = z.object({
+  seriesId: z.string().trim().min(1).max(80),
+  questionId: z.string().trim().min(1).max(80),
+  selectedChoiceId: z.string().trim().min(1).max(80),
+}).strict();
 
 /**
  * POST /api/student/automatismes/check-answer
@@ -20,15 +27,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const body = await request.json();
-    const { seriesId, questionId, selectedChoiceId } = body;
-
-    if (!seriesId || !questionId || !selectedChoiceId) {
+    const rawBody = await request.json().catch(() => null);
+    const parsedBody = checkAnswerSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: "Missing required fields: seriesId, questionId, selectedChoiceId" },
+        { error: "Invalid answer payload" },
         { status: 400 }
       );
     }
+    const { seriesId, questionId, selectedChoiceId } = parsedBody.data;
 
     const series = PREMIERE_EDS_SIMULATIONS.find((s) => s.id === seriesId);
     if (!series) {

--- a/app/api/student/automatismes/series/[id]/route.ts
+++ b/app/api/student/automatismes/series/[id]/route.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { PREMIERE_EDS_SIMULATIONS } from "@/data/automatismes/premiere-eds/simulations";
 import { serializeError } from '@/lib/utils/serialize-error';
+import { z } from "zod";
+
+const paramsSchema = z.object({
+  id: z.string().min(1).max(120).regex(/^[a-z0-9-]+$/i),
+});
 
 export async function GET(
   request: NextRequest,
@@ -13,7 +18,11 @@ export async function GET(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { id } = await params;
+    const parsedParams = paramsSchema.safeParse(await params);
+    if (!parsedParams.success) {
+      return NextResponse.json({ error: "Bad Request" }, { status: 400 });
+    }
+    const { id } = parsedParams.data;
     const series = PREMIERE_EDS_SIMULATIONS.find(s => s.id === id);
 
     if (!series) {

--- a/app/api/student/documents/[id]/download/route.ts
+++ b/app/api/student/documents/[id]/download/route.ts
@@ -49,7 +49,10 @@ export async function GET(
       },
     });
   } catch (err) {
-    console.error('[documents/download] file read failed', { id, err });
+    const code = err instanceof Error && 'code' in err
+      ? String((err as NodeJS.ErrnoException).code)
+      : 'UNKNOWN';
+    console.error('[documents/download] file read failed', { documentId: id, code });
     return NextResponse.json({ error: 'File unavailable' }, { status: 500 });
   }
 }

--- a/app/api/student/nexus-index/route.ts
+++ b/app/api/student/nexus-index/route.ts
@@ -5,6 +5,11 @@ import { auth } from '@/auth';
 import { computeNexusIndex } from '@/lib/nexus-index';
 import { resolveStudentScope } from '@/lib/scopes';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const nexusIndexQuerySchema = z.object({
+  studentId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/).optional(),
+}).strict();
 
 /**
  * GET /api/student/nexus-index?studentId=...
@@ -26,7 +31,8 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const { role, id: userId } = session.user;
+    const role = session.user.role;
+    const userId = session.user.id;
 
     // Only students, parents, admin, and assistants can access
     if (!['ELEVE', 'PARENT', 'ADMIN', 'ASSISTANTE'].includes(role)) {
@@ -37,7 +43,13 @@ export async function GET(request: NextRequest) {
     }
 
     // Extract optional studentId from query params
-    const studentId = request.nextUrl.searchParams.get('studentId') || undefined;
+    const parsedQuery = nexusIndexQuerySchema.safeParse({
+      studentId: request.nextUrl.searchParams.get('studentId') || undefined,
+    });
+    if (!parsedQuery.success) {
+      return NextResponse.json({ error: 'Paramètres invalides' }, { status: 400 });
+    }
+    const { studentId } = parsedQuery.data;
 
     const scope = await resolveStudentScope(
       { id: userId, role },

--- a/app/api/student/survival/phrases/[phraseId]/copied/route.ts
+++ b/app/api/student/survival/phrases/[phraseId]/copied/route.ts
@@ -6,8 +6,12 @@ import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { getPhraseMagique } from '@/lib/survival/phrases';
 import { DEFAULT_EXAM_DATE, snapshotFromStoredProgress, toPrismaSurvivalData } from '@/lib/survival/progress';
+import { z } from 'zod';
 
 const lastCopyByUserAndPhrase = new Map<string, number>();
+const copiedParamsSchema = z.object({
+  phraseId: z.string().trim().min(1).max(80).regex(/^phrase_[0-9]+$/),
+}).strict();
 
 export async function POST(
   _request: Request,
@@ -19,7 +23,11 @@ export async function POST(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { phraseId } = await context.params;
+    const parsedParams = copiedParamsSchema.safeParse(await context.params);
+    if (!parsedParams.success) {
+      return NextResponse.json({ error: 'Invalid phrase' }, { status: 400 });
+    }
+    const { phraseId } = parsedParams.data;
     const phrase = getPhraseMagique(phraseId);
     if (!phrase) {
       return NextResponse.json({ error: 'Unknown phrase' }, { status: 404 });

--- a/app/api/student/survival/progress/route.ts
+++ b/app/api/student/survival/progress/route.ts
@@ -6,6 +6,18 @@ import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { DEFAULT_EXAM_DATE, normalizeSurvivalSnapshot, snapshotFromStoredProgress, toPrismaSurvivalData } from '@/lib/survival/progress';
 import type { SurvivalState } from '@/lib/survival/types';
+import { z } from 'zod';
+
+const survivalStateSchema = z.enum(['ACQUIS', 'REVOIR', 'PAS_VU']);
+const survivalProgressPayloadSchema = z.object({
+  reflexesState: z.record(z.string().trim().min(1).max(80), survivalStateSchema).optional(),
+  phrasesState: z.record(z.string().trim().min(1).max(80), z.coerce.number().int().min(0).max(10_000)).optional(),
+  rituals: z.array(z.object({
+    date: z.string().trim().min(1).max(40),
+    taskId: z.string().trim().min(1).max(120),
+    completed: z.boolean(),
+  }).strict()).max(500).optional(),
+}).strict();
 
 async function getCurrentSurvivalStudent() {
   const session = await auth();
@@ -61,15 +73,16 @@ export async function POST(request: Request) {
     const current = await getCurrentSurvivalStudent();
     if ('error' in current) return current.error;
 
-    const payload = await request.json().catch(() => null) as Partial<{
+    const rawPayload = await request.json().catch(() => null);
+    const parsedPayload = survivalProgressPayloadSchema.safeParse(rawPayload);
+    if (!parsedPayload.success) {
+      return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+    }
+    const payload = parsedPayload.data as Partial<{
       reflexesState: Record<string, SurvivalState>;
       phrasesState: Record<string, number>;
       rituals: Array<{ date: string; taskId: string; completed: boolean }>;
-    }> | null;
-
-    if (!payload || typeof payload !== 'object') {
-      return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
-    }
+    }>;
 
     const currentSnapshot = snapshotFromStoredProgress(current.student.survivalProgress);
     const nextSnapshot = normalizeSurvivalSnapshot({

--- a/app/api/student/survival/qcm/attempt/route.ts
+++ b/app/api/student/survival/qcm/attempt/route.ts
@@ -6,6 +6,13 @@ import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { DEFAULT_EXAM_DATE, snapshotFromStoredProgress, toPrismaSurvivalData } from '@/lib/survival/progress';
 import { QCM_BANK } from '@/lib/survival/qcm-bank';
+import { z } from 'zod';
+
+const qcmAttemptSchema = z.object({
+  itemId: z.string().trim().min(1).max(80),
+  givenAnswer: z.string().trim().min(1).max(20),
+  timeSpentSec: z.coerce.number().finite().nonnegative().max(24 * 60 * 60).optional(),
+}).strict();
 
 export async function POST(request: Request) {
   try {
@@ -14,14 +21,15 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const payload = await request.json().catch(() => null) as {
-      itemId?: string;
-      givenAnswer?: string;
-      timeSpentSec?: number;
-    } | null;
+    const parsedPayload = qcmAttemptSchema.safeParse(await request.json().catch(() => null));
 
-    const question = QCM_BANK.find((item) => item.id === payload?.itemId);
-    if (!question || typeof payload?.givenAnswer !== 'string') {
+    if (!parsedPayload.success) {
+      return NextResponse.json({ error: 'Invalid QCM attempt payload' }, { status: 400 });
+    }
+    const payload = parsedPayload.data;
+
+    const question = QCM_BANK.find((item) => item.id === payload.itemId);
+    if (!question) {
       return NextResponse.json({ error: 'Invalid QCM attempt payload' }, { status: 400 });
     }
 

--- a/app/api/student/survival/reflexes/[reflexId]/attempt/route.ts
+++ b/app/api/student/survival/reflexes/[reflexId]/attempt/route.ts
@@ -6,6 +6,16 @@ import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { getReflex } from '@/lib/survival/reflex-data';
 import { DEFAULT_EXAM_DATE, snapshotFromStoredProgress, toPrismaSurvivalData } from '@/lib/survival/progress';
+import { z } from 'zod';
+
+const reflexParamsSchema = z.object({
+  reflexId: z.string().trim().min(1).max(80).regex(/^reflex_[0-9]+$/),
+}).strict();
+const reflexAttemptSchema = z.object({
+  itemId: z.string().trim().min(1).max(80),
+  givenAnswer: z.string().trim().min(1).max(200),
+  timeSpentSec: z.coerce.number().finite().nonnegative().max(24 * 60 * 60).optional(),
+}).strict();
 
 export async function POST(
   request: Request,
@@ -17,21 +27,21 @@ export async function POST(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { reflexId } = await context.params;
+    const parsedParams = reflexParamsSchema.safeParse(await context.params);
+    if (!parsedParams.success) {
+      return NextResponse.json({ error: 'Invalid reflex' }, { status: 400 });
+    }
+    const { reflexId } = parsedParams.data;
     const reflex = getReflex(reflexId);
     if (!reflex) {
       return NextResponse.json({ error: 'Unknown reflex' }, { status: 404 });
     }
 
-    const payload = await request.json().catch(() => null) as {
-      itemId?: string;
-      givenAnswer?: string;
-      timeSpentSec?: number;
-    } | null;
-
-    if (!payload?.itemId || typeof payload.givenAnswer !== 'string') {
+    const parsedPayload = reflexAttemptSchema.safeParse(await request.json().catch(() => null));
+    if (!parsedPayload.success) {
       return NextResponse.json({ error: 'Invalid attempt payload' }, { status: 400 });
     }
+    const payload = parsedPayload.data;
 
     const student = await prisma.student.findUnique({
       where: { userId: session.user.id },

--- a/app/api/student/trajectory/route.ts
+++ b/app/api/student/trajectory/route.ts
@@ -5,6 +5,11 @@ import { auth } from '@/auth';
 import { resolveStudentScope } from '@/lib/scopes';
 import { getActiveTrajectory } from '@/lib/trajectory';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const trajectoryQuerySchema = z.object({
+  studentId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/).optional(),
+}).strict();
 
 /**
  * GET /api/student/trajectory?studentId=...
@@ -30,7 +35,8 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const { role, id: userId } = session.user;
+    const role = session.user.role;
+    const userId = session.user.id;
 
     if (!['ELEVE', 'PARENT', 'ADMIN', 'ASSISTANTE'].includes(role)) {
       return NextResponse.json(
@@ -39,7 +45,13 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const studentId = request.nextUrl.searchParams.get('studentId') || undefined;
+    const parsedQuery = trajectoryQuerySchema.safeParse({
+      studentId: request.nextUrl.searchParams.get('studentId') || undefined,
+    });
+    if (!parsedQuery.success) {
+      return NextResponse.json({ error: 'Paramètres invalides' }, { status: 400 });
+    }
+    const { studentId } = parsedQuery.data;
 
     const scope = await resolveStudentScope(
       { id: userId, role },

--- a/app/bilan-gratuit/assessment/AssessmentClient.tsx
+++ b/app/bilan-gratuit/assessment/AssessmentClient.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { AssessmentRunner } from "@/components/assessments/AssessmentRunner";
+import { Grade, Subject } from "@/lib/assessments/core/types";
+
+interface AssessmentClientProps {
+  subject: Subject;
+  grade: Grade;
+  name: string;
+  email: string;
+  assessmentPublicToken: string;
+}
+
+export function AssessmentClient({
+  subject,
+  grade,
+  name,
+  email,
+  assessmentPublicToken,
+}: AssessmentClientProps) {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    setReady(true);
+  }, []);
+
+  if (!ready) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center space-y-4">
+          <Loader2 className="w-12 h-12 animate-spin text-brand-accent mx-auto" />
+          <p className="text-lg text-neutral-400">Chargement de l&apos;évaluation...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <AssessmentRunner
+      subject={subject}
+      grade={grade}
+      studentData={{
+        email,
+        name,
+      }}
+      apiEndpoint="/api/assessments/submit"
+      assessmentPublicToken={assessmentPublicToken}
+    />
+  );
+}

--- a/app/bilan-gratuit/assessment/page.tsx
+++ b/app/bilan-gratuit/assessment/page.tsx
@@ -1,96 +1,80 @@
-"use client";
-
-import { Suspense, useEffect, useState } from "react";
-import { useSearchParams } from "next/navigation";
-import { AssessmentRunner } from "@/components/assessments/AssessmentRunner";
-import { Subject, Grade } from "@/lib/assessments/core/types";
-import { CorporateNavbar } from "@/components/layout/CorporateNavbar";
-import { CorporateFooter } from "@/components/layout/CorporateFooter";
+import { Suspense } from "react";
 import { Loader2 } from "lucide-react";
+import { AssessmentClient } from "./AssessmentClient";
+import { CorporateFooter } from "@/components/layout/CorporateFooter";
+import { CorporateNavbar } from "@/components/layout/CorporateNavbar";
+import {
+  ASSESSMENT_FLOW_COOKIE_NAME,
+  buildAssessmentAliasEmail,
+  createAssessmentPublicToken,
+  verifyAssessmentFlowToken,
+} from "@/lib/assessments/public-token";
+import { Grade } from "@/lib/assessments/core/types";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 
-/**
- * Map bilan-gratuit subject names to Assessment Subject enum.
- * MATHS and NSI get their dedicated assessments.
- * All other subjects (Français, Physique, SVT, etc.) get the GENERAL diagnostic.
- */
-function mapSubject(bilanSubject: string): Subject {
-  switch (bilanSubject) {
-    case "MATHEMATIQUES":
-      return Subject.MATHS;
-    case "NSI":
-      return Subject.NSI;
-    case "GENERAL":
-    default:
-      return Subject.GENERAL;
-  }
-}
+export const dynamic = "force-dynamic";
 
-/**
- * Map bilan-gratuit grade to Assessment Grade enum.
- */
-function mapGrade(bilanGrade: string): Grade {
-  switch (bilanGrade) {
-    case "terminale":
-      return Grade.TERMINALE;
-    case "premiere":
-    case "seconde":
-    default:
-      return Grade.PREMIERE;
-  }
+type SearchParams = Record<string, string | string[] | undefined>;
+
+function AssessmentAccessUnavailable() {
+  return (
+    <div className="mx-auto flex min-h-[60vh] max-w-2xl flex-col items-center justify-center px-6 text-center">
+      <div className="rounded-lg border border-white/10 bg-white/5 p-8">
+        <h1 className="text-3xl font-semibold text-white">Accès au diagnostic expiré</h1>
+        <p className="mt-4 text-sm text-neutral-300">
+          Pour accéder au diagnostic, commencez par envoyer la demande de bilan gratuit.
+          Notre équipe pourra ensuite exploiter les réponses dans le bon contexte pédagogique.
+        </p>
+      </div>
+    </div>
+  );
 }
 
 /**
  * Page: /bilan-gratuit/assessment
  *
- * After bilan-gratuit registration, the student is redirected here
- * with query params: ?subject=MATHEMATIQUES&grade=premiere&name=...&email=...
- *
- * This page hosts the AssessmentRunner which loads QCM questions,
- * lets the student answer, then submits to /api/assessments/submit
- * for scoring + RAG+LLM bilan generation.
+ * The assessment submission API requires a short-lived signed token bound to a
+ * lead/session flow. This page never issues a token from public query params.
  */
-function AssessmentContent() {
-  const searchParams = useSearchParams();
+export default async function BilanAssessmentPage({
+  searchParams,
+}: {
+  searchParams?: Promise<SearchParams>;
+}) {
+  const resolvedSearchParams = searchParams ? await searchParams : {};
+  if (Object.keys(resolvedSearchParams).length > 0) {
+    redirect("/bilan-gratuit/assessment");
+  }
 
-  const subjectParam = searchParams?.get("subject") || "MATHEMATIQUES";
-  const gradeParam = searchParams?.get("grade") || "premiere";
-  const nameParam = searchParams?.get("name") || "Élève";
-  const emailParam = searchParams?.get("email") || "";
+  const cookieStore = await cookies();
+  const flowCookie = cookieStore.get(ASSESSMENT_FLOW_COOKIE_NAME)?.value;
+  const flowVerification = verifyAssessmentFlowToken(flowCookie, {
+    source: "bilan-gratuit",
+  });
 
-  const [ready, setReady] = useState(false);
-
-  const subject = mapSubject(subjectParam);
-  const grade = mapGrade(gradeParam);
-
-  useEffect(() => {
-    setReady(true);
-  }, []);
-
-  if (!ready) {
+  if (!flowVerification.valid) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center space-y-4">
-          <Loader2 className="w-12 h-12 animate-spin text-brand-accent mx-auto" />
-          <p className="text-lg text-neutral-400">Chargement de l&apos;évaluation...</p>
-        </div>
+      <div className="min-h-screen bg-surface-darker text-neutral-100">
+        <CorporateNavbar />
+        <main id="main-content" className="py-8">
+          <AssessmentAccessUnavailable />
+        </main>
+        <CorporateFooter />
       </div>
     );
   }
 
-  return (
-    <AssessmentRunner
-      subject={subject}
-      grade={grade}
-      studentData={{
-        email: emailParam,
-        name: nameParam,
-      }}
-      apiEndpoint="/api/assessments/submit"
-    />
-  );
-}
+  const { subject, grade, leadEmailHash, source } = flowVerification.payload;
+  const assessmentPublicToken = createAssessmentPublicToken({
+    subject,
+    grade,
+    source,
+    binding: "lead",
+    leadEmailHash,
+  });
+  const email = buildAssessmentAliasEmail(leadEmailHash);
 
-export default function BilanAssessmentPage() {
   return (
     <div className="min-h-screen bg-surface-darker text-neutral-100">
       <CorporateNavbar />
@@ -102,7 +86,13 @@ export default function BilanAssessmentPage() {
             </div>
           }
         >
-          <AssessmentContent />
+          <AssessmentClient
+            subject={subject}
+            grade={grade as Grade}
+            name="Élève Nexus"
+            email={email}
+            assessmentPublicToken={assessmentPublicToken}
+          />
         </Suspense>
       </main>
       <CorporateFooter />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,8 @@ import { getAllOffers, getEffectivePrice } from "@/lib/pricing";
 import { OG_DEFAULT_IMAGE } from "@/lib/seo";
 import "./globals.css";
 
-const GA_MEASUREMENT_ID = "G-3XPB54QL5N";
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+const ENABLE_GOOGLE_ANALYTICS = process.env.NEXT_PUBLIC_ENABLE_GOOGLE_ANALYTICS === 'true';
 
 const inter = localFont({
   src: "./fonts/Inter-Variable.woff2",
@@ -112,22 +113,27 @@ export default function RootLayout({
       offerCount: String(publicPrices.length),
     } : undefined,
   };
+  const shouldLoadGoogleAnalytics = ENABLE_GOOGLE_ANALYTICS && Boolean(GA_MEASUREMENT_ID);
 
   return (
     <html lang="fr">
       <head>
-        <Script
-          src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
-          strategy="lazyOnload"
-        />
-        <Script id="gtag-init" strategy="lazyOnload">
-          {`
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', '${GA_MEASUREMENT_ID}');
-          `}
-        </Script>
+        {shouldLoadGoogleAnalytics && (
+          <>
+            <Script
+              src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+              strategy="lazyOnload"
+            />
+            <Script id="gtag-init" strategy="lazyOnload">
+              {`
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${GA_MEASUREMENT_ID}');
+              `}
+            </Script>
+          </>
+        )}
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}

--- a/components/assessments/AssessmentRunner.tsx
+++ b/components/assessments/AssessmentRunner.tsx
@@ -44,6 +44,7 @@ interface AssessmentRunnerProps {
   studentData?: StudentData;
   onComplete?: (answers: StudentAnswer[]) => void;
   apiEndpoint?: string;
+  assessmentPublicToken?: string;
 }
 
 export function AssessmentRunner({
@@ -53,6 +54,7 @@ export function AssessmentRunner({
   studentData,
   onComplete,
   apiEndpoint,
+  assessmentPublicToken,
 }: AssessmentRunnerProps) {
   const router = useRouter();
 
@@ -131,7 +133,12 @@ export function AssessmentRunner({
 
         const response = await fetch(apiEndpoint, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            ...(assessmentPublicToken
+              ? { 'x-assessment-public-token': assessmentPublicToken }
+              : {}),
+          },
           body: JSON.stringify({
             subject,
             grade,
@@ -164,7 +171,7 @@ export function AssessmentRunner({
       setState('ERROR');
       toast.error('Erreur lors de la soumission');
     }
-  }, [apiEndpoint, grade, onComplete, router, selectedOptions, startTime, studentData, subject]);
+  }, [apiEndpoint, assessmentPublicToken, grade, onComplete, router, selectedOptions, startTime, studentData, subject]);
 
   // Validate answer
   const handleValidate = useCallback(() => {

--- a/components/marketing/PaymentMethodsNote.tsx
+++ b/components/marketing/PaymentMethodsNote.tsx
@@ -8,6 +8,37 @@ type PaymentMethodsNoteProps = {
 
 export function PaymentMethodsNote({ tone = 'light', compact = false }: PaymentMethodsNoteProps) {
   const isDark = tone === 'dark';
+  const cardPaymentPubliclyEnabled = process.env.NEXT_PUBLIC_ENABLE_CLICTOPAY_PUBLIC === 'true';
+
+  if (!cardPaymentPubliclyEnabled) {
+    return (
+      <div
+        className={
+          isDark
+            ? 'rounded-2xl border border-lux-line/30 bg-white/5 p-4 text-lux-on-dark-muted'
+            : 'rounded-2xl border border-lux-line bg-lux-paper/70 p-4 text-lux-slate'
+        }
+        data-testid="payment-methods-note"
+      >
+        <div className="flex items-start gap-3">
+          <ShieldCheck className={isDark ? 'mt-0.5 h-5 w-5 text-lux-gold-wash' : 'mt-0.5 h-5 w-5 text-lux-evergreen'} aria-hidden="true" />
+          <div className="min-w-0">
+            <p className={isDark ? 'text-sm font-semibold text-lux-ivory' : 'text-sm font-semibold text-lux-ink'}>
+              Paiement confirmé après validation pédagogique
+            </p>
+            <p className="mt-1 text-sm">
+              Les modalités de règlement sont communiquées par l’équipe Nexus avant toute inscription définitive.
+            </p>
+            {!compact && (
+              <p className="mt-3 text-xs">
+                Aucun identifiant bancaire sensible n’est affiché sur les pages publiques.
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/components/stages/StageInscriptionForm.tsx
+++ b/components/stages/StageInscriptionForm.tsx
@@ -13,7 +13,7 @@ const confirmationSchema = publicStageInscriptionSchema.extend({
   dataProcessingAccepted: z.literal(true),
 });
 
-type ConfirmationData = PublicStageInscriptionInput & {
+type ConfirmationData = Omit<PublicStageInscriptionInput, 'stageTermsAccepted' | 'dataProcessingAccepted'> & {
   stageTermsAccepted: boolean;
   dataProcessingAccepted: boolean;
 };
@@ -139,6 +139,8 @@ export function StageInscriptionForm({ stage }: { stage: StageSummary }) {
           parentEmail: formData.parentEmail,
           parentPhone: formData.parentPhone,
           notes: formData.notes,
+          stageTermsAccepted: formData.stageTermsAccepted,
+          dataProcessingAccepted: formData.dataProcessingAccepted,
         }),
       });
 

--- a/docs/go-live/00_EXECUTIVE_STATE.md
+++ b/docs/go-live/00_EXECUTIVE_STATE.md
@@ -1,0 +1,112 @@
+# État exécutif go-live
+
+## Date
+
+2026-07-02 14:46 CET  
+Addendum Lot 0-bis : 2026-07-02 18:20 CET
+
+## Résumé exécutif
+
+Le dépôt local `nexus-project_v0` compile, typecheck, lint et tests unitaires passent. Le site public marketing est techniquement générable en production Next.js, et les pages critiques publiques apparaissent dans le build : `/`, `/offres`, `/recommandation`, `/bilan-gratuit`, `/stages`, `/plateforme-aria`, `/accompagnement-scolaire`, `/contact`.
+
+Lot 0-bis a trié le smoke Playwright public : l'échec `/bilan-gratuit` venait d'un serveur standalone ancien réutilisé avec chunks `_next/static` en 404 ; le test WhatsApp exact était obsolète. Après build propre Node 20, le smoke ciblé passe : 24 tests passés, 0 échoué.
+
+Lot 0-bis a aussi verrouillé deux angles morts marketing : Google Analytics n'est plus chargé par défaut sans variable explicite, et ClicToPay n'est plus exposé sur les pages publiques tant que l'intégration publique n'est pas activée.
+
+La plateforme n'est pas prête pour un go-live large. Les risques bloquants sont surtout sécurité API/ownership, rate limiting distribué non prouvé en runtime, paiement carte ClicToPay non configuré, canonicalisation incomplète paiement/facture/entitlement, RGPD mineurs, stockage documents, monitoring et backup/restore.
+
+Décision provisoire : **bêta contrôlée possible sous conditions strictes**, **go-live large non autorisé** tant qu'un P0 reste ouvert.
+
+## Niveau de maturité actuel
+
+- Site public : **maturité moyenne-haute avec smoke ciblé vert**, mais campagne payante encore bloquée par le statut du tunnel bilan gratuit, l'absence de CMP complète et les reliquats marketing à neutraliser.
+- Tunnel bilan gratuit : **partiel**. L'UI ne demande pas de mot de passe, mais l'API crée déjà des comptes parent/élève inactifs et envoie une activation.
+- Pricing public : **globalement solide** sur les pages Next.js critiques, avec source canonique `data/pricing.canonical.json` via `lib/pricing.ts` / `lib/pricing-client.ts`.
+- Plateforme applicative : **maturité bêta**, pas go-live large.
+- Sécurité API : **insuffisante pour ouverture large**. Inventaire statique Lot 0 : 176 routes, 44 P0, 42 P1.
+- Paiement : **virement manuel actif côté code**, ClicToPay explicitement non configuré.
+- IA/RAG/NPC : **fonctionnellement présent mais à verrouiller**. RAG canonique ChromaDB documenté, NPC par défaut en mode `stub`.
+
+## Décision
+
+- Marketing go-live : **autorisable uniquement en pré-campagne/organique avec réserves** si GA reste désactivé, ClicToPay reste masqué et la production est vérifiée ; **campagne paid Meta/Google non autorisée** tant que le tunnel bilan gratuit n'est pas aligné lead-only ou explicitement assumé avec consentement.
+- Bêta contrôlée plateforme : **autorisable seulement avec utilisateurs connus, périmètre restreint, paiement carte désactivé et supervision manuelle**.
+- Bêta élargie : **non autorisée à ce stade**.
+- Go-live large : **non autorisé**.
+
+## Principaux risques P0
+
+- 44 routes API classées P0 par `node scripts/security/audit-api-guards.mjs`, dont documents, factures, bilans, coach, parent, stages, paiements et webhooks.
+- Rate limiting distribué supporté par code mais non prouvé actif en production : fallback mémoire possible.
+- ClicToPay retourne `501 CLICTOPAY_NOT_CONFIGURED` sur init et webhook.
+- Chaîne paiement -> facture -> entitlement réelle mais partielle, avec coexistence legacy `Subscription`, crédits et `Entitlement`.
+- Données de mineurs, documents PDF et bilans manipulés sans preuve complète de politique de rétention, suppression, consentement et journalisation minimisée.
+- Backup/restore, monitoring, alerting et rollback non prouvés par commande de production.
+- Google Analytics désormais désactivé par défaut dans `app/layout.tsx`, mais aucune CMP/consent mode complète n'existe ; activation interdite avant consentement.
+- Smoke Playwright public ciblé vert en Lot 0-bis, mais warning DB e2e `business_configs` absent à traiter.
+
+## Principaux risques P1
+
+- Nombreux warnings lint, dont `any`, variables inutilisées et hooks.
+- `next.config.mjs` ignore le lint pendant `next build`.
+- Inventaires générés précédents étaient obsolètes avant régénération.
+- RAG : code et documentation doivent être alignés sur l'URL par environnement.
+- `lib/entitlement/types.ts` garde un registre produit distinct du pricing canonique.
+- Pages/archives historiques contiennent encore des montants TND hors source canonique, même si le check officiel passe.
+
+## Ce qui est déjà solide
+
+- `npm run typecheck` OK.
+- `npm run lint` OK avec warnings.
+- `npm run test:unit -- --runInBand` OK : 504 suites passées, 1 ignorée, 6345 tests passés.
+- `npm run build` OK : 143 pages générées.
+- `npm run check:no-hardcoded` OK.
+- `npm run check:bundle-weight` OK sur les routes publiques suivies.
+- `/offres`, `/stages`, `/recommandation` et les landings SEO utilisent les getters pricing ou le contenu centralisé.
+- La page contact distingue siège administratif et centre pédagogique.
+- ARIA est présentée comme complément de l'humain sur les pages inspectées.
+
+## Ce qui est bloquant
+
+- Aucun go-live large avec P0 API ouverts.
+- Aucun paiement carte tant que ClicToPay reste en `501`.
+- Aucun élargissement sans preuve de rate limit distribué effectif.
+- Aucun go-live plateforme sans matrice RGPD mineurs, documents, logs et droits d'accès.
+- Aucun go-live production sans test restore backup et monitoring d'alerte.
+
+## À vérifier sur production réelle
+
+- Statut HTTP réel des pages critiques sur `https://nexusreussite.academy`.
+- Mode rate limiting réel : Redis/Upstash ou mémoire.
+- Présence et validité des variables ClicToPay, SMTP, Telegram, RAG, OpenAI/ARIA/NPC.
+- Healthcheck public et healthcheck interne.
+- Nginx, SSL, PM2 ou Docker, port exposé et headers.
+- Backups, restauration testée, volume documents et stockage factures.
+- Consentement analytics, Meta Pixel éventuel et journalisation réelle.
+- Absence de secrets et PII excessive dans les logs runtime.
+
+## Verdict honnête
+
+**Non prêt pour go-live large.**
+
+**Pas prêt pour campagne marketing payante immédiate.** Le smoke QA public ciblé est vert et GA/ClicToPay publics sont verrouillés, mais le tunnel bilan gratuit crée encore des comptes inactifs côté API et la production réelle n'a pas été vérifiée.
+
+**Bêta contrôlée plateforme possible** uniquement avec comptes connus, données limitées, supervision humaine, paiement carte désactivé, validation manuelle des accès et monitoring renforcé.
+
+## Réponses aux questions obligatoires Lot 0
+
+1. Le site public peut-il être utilisé pour une campagne marketing maintenant ? **Pré-campagne organique possible avec réserves ; paid ads non.** Le smoke public ciblé est vert, mais la production réelle, le consentement analytics complet et le statut lead-only du bilan doivent être verrouillés.
+2. Le tunnel bilan gratuit est-il prêt à recevoir des leads ? **Techniquement testable, mais produit/RGPD partiel.** L'UI est bas-friction et les validations Playwright passent ; l'API crée cependant des comptes inactifs avec activation email, donc le choix lead pur vs compte différé doit être figé.
+3. Les prix affichés sont-ils tous issus du pricing canonique ? **Sur les pages critiques inspectées, oui majoritairement.** Le check officiel passe, mais des reliquats avec montants TND existent dans des fichiers historiques ou composants à qualifier.
+4. La promesse “groupes réduits” est-elle cohérente partout ? **Globalement oui sur les pages inspectées**, avec `group_max = 5` dans le pricing canonique ; audit exhaustif contenu à finaliser.
+5. Les stages de prérentrée août 2026 sont-ils bien configurés ? **Oui localement.** `pre-rentree-2026` est configuré du 24 au 28 août 2026 dans le pricing canonique.
+6. La niche candidat libre est-elle correctement représentée ? **Oui localement**, via `/candidat-libre-bac-francais`, les contenus SEO et les offres libres ; validation humaine requise sur les règles session 2027.
+7. Le paiement carte est-il activable ou doit-il rester désactivé ? **Il doit rester désactivé.** ClicToPay retourne `501 CLICTOPAY_NOT_CONFIGURED` et n'est plus exposé sur les pages publiques par défaut.
+8. Les entitlements sont-ils la source de vérité réelle ou seulement partielle ? **Partielle.** Le flux existe, mais coexiste avec `Subscription`, crédits legacy et registre produit séparé.
+9. Le rate limiting distribué est-il réellement actif ou seulement prévu ? **Seulement prévu/supporté par code localement.** Activation production Redis/Upstash non prouvée.
+10. Le go-live large est-il autorisable ? **Non.** Des P0 API, RGPD, paiement, infra et monitoring restent ouverts.
+11. La bêta contrôlée est-elle autorisable ? **Oui sous conditions strictes**, avec périmètre fermé, paiement carte off, supervision humaine et routes utilisées auditées.
+12. Quels sont les 10 prochains tickets prioritaires ? Documents API IDOR, factures/PDF IDOR, ClicToPay webhook/init, assessments submit, bilan gratuit lead/account, coach reports `[studentId]`, stages réservations/bilans, rate limit distribué, pricing/entitlements, RGPD analytics/CMP.
+13. Quelles routes API doivent être ré-auditées manuellement ? Documents, factures, paiements, bilans, assessments, coach `[studentId]`, parent PDF, stages `[stageSlug]`, NPC files/submissions, activation/abonnements.
+14. Quels fichiers contiennent des montants TND hors pricing canonique ? `data/Nexus_Reussite_Accueil.html` est archive morte dans `data/`; `Nexus_Reussite_Accueil.html` racine est encore inclus dans le tracing standalone ; `components/ui/specialized-packs.tsx` est exporté mais non importé. Voir `_evidence/hardcoded-pricing-triage.md`.
+15. Quels éléments RGPD/mineurs manquent encore ? CMP/consent mode, registre traitements, durée de conservation, suppression/export, sous-traitants IA/email/storage, logs redacted, politique documents, minimisation du tunnel bilan gratuit et preuve de consentement parent.

--- a/docs/go-live/01_ACTION_PLAN.md
+++ b/docs/go-live/01_ACTION_PLAN.md
@@ -1,0 +1,100 @@
+# Plan d’action go-live Nexus Réussite
+
+## Phase 0 — Baseline et cadrage
+
+- Objectif : figer l'état réel local, les risques, les gates et les prochains lots.
+- Fichiers concernés : `rapport_audit_2_07_2026.md`, `AGENTS.md`, `docs/go-live/*`, `docs/security/API_GUARD_INVENTORY.md`, `docs/architecture/SITE_MAP.md`.
+- Actions : lire l'audit racine, croiser avec le code, exécuter les commandes, créer backlog P0/P1/P2 et release gates.
+- Risques : basculer en refonte prématurée sans preuve ; confondre audit et état courant.
+- Tests attendus : typecheck, lint, unit, build, audit API guards, site map, hardcoded, archive, bundle.
+- Critères d'acceptation : documents Lot 0 créés, verdict clair, commandes tracées.
+- Dépendances : aucune.
+- Statut initial : **réalisé Lot 0**.
+
+## Phase 1 — Sécurité API / IDOR / rate limiting
+
+- Objectif : rendre les API sensibles compatibles bêta élargie et go-live large.
+- Fichiers concernés : `app/api/**/route.ts`, `lib/rbac.ts`, `lib/guards.ts`, `lib/access/*`, `lib/rate-limit/*`, `docs/security/API_GUARD_INVENTORY.md`.
+- Actions : auditer les 44 P0 et 42 P1, ajouter ownership explicite, tests IDOR, Zod manquant, rate limit sur routes publiques et coûteuses, preuve Redis/Upstash.
+- Risques : accès croisé parent/élève/coach, lecture de documents ou factures hors périmètre, spam formulaire, contournement par multi-instance.
+- Tests attendus : unit IDOR par route dynamique, tests 401/403/404, tests 429 distribués, `node scripts/security/audit-api-guards.mjs`.
+- Critères d'acceptation : 0 P0 ouvert, routes dynamiques propriétaires couvertes, rate limiting distribué prouvé hors mémoire.
+- Dépendances : décisions de rôle et ownership.
+- Statut initial : **P0 ouvert**.
+
+## Phase 2 — Pricing, offres et conversion
+
+- Objectif : garantir cohérence commerciale 2026/2027, source canonique et tunnels sans friction.
+- Fichiers concernés : `data/pricing.canonical.json`, `lib/pricing.ts`, `lib/pricing-client.ts`, `app/offres/page.tsx`, `app/stages/page.tsx`, `app/bilan-gratuit/*`, `app/HomePageClient.tsx`, `content/marketing/*`.
+- Actions : vérifier tous les montants affichés, supprimer reliquats archives activables, aligner stages août 2026, clarifier candidat libre, vérifier CTA, consentement analytics.
+- Risques : prix contradictoires, promesse non défendable, campagne vers tunnel trop agressif, perte de confiance.
+- Tests attendus : `npm run check:no-hardcoded`, tests marketing existants, smoke mobile Playwright.
+- Critères d'acceptation : aucune page publique critique avec montant hors getter, promesse engagement de moyens, CTA principal clair.
+- Dépendances : validation humaine des offres.
+- Statut initial : **P1 ouvert, P0 si campagne immédiate sans consentement/tracking**.
+
+## Phase 3 — Paiement, facturation, entitlements
+
+- Objectif : rendre la chaîne d'achat fiable, traçable et réconciliable.
+- Fichiers concernés : `app/api/payments/*`, `app/api/invoices/*`, `app/api/admin/invoices/*`, `lib/invoice/*`, `lib/entitlement/*`, `prisma/schema.prisma`.
+- Actions : décider ClicToPay off/on, finaliser webhook, aligner `PRODUCT_REGISTRY` et pricing, garantir `InvoiceItem.productCode`, retraiter les cas sans beneficiary, clarifier projections legacy.
+- Risques : paiement validé sans droit, droit accordé sans paiement, facture non générée, crédit doublé.
+- Tests attendus : tests transaction paiement, webhook signature, idempotence, accès PDF parent/admin, entitlement registry vs pricing.
+- Critères d'acceptation : virement manuel robuste, ClicToPay soit désactivé proprement soit complet, entitlements source de vérité.
+- Dépendances : pricing et catalogue produit figés.
+- Statut initial : **P0 ouvert pour ClicToPay/entitlements**.
+
+## Phase 4 — Dashboards par rôle
+
+- Objectif : stabiliser parent, élève, coach, assistante, admin sur droits et données utiles.
+- Fichiers concernés : `app/dashboard/**`, `app/api/parent/**`, `app/api/student/**`, `app/api/coach/**`, `app/api/assistante/**`, `lib/access/*`, `lib/rbac/*`.
+- Actions : smoke par rôle, vérifier navigation, données masquées, actions critiques, états vides, mobile.
+- Risques : fuite inter-rôle, confusion opérationnelle, actions staff non journalisées.
+- Tests attendus : E2E login par rôle, tests API 403/404, smoke dashboards.
+- Critères d'acceptation : chaque rôle voit uniquement son périmètre et peut accomplir ses workflows clés.
+- Dépendances : Phase 1 sécurité API.
+- Statut initial : **P1 ouvert, P0 sur routes classées critiques**.
+
+## Phase 5 — IA, ARIA, RAG, NPC
+
+- Objectif : garantir une IA utile, bornée, traçable et non survendue.
+- Fichiers concernés : `app/api/aria/*`, `lib/aria.ts`, `lib/rag-client.ts`, `docs/RAG_ARCHITECTURE.md`, `app/api/npc/*`, `lib/npc/*`, `services/npc-worker/*`.
+- Actions : figer backend RAG canonique, aligner docs/code, vérifier feature flags ARIA, clarifier mode NPC `stub/live/off`, tester uploads et ownership.
+- Risques : réponses IA non maîtrisées, NPC stub présenté comme live, fuite de copies ou bilans, dépendance externe non monitorée.
+- Tests attendus : ARIA feature/ownership, RAG health, NPC upload/file access, worker mode, prompts sans PII inutile.
+- Critères d'acceptation : IA présentée comme complément, mode runtime explicite, RAG backend unique vérifié.
+- Dépendances : env RAG/LLM et sécurité documents.
+- Statut initial : **P0/P1 ouvert**.
+
+## Phase 6 — RGPD, mineurs, logs, documents
+
+- Objectif : réduire l'exposition des données mineurs, documents, bilans et logs.
+- Fichiers concernés : `app/politique-confidentialite/page.tsx`, `app/conditions-generales/page.tsx`, `app/api/documents/*`, `app/api/student/documents/*`, `app/api/npc/files/*`, `lib/logger*`, `lib/utils/serialize-error.ts`.
+- Actions : registre traitements, consentement, minimisation formulaire, durée conservation, suppression/export, logs safe, stockage privé, antivirus éventuel.
+- Risques : non-conformité, exposition de PII, conservation excessive, fichiers sensibles servis sans contrôle.
+- Tests attendus : no-leak tests, route document IDOR, logs redaction, consentement analytics.
+- Critères d'acceptation : documents privés uniquement via contrôle d'accès, logs sans PII excessive, consentement explicite.
+- Dépendances : Phase 1 et décisions légales humaines.
+- Statut initial : **P0 ouvert**.
+
+## Phase 7 — Infra, backup, monitoring, rollback
+
+- Objectif : rendre la production opérable et restaurable.
+- Fichiers concernés : `Dockerfile.prod`, `docker-compose.prod.yml`, `next.config.mjs`, `.github/workflows/ci.yml`, `app/api/health/route.ts`, `app/api/internal/health/route.ts`.
+- Actions : confirmer PM2 ou Docker, ports, Nginx, SSL, healthchecks, logs, sauvegarde DB/storage, restore drill, monitoring alertes.
+- Risques : production non restaurable, panne silencieuse, port exposé, dépendance env manquante.
+- Tests attendus : healthchecks, restore backup, curl pages critiques, monitoring synthetic.
+- Critères d'acceptation : rollback documenté, backup restauré au moins une fois, alerting opérationnel.
+- Dépendances : accès production et décision infra.
+- Statut initial : **P0 ouvert**.
+
+## Phase 8 — QA finale, smoke tests, release gates
+
+- Objectif : décider factuellement de la release.
+- Fichiers concernés : `tests/e2e/**`, `playwright.config.*`, `docs/go-live/03_RELEASE_GATES.md`, CI.
+- Actions : smoke public, mobile, accessibilité, SEO, parcours leads, parcours paiement manuel, dashboards par rôle, non-régression API P0.
+- Risques : release basée sur build uniquement, régression mobile, pages campagnes cassées.
+- Tests attendus : `npm run typecheck`, `npm run lint`, `npm run test:unit -- --runInBand`, `npm run build`, `npx playwright test`, curls production.
+- Critères d'acceptation : gate atteint, P0 fermé, rapport de release signé.
+- Dépendances : Phases 1 à 7.
+- Statut initial : **à faire après lots correctifs**.

--- a/docs/go-live/02_P0_P1_BACKLOG.md
+++ b/docs/go-live/02_P0_P1_BACKLOG.md
@@ -1,5 +1,23 @@
 # Backlog P0/P1 go-live
 
+## Mise à jour Lot 15 — 2026-07-06
+
+- Les 39 fichiers non suivis restants après Lot 14 ont été inventoriés.
+- 37 fichiers utiles RC ont été commités : 3 tests release et 34 preuves/reports Lots 9 à 13.
+- 2 fichiers restent exclus : `docs/audits/audit-nexus-reussite.md` et `rapport_audit_2_07_2026.md`.
+- Aucun fichier `REVIEW`.
+- Les 6 P1 restent visibles et non requalifiés.
+- Décision : `LOCAL_COMMITS_COMPLETE`, `READY_FOR_PUSH_REVIEW`, `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`, `BETA_ELARGIE_BLOCKED`, `GO_LIVE_LARGE_BLOCKED`.
+
+Blocages maintenus :
+
+1. Redis/Upstash staging/production non prouvé.
+2. Test `429` runtime réel non exécuté.
+3. ContactLead dry-run DB non production non exécuté.
+4. ClicToPay disabled.
+
+---
+
 ## Mise à jour Lot 14 — 2026-07-06
 
 - Les 9 commits locaux du runbook Lot 11 ont été exécutés dans l'ordre demandé.

--- a/docs/go-live/02_P0_P1_BACKLOG.md
+++ b/docs/go-live/02_P0_P1_BACKLOG.md
@@ -524,6 +524,26 @@ Backlog bloquant restant :
 
 Décision : `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`; `BETA_ELARGIE_BLOCKED`; `GO_LIVE_LARGE_BLOCKED`.
 
+# Mise à jour Lot 16 — 2026-07-06
+
+Lot 16 ne requalifie aucune route et ne ferme aucun P1.
+
+- `P0=0` maintenu.
+- `P1=6` maintenus et visibles dans `docs/go-live/api-security-matrix.full.md`.
+- Revue finale du diff : `main...HEAD`, 329 fichiers, 21 339 insertions, 1 258 suppressions avant commit documentaire Lot 16.
+- Staging Git vide au demarrage Lot 16.
+- Seuls fichiers non suivis acceptes : `docs/audits/audit-nexus-reussite.md` et `rapport_audit_2_07_2026.md`.
+- Push de la branche autorise uniquement apres gates minimales vertes et re-verification pre-push.
+
+Blocages maintenus :
+
+1. Redis/Upstash staging/production non prouve.
+2. Test `429` runtime reel non execute.
+3. ContactLead dry-run DB non production non execute.
+4. Les 6 P1 publics/paiement restent bloquants pour beta elargie et go-live large.
+
+Decision : `READY_TO_PUSH_BRANCH` sous reserve des gates pre-push ; `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`; `BETA_ELARGIE_BLOCKED`; `GO_LIVE_LARGE_BLOCKED`.
+
 # Mise à jour Lot 8 — 2026-07-03
 
 Lot 8 a nettoyé la préparation release candidate sans fermer de P1 :

--- a/docs/go-live/02_P0_P1_BACKLOG.md
+++ b/docs/go-live/02_P0_P1_BACKLOG.md
@@ -1,0 +1,521 @@
+# Backlog P0/P1 go-live
+
+## Mise à jour Lot 13 — 2026-07-06
+
+- Inventaire inchangé : `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178`.
+- Les 6 P1 restent visibles et non requalifiés.
+- Runbook humain Lot 11 relancé sous Node 20 : `1` suite passée, `5` tests passés.
+- `docs/audits/audit-nexus-reussite.md` reste `PRESENT_UNTRACKED_IN_WORKTREE` et `EXCLUDE_FROM_STANDARD_COMMITS`.
+- Staging Git resté vide ; aucun `git add` réel, aucun commit, aucun push, aucune PR.
+- Décision : `READY_TO_EXECUTE_MANUALLY`, `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`, `BETA_ELARGIE_BLOCKED`, `GO_LIVE_LARGE_BLOCKED`.
+
+Blocages maintenus :
+
+1. Redis/Upstash staging/production non prouvé.
+2. Test `429` runtime réel non exécuté.
+3. ContactLead dry-run DB non production non exécuté.
+4. ClicToPay disabled.
+
+---
+
+## Mise à jour Lot 11 — 2026-07-03
+
+- Inventaire inchangé : `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178`.
+- Les 6 P1 restent visibles et non requalifiés : ClicToPay webhook, assessment submit, bilan gratuit, Lamis teacher report, stage inscription, student activation.
+- Runbook humain créé : `docs/go-live/_evidence/lot11-human-commit-runbook.md`.
+- Preuve mécanique : `281` fichiers `Include RC` couverts exactement une fois, aucun `Exclude`, aucun `Needs human review` dans les commits standards.
+- Aucun `git add` réel, aucun commit, aucune PR.
+- Décision : `READY_FOR_HUMAN_EXECUTION`, `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`, `BETA_ELARGIE_BLOCKED`, `GO_LIVE_LARGE_BLOCKED`.
+
+---
+
+## Mise à jour Lot 10 — 2026-07-03
+
+- Inventaire inchangé : `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178`.
+- Les 6 P1 restent visibles et non requalifiés : ClicToPay webhook, assessment submit, bilan gratuit, Lamis teacher report, stage inscription, student activation.
+- Plan `git add --dry-run` créé : `docs/go-live/_evidence/lot10-git-add-dry-run-plan.md`.
+- Preuve mécanique : `281` fichiers `Include RC` couverts exactement une fois, aucun `Exclude`, aucun `Needs human review`, aucun `.env`, aucun `rapport_audit_2_07_2026.md`.
+- Staging Git vide avant/après dry-runs ; aucun `git add` réel, aucun commit, aucune PR.
+- Décision : `READY_FOR_HUMAN_COMMIT`, `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`, `BETA_ELARGIE_BLOCKED`, `GO_LIVE_LARGE_BLOCKED`.
+
+---
+
+## Mise à jour Lot 9 — 2026-07-03
+
+- Inventaire inchangé : `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178`.
+- Les 6 P1 restent visibles : ClicToPay webhook, assessment submit, bilan gratuit, Lamis teacher report, stage inscription, student activation.
+- Validation mécanique ajoutée : `__tests__/scripts/release-candidate-manifest-consistency.test.ts`.
+- Résultat ciblé : `2` suites passées, `14` tests passés avec la régression scripts.
+- Manifeste Lot 8 et plan de commits Lot 8 cohérents : `281` fichiers `Include RC` couverts exactement une fois, aucun `Exclude` ni `Needs human review` inclus.
+- Décision : `RC_READY_FOR_HUMAN_REVIEW`, `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`, `BETA_ELARGIE_BLOCKED`, `GO_LIVE_LARGE_BLOCKED`.
+
+---
+
+## Mise à jour Lot 5 — 2026-07-03
+
+- Inventaire après ajout de la probe interne : `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178`.
+- Les 6 P1 restent inchangés : ClicToPay webhook, assessment submit, bilan gratuit, Lamis teacher report, stage inscription, student activation.
+- `/api/internal/rate-limit-probe` ajouté pour test 429 non destructif ; route protégée et classée OK statique.
+- Redis/Upstash non prouvé : `NEXUS_HEALTH_AUTH_ABSENT`, production sans secret `401`, local `memory/blocked`.
+- Test 429 local route probe : OK ; test 429 staging/production : non exécuté, procédure documentée et bloquante.
+- ContactLead retention : dry-run DB local échoue faute de DB disponible ; tests fixtures OK ; `--apply` production interdit sans validation humaine.
+- ClicToPay : décision finale `DISABLED`, paiement manuel uniquement, carte publique non disponible.
+- Registre go/no-go des 6 P1 créé : bêta contrôlée possible avec réserves, bêta élargie interdite, go-live large interdit.
+
+---
+
+## Mise à jour Lot 4 — 2026-07-03
+
+- Inventaire attendu après régénération : `P0=0`, `P1=6`, `P2=144`, `OK=27`, total `177`.
+- Les 6 P1 restent visibles par décision : ClicToPay webhook, assessment submit, bilan gratuit, Lamis teacher report, stage inscription, student activation.
+- Angle mort token assessment libre fermé : `/bilan-gratuit/assessment` exige un cookie HttpOnly signé issu de `/api/bilan-gratuit` et redirige toute URL avec query params vers l'URL canonique avant rendu.
+- `/api/assessments/submit` vérifie maintenant un token `binding=lead` avec `leadEmailHash` et email assessment pseudonyme, ou un token staff-only contrôlé.
+- Purge/anonymisation `ContactLead` : script dry-run/apply ajouté, application production à valider.
+- `business_configs` : fallback inattendu en production devient dégradé.
+- ClicToPay : flag public actif + backend désactivé échoue en `503`, pas de succès ambigu.
+- Redis/Upstash reste non prouvé : bêta élargie et go-live large interdits.
+
+---
+
+## Mise à jour Lot 3 — 2026-07-03
+
+- Inventaire API régénéré : `P0=0`, `P1=6`, `P2=144`, `OK=27`, total `177`.
+- `/api/assessments/submit` exige désormais un token signé court HMAC, TTL 15 minutes, scope `assessment_submit`, `subject`, `grade`.
+- Nouvelle route staff-only `/api/assessments/public-token`, classée `P2`, pour émission contrôlée de token.
+- `/api/bilan-gratuit` reste `lead_only` et refuse maintenant `studentBirthDate` ; registre RGPD, rétention et suppression sont documentés.
+- `ContactLead` a une politique de rétention proposée (`365` jours) et SLA d'effacement (`30` jours), avec dédoublonnage email/source des leads `NEW`.
+- `business_configs` absent est classé comme fallback statique optionnel ; healthcheck interne expose `runtime.businessConfig`.
+- ClicToPay reste désactivé contractuellement ; webhook `501`, signature obligatoire, aucune mutation.
+- Redis/Upstash production/staging reste non prouvé : healthcheck production sans secret retourne `401`, mode local `memory` bloqué.
+- Le prochain backlog prioritaire reste runtime/paiement : prouver Redis/Upstash, finaliser ou désactiver durablement ClicToPay, implémenter purge/anonymisation leads.
+
+---
+
+## Mise à jour Lot 2 — 2026-07-03
+
+- Les 6 P1 restants ne sont plus des angles morts : chaque route a une décision produit/RGPD/paiement/runtime documentée.
+- `/api/bilan-gratuit` est transformée en `lead_only` : création de lead CRM seulement, aucune création de `User`, `ParentProfile`, `Student`, token d'activation ou email d'activation. Le risque "création de comptes depuis formulaire public sans consentement explicite" est fermé dans le code.
+- `/api/stages/[stageSlug]/inscrire` reste publique par décision conversion, avec consentement traitement et modalités stage obligatoires avant écriture CRM.
+- `/api/payments/clictopay/webhook` reste `501/P1` : signature obligatoire, aucune mutation Prisma, aucun succès ambigu. Carte bancaire indisponible tant que l'intégration n'est pas complète.
+- `/api/assessments/submit` et `/api/lamis/teacher-report` restent publiques et minimisées ; elles doivent passer derrière token/session si elles collectent des données nominatives ou produisent un résultat rattaché à un élève.
+- `/api/student/activate` reste publique par token, avec lifecycle hash/expiration/no-replay testé.
+- Redis/Upstash staging/production reste non prouvé : go-live large interdit.
+- Le prochain backlog prioritaire bascule vers Lot 3 : runtime Redis/Upstash, token court pour assessments publics, finalisation ClicToPay ou désactivation contractuelle, et registre RGPD mineurs.
+
+---
+
+## Mise à jour Lot 1-quinquies — 2026-07-03
+
+- Inventaire API régénéré : `P0=0`, `P1=6`, `P2=143`, `OK=27`.
+- 6 P1 admin ont été fermés par corrections de code/tests : config, rollback, directeur stats, recompute SSN, subscriptions, test-email.
+- ClicToPay webhook reste `501/P1` : signature obligatoire, aucun succès ambigu, aucune mutation.
+- Les P1 restants sont publics sensibles ou activation par token : `/api/assessments/submit`, `/api/bilan-gratuit`, `/api/lamis/teacher-report`, `/api/stages/[stageSlug]/inscrire`, `/api/student/activate`.
+- Le test no-leak couvre désormais 20 réponses mockables, dont les 12 P1 de départ ou leurs réponses de validation.
+- `rate limiting` distribué production/staging non prouvé : `/api/internal/health` production répond `401` sans secret, donc go-live large reste interdit.
+- `/api/bilan-gratuit` reste dette produit/RGPD : route sans fuite en sortie, mais création de comptes inactifs.
+
+---
+
+## Mise à jour Lot 1-quater — 2026-07-02
+
+- Inventaire API régénéré : `P0=0`, `P1=12`, `P2=137`, `OK=27`.
+- 25 P1 ont été fermés par corrections de code/tests, principalement assistante, parent, student/eleve, coach et stages confirm.
+- Le test global no-leak couvre désormais 12 routes mockables.
+- Le healthcheck interne expose explicitement le mode rate limiting et bloque `memory` pour go-live large.
+- Restent bloquants bêta élargie/go-live large : ClicToPay webhook `501/P1`, routes publiques sensibles (`assessments/submit`, `bilan-gratuit`, `lamis/teacher-report`, `stages inscrire`, `student activate`), 6 routes admin P1, rate limiting distribué production non prouvé.
+- `/api/bilan-gratuit` reste une dette produit/RGPD : sortie durcie, mais création de comptes inactifs.
+
+---
+
+## Mise à jour Lot 1-ter — 2026-07-02
+
+- Inventaire API régénéré : `P0=0`, `P1=37`, `P2=112`, `OK=27`.
+- 17 P1 ont été fermés par corrections de code/tests : admin invoices, ClicToPay init, bilans, NPC submissions/documents/uploads/generate, sessions cancel et routes coach reports ciblées.
+- ClicToPay reste non actif : `init` est durci et retourne toujours `501`, `webhook` reste P1/501.
+- Restent bloquants bêta élargie/go-live large : ClicToPay webhook, `/api/assessments/submit`, `/api/bilan-gratuit`, `/api/stages/[stageSlug]/inscrire`, `/api/assistante/quotes/pdf`, P1 assistante/parent/student/coach restants, rate limiting distribué production.
+- Le backlog prioritaire suivant doit traiter les P1 publics/stages/assistante/parent/student et prouver le mode Redis/Upstash en production ou staging.
+
+---
+
+## Mise à jour Lot 1-bis — 2026-07-02
+
+- Inventaire API régénéré : `P0=0`, `P1=54`, `P2=95`, `OK=27`.
+- `P0-001` est accepté avec réserves côté inventaire statique : les requalifications P0 sont contre-auditées dans `docs/go-live/_evidence/lot1bis-p0-reclassification-audit.md`.
+- Deux P1 fermés : `/api/sessions/video`, `/api/admin/documents`.
+- Restent bloquants bêta élargie/go-live large : ClicToPay, `/api/admin/invoices`, `/api/assessments/submit`, `/api/bilan-gratuit` décision produit/RGPD, `/api/bilans*`, routes coach generate/regenerate, NPC documents, rate limiting distribué production.
+- Le rate limiting distribué reste P0 runtime pour go-live large tant que production n’est pas vérifiée.
+
+---
+
+## P0-001 — Auditer et fermer les P0 API ownership/IDOR
+
+- Sévérité : P0
+- Domaine : Sécurité API
+- Preuve : `docs/security/API_GUARD_INVENTORY.md` généré le 2026-07-02 : 176 routes, 44 P0.
+- Fichiers concernés : `app/api/**/route.ts`, `lib/rbac.ts`, `lib/guards.ts`, `lib/access/*`.
+- Risque : accès croisé à documents, factures, bilans, élèves, coachs ou paiements.
+- Action attendue : audit manuel des routes P0, ownership explicite, tests IDOR.
+- Tests attendus : tests 401/403/404 par rôle et ressource, `node scripts/security/audit-api-guards.mjs`.
+- Critère d’acceptation : 0 route P0 ouverte, chaque route dynamique sensible a un test d'accès croisé.
+- Owner suggéré : Lead backend sécurité.
+- Statut : Accepté avec réserves après Lot 1-bis pour l’inventaire statique (`P0=0`). Reste bloquant fonctionnel sur 54 P1 avant bêta élargie.
+
+## P0-002 — Prouver le rate limiting distribué en production
+
+- Sévérité : P0
+- Domaine : Sécurité runtime
+- Preuve : `lib/rate-limit/index.ts` supporte Redis/Upstash mais fallback mémoire possible ; `app/api/internal/health/route.ts` marque Redis KO si mode mémoire.
+- Fichiers concernés : `lib/rate-limit/*`, `docker-compose.prod.yml`, env production.
+- Risque : spam formulaires et brute force non bloqués sur multi-instance.
+- Action attendue : config Redis/Upstash, test 429, alerte si mémoire en production.
+- Tests attendus : test 429 distribué, healthcheck interne, simulation multi-process.
+- Critère d’acceptation : production indique `redis` ou `upstash`, jamais `memory`.
+- Owner suggéré : DevOps / backend.
+- Statut : Ouvert.
+
+## P0-003 — Maintenir ClicToPay désactivé ou finaliser intégration complète
+
+- Sévérité : P0
+- Domaine : Paiement
+- Preuve : `app/api/payments/clictopay/init/route.ts` et `webhook/route.ts` retournent `501 CLICTOPAY_NOT_CONFIGURED`.
+- Fichiers concernés : `app/api/payments/clictopay/*`, `app/dashboard/parent/paiement/*`.
+- Risque : promesse de paiement carte non tenue ou paiement non réconcilié.
+- Action attendue : conserver le masquage public ajouté en Lot 0-bis, ou implémenter init/webhook/idempotence.
+- Tests attendus : tests init, webhook signature, paiement réussi/échoué, double webhook.
+- Critère d’acceptation : carte soit absente du parcours public, soit validée bout-en-bout.
+- Owner suggéré : Backend paiement.
+- Statut : Ouvert côté paiement ; exposition publique masquée en Lot 0-bis.
+
+## P0-004 — Canoniser paiement -> facture -> entitlement
+
+- Sévérité : P0
+- Domaine : Paiement / droits produit
+- Preuve : `app/api/payments/validate/route.ts` active `activateEntitlements`, mais conserve activation legacy `Subscription` et `CreditTransaction`.
+- Fichiers concernés : `lib/entitlement/*`, `app/api/payments/validate/route.ts`, `prisma/schema.prisma`.
+- Risque : droits doublés, crédits incohérents, paiement sans entitlement ou entitlement sans facture.
+- Action attendue : documenter la source de vérité, aligner projections legacy et tests d'idempotence.
+- Tests attendus : `__tests__/api/payments.validate.entitlement.route.test.ts`, tests crédits, tests facture PDF.
+- Critère d’acceptation : `InvoiceItem.productCode` + paiement payé déclenchent les droits, legacy seulement projection.
+- Owner suggéré : Backend billing.
+- Statut : Ouvert.
+
+## P0-005 — Aligner registre produit entitlement et pricing canonique
+
+- Sévérité : P0
+- Domaine : Business logic
+- Preuve : `data/pricing.canonical.json` expose les plans opérationnels 150/450/750 avec crédits 0/4/8, alors que `lib/entitlement/types.ts` accorde 4/8/16 sur les abonnements.
+- Fichiers concernés : `data/pricing.canonical.json`, `lib/entitlement/types.ts`, `lib/operational-catalog*`.
+- Risque : droits accordés incohérents avec l'offre vendue.
+- Action attendue : définir mapping canonique et tests contractuels pricing -> entitlement.
+- Tests attendus : test registre produit vs pricing, test activation crédits.
+- Critère d’acceptation : aucun crédit accordé hors décision métier validée.
+- Owner suggéré : Produit + backend.
+- Statut : Ouvert.
+
+## P0-006 — RGPD mineurs et consentement analytics
+
+- Sévérité : P0
+- Domaine : RGPD / mineurs
+- Preuve : Lot 0 montrait GA chargé directement ; Lot 0-bis désactive GA par défaut via `NEXT_PUBLIC_ENABLE_GOOGLE_ANALYTICS`, mais aucune CMP/consent mode complète n'existe.
+- Fichiers concernés : `app/layout.tsx`, `app/politique-confidentialite/page.tsx`, `app/bilan-gratuit/*`, `app/api/analytics/event/route.ts`.
+- Risque : collecte non consentie, traitement mineurs insuffisamment cadré.
+- Action attendue : CMP/consent mode, registre traitements, minimisation, preuve de consentement.
+- Tests attendus : tracking absent avant consentement, politique à jour, logs no-PII.
+- Critère d’acceptation : aucun script analytics non essentiel avant consentement.
+- Owner suggéré : Produit légal + frontend.
+- Statut : Ouvert ; script GA public verrouillé par défaut en Lot 0-bis.
+
+## P0-016 — Clarifier `/bilan-gratuit` lead-only vs création de compte
+
+- Sévérité : P0
+- Domaine : Conversion / RGPD mineurs
+- Preuve : Lot 2 a transformé `app/api/bilan-gratuit/route.ts` en lead CRM uniquement ; Lot 3 retire/refuse `studentBirthDate` et documente registre/rétention dans `docs/go-live/_evidence/lot3-bilan-gratuit-rgpd-register.md`.
+- Fichiers concernés : `app/bilan-gratuit/*`, `app/api/bilan-gratuit/route.ts`, `lib/validations.ts`, `lib/crm/contact-leads.ts`.
+- Risque : formulaire public mineur encore sensible et dépendant du rate limiting distribué pour campagne large.
+- Action attendue : conserver `lead_only`, valider la politique de confidentialité et implémenter purge/anonymisation `ContactLead` avant go-live large.
+- Tests attendus : soumission lead sans compte, consentement, email interne, rate limit, aucune PII en logs, refus `studentBirthDate`.
+- Critère d'acceptation : comportement API aligné avec la promesse affichée, minimisation documentée, purge opérationnelle.
+- Owner suggéré : Produit + backend CRM.
+- Statut : Fermé côté ambiguïté création compte ; réserve RGPD/runtime ouverte pour purge et Redis/Upstash.
+
+## P0-007 — Documents et fichiers sensibles
+
+- Sévérité : P0
+- Domaine : Documents / PII
+- Preuve : routes documents classées P0/P1 dans `API_GUARD_INVENTORY.md`; `app/api/documents/[id]/route.ts` lit des chemins locaux privés.
+- Fichiers concernés : `app/api/documents/*`, `app/api/student/documents/*`, `app/api/npc/files/*`, `storage/*`.
+- Risque : fuite de PDF, factures, bilans ou copies.
+- Action attendue : audit IDOR, stockage hors webroot, headers, logs sans chemin local, politique suppression.
+- Tests attendus : parent/élève/coach croisés, document inexistant, path traversal, no-leak.
+- Critère d’acceptation : accès document strictement propriétaire ou staff autorisé.
+- Owner suggéré : Backend sécurité.
+- Statut : Ouvert.
+
+## P0-008 — Backup / restore DB et fichiers
+
+- Sévérité : P0
+- Domaine : Infra
+- Preuve : audit racine exige backup/restore ; aucune commande production n'a été exécutée Lot 0.
+- Fichiers concernés : `docker-compose.prod.yml`, volumes DB, storage documents/factures.
+- Risque : perte de données familles, factures, bilans.
+- Action attendue : stratégie backup, chiffrement, test restore, RPO/RTO.
+- Tests attendus : restore sur environnement isolé, checksum fichiers.
+- Critère d’acceptation : restauration validée et documentée.
+- Owner suggéré : DevOps.
+- Statut : Ouvert.
+
+## P0-009 — Monitoring, alerting et healthchecks
+
+- Sévérité : P0
+- Domaine : Observabilité
+- Preuve : `app/api/health/route.ts` existe ; `app/api/internal/health/route.ts` vérifie DB/SMTP/RAG/Redis/NPC mais nécessite validation runtime.
+- Fichiers concernés : `app/api/health/route.ts`, `app/api/internal/health/route.ts`, infra monitoring.
+- Risque : panne silencieuse, SMTP/RAG/Redis dégradés non détectés.
+- Action attendue : sondes, alertes, logs centralisés, synthetic checks pages critiques.
+- Tests attendus : health 200/503, alerte de test, restart app.
+- Critère d’acceptation : alerte vérifiée pour DB/RAG/Redis/SMTP/app down.
+- Owner suggéré : DevOps.
+- Statut : Ouvert.
+
+## P0-010 — Runtime minimal production
+
+- Sévérité : P0
+- Domaine : Production
+- Preuve : `Dockerfile.prod`, `docker-compose.prod.yml`, `next.config.mjs` existent ; production réelle non vérifiée en Lot 0.
+- Fichiers concernés : Docker, Nginx, PM2/Docker, SSL, headers.
+- Risque : port exposé, mauvais mode Node, secrets mal injectés, rollback non prêt.
+- Action attendue : état initial prod lecture seule, choix Docker/PM2, port localhost, headers, rollback.
+- Tests attendus : curls production, `docker compose ps` ou PM2, SSL labs interne, headers.
+- Critère d’acceptation : runbook prod signé, rollback testé.
+- Owner suggéré : CTO / DevOps.
+- Statut : Ouvert.
+
+## P0-011 — Logs sans PII excessive
+
+- Sévérité : P0
+- Domaine : Sécurité / conformité
+- Preuve : plusieurs routes loggent des erreurs sérialisées ; tests unitaires montrent des chemins d'erreur API/DB/SMTP. `app/api/documents/[id]/route.ts` loggue un `localPath` en cas de fichier manquant.
+- Fichiers concernés : `lib/utils/serialize-error.ts`, `lib/logger*`, routes documents, paiements, bilans, ARIA.
+- Risque : PII, chemins locaux ou données pédagogiques dans logs.
+- Action attendue : redaction centralisée, interdiction chemin local/email/téléphone en logs applicatifs.
+- Tests attendus : no-leak logs, snapshot redaction.
+- Critère d’acceptation : logs opérationnels sans PII ni chemins locaux sensibles.
+- Owner suggéré : Backend sécurité.
+- Statut : Ouvert.
+
+## P0-012 — Backend RAG canonique et santé IA
+
+- Sévérité : P0
+- Domaine : IA/RAG
+- Preuve : `lib/rag-client.ts` indique ChromaDB canonical ; docs/code doivent être alignés par environnement.
+- Fichiers concernés : `lib/rag-client.ts`, `docs/RAG_ARCHITECTURE.md`, `app/api/aria/*`.
+- Risque : IA indisponible ou source documentaire non maîtrisée.
+- Action attendue : fixer URL par environnement, healthcheck RAG, fallback clair.
+- Tests attendus : RAG health, ARIA chat sans fuite inter-élève, timeout.
+- Critère d’acceptation : backend RAG unique, sain, monitoré.
+- Owner suggéré : IA/backend.
+- Statut : Ouvert.
+
+## P0-013 — NPC en mode stub explicite
+
+- Sévérité : P0
+- Domaine : IA/NPC
+- Preuve : `lib/npc/config.ts` définit `NPC_LLM_MODE` par défaut à `stub`; `services/npc-worker/processors/ai-service.ts` retourne des fallbacks en stub.
+- Fichiers concernés : `lib/npc/*`, `services/npc-worker/*`, `app/api/npc/*`, dashboards NPC.
+- Risque : présenter un diagnostic IA live alors qu'il est simulé.
+- Action attendue : afficher état runtime, interdire promesse live si `stub`, config env obligatoire.
+- Tests attendus : worker `stub/off/live`, dashboard flag, upload/file IDOR.
+- Critère d’acceptation : aucun utilisateur ne confond stub et diagnostic IA réel.
+- Owner suggéré : IA/produit.
+- Statut : Ouvert.
+
+## P0-014 — Canonicaliser Session / SessionBooking
+
+- Sévérité : P0
+- Domaine : Données / planning
+- Preuve : `prisma/schema.prisma` contient `model Session` et `model SessionBooking`; de nombreux services utilisent `SessionBooking`.
+- Fichiers concernés : `prisma/schema.prisma`, `lib/session-booking.ts`, `app/api/sessions/*`, dashboards planning.
+- Risque : planning incohérent, crédits remboursés sur mauvais modèle, ownership coach ambigu.
+- Action attendue : décider source canonique et migrer lectures/écritures critiques.
+- Tests attendus : booking, cancel, conflict, coach/student ownership.
+- Critère d’acceptation : un modèle canonique documenté, l'autre projection/legacy.
+- Owner suggéré : Backend planning.
+- Statut : Ouvert.
+
+## P0-015 — Canonicaliser Diagnostic / Assessment / StageBilan / Bilan
+
+- Sévérité : P0
+- Domaine : Données pédagogiques
+- Preuve : `prisma/schema.prisma` contient les quatre modèles, avec `Bilan` documenté comme modèle canonique consolidateur.
+- Fichiers concernés : `prisma/schema.prisma`, `lib/bilan/*`, `app/api/bilans/*`, `app/api/assessments/*`, stages.
+- Risque : bilan parent/élève incohérent, droits d'accès dispersés, exports incomplets.
+- Action attendue : définir `Bilan` comme canonical ou maintenir coexistence formelle avec adapters.
+- Tests attendus : génération, export, accès parent/coach/élève, migration non destructive.
+- Critère d’acceptation : un chemin canonique pour lire et servir un bilan.
+- Owner suggéré : Backend pédagogique.
+- Statut : Ouvert.
+
+## P1-001 — Durcir lint et build gate
+
+- Sévérité : P1
+- Domaine : Qualité
+- Preuve : `npm run lint` OK avec nombreux warnings ; `next.config.mjs` ignore le lint pendant build.
+- Fichiers concernés : `next.config.mjs`, fichiers listés par lint.
+- Risque : dette type safety masquant régressions.
+- Action attendue : réduire warnings et retirer ignore build quand réaliste.
+- Tests attendus : lint strict progressif.
+- Critère d’acceptation : seuil warnings abaissé et suivi CI.
+- Owner suggéré : Front/backend.
+- Statut : Ouvert.
+
+## P1-002 — Finaliser tunnel bilan gratuit bas-friction
+
+- Sévérité : P1
+- Domaine : Conversion / CRM
+- Preuve : UI sans mot de passe, mais `app/api/bilan-gratuit/route.ts` crée des comptes parent/élève inactifs.
+- Fichiers concernés : `app/bilan-gratuit/*`, `app/api/bilan-gratuit/route.ts`, `lib/crm/*`.
+- Risque : friction implicite, activation prématurée, CRM incomplet.
+- Action attendue : décider lead pur vs compte différé, ajouter UTM/source/referrer.
+- Tests attendus : formulaire, email, CRM, consentement, anti-spam.
+- Critère d’acceptation : lead reçu sans création de compte agressive ou décision assumée.
+- Owner suggéré : Produit + backend.
+- Statut : Reclassé P0-016 pour campagne paid ; reste P1 pour polish CRM/UTM après décision.
+
+## P1-003 — Nettoyer reliquats marketing et archives activables
+
+- Sévérité : P1
+- Domaine : Marketing contenu
+- Preuve : recherche manuelle trouve des montants dans `data/Nexus_Reussite_Accueil.html` et `components/ui/specialized-packs.tsx`.
+- Fichiers concernés : archives HTML, composants UI anciens, pages non prioritaires.
+- Risque : réactivation d'une page avec prix obsolètes.
+- Action attendue : classer archive ou migrer vers pricing canonique.
+- Tests attendus : `npm run check:no-hardcoded`, recherche `TND`.
+- Critère d’acceptation : aucune source non archive activable avec montant hardcodé.
+- Owner suggéré : Front produit.
+- Statut : Ouvert.
+
+## P1-004 — Vérifier promesse groupes réduits partout
+
+- Sévérité : P1
+- Domaine : Marketing / juridique
+- Preuve : `data/pricing.canonical.json` indique `group_max` 5 ; pages critiques inspectées utilisent ce repère.
+- Fichiers concernés : pages publiques, contenu SEO, composants marketing.
+- Risque : promesse contradictoire ou non tenue.
+- Action attendue : smoke contenu et test invariant.
+- Tests attendus : guard marketing `group_max`.
+- Critère d’acceptation : toute mention du groupe max dérive du canonique.
+- Owner suggéré : Produit/front.
+- Statut : Ouvert.
+
+## P1-005 — Valider production réelle avant campagne
+
+- Sévérité : P1
+- Domaine : Go-live marketing
+- Preuve : Lot 0 n'a pas interrogé production ; commandes HTTP production non exécutées.
+- Fichiers concernés : runbook production.
+- Risque : local OK mais prod cassée.
+- Action attendue : curls production, screenshot mobile, formulaire test.
+- Tests attendus : smoke public production et monitoring.
+- Critère d’acceptation : pages critiques 200, H1, CTA, pas de débordement mobile.
+- Owner suggéré : QA/DevOps.
+- Statut : Ouvert.
+
+## P1-006 — Trier les échecs Playwright publics Lot 0
+
+- Sévérité : P1
+- Domaine : QA publique / conversion
+- Preuve : Lot 0 reproduit `18 passés, 4 échoués`; Lot 0-bis identifie un serveur Playwright stale avec chunks `_next/static` 404 pour `/bilan-gratuit` et un test WhatsApp trop couplé au nombre exact de liens ; relance finale Node 20 : `24 passed`.
+- Fichiers concernés : `e2e/pages-public-bilan-gratuit.spec.ts`, `e2e/pages-public-homepage.spec.ts`, `app/bilan-gratuit/*`, `app/HomePageClient.tsx`.
+- Risque : parcours lead non validé ou tests obsolètes masquant une régression UX.
+- Action attendue : déterminer si les tests sont obsolètes ou si les messages validation/CTA ont régressé, puis corriger.
+- Tests attendus : relance du smoke public ciblé et, ensuite, `npx playwright test` selon périmètre Gate A.
+- Critère d’acceptation : smoke public critique vert ou échecs explicitement acceptés par décision QA.
+- Owner suggéré : Front QA.
+- Statut : Fermé Lot 0-bis. Preuve : `docs/go-live/_evidence/playwright-public-smoke-triage.md`, smoke ciblé Node 20 `24 passed`.
+
+## P1-007 — Aligner Node local et validations Node 20
+
+- Sévérité : P1
+- Domaine : QA / CI
+- Preuve : `node -v` local par défaut `v22.21.0`, `.github/workflows/ci.yml` et `Dockerfile.prod` ciblent Node 20 ; `nvm use 20.20.0` disponible.
+- Fichiers concernés : `.github/workflows/ci.yml`, `Dockerfile.prod`, `package.json`, docs QA.
+- Risque : build local Node 22 vert mais CI/Docker Node 20 différent.
+- Action attendue : documenter Node 20 comme runtime de validation, ajouter `.nvmrc`/`engines` si décidé.
+- Tests attendus : typecheck/build/Playwright sous Node 20.
+- Critère d’acceptation : CI et local utilisent le même runtime ou l'écart est assumé.
+- Owner suggéré : DevEx / DevOps.
+- Statut : Ouvert.
+# Mise à jour Lot 1 — 2026-07-02
+
+L’inventaire API régénéré après Lot 1 indique `P0=0`, `P1=56`, `P2=93`, `OK=27` sur 176 routes. Les anciens P0 API documents/factures/activation/teacher-report ont été corrigés ou requalifiés avec preuves dans :
+
+- `docs/go-live/11_LOT1_SECURITY_CLOSURE.md`
+- `docs/go-live/_evidence/lot1-api-route-triage.md`
+- `docs/go-live/_evidence/lot1-idor-tests.md`
+- `docs/go-live/_evidence/lot1-rate-limit-runtime.md`
+
+Les P1 restants deviennent le backlog bloquant bêta élargie. Aucun go-live large n’est autorisé tant que le rate limiting distribué production n’est pas prouvé et que les P1 documents/factures/bilans/paiements listés dans `api-security-matrix.full.md` ne sont pas fermés.
+
+# Mise à jour Lot 6 — 2026-07-03
+
+Lot 6 maintient `P0=0` et ne requalifie aucun des 6 P1 publics/paiement restants. Les réserves prioritaires deviennent des preuves d'exploitation, pas de nouvelles fonctionnalités locales :
+
+- Redis/Upstash staging/production : NON PROUVÉ (`NEXUS_HEALTH_AUTH_ABSENT`).
+- Test 429 runtime : NON EXÉCUTÉ (`AUTH_ABSENT`, `RL_PROBE_NOT_ALLOWED`).
+- ContactLead dry-run DB non production : NON EXÉCUTÉ (`DATABASE_URL_ABSENT`, `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED`).
+- ClicToPay : `DISABLED`, paiement carte interdit.
+- Worktree release candidate : audité, aucun diff `.env`, rapport racine non suivi à exclure.
+
+Décision backlog : bêta contrôlée possible avec réserves et volume limité ; bêta élargie et go-live large restent bloqués.
+
+# Mise à jour Lot 7 — 2026-07-03
+
+Lot 7 ne ferme aucun P1 et ne requalifie aucune route. L'objectif est release candidate/audit :
+
+- P0 maintenu à `0`.
+- P1 maintenus à `6`.
+- Scripts d'audit sécurité acceptés avec tests de non-régression : `__tests__/scripts/audit-api-guards.classification.test.ts` et `__tests__/scripts/security-audit-scripts-regression.test.ts`.
+- Worktree : `269` entrées initiales, manifeste RC créé dans `docs/go-live/_evidence/lot7-release-candidate-file-manifest.md`.
+- Plan de commits proposé sans exécution dans `docs/go-live/_evidence/lot7-release-candidate-commit-plan.md`.
+- Runtime humain assisté : credentials absents, preuves Redis/429/DB non exécutées.
+
+Backlog bloquant restant :
+
+1. Prouver Redis/Upstash via healthcheck authentifié.
+2. Prouver un `429` runtime réel sur staging/fenêtre autorisée.
+3. Exécuter dry-run DB ContactLead non production sans PII.
+4. Obtenir décision humaine formelle sur les 6 P1 publics/paiement.
+
+Décision : `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`; `BETA_ELARGIE_BLOCKED`; `GO_LIVE_LARGE_BLOCKED`.
+
+# Mise à jour Lot 8 — 2026-07-03
+
+Lot 8 a nettoyé la préparation release candidate sans fermer de P1 :
+
+- `P0=0` maintenu.
+- `P1=6` maintenus.
+- Manifest RC propre : `docs/go-live/_evidence/lot8-release-candidate-file-manifest-clean.md`.
+- Plan de commits propre : `docs/go-live/_evidence/lot8-release-candidate-commit-plan-clean.md`.
+- `rapport_audit_2_07_2026.md` reste exclu.
+- `docs/audits/audit-nexus-reussite.md` reste en revue humaine.
+- Aucun `.env` modifié.
+
+Décision backlog : `RC_READY_FOR_HUMAN_REVIEW`, mais `BETA_ELARGIE_BLOCKED` et `GO_LIVE_LARGE_BLOCKED`.
+
+# Mise à jour Lot 12 — 2026-07-03
+
+Lot 12 ne requalifie aucune route.
+
+- `P0=0` maintenu.
+- `P1=6` maintenus et visibles dans `docs/go-live/api-security-matrix.full.md`.
+- `docs/audits/audit-nexus-reussite.md` existe mais reste exclu des commits standards : il mentionne `173 routes API` et une sécurité "sans trou", contradictoires avec la RC actuelle `178` routes / `6` P1.
+- Le runbook humain reste `READY_FOR_HUMAN_EXECUTION`.
+
+Blocages maintenus :
+
+1. Redis/Upstash staging/production non prouvé.
+2. Test `429` runtime réel non exécuté.
+3. ContactLead dry-run DB non production non exécuté.
+4. Décision humaine toujours requise si l'audit Nexus doit être inclus comme historique ou réécrit.
+
+Décision : `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`; `BETA_ELARGIE_BLOCKED`; `GO_LIVE_LARGE_BLOCKED`.

--- a/docs/go-live/02_P0_P1_BACKLOG.md
+++ b/docs/go-live/02_P0_P1_BACKLOG.md
@@ -1,5 +1,23 @@
 # Backlog P0/P1 go-live
 
+## Mise à jour Lot 14 — 2026-07-06
+
+- Les 9 commits locaux du runbook Lot 11 ont été exécutés dans l'ordre demandé.
+- Inventaire confirmé après gates finales : `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178`.
+- Les 6 P1 restent visibles et non requalifiés : ClicToPay webhook, assessment submit, bilan gratuit, Lamis teacher report, stage inscription, student activation.
+- Gates finales post-commits passées : typecheck, lint, full unit, build, audit API, matrice API, site-map, no-hardcoded, docs archive, bundle weight, Playwright public (`24` tests) et Playwright assessment (`1` test).
+- Aucun push, aucune PR, aucun déploiement, aucune migration et aucune modification `.env`.
+- Décision : `LOCAL_COMMITS_EXECUTED`, `READY_FOR_PUSH_REVIEW`, `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`, `BETA_ELARGIE_BLOCKED`, `GO_LIVE_LARGE_BLOCKED`.
+
+Blocages maintenus :
+
+1. Redis/Upstash staging/production non prouvé.
+2. Test `429` runtime réel non exécuté.
+3. ContactLead dry-run DB non production non exécuté.
+4. ClicToPay disabled.
+
+---
+
 ## Mise à jour Lot 13 — 2026-07-06
 
 - Inventaire inchangé : `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178`.

--- a/docs/go-live/03_RELEASE_GATES.md
+++ b/docs/go-live/03_RELEASE_GATES.md
@@ -1,0 +1,54 @@
+# Gates de release
+
+Règle globale : **aucun go-live large n'est autorisé si un P0 reste ouvert**.
+
+## Gate A — Site public marketing
+
+- Conditions techniques : `typecheck`, `lint`, `test:unit`, `build`, `check:no-hardcoded`, `check:bundle-weight` OK ; pages publiques critiques en 200 en production.
+- Conditions produit : promesse engagement de moyens, offres 2026/2027, stages août 2026, candidat libre clair, CTA bilan/WhatsApp.
+- Conditions sécurité : formulaires publics avec validation, anti-spam/rate-limit, erreurs sobres.
+- Conditions RGPD : consentement analytics avant GA/Pixel, politique confidentialité à jour, minimisation formulaire.
+- Conditions monitoring : synthetic check `/`, `/offres`, `/bilan-gratuit`, `/contact`.
+- Conditions support : WhatsApp, email et routage leads testés.
+- Tests obligatoires : curls production, smoke Playwright mobile/desktop, soumission lead de test, vérification logs sans PII.
+- Décision autorisée ou non : **autorisable pour pré-campagne organique avec réserves** si GA reste désactivé et ClicToPay masqué ; **non autorisable pour campagne paid** tant que `/bilan-gratuit` n'est pas aligné lead-only ou assumé avec consentement.
+
+Conditions Lot 0-bis ajoutées :
+
+- Smoke ciblé obligatoire : `npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium`.
+- GA/Pixel : aucun script non essentiel ne peut charger avant consentement ; `NEXT_PUBLIC_ENABLE_GOOGLE_ANALYTICS` doit rester absent/false tant qu'une CMP n'existe pas.
+- ClicToPay : aucune mention/CTA public tant que `app/api/payments/clictopay/init/route.ts` ou webhook retournent `501`.
+- Playwright : ne pas réutiliser un serveur local existant sauf opt-in explicite `PLAYWRIGHT_REUSE_EXISTING_SERVER=true`.
+
+## Gate B — Bêta contrôlée plateforme
+
+- Conditions techniques : Gate A OK, authentification stable, dashboards clés utilisables par comptes internes.
+- Conditions produit : périmètre limité, familles pilotes informées, paiement carte désactivé si ClicToPay non finalisé.
+- Conditions sécurité : routes P0 utilisées par bêta fermées ou désactivées ; documents/factures strictement propriétaires.
+- Conditions RGPD : consentement familles, données minimisées, procédure suppression/export.
+- Conditions monitoring : health public/interne, alertes DB/app/Redis/RAG/SMTP.
+- Conditions support : canal incident, rollback compte, support manuel.
+- Tests obligatoires : E2E par rôle, tests IDOR prioritaires, paiement manuel, facture PDF, entitlement.
+- Décision autorisée ou non : **possible sous périmètre restreint**, pas en self-serve public.
+
+## Gate C — Bêta élargie
+
+- Conditions techniques : 0 P0 API, P1 critiques fermés, rate limiting distribué prouvé, backups restaurés.
+- Conditions produit : parcours admission, paiement, droits et dashboards stables.
+- Conditions sécurité : audit manuel routes dynamiques, logs redacted, headers/CSP revus.
+- Conditions RGPD : registre traitement mineurs, consentements, politique documents, durée conservation.
+- Conditions monitoring : alerting 24/7 ou astreinte définie, métriques erreurs, logs centralisés.
+- Conditions support : procédures remboursement, incident, suppression compte/document.
+- Tests obligatoires : suite E2E complète, tests charge légers formulaires, restore drill, test alerte.
+- Décision autorisée ou non : **non autorisée aujourd'hui**.
+
+## Gate D — Go-live large
+
+- Conditions techniques : CI stricte, build sans lint ignoré ou exceptions acceptées, infra validée, rollback testé.
+- Conditions produit : catalogue figé, paiement/facturation/entitlements canonisés, CRM opérationnel.
+- Conditions sécurité : 0 P0 ouvert, P1 résiduels acceptés par risque documenté, pentest ciblé recommandé.
+- Conditions RGPD : conformité mineurs, analytics consent mode, logs, contrats sous-traitants IA/email/storage.
+- Conditions monitoring : SLO, alerting, sauvegardes, tests restore périodiques.
+- Conditions support : support commercial/pédagogique/facturation prêt, runbooks incidents.
+- Tests obligatoires : toutes commandes locales, Playwright, smoke production, API security audit, restore, paiement bout-en-bout.
+- Décision autorisée ou non : **non autorisée tant qu'un P0 subsiste**.

--- a/docs/go-live/04_TEST_MATRIX.md
+++ b/docs/go-live/04_TEST_MATRIX.md
@@ -1,0 +1,362 @@
+# Matrice de tests
+
+## Mise à jour Lot 13 — final precommit 2026-07-06
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| `npm run test:unit -- --runInBand __tests__/scripts/release-candidate-human-commit-runbook.test.ts` | Vérifier que le runbook humain reste exécutable avant commit réel | OK | 1 suite passée, 5 tests passés sous Node 20 | Ne remplace pas les preuves runtime Redis/Upstash, 429 et ContactLead DB | Obligatoire human execution |
+| Runtime variables presence check | Tenter preuves assistées sans secret | PARTIEL | `NEXUS_HEALTH_AUTH_ABSENT`, `RL_PROBE_NOT_ALLOWED`, `DATABASE_URL_ABSENT`, `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED` | Preuves non exécutées | Bloquant bêta élargie/go-live large |
+| Audit Nexus status | Vérifier que l'audit Nexus n'entre pas dans les commits standards | OK documentaire | `PRESENT_UNTRACKED_IN_WORKTREE`, décision `EXCLUDE_FROM_STANDARD_COMMITS` | Décision humaine explicite requise pour inclusion | Obligatoire avant commit humain |
+
+## Mise à jour Lot 11 — 2026-07-03
+
+Tests ciblés ajoutés ou relancés :
+
+| Domaine | Tests | Résultat ciblé |
+| --- | --- | --- |
+| Runbook commit humain | `__tests__/scripts/release-candidate-human-commit-runbook.test.ts` | RED attendu avant génération du runbook, puis OK après génération |
+| Scripts audit + manifeste + dry-run + runbook | `npm run test:unit -- --runInBand __tests__/scripts/security-audit-scripts-regression.test.ts __tests__/scripts/release-candidate-manifest-consistency.test.ts __tests__/scripts/release-candidate-git-add-dry-run-plan.test.ts __tests__/scripts/release-candidate-human-commit-runbook.test.ts` | À exécuter comme gate finale Lot 11 |
+
+Le test Lot 11 vérifie que chaque fichier `Include RC` du manifeste Lot 8 apparaît dans exactement un bloc de commit humain, qu'aucun fichier `Exclude` ou `Needs human review` n'apparaît dans les commits standards, que les commandes restent destinées à l'humain, et que les 6 P1 restent visibles.
+
+---
+
+## Mise à jour Lot 10 — 2026-07-03
+
+Tests ciblés ajoutés ou relancés :
+
+| Domaine | Tests | Résultat ciblé |
+| --- | --- | --- |
+| Plan dry-run commit humain | `__tests__/scripts/release-candidate-git-add-dry-run-plan.test.ts` | RED attendu avant génération du plan, puis OK après génération |
+| Scripts audit + manifeste + dry-run | `npm run test:unit -- --runInBand __tests__/scripts/security-audit-scripts-regression.test.ts __tests__/scripts/release-candidate-manifest-consistency.test.ts __tests__/scripts/release-candidate-git-add-dry-run-plan.test.ts` | À exécuter comme gate finale Lot 10 |
+
+Le test Lot 10 vérifie que chaque fichier `Include RC` du manifeste Lot 8 apparaît dans exactement un bloc `git add --dry-run`, qu'aucun fichier `Exclude` ou `Needs human review` n'apparaît, que les commandes restent en dry-run, et que les 6 P1 restent visibles.
+
+---
+
+## Mise à jour Lot 5 — 2026-07-03
+
+Tests ciblés ajoutés ou relancés :
+
+| Domaine | Tests | Résultat ciblé |
+| --- | --- | --- |
+| Rate-limit probe interne | `__tests__/api/internal.rate-limit-probe.test.ts` | OK, 401 policy, 200 metadata sûre, 429 local |
+| ContactLead retention | `__tests__/scripts/contact-leads-retention.test.ts` | OK, dry-run par défaut et pas de PII ; dry-run DB local échoue faute de DB |
+| ClicToPay disabled final | `__tests__/api/payments.clictopay.disabled-contract.test.ts`, `__tests__/api/payments.clictopay.feature-flag-consistency.test.ts`, `__tests__/ui/payment-methods.clictopay-disabled.test.tsx` | OK, `3` suites, `5` tests |
+| BusinessConfig production gate | `__tests__/lib/business-config.production-gate.test.ts`, `__tests__/api/internal.business-config.health.test.ts`, `__tests__/lib/business-config.fallback.test.ts` | OK, `3` suites, `6` tests |
+
+Résultat final Lot 5 sous Node 20 : typecheck OK, lint OK, full unit OK (`537` suites passées, `6507` tests passés), build OK, audit API OK (`178` routes), matrice OK (`P0=0`, `P1=6`, `P2=144`, `OK=28`), site-map OK, hardcoded OK, docs archive OK, bundle weight OK, smoke Playwright public OK sur port isolé `3012` (`24` tests passés), smoke Playwright assessment OK sur port isolé `3012` (`1` test passé).
+
+Note : première tentative Playwright sur port `3002` bloquée par un autre projet local ; relance sur `3012` OK.
+
+Réserve : Redis/Upstash production/staging non prouvé ; test 429 réel staging/production non exécuté faute d'environnement/authentifié.
+
+---
+
+## Mise à jour Lot 4 — 2026-07-03
+
+Tests ciblés ajoutés ou renforcés :
+
+| Domaine | Tests | Résultat ciblé |
+| --- | --- | --- |
+| Token assessment binding | `__tests__/api/assessments.public-token.binding.test.ts`, `__tests__/api/assessments.submit.token-binding.test.ts`, `__tests__/app/bilan-gratuit.assessment-page-token.test.tsx` | OK ciblé, query params refusés sans cookie flow |
+| Cookie flow bilan gratuit | `__tests__/api/bilan-gratuit.product-rgpd.test.ts` | OK ciblé, cookie HttpOnly posé, JSON sans ID/token |
+| Rétention ContactLead | `__tests__/scripts/contact-leads-retention.test.ts` | OK ciblé, dry-run par défaut, `--apply` explicite |
+| BusinessConfig production gate | `__tests__/lib/business-config.production-gate.test.ts`, `__tests__/api/internal.business-config.health.test.ts` | OK ciblé, prod table absente non autorisée = dégradé |
+| ClicToPay flag consistency | `__tests__/api/payments.clictopay.feature-flag-consistency.test.ts` | OK ciblé, flag public actif + backend disabled = `503` |
+| No-leak token binding | `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts` | OK ciblé, succès assessment lead-bound sans champs interdits |
+| E2E assessment direct access | `e2e/pages-public-bilan-assessment-token.spec.ts` | OK final, accès direct avec query params redirigé/nettoyé, aucun email/token dans HTML |
+
+Résultat ciblé Lot 4 : `11` suites passées, `53` tests passés.
+
+Résultat final Lot 4 sous Node 20 : typecheck OK, lint OK, full unit OK (`536` suites passées, `6504` tests passés), build OK, audit API OK (`177` routes), matrice OK (`P0=0`, `P1=6`, `P2=144`, `OK=27`), site-map OK, hardcoded OK, docs archive OK, bundle weight OK, smoke Playwright public OK (`24` tests passés), smoke Playwright assessment OK (`1` test passé).
+
+Réserve : Redis/Upstash production/staging non prouvé ; test 429 réel non exécuté faute d'environnement staging/authentifié.
+
+---
+
+## Mise à jour Lot 3 — 2026-07-03
+
+Tests ciblés ajoutés ou renforcés :
+
+| Domaine | Tests | Résultat ciblé |
+| --- | --- | --- |
+| Token assessment public | `__tests__/lib/assessments/public-token.test.ts`, `__tests__/api/assessments.public-token.route.test.ts`, `__tests__/api/assessments.submit.token-security.test.ts` | OK ciblé, token absent/expiré/mal signé/mismatch rejeté |
+| Assessment submit existant | `__tests__/api/assessments-submit.test.ts` | OK ciblé, succès aligné avec token court |
+| Bilan gratuit RGPD | `__tests__/api/bilan-gratuit.rgpd-minimization.test.ts`, suites bilan existantes | OK ciblé, `studentBirthDate` refusé, lead only |
+| ContactLead retention | `__tests__/lib/crm/contact-leads.retention.test.ts` | OK ciblé, conservation/SLA documentés |
+| BusinessConfig drift | `__tests__/lib/business-config.fallback.test.ts`, `__tests__/api/internal.business-config.health.test.ts` | OK ciblé, fallback statique classé |
+| ClicToPay disabled contract | `__tests__/api/payments.clictopay.disabled-contract.test.ts` | OK ciblé, webhook/init sans mutation |
+| No-leak succès/erreurs | `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts` | OK ciblé, succès assessment sous token couvert |
+
+Résultat ciblé Lot 3 : `14` suites passées, `99` tests passés.
+
+Typecheck intermédiaire Lot 3 : premier passage ÉCHEC sur typage `searchParams` et tests, puis OK après correction.
+
+Matrice API régénérée : `P0=0`, `P1=6`, `P2=144`, `OK=27`, total `177`.
+
+Réserve : Redis/Upstash production/staging non prouvé ; test 429 réel non exécuté faute d'environnement staging/authentifié et parce que le code Lot 3 n'est pas déployé.
+
+---
+
+## Mise à jour Lot 2 — 2026-07-03
+
+Tests ciblés ajoutés ou renforcés :
+
+| Domaine | Tests | Résultat ciblé |
+| --- | --- | --- |
+| Bilan gratuit `lead_only` | `__tests__/api/bilan-gratuit.product-rgpd.test.ts`, `__tests__/api/bilan-gratuit.test.ts`, `__tests__/api/bilan-gratuit.security.test.ts` | OK ciblé, lead CRM sans compte inactif ni token |
+| Stages inscription publique | `__tests__/api/stages.inscrire.product-rgpd.test.ts`, `__tests__/api/stages.inscrire.security.test.ts`, `__tests__/api/stages/inscriptions.test.ts` | OK ciblé, consentement obligatoire |
+| ClicToPay webhook désactivé | `__tests__/api/payments.clictopay.webhook.disabled.test.ts`, suites webhook existantes | OK ciblé, `501` sans mutation |
+| Student activation | `__tests__/api/student.activate.lifecycle-security.test.ts`, suites activation existantes | OK ciblé, token hashé/expiré/no-leak |
+| No-leak succès/erreurs | `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts` | OK ciblé, chemins succès et erreurs des 6 P1 autant que mockable |
+| Runtime Redis/Upstash | preuve locale + `curl` production sans secret | `memory` local observé, production non vérifiée car healthcheck `401` |
+
+Résultat ciblé Lot 2 avant commandes finales : 16 suites passées, 99 tests passés.
+
+Résultat final Lot 2 sous Node 20 : typecheck OK, lint OK, full unit OK (`522` suites passées, `6466` tests passés), build OK, audit API OK, matrice OK, site-map OK, hardcoded OK, docs archive OK, bundle weight OK, smoke Playwright public OK (`24` tests passés).
+
+Réserve : Redis/Upstash staging/production non prouvé ; Playwright signale en webserver local une table `business_configs` absente pendant un refresh passif, sans échec smoke.
+
+---
+
+## Mise à jour Lot 1-quinquies — 2026-07-03
+
+Tests ciblés ajoutés ou renforcés :
+
+| Domaine | Tests | Résultat ciblé |
+| --- | --- | --- |
+| ClicToPay webhook | `__tests__/api/payments.clictopay.webhook.route.test.ts`, `__tests__/api/payments.clictopay.webhook.security.test.ts` | OK ciblé |
+| Routes admin restantes | `admin.config`, `admin.directeur.stats`, `admin.recompute-ssn`, `admin.subscriptions`, `admin.test-email` | OK ciblé |
+| Routes publiques sensibles | `assessments-submit`, `student.activate`, `stages.inscrire.security` | OK ciblé |
+| No-leak | `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts` | OK ciblé, 20 réponses mockables |
+| Rate limit runtime | `__tests__/lib/rate-limit.production-gate.test.ts`, `__tests__/api/internal.health.rate-limit.test.ts` | Couvert par lots précédents, runtime prod non prouvé |
+
+Résultat ciblé Lot 1-quinquies : 11 suites passées, 96 tests passés ; puis tests admin rate-limit/no-leak : 3 suites passées, 37 tests passés.
+
+Matrice API régénérée : `P0=0`, `P1=6`, `P2=143`, `OK=27`.
+
+Réserve : Redis/Upstash staging/production non prouvé ; la commande production sans secret sur `/api/internal/health` retourne `401`.
+
+---
+
+## Mise à jour Lot 1-quater — 2026-07-02
+
+Tests ciblés ajoutés ou renforcés :
+
+| Domaine | Tests | Résultat ciblé |
+| --- | --- | --- |
+| Rate limit runtime | `__tests__/lib/rate-limit.production-gate.test.ts`, `__tests__/api/internal.health.rate-limit.test.ts` | OK ciblé |
+| Coach ownership | `__tests__/api/coach.trajectory.security.test.ts` | OK ciblé |
+| Eleve diagnostic | `__tests__/api/eleve.bilan-diagnostic-maths-terminale.security.test.ts` | OK ciblé |
+| Assistante | `assistant.credit-requests`, `assistant.students.credits`, `assistant.subscription-requests`, `assistant.subscriptions`, `assistante.quotes.pdf` | OK ciblé |
+| Parent/activation | `parent.children.route`, `parent.children.activation.route` | OK ciblé |
+| Stages confirm | `__tests__/api/stages/confirm.test.ts` | OK ciblé |
+| No-leak | `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts` | OK ciblé, 12 routes mockables |
+
+Résultat ciblé Lot 1-quater : 13 suites passées, 77 tests passés.
+
+Résultat final Lot 1-quater sous Node 20 : typecheck OK, lint OK, full unit OK, build OK, audit API OK, matrice OK, site-map OK, hardcoded OK, docs archive OK, bundle weight OK, smoke Playwright public OK.
+
+---
+
+## Mise à jour Lot 1-ter — 2026-07-02
+
+Tests ciblés ajoutés ou renforcés :
+
+| Domaine | Tests | Résultat ciblé |
+| --- | --- | --- |
+| Admin invoices | `__tests__/api/admin.invoices.route.test.ts` | OK ciblé |
+| ClicToPay init | `__tests__/api/payments.clictopay.init.route.test.ts` | OK ciblé |
+| Bilans | `__tests__/api/bilans.id.route.test.ts`, `__tests__/api/bilans.idor.test.ts`, `__tests__/api/bilans/generate.test.ts` | OK ciblé |
+| NPC | `__tests__/api/npc.documents.route.test.ts`, `__tests__/api/npc.submissions.security.test.ts`, `__tests__/api/npc.generate.test.ts`, `__tests__/api/npc.uploads.route.test.ts` | OK ciblé |
+| Coach reports | `__tests__/api/coach.generated-reports.route.test.ts`, `__tests__/api/coach.eaf-preparation-report.validate.test.ts`, `__tests__/api/coach.eaf-stage-regenerate.security.test.ts`, `__tests__/api/coach.bilan-diagnostic-maths-terminale.security.test.ts` | OK ciblé |
+| No-leak | `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts` | OK ciblé, 9 routes mockables |
+
+Résultat ciblé Lot 1-ter : 14 suites passées, 94 tests passés.
+
+Les commandes finales complètes du lot restent consignées dans `docs/go-live/_evidence/lot1ter-command-log.md`.
+
+---
+
+## Mise à jour Lot 1-bis — 2026-07-02
+
+Nouveaux tests/renforcements :
+
+| Test | Objectif | Statut actuel | Critère go-live |
+| --- | --- | --- | --- |
+| `__tests__/scripts/audit-api-guards.classification.test.ts` | Empêcher faux reclassement P0 par heuristique | OK ciblé | Toute évolution du script conserve P0 pour public sensible non protégé |
+| `__tests__/api/admin.documents.route.test.ts` | Upload staff sans `localPath`, MIME/taille, RBAC | OK ciblé | Aucun fichier invalide écrit, réponse projetée |
+| `__tests__/api/bilan-gratuit.security.test.ts` | No enumeration, honeypot, rate limit, no token/IDs | OK ciblé | Route défendable en attendant décision Lot 3 |
+| `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts` | Champs interdits absents des réponses mockables | OK ciblé | Couverture à élargir aux bilans/factures restantes |
+| `__tests__/api/sessions.video.route.test.ts` | Zod strict, rate limit, ownership session | OK ciblé | Route P2, pas P1 |
+| `__tests__/api/npc.files.route.test.ts` | Coach non assigné sans lecture disque | OK ciblé | Pas de lecture fichier avant ownership |
+| `__tests__/api/npc.documents.route.test.ts` | Coach non assigné GET/POST/DELETE | OK ciblé | Pas de mutation/document hors périmètre |
+
+Les commandes finales complètes restent obligatoires et sont consignées dans `docs/go-live/_evidence/lot1bis-command-log.md`.
+
+---
+
+## Tests unitaires
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| `npm run test:unit -- --runInBand` | Valider logique unitaire/API mockée | OK | 516 suites passées, 1 ignorée ; 6425 tests passés, 4 ignorés | Logs console nombreux sur erreurs simulées | 0 échec, logs sensibles maîtrisés |
+| `npm run typecheck` | TypeScript sans erreur | OK | `tsc --noEmit` OK | Aucun | Obligatoire |
+| `npm run lint` | Qualité statique | OK avec warnings | Next lint OK, nombreux warnings | Dette `any`, unused vars, hooks | Seuil warning accepté ou réduit |
+
+## Tests intégration DB
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| `npm run test:unit -- --runInBand` | Couvrir routes avec Prisma mocké | PARTIEL | Tests DB simulés passent | Pas de DB réelle testée Lot 0 | Intégration DB dédiée sur env isolé |
+| À définir | Valider migrations non destructives | NON EXÉCUTÉ | Migration destructive interdite Lot 0 | Pas d'accès DB décidé | Migration dry-run ou staging |
+
+## Tests E2E
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| `npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | Smoke public ciblé | OK Lot 1-quater | 24 passés, 0 échoué sous Node 20 après build propre | Warning e2e DB locale `business_configs` absent à traiter | 0 échec ou décision QA explicite |
+| `npx playwright test` | Suite navigateur complète | NON EXÉCUTÉ | Suite complète non lancée Lot 0 | Large périmètre avec parcours auth/DB ; à planifier Gate A/B | Obligatoire avant go-live large |
+
+## Tests sécurité
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| `node scripts/security/audit-api-guards.mjs` | Inventaire statique guards API | OK | 176 routes, 0 P0, 12 P1, 137 P2, 27 OK | Statique, pas preuve d'exploitation | 0 P0 avant go-live large |
+| Tests no-leak existants | Logs/erreurs | PARTIEL | Plusieurs tests no-leak passent | Couverture logs runtime à compléter | Logs sans PII |
+
+## Tests IDOR
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| Tests unitaires existants `idor` | Accès croisé ciblé | PARTIEL | Des tests IDOR existent et passent | Inventaire signale encore P0 | Une preuve par route dynamique sensible |
+
+## Tests pricing
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| `npm run check:no-hardcoded` | Montants hors canonique | OK | 0 valeur hardcodée selon script | Recherche manuelle trouve archives/reliquats | Script + audit archives |
+| Tests pricing existants | Cohérence affichage | OK | Suites pricing passent | Registry entitlement séparé | Pricing -> entitlement aligné |
+| `rg -n "TND\|DT\|dès [0-9]\|[0-9][0-9][0-9]\\s*TND\|[0-9][0-9][0-9]\\s*DT\|prix\|tarif\|montant" app components data lib content docs --glob '!docs/archive/**'` | Triage montants | PARTIEL | Reliquats classés dans `_evidence/hardcoded-pricing-triage.md` | Script officiel ne couvre pas toutes les zones | Aucun fichier activable avec prix obsolète avant campagne |
+
+## Tests paiement
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| Tests `payments.*` unitaires | Paiement manuel, validate, ClicToPay 501 | OK | Suites paiement passent | ClicToPay non activé | Carte off ou E2E complet |
+| Tests contrat pricing -> entitlement | Crédits accordés | À créer | Écart Lot 0-bis confirmé 0/4/8 vs 4/8/16 | Risque sur-crédit | Obligatoire Lot 4 |
+| À définir staging | Paiement bout-en-bout | NON EXÉCUTÉ | Aucun paiement réel Lot 0 | Pas de clés ClicToPay validées | Obligatoire avant carte |
+
+## Tests email
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| Tests mailer unitaires | Templates/erreurs SMTP | OK | Tests passent avec erreurs simulées | SMTP réel non vérifié | Envoi test production/staging |
+
+## Tests documents
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| Tests documents unitaires | Accès document et no-leak | PARTIEL | Tests passent | Inventaire classe routes documents P0/P1 | IDOR complet + logs redacted |
+
+## Tests IA/RAG
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| Tests ARIA/RAG unitaires | Fallbacks et API ARIA | OK partiel | Tests ARIA passent | RAG runtime non vérifié | Health RAG + ownership |
+
+## Tests dashboards par rôle
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| Tests API par rôle | Parent/élève/coach/assistante/admin | PARTIEL | Plusieurs tests passent | Pas de E2E complet par rôle | Smoke E2E rôle |
+
+## Tests mobile
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| Playwright mobile | Débordements et CTA | NON EXÉCUTÉ | Non couvert Lot 0 | Dev server/snapshots à lancer Lot QA | Obligatoire Gate A |
+| Smoke public ciblé mobile partiel | Liens WhatsApp homepage | OK Lot 0-bis | Le test homepage vérifie des liens WhatsApp visibles desktop/mobile après scroll | Ne remplace pas audit mobile complet | Compléter par screenshots Gate A |
+
+## Tests accessibilité
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| Axe/Playwright à définir | Contrastes, labels, zoom | NON EXÉCUTÉ | Non couvert Lot 0 | Outillage à confirmer | Obligatoire Gate C/D |
+
+## Tests SEO
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| `npm run audit:site-map` | Routes/liens/sources | OK | 290 routes, 412 edges, 0 link finding, 13 orphan entries | Orphelins à qualifier | 0 lien critique cassé |
+
+## Smoke tests production
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| `curl -I https://nexusreussite.academy/...` | Vérifier prod réelle | NON EXÉCUTÉ | Lot 0 local uniquement | Production non consultée | Obligatoire avant campagne |
+
+## Build et bundle
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| `npm run build` | Build production local | OK | 143 pages générées, assets standalone copiés | Lint sauté pendant build | Obligatoire |
+| `npm run check:bundle-weight` | Poids routes publiques | OK | Toutes routes dans baseline + 5 kB | Dépend de `build-output.log` existant | Obligatoire Gate A |
+# Mise à jour Lot 1 — 2026-07-02
+
+Tests ciblés ajoutés ou renforcés :
+
+| Domaine | Tests | Résultat ciblé |
+| --- | --- | --- |
+| Documents IDOR/no-leak | `__tests__/api/documents.id.route.test.ts`, `__tests__/api/documents-access.test.ts` | OK ciblé |
+| Factures PDF ownership | `__tests__/lib/invoice/access-scope.test.ts`, `__tests__/api/invoices.pdf.route.test.ts`, `__tests__/api/invoices.receipt.pdf.route.test.ts` | OK ciblé |
+| Rate limit public | `__tests__/api/student.activate.route.test.ts`, `__tests__/api/lamis.teacher-report.route.test.ts`, `__tests__/api/public-rate-limit.coverage.test.ts` | OK ciblé |
+| Coach/stages déjà couverts | `__tests__/api/coach.sessions.report.route.test.ts`, `__tests__/api/stages.reservations.access.test.ts`, `__tests__/api/stages/stages-list.test.ts` | OK ciblé |
+
+Les commandes finales complètes Lot 1 restent la source de vérité finale du verdict.
+
+## Mise à jour Lot 6 — runtime et release candidate
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| `curl ... /api/internal/health` avec `NEXUS_HEALTH_AUTH` | Prouver Redis/Upstash runtime | NON EXÉCUTÉ | `NEXUS_HEALTH_AUTH_ABSENT`; sans auth `401` | Credential absent | Obligatoire bêta élargie/go-live large |
+| `/api/internal/rate-limit-probe` runtime | Prouver un vrai `429` staging/prod | NON EXÉCUTÉ | `AUTH_ABSENT`, `RL_PROBE_NOT_ALLOWED` | Fenêtre/credential absents | Obligatoire bêta élargie/go-live large |
+| `npx tsx scripts/maintenance/contact-leads-retention.ts` | Dry-run DB ContactLead sans PII | NON EXÉCUTÉ | `DATABASE_URL_ABSENT`, `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED` | DB non production absente | Obligatoire go-live large |
+| `git diff --name-only \| rg '(^\|/)\\.env($\|\\.)'` | Vérifier absence modification `.env` | OK | aucune sortie | Aucun | Obligatoire release candidate |
+| Gates finales Node 20 Lot 6 | Typecheck/lint/tests/build/audits/Playwright | OK | Typecheck OK, lint OK, unit `537` suites/`6507` tests, build OK, audit API `P0=0 P1=6`, Playwright `24+1` passed | Redis/429/DB runtime non prouvés hors local | Obligatoire verdict final |
+
+## Mise à jour Lot 7 — release candidate audit
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| `npm run test:unit -- --runInBand __tests__/scripts/audit-api-guards.classification.test.ts __tests__/scripts/security-audit-scripts-regression.test.ts` | Vérifier que les scripts ne maquillent pas les risques | OK ciblé | `2` suites passées, `10` tests passés | Ne remplace pas les gates finales complètes | Obligatoire RC |
+| Healthcheck avec `NEXUS_HEALTH_AUTH` | Prouver Redis/Upstash runtime | NON EXÉCUTÉ | `NEXUS_HEALTH_AUTH_ABSENT`; sans auth production `401` | Credential absent | Obligatoire bêta élargie/go-live large |
+| `/api/internal/rate-limit-probe` runtime | Prouver vrai `429` staging/prod | NON EXÉCUTÉ | `RL_PROBE_NOT_ALLOWED` | Fenêtre/credential absents | Obligatoire bêta élargie/go-live large |
+| `scripts/maintenance/contact-leads-retention.ts` contre DB non prod | Prouver dry-run DB sans PII | NON EXÉCUTÉ | `DATABASE_URL_ABSENT`, `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED` | DB non production absente | Obligatoire go-live large |
+| Gates finales Node 20 Lot 7 | Typecheck/lint/tests/build/audits/Playwright | OK | Typecheck OK, lint OK, unit `538` suites/`6510` tests, build OK, audit API `P0=0 P1=6`, Playwright `24+1` passed | Redis/429/DB runtime non prouvés hors local | Obligatoire RC |
+
+## Mise à jour Lot 8 — release candidate cleanup
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| `npm run test:unit -- --runInBand __tests__/scripts/audit-api-guards.classification.test.ts __tests__/scripts/security-audit-scripts-regression.test.ts` | Vérifier les régressions scripts audit renforcées | OK ciblé | `2` suites passées, `16` tests passés | Ne remplace pas les gates finales complètes | Obligatoire RC |
+| Runtime variables presence check | Tenter preuves assistées sans secret | PARTIEL | `NEXUS_HEALTH_AUTH_ABSENT`, `RL_PROBE_NOT_ALLOWED`, `DATABASE_URL_ABSENT`, `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED` | Preuves non exécutées | Bloquant bêta élargie/go-live large |
+| Manifest RC clean | Vérifier classification fichiers | OK documentaire | `283` entrées, `281` Include RC, `1` Exclude, `1` Needs human review | Revue humaine requise avant commit | Obligatoire RC |
+| Gates finales Node 20 Lot 8 | Typecheck/lint/tests/build/audits/Playwright | OK | Typecheck OK, lint OK, unit `538` suites passées sur `539` (`6516` tests passés), build OK, audit API `P0=0 P1=6`, site-map OK, checks OK, Playwright `24+1` passed | Redis/429/DB runtime non prouvés hors local | Obligatoire RC |
+
+## Mise à jour Lot 9 — release candidate manifest validation
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| `npm run test:unit -- --runInBand __tests__/scripts/security-audit-scripts-regression.test.ts __tests__/scripts/release-candidate-manifest-consistency.test.ts` | Vérifier que le manifeste Lot 8 et le plan de commits Lot 8 sont mécaniquement cohérents | OK ciblé | `2` suites passées, `14` tests passés | Ne remplace pas les gates finales complètes | Obligatoire RC |
+| Runtime variables presence check | Tenter preuves assistées sans secret | PARTIEL | `NEXUS_HEALTH_AUTH_ABSENT`, `RL_PROBE_NOT_ALLOWED`, `DATABASE_URL_ABSENT`, `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED` | Preuves non exécutées | Bloquant bêta élargie/go-live large |
+| Gates finales Node 20 Lot 9 | Typecheck/lint/tests/build/audits/Playwright | OK | Typecheck OK, lint OK, unit `539` suites passées sur `540` (`6521` tests passés), build OK, audit API `P0=0 P1=6`, site-map OK, checks OK, Playwright `24+1` passed | Redis/429/DB runtime non prouvés hors local | Obligatoire RC |
+
+## Mise à jour Lot 12 — décision audit Nexus
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| `npm run test:unit -- --runInBand __tests__/scripts/release-candidate-human-commit-runbook.test.ts` | Vérifier que le runbook humain n'inclut pas de fichier exclu ou en revue humaine dans les commits standards | OK | 1 suite passée, 5 tests passés | Ne remplace pas les preuves runtime Redis/Upstash, 429 et ContactLead DB | Obligatoire human execution |
+| Runtime variables presence check | Tenter preuves assistées sans secret | PARTIEL | `NEXUS_HEALTH_AUTH_ABSENT`, `RL_PROBE_NOT_ALLOWED`, `DATABASE_URL_ABSENT`, `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED` | Preuves non exécutées | Bloquant bêta élargie/go-live large |
+| Revue `docs/audits/audit-nexus-reussite.md` | Décider inclusion/exclusion audit humain | OK documentaire | `EXCLUDE_FROM_STANDARD_COMMITS` car `173 routes` et statut sécurité obsolète | Décision humaine requise pour inclusion historique ou réécriture | Obligatoire avant commit humain |

--- a/docs/go-live/04_TEST_MATRIX.md
+++ b/docs/go-live/04_TEST_MATRIX.md
@@ -400,3 +400,14 @@ Les commandes finales complètes Lot 1 restent la source de vérité finale du v
 | `npm run lint` | Gate pre-push minimale | OK | PASSED sous Node 20 avec warnings existants sous seuil | Warnings a traiter hors Lot 16 | Obligatoire push review |
 | `npm run test:unit -- --runInBand __tests__/scripts/release-candidate-human-commit-runbook.test.ts` | Verrou runbook humain | OK | PASSED, 1 suite, 5 tests | Aucun | Obligatoire push review |
 | `npm run check:docs-archive` | Verifier archives docs | OK | PASSED | Aucun | Obligatoire push review |
+
+## Mise à jour Lot 18 — CI E2E bilan gratuit
+
+| Commande | Objectif | Statut actuel | Resultat observe | Blocage eventuel | Critere go-live |
+| --- | --- | --- | --- | --- | --- |
+| `gh pr checks 58` | Identifier l'echec CI PR #58 | OK | `E2E Tests` failed, autres jobs principaux passed | `CI Success` echoue par synthese | Corriger E2E |
+| `npm run typecheck` | Gate locale apres correctif test | OK | PASSED sous Node 20 | Aucun | Obligatoire PR recheck |
+| `npm run lint` | Gate locale apres correctif test | OK | PASSED sous Node 20 avec warnings existants sous seuil | Warnings preexistants | Obligatoire PR recheck |
+| `npm run test:unit -- --runInBand __tests__/api/bilan-gratuit.product-rgpd.test.ts` | Prouver contrat API public securise | OK | PASSED, 8 tests | Aucun | Obligatoire RGPD mineurs |
+| `PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium --reporter=line` | Verifier refus acces direct assessment token | OK | PASSED, 1 test | Aucun | Obligatoire regression token |
+| `npx playwright test --config=playwright.ci.config.ts e2e/real/pages/04-bilan-gratuit.spec.ts --project=chromium --reporter=line` | Rejouer le fichier CI fautif | PARTIEL | 6 passed, 1 failed localement sur DB absente `127.0.0.1:5435` | DB E2E locale non disponible, migrations interdites | GitHub CI doit rechecker avec sa DB E2E |

--- a/docs/go-live/04_TEST_MATRIX.md
+++ b/docs/go-live/04_TEST_MATRIX.md
@@ -1,5 +1,24 @@
 # Matrice de tests
 
+## Mise à jour Lot 14 — local commits 2026-07-06
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| `npm run typecheck` | Valider TypeScript après commits locaux | OK | `tsc --noEmit` OK | Aucun | Obligatoire push review |
+| `npm run lint` | Valider lint après commits locaux | OK avec warnings | Next lint OK sous `--max-warnings 300` | Dette warnings existante | Obligatoire push review |
+| `npm run test:unit -- --runInBand` | Valider suite unitaire complète | OK | 541 suites passées, 1 skipped ; 6531 tests passés, 4 skipped | Logs simulés attendus | Obligatoire push review |
+| `npm run build` | Valider build production local | OK | Next build OK, 142 pages statiques générées | Charge les env sans afficher de valeurs | Obligatoire push review |
+| `node scripts/security/audit-api-guards.mjs` | Régénérer inventaire API | OK | 178 routes | Statique uniquement | 0 P0 |
+| `node scripts/go-live/generate-api-security-matrix.mjs` | Régénérer matrice API | OK | `P0=0`, `P1=6`, `P2=144`, `OK=28` | P1 maintenus | 0 P0, P1 visibles |
+| `npm run audit:site-map` | Vérifier graphe de routes/liens | OK | 292 routes, 413 edges, 0 link finding | 13 public orphan entries documentées par l'audit | Obligatoire |
+| `npm run check:no-hardcoded` | Vérifier prix/valeurs canoniques | OK | 0 valeur hardcodée hors sources canoniques | Aucun | Obligatoire |
+| `npm run check:docs-archive` | Vérifier placement docs historiques | OK | Aucun audit/rapport historique à la racine `docs/` | Aucun | Obligatoire |
+| `npm run check:bundle-weight` | Contrôler poids bundle | OK | Toutes les routes dans baseline + 5 kB | Aucun | Obligatoire |
+| Playwright public ciblé | Smoke public homepage/offres/bilan | OK | 24 tests passés | Refresh passif Prisma non bloquant | Obligatoire |
+| Playwright assessment token | Protéger accès direct assessment | OK | 1 test passé | Refresh passif Prisma non bloquant | Obligatoire |
+
+---
+
 ## Mise à jour Lot 13 — final precommit 2026-07-06
 
 | Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |

--- a/docs/go-live/04_TEST_MATRIX.md
+++ b/docs/go-live/04_TEST_MATRIX.md
@@ -389,3 +389,14 @@ Les commandes finales complètes Lot 1 restent la source de vérité finale du v
 | `npm run test:unit -- --runInBand __tests__/scripts/release-candidate-human-commit-runbook.test.ts` | Vérifier que le runbook humain n'inclut pas de fichier exclu ou en revue humaine dans les commits standards | OK | 1 suite passée, 5 tests passés | Ne remplace pas les preuves runtime Redis/Upstash, 429 et ContactLead DB | Obligatoire human execution |
 | Runtime variables presence check | Tenter preuves assistées sans secret | PARTIEL | `NEXUS_HEALTH_AUTH_ABSENT`, `RL_PROBE_NOT_ALLOWED`, `DATABASE_URL_ABSENT`, `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED` | Preuves non exécutées | Bloquant bêta élargie/go-live large |
 | Revue `docs/audits/audit-nexus-reussite.md` | Décider inclusion/exclusion audit humain | OK documentaire | `EXCLUDE_FROM_STANDARD_COMMITS` car `173 routes` et statut sécurité obsolète | Décision humaine requise pour inclusion historique ou réécriture | Obligatoire avant commit humain |
+
+## Mise à jour Lot 16 — final diff et pre-push
+
+| Commande | Objectif | Statut actuel | Resultat observe | Blocage eventuel | Critere go-live |
+| --- | --- | --- | --- | --- | --- |
+| `git diff --stat main...HEAD` | Resumer le diff a pousser | OK | `329 files changed, 21339 insertions(+), 1258 deletions(-)` avant commit documentaire Lot 16 | Revue humaine PR toujours requise | Obligatoire push review |
+| `git status --short --untracked-files=all` | Verifier le worktree pre-push | OK | seuls `docs/audits/audit-nexus-reussite.md` et `rapport_audit_2_07_2026.md` non suivis | Exclusions a ne pas ajouter | Obligatoire push review |
+| `npm run typecheck` | Gate pre-push minimale | OK | PASSED sous Node 20 | Aucun | Obligatoire push review |
+| `npm run lint` | Gate pre-push minimale | OK | PASSED sous Node 20 avec warnings existants sous seuil | Warnings a traiter hors Lot 16 | Obligatoire push review |
+| `npm run test:unit -- --runInBand __tests__/scripts/release-candidate-human-commit-runbook.test.ts` | Verrou runbook humain | OK | PASSED, 1 suite, 5 tests | Aucun | Obligatoire push review |
+| `npm run check:docs-archive` | Verifier archives docs | OK | PASSED | Aucun | Obligatoire push review |

--- a/docs/go-live/04_TEST_MATRIX.md
+++ b/docs/go-live/04_TEST_MATRIX.md
@@ -1,5 +1,15 @@
 # Matrice de tests
 
+## Mise à jour Lot 15 — untracked files regularization 2026-07-06
+
+| Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |
+| --- | --- | --- | --- | --- | --- |
+| `npm run test:unit -- --runInBand __tests__/scripts/release-candidate-manifest-consistency.test.ts __tests__/scripts/release-candidate-git-add-dry-run-plan.test.ts __tests__/scripts/release-candidate-human-commit-runbook.test.ts` | Valider les tests release régularisés | OK | 3 suites passées, 15 tests passés | Aucun | Obligatoire push review |
+| `npm run check:docs-archive` | Vérifier que les rapports historiques exclus ne sont pas à la racine `docs/` | OK | OK | Aucun | Obligatoire push review |
+| `npm run test:unit -- --runInBand __tests__/scripts/release-candidate-human-commit-runbook.test.ts` | Vérifier le runbook après inclusion preuves | OK | 1 suite passée, 5 tests passés | Aucun | Obligatoire push review |
+
+---
+
 ## Mise à jour Lot 14 — local commits 2026-07-06
 
 | Commande | Objectif | Statut actuel | Résultat observé | Blocage éventuel | Critère go-live |

--- a/docs/go-live/05_API_SECURITY_MATRIX.md
+++ b/docs/go-live/05_API_SECURITY_MATRIX.md
@@ -1,0 +1,471 @@
+# Matrice API sécurité
+
+## Mise à jour Lot 13 — 2026-07-06
+
+Lot 13 ne modifie pas la matrice et ne requalifie aucun P1.
+
+| Élément | Statut |
+| --- | --- |
+| Compteurs API | `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178` |
+| 6 P1 | Toujours visibles |
+| Runbook humain | Toujours valide, 1 suite / 5 tests passés |
+| Audit Nexus | `PRESENT_UNTRACKED_IN_WORKTREE`, exclu des commits standards |
+| Staging Git | Vide pendant le verrou pré-commit |
+| Redis/Upstash | Non prouvé |
+| 429 runtime | Non exécuté |
+| ContactLead DB dry-run | Non exécuté |
+
+Décision : `READY_TO_EXECUTE_MANUALLY`; bêta contrôlée possible avec réserves ; bêta élargie et go-live large bloqués.
+
+---
+
+## Mise à jour Lot 11 — 2026-07-03
+
+Lot 11 ne requalifie aucune route et ne modifie pas le code métier. Il transforme uniquement le plan dry-run Lot 10 en runbook humain de commits.
+
+| Élément | Statut |
+| --- | --- |
+| Compteurs API | `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178` |
+| 6 P1 | Toujours visibles |
+| Runbook humain | `docs/go-live/_evidence/lot11-human-commit-runbook.md` |
+| Preuve runbook | `docs/go-live/_evidence/lot11-human-commit-runbook-proof.md` |
+| Staging Git | Vide pendant la préparation |
+| Redis/Upstash | Non prouvé |
+| 429 runtime | Non exécuté |
+| ContactLead DB dry-run | Non exécuté |
+
+Décision : exécution humaine possible en suivant le runbook ; bêta contrôlée possible avec réserves ; bêta élargie et go-live large bloqués.
+
+---
+
+## Mise à jour Lot 10 — 2026-07-03
+
+Lot 10 ne requalifie aucune route et ne modifie pas le code métier. Il prépare uniquement les commandes `git add --dry-run -- ...` par commit humain.
+
+| Élément | Statut |
+| --- | --- |
+| Compteurs API | `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178` |
+| 6 P1 | Toujours visibles |
+| Plan dry-run | `docs/go-live/_evidence/lot10-git-add-dry-run-plan.md` |
+| Preuve dry-run | `docs/go-live/_evidence/lot10-git-add-dry-run-proof.md` |
+| Staging Git | Vide avant/après dry-runs |
+| Redis/Upstash | Non prouvé |
+| 429 runtime | Non exécuté |
+| ContactLead DB dry-run | Non exécuté |
+
+Décision : commit humain possible en suivant le plan, bêta contrôlée possible avec réserves ; bêta élargie et go-live large bloqués.
+
+---
+
+## Mise à jour Lot 9 — 2026-07-03
+
+Lot 9 ne requalifie aucune route. Il ajoute une validation mécanique du manifeste RC et du plan de commits.
+
+| Élément | Statut |
+| --- | --- |
+| Compteurs API | `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178` |
+| 6 P1 | Toujours visibles |
+| Test cohérence RC | `__tests__/scripts/release-candidate-manifest-consistency.test.ts` |
+| Résultat ciblé | `2` suites passées, `14` tests passés avec la régression scripts |
+| Redis/Upstash | Non prouvé |
+| 429 runtime | Non exécuté |
+| ContactLead DB dry-run | Non exécuté |
+
+Décision : bêta contrôlée possible avec réserves ; bêta élargie et go-live large bloqués.
+
+---
+
+## Mise à jour Lot 5 — 2026-07-03
+
+Lot 5 ajoute une route interne non destructive de probe rate-limit sans masquer les P1 :
+
+| Route | Décision Lot 5 | Statut sécurité |
+| --- | --- | --- |
+| `/api/internal/rate-limit-probe` | Route interne protégée par `admin.dashboard`, preset `auth`, réponse minimale sans secret ; sert à tester un 429 sans frapper une route métier | OK statique, preuve runtime staging/production à exécuter |
+| `/api/internal/health` | Healthcheck authentifié requis pour prouver Redis/Upstash ; production sans secret retourne `401` | Redis/Upstash non prouvé |
+| `/api/payments/clictopay/webhook` | Maintenu `501/P1`, ClicToPay désactivé contractuellement | Paiement carte interdit |
+
+Compteurs confirmés après régénération intermédiaire : `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178`.
+
+Réserve runtime : Redis/Upstash staging/production non prouvé ; test 429 réel staging/production non exécuté. Bêta élargie et go-live large interdits.
+
+---
+
+## Mise à jour Lot 4 — 2026-07-03
+
+Lot 4 ne baisse pas artificiellement les P1. Il ferme l'angle mort du token assessment librement générable depuis `/bilan-gratuit/assessment`.
+
+| Route | Décision Lot 4 | Statut sécurité |
+| --- | --- | --- |
+| `/api/assessments/submit` | Token `assessment_submit` lié à un lead via `binding=lead`, `leadEmailHash` et email assessment pseudonyme ; token staff-only toujours accepté pour émission contrôlée | Reste P1 par surface publique mineur |
+| `/bilan-gratuit/assessment` | Ne génère plus de token depuis query params ; redirige les URL avec query params vers l'URL canonique ; exige cookie HttpOnly signé `nexus_assessment_flow` | Front public verrouillé |
+| `/api/bilan-gratuit` | Pose le cookie de flux après lead_only, sans ID/token dans JSON | Reste P1 formulaire public mineur |
+| `/api/payments/clictopay/init` | Fail-closed `503` si flag public ClicToPay activé alors que backend désactivé | Pas de succès ambigu |
+| `/api/payments/clictopay/webhook` | Contrat désactivé inchangé : signature requise, `501`, aucune mutation | P1 tant que webhook incomplet |
+| `/api/internal/health` | BusinessConfig distingue `database`, `static_fallback_allowed`, `static_fallback_unexpected` | P2 health protégé |
+
+Preuves Lot 4 :
+
+- `docs/go-live/18_LOT4_RUNTIME_PAYMENT_RETENTION_TOKEN_BINDING.md`
+- `docs/go-live/_evidence/lot4-assessment-token-binding.md`
+- `docs/go-live/_evidence/lot4-redis-upstash-runtime-proof.md`
+- `docs/go-live/_evidence/lot4-contact-lead-retention-job.md`
+- `docs/go-live/_evidence/lot4-clictopay-disabled-runbook.md`
+- `docs/go-live/_evidence/lot4-business-config-production-gate.md`
+- `docs/go-live/_evidence/lot4-no-leak-e2e-runtime-coverage.md`
+
+Compteurs confirmés après régénération finale : `P0=0`, `P1=6`, `P2=144`, `OK=27`, total `177`.
+
+Réserve runtime : Redis/Upstash staging/production non prouvé ; bêta élargie et go-live large interdits.
+
+---
+
+## Mise à jour Lot 3 — 2026-07-03
+
+Lot 3 ajoute un mécanisme de token signé court pour les assessments publics sans masquer les P1 restants.
+
+| Route | Décision Lot 3 | Statut sécurité |
+| --- | --- | --- |
+| `/api/assessments/submit` | Token HMAC court obligatoire ; scope `assessment_submit`, `subject`, `grade`; rejet absent/expiré/mal signé/mismatch | Reste P1 par surface publique données pédagogiques mineur |
+| `/api/assessments/public-token` | Nouvelle route d'émission contrôlée staff-only `ADMIN/ASSISTANTE`, Zod, rate limit | P2 |
+| `/api/bilan-gratuit` | `lead_only` confirmé ; `studentBirthDate` refusé ; rétention/effacement documentés | Reste P1 par formulaire public mineur |
+| `/api/payments/clictopay/webhook` | Désactivation contractuelle confirmée ; signature requise ; `501`; aucune mutation | P1 tant que paiement carte incomplet |
+| `/api/internal/health` | Expose `runtime.businessConfig` et classe `business_configs` absent en `static_fallback` | P2, health protégé |
+
+Preuves Lot 3 :
+
+- `docs/go-live/17_LOT3_RUNTIME_RGPD_ASSESSMENT_TOKEN.md`
+- `docs/go-live/_evidence/lot3-redis-upstash-runtime-proof.md`
+- `docs/go-live/_evidence/lot3-assessments-public-token.md`
+- `docs/go-live/_evidence/lot3-bilan-gratuit-rgpd-register.md`
+- `docs/go-live/_evidence/lot3-contact-lead-retention-policy.md`
+- `docs/go-live/_evidence/lot3-clictopay-disabled-contract.md`
+- `docs/go-live/_evidence/lot3-business-configs-db-drift.md`
+- `docs/go-live/_evidence/lot3-no-leak-success-error-runtime-coverage.md`
+
+Compteurs après régénération :
+
+| Priorité | Nombre |
+| --- | ---: |
+| P0 | 0 |
+| P1 | 6 |
+| P2 | 144 |
+| OK | 27 |
+| Total | 177 |
+
+Réserve runtime : Redis/Upstash staging/production non prouvé ; go-live large interdit.
+
+---
+
+## Mise à jour Lot 2 — 2026-07-03
+
+Les 6 P1 restants ont été arbitrés comme décisions produit/RGPD/paiement/runtime, pas comme simples anomalies de guards :
+
+| Route | Décision Lot 2 | Statut sécurité |
+| --- | --- | --- |
+| `/api/payments/clictopay/webhook` | ClicToPay reste désactivé ; signature requise, réponse `501`, aucune mutation | P1 assumé tant que l'intégration paiement n'est pas complète |
+| `/api/assessments/submit` | Route publique assumée uniquement pour assessment anonyme/minimisé ; token/session recommandé en prochain lot pédagogique | P1 assumé par surface publique mineurs |
+| `/api/bilan-gratuit` | Passage en `lead_only` : lead CRM uniquement, aucun `User`, aucun compte parent/élève, aucun token | Dette produit/RGPD compte public fermée ; P1 possible par formulaire public sensible |
+| `/api/lamis/teacher-report` | Route pédagogique publique maintenue avec payload borné/rate limit/no-leak ; token/session recommandé si usage nominatif | P1 assumé par surface publique |
+| `/api/stages/[stageSlug]/inscrire` | Inscription publique maintenue ; consentement traitement et modalités stage obligatoires ; pas de compte ni ID interne en réponse | P1 assumé par conversion publique famille/mineur |
+| `/api/student/activate` | Route publique par token maintenue ; token hashé, expiration, rate limit, no-leak testés | P1 assumé par cycle d'activation token |
+
+Redis/Upstash runtime n'est pas prouvé en staging/production : `/api/internal/health` production répond `401` sans secret. Le mode local observé est `memory`, donc le go-live large reste interdit tant qu'un healthcheck authentifié ne prouve pas `redis` ou `upstash` et un test 429 réel.
+
+Preuves Lot 2 :
+
+- `docs/go-live/16_LOT2_PUBLIC_PRODUCT_RGPD_PAYMENT_DECISIONS.md`
+- `docs/go-live/_evidence/lot2-rate-limit-runtime-decision.md`
+- `docs/go-live/_evidence/lot2-bilan-gratuit-product-rgpd.md`
+- `docs/go-live/_evidence/lot2-clictopay-payment-decision.md`
+- `docs/go-live/_evidence/lot2-assessments-submit-decision.md`
+- `docs/go-live/_evidence/lot2-lamis-teacher-report-decision.md`
+- `docs/go-live/_evidence/lot2-stages-inscrire-product-rgpd.md`
+- `docs/go-live/_evidence/lot2-student-activate-token-lifecycle.md`
+- `docs/go-live/_evidence/lot2-sensitive-fields-success-error-coverage.md`
+
+Compteurs après régénération :
+
+| Priorité | Nombre |
+| --- | ---: |
+| P0 | 0 |
+| P1 | 6 |
+| P2 | 143 |
+| OK | 27 |
+| Total | 176 |
+
+Les 6 P1 restent visibles car ils portent des décisions publiques/paiement/runtime non fermées par simple durcissement statique.
+
+---
+
+## Mise à jour Lot 1-quinquies — 2026-07-03
+
+Inventaire et matrice régénérés après fermeture des P1 admin et durcissement des routes publiques restantes :
+
+| Priorité | Nombre |
+| --- | ---: |
+| P0 | 0 |
+| P1 | 6 |
+| P2 | 143 |
+| OK | 27 |
+| Total | 176 |
+
+Delta Lot 1-quinquies : `P1 -6`, `P2 +6`, `P0` maintenu à `0`.
+
+Preuves :
+
+- `docs/security/API_GUARD_INVENTORY.md`
+- `docs/go-live/api-security-matrix.full.md`
+- `docs/go-live/15_LOT1QUINQUIES_FINAL_P1_SECURITY_CLOSURE.md`
+- `docs/go-live/_evidence/lot1quinquies-p1-before-after.md`
+- `docs/go-live/_evidence/lot1quinquies-clictopay-webhook.md`
+- `docs/go-live/_evidence/lot1quinquies-public-sensitive-routes.md`
+- `docs/go-live/_evidence/lot1quinquies-admin-routes.md`
+- `docs/go-live/_evidence/lot1quinquies-rate-limit-runtime-proof.md`
+
+Routes passées P2 : `/api/admin/config`, `/api/admin/config/rollback`, `/api/admin/directeur/stats`, `/api/admin/recompute-ssn`, `/api/admin/subscriptions`, `/api/admin/test-email`.
+
+Réserves : `/api/payments/clictopay/webhook` reste P1/501 ; les routes publiques sensibles `/api/assessments/submit`, `/api/bilan-gratuit`, `/api/lamis/teacher-report`, `/api/stages/[stageSlug]/inscrire`, `/api/student/activate` restent P1 par surface publique ; `rate limiting` distribué production/staging non prouvé.
+
+---
+
+## Mise à jour Lot 1-quater — 2026-07-02
+
+Inventaire et matrice régénérés après fermeture P1 publics/rôles :
+
+| Priorité | Nombre |
+| --- | ---: |
+| P0 | 0 |
+| P1 | 12 |
+| P2 | 137 |
+| OK | 27 |
+| Total | 176 |
+
+Delta Lot 1-quater : `P1 -25`, `P2 +25`, `P0` maintenu à `0`.
+
+Preuves :
+
+- `docs/security/API_GUARD_INVENTORY.md`
+- `docs/go-live/api-security-matrix.full.md`
+- `docs/go-live/14_LOT1QUATER_PUBLIC_ROLE_SECURITY_CLOSURE.md`
+- `docs/go-live/_evidence/lot1quater-p1-before-after.md`
+- `docs/go-live/_evidence/lot1quater-rate-limit-runtime-proof.md`
+- `docs/go-live/_evidence/lot1quater-sensitive-fields-coverage.md`
+
+Routes passées P2 : routes assistante restantes, parent subscriptions/children, student automatismes/survival/trajectory, coach notes/survival/trajectory, stage reservation confirm, bilan gratuit dismiss et programme STMG stage progress.
+
+Réserves : `/api/payments/clictopay/webhook` reste P1/501 ; routes publiques sensibles restent P1 par design ; 6 routes admin restent P1 ; `rate limiting` distribué production/staging non prouvé.
+
+---
+
+## Mise à jour Lot 1-ter — 2026-07-02
+
+Inventaire et matrice régénérés après fermeture P1 critiques :
+
+| Priorité | Nombre |
+| --- | ---: |
+| P0 | 0 |
+| P1 | 37 |
+| P2 | 112 |
+| OK | 27 |
+| Total | 176 |
+
+Delta Lot 1-ter : `P1 -17`, `P2 +17`, `P0` maintenu à `0`.
+
+Preuves :
+
+- `docs/security/API_GUARD_INVENTORY.md`
+- `docs/go-live/api-security-matrix.full.md`
+- `docs/go-live/13_LOT1TER_P1_SECURITY_CLOSURE.md`
+- `docs/go-live/_evidence/lot1ter-p1-before-after.md`
+- `docs/go-live/_evidence/lot1ter-payments-invoices.md`
+- `docs/go-live/_evidence/lot1ter-bilans-assessments.md`
+- `docs/go-live/_evidence/lot1ter-npc-documents.md`
+- `docs/go-live/_evidence/lot1ter-coach-reports.md`
+
+Routes passées P2 : `/api/admin/invoices`, `/api/payments/clictopay/init`, routes `bilans*`, routes NPC submissions/documents/uploads/generate, routes coach reports ciblées et `/api/sessions/cancel`.
+
+Réserves : `/api/payments/clictopay/webhook` reste P1/501 ; `/api/bilan-gratuit` reste P1 produit/RGPD ; `rate limiting` distribué production non prouvé ; 37 P1 restent bloquants pour bêta élargie et go-live large.
+
+---
+
+## Mise à jour Lot 1-bis — 2026-07-02
+
+Inventaire régénéré après contre-audit :
+
+| Priorité | Nombre |
+| --- | ---: |
+| P0 | 0 |
+| P1 | 54 |
+| P2 | 95 |
+| OK | 27 |
+| Total | 176 |
+
+Preuves :
+
+- `docs/security/API_GUARD_INVENTORY.md`
+- `docs/go-live/api-security-matrix.full.md`
+- `docs/go-live/_evidence/lot1bis-p0-reclassification-audit.md`
+- `docs/go-live/_evidence/lot1bis-audit-script-review.md`
+- `docs/go-live/_evidence/lot1bis-p1-closure.md`
+
+Corrections Lot 1-bis : `/api/sessions/video` et `/api/admin/documents` passent en P2 ; `/api/bilan-gratuit` reste P1 mais ne renvoie plus d’email-existence, d’IDs ou de token ; ClicToPay reste P1/501.
+
+---
+
+Inventaire source régénéré : `docs/security/API_GUARD_INVENTORY.md`.
+
+Lecture statique seulement : le statut P0/P1 indique une priorité d'audit, pas une preuve d'exploitation. Les colonnes `Ownership requis`, `Zod` et `Rate limit` doivent être confirmées manuellement dans les lots sécurité.
+
+## Synthèse Lot 0
+
+| Niveau | Nombre |
+| --- | ---: |
+| P0 | 44 |
+| P1 | 42 |
+| P2 | 62 |
+| OK | 28 |
+| Total routes | 176 |
+
+## Routes prioritaires
+
+| Route | Méthodes | Domaine | Public/Auth | Rôle requis | Ownership requis | Zod | Rate limit | Données sensibles | Statut | Action |
+| ----- | -------- | ------- | ----------- | ----------- | ---------------- | --- | ---------- | ----------------- | ------ | ------ |
+| `/api/admin/invoices/[id]` | PATCH | Facturation | Auth | Admin/staff à confirmer | Oui | Oui | À vérifier | Facture, paiement | P0 | Audit IDOR + rôle explicite |
+| `/api/admin/invoices/[id]/send` | POST | Facturation | Auth | Admin/staff | Oui | Oui | À vérifier | Facture, email | P0 | Audit envoi hors périmètre |
+| `/api/invoices/[id]/pdf` | GET | Facturation | Auth | Parent/admin selon ressource | Oui | Non | À vérifier | PDF facture | P0 | Ownership strict + no-leak |
+| `/api/invoices/[id]/receipt/pdf` | GET | Facturation | Auth | Parent/admin selon ressource | Oui | Oui | À vérifier | Reçu PDF | P0 | Ownership strict + token |
+| `/api/documents/[id]` | GET | Documents | Auth | User/staff | Oui | Non | À vérifier | Document privé | P0 | Audit document owner/staff |
+| `/api/student/documents/[id]/download` | GET | Documents | Auth | Élève | Oui | Non | À vérifier | Document élève | P2 | Confirmer logs et path |
+| `/api/assistante/students/[studentId]/documents` | GET, POST | Documents | Auth | Assistante | Oui | Oui | À vérifier | Documents mineurs | P0 | Ownership assistante/périmètre |
+| `/api/coach/students/[studentId]/documents` | GET, POST | Documents | Auth | Coach | Oui | Oui | À vérifier | Documents mineurs | P0 | Assignment actif obligatoire |
+| `/api/npc/files/[...path]` | GET | NPC/documents | Auth | Rôle selon soumission | Oui | Non | À vérifier | Copies, exports | P0 | Traversal + DB match + tests |
+| `/api/payments/clictopay/webhook` | POST | Paiement | Public webhook | Aucun | N/A | Non | À vérifier | Paiement | P0 | Signature obligatoire + idempotence |
+| `/api/payments/clictopay/init` | POST | Paiement | Auth | Parent | Oui | Non | À vérifier | Paiement | P1 | Reste `501` ou finaliser |
+| `/api/payments/validate` | POST | Paiement | Auth | Admin/assistante | Oui | Oui | À vérifier | Paiement, droits | P2 | Couvrir idempotence/ownership |
+| `/api/bilan-gratuit` | POST | Lead/bilan | Public | Aucun | N/A | Oui | Oui async | Mineur/parent | P0 | Revoir création compte + anti-spam |
+| `/api/contact` | POST | Lead | Public | Aucun | N/A | Via CRM schema | Oui async | Contact | OK | Ajouter UTM/referrer |
+| `/api/stages/[stageSlug]/inscrire` | POST | Stages | Public | Aucun | N/A | Oui | Oui | Lead stage | P0 | Anti-spam renforcé + CSRF/CAPTCHA à décider |
+| `/api/stages/[stageSlug]/reservations` | GET | Stages | Auth | Staff | Oui | Non | À vérifier | Réservations | P0 | Audit staff/ownership |
+| `/api/stages/[stageSlug]/bilans` | GET, POST | Bilans stages | Auth | Staff/coach | Oui | Oui | À vérifier | Bilans mineurs | P0 | Audit IDOR |
+| `/api/assessments/submit` | POST | Assessments | Public/technique | À vérifier | Oui | Oui | À vérifier | Réponses élève | P0 | Auth ou token signé |
+| `/api/assessments/[id]/result` | GET | Assessments | Auth | Owner/staff | Oui | Non | À vérifier | Résultat pédagogique | P2 | Test IDOR |
+| `/api/bilans/[id]` | GET, PUT, DELETE | Bilans | Auth | Owner/staff | Oui | Non | À vérifier | Bilan pédagogique | P1 | Test IDOR + Zod |
+| `/api/parent/bilans/[id]/pdf` | GET | Bilans PDF | Auth | Parent | Oui | Non | À vérifier | PDF bilan | P0 | Parent owns child |
+| `/api/coach/students/[studentId]/generated-reports/[reportId]/download` | GET | Coach/bilans | Auth | Coach | Oui | Non | À vérifier | Rapport pédagogique | P0 | Assignment actif + report owner |
+| `/api/aria/chat` | POST | ARIA | Auth | Élève | Oui | Oui | À vérifier | Conversation IA | P2 | Feature + conversation owner |
+| `/api/aria/conversations` | GET | ARIA | Auth | Élève | Oui | Non | À vérifier | Historique IA | P2 | Conversation scoped student |
+| `/api/subscriptions/aria-addon` | POST | Abonnements | Public selon inventaire | À vérifier | Oui | Non | À vérifier | Droit produit | P0 | Auth obligatoire |
+| `/api/student/activate` | GET, POST | Activation | Public | Aucun | Token | Oui | À vérifier | Compte mineur | P0 | Token, rate limit, expiration |
+| `/api/student/automatismes/series/[id]` | GET | Élève | Auth | Élève | Oui | Non | À vérifier | Progression | P0 | Owner série/tentatives |
+| `/api/coach/students/[studentId]/eaf-preparation-report` | GET, PUT | Coach | Auth | Coach | Oui | Oui | À vérifier | Rapport EAF | P0 | Assignment actif |
+| `/api/coach/sessions/[sessionId]/report` | GET, POST | Coach/session | Auth | Coach | Oui | Oui | À vérifier | Rapport session | P0 | Session owner |
+
+## Routes publiques sensibles
+
+- `/api/bilan-gratuit`
+- `/api/contact`
+- `/api/newsletter`
+- `/api/notify/email`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/public-documents/corrige-dnb-maths-2026`
+- `/api/student/activate`
+
+## Routes dynamiques `[id]` à ré-auditer manuellement
+
+- Factures : `/api/admin/invoices/[id]`, `/api/invoices/[id]/pdf`, `/api/invoices/[id]/receipt/pdf`.
+- Documents : `/api/documents/[id]`, `/api/student/documents/[id]/download`.
+- Bilans/assessments : `/api/bilans/[id]`, `/api/assessments/[id]/*`, `/api/parent/bilans/[id]/pdf`.
+- Coach : `/api/coach/students/[studentId]/**`, `/api/coach/sessions/[sessionId]/report`.
+- Stages : `/api/stages/[stageSlug]/**`.
+- NPC : `/api/npc/submissions/[submissionId]/**`, `/api/npc/files/[...path]`.
+
+## Annexe
+
+L'inventaire exhaustif généré par script est dans `docs/security/API_GUARD_INVENTORY.md`.
+
+Une annexe de pilotage Lot 0-bis est générée dans `docs/go-live/api-security-matrix.full.md`.
+
+## Addendum Lot 0-bis
+
+- Générateur : `scripts/go-live/generate-api-security-matrix.mjs`.
+- Résultat : 176 routes recensées dans une table exploitable avec colonnes `Priorité`, `Route`, `Méthodes`, `Domaine`, `Public/Auth`, `Rôle requis`, `Ownership requis`, guards détectés, Zod, rate limit, données sensibles et action lot suivant.
+- Synthèse inchangée : 44 P0, 42 P1, 62 P2, 28 OK.
+- Top 20 Lot 1 : documents, factures/PDF, webhook ClicToPay, assessments/bilans, routes coach `[studentId]`.
+- Limite : la matrice reste statique ; `Rate limit détecté = Oui` prouve seulement un motif de code local, pas une protection distribuée runtime.
+
+Commande de régénération :
+
+```bash
+node scripts/go-live/generate-api-security-matrix.mjs
+```
+
+## Mise à jour Lot 6 — 2026-07-03
+
+La matrice complète reste la source opérationnelle : `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178` au démarrage Lot 6.
+
+Les 6 P1 ne sont pas requalifiés dans ce lot :
+
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+Décision : ces routes restent acceptables uniquement pour bêta contrôlée avec réserves, volume limité et monitoring. Bêta élargie interdite tant que Redis/Upstash runtime et un vrai `429` ne sont pas prouvés.
+
+## Mise à jour Lot 7 — 2026-07-03
+
+La matrice reste volontairement inchangée côté risque : `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178`.
+
+Audit release candidate :
+
+- `scripts/security/audit-api-guards.mjs` audité : accepté comme triage statique avec tests de classification et régression.
+- `scripts/go-live/generate-api-security-matrix.mjs` audité : accepté comme générateur documentaire depuis l'inventaire, sans reclassification indépendante vers `OK`.
+- `scripts/check-bundle-weight.sh` audité : accepté, la correction couvre les routes Next dynamiques sans masquer une route absente.
+- Les 6 P1 restent P1 dans l'inventaire et la matrice.
+
+Preuves manquantes :
+
+- Redis/Upstash staging/production : `NON PROUVÉ`.
+- Test `429` runtime réel : `NON EXÉCUTÉ`.
+- Dry-run DB ContactLead : `NON EXÉCUTÉ`.
+
+Décision : bêta contrôlée possible avec réserves ; bêta élargie et go-live large restent interdits.
+
+## Mise à jour Lot 8 — 2026-07-03
+
+Lot 8 ne requalifie aucune route.
+
+- Matrice attendue maintenue : `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178`.
+- Les 6 P1 publics/paiement restent visibles.
+- Le manifeste RC propre classe tous les fichiers sans modifier la matrice.
+- Les scripts d'audit restent acceptés avec régressions renforcées.
+
+Décision : la matrice est prête pour revue humaine RC, mais bêta élargie et go-live large restent interdits sans preuve Redis/Upstash et `429` runtime.
+
+## Mise à jour Lot 12 — 2026-07-03
+
+Lot 12 ne modifie pas la matrice et ne requalifie aucun P1.
+
+- État courant : `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178`.
+- Les 6 P1 restent visibles.
+- `docs/audits/audit-nexus-reussite.md` est exclu des commits standards car il contient un compteur API historique (`173 routes`) et une formulation de sécurité incompatible avec les 6 P1 ouverts.
+
+Décision : l'audit peut être inclus uniquement après décision humaine explicite comme historique/stale ou après réécriture.
+# Mise à jour Lot 1 — 2026-07-02
+
+La matrice complète a été régénérée depuis `docs/security/API_GUARD_INVENTORY.md`.
+
+| Priorité | Nombre Lot 1 |
+| --- | ---: |
+| P0 | 0 |
+| P1 | 56 |
+| P2 | 93 |
+| OK | 27 |
+| Total | 176 |
+
+Le Top 20 opérationnel pointe désormais vers les P1 restants dans `docs/go-live/api-security-matrix.full.md`. Les routes P0 historiques ne sont pas déclarées “go-live ready” par simple statique : leur fermeture est documentée dans `docs/go-live/11_LOT1_SECURITY_CLOSURE.md`.

--- a/docs/go-live/05_API_SECURITY_MATRIX.md
+++ b/docs/go-live/05_API_SECURITY_MATRIX.md
@@ -1,5 +1,24 @@
 # Matrice API sécurité
 
+## Mise à jour Lot 14 — 2026-07-06
+
+Lot 14 exécute les commits locaux et les gates finales sans requalifier les P1.
+
+| Élément | Statut |
+| --- | --- |
+| Compteurs API | `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178` |
+| 6 P1 | Toujours visibles |
+| Commits locaux | 9 commits Lot 11 exécutés |
+| Gates finales | Toutes passées |
+| Staging Git | Vide après les 9 commits et les gates |
+| Redis/Upstash | Non prouvé |
+| 429 runtime | Non exécuté |
+| ContactLead DB dry-run | Non exécuté |
+
+Décision : `READY_FOR_PUSH_REVIEW`; bêta contrôlée possible avec réserves ; bêta élargie et go-live large bloqués.
+
+---
+
 ## Mise à jour Lot 13 — 2026-07-06
 
 Lot 13 ne modifie pas la matrice et ne requalifie aucun P1.

--- a/docs/go-live/05_API_SECURITY_MATRIX.md
+++ b/docs/go-live/05_API_SECURITY_MATRIX.md
@@ -507,3 +507,14 @@ La matrice complète a été régénérée depuis `docs/security/API_GUARD_INVEN
 | Total | 176 |
 
 Le Top 20 opérationnel pointe désormais vers les P1 restants dans `docs/go-live/api-security-matrix.full.md`. Les routes P0 historiques ne sont pas déclarées “go-live ready” par simple statique : leur fermeture est documentée dans `docs/go-live/11_LOT1_SECURITY_CLOSURE.md`.
+
+## Mise à jour Lot 16 — 2026-07-06
+
+Lot 16 ne modifie pas la classification API.
+
+- Etat courant : `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178`.
+- Les 6 P1 restent visibles dans `docs/go-live/api-security-matrix.full.md`.
+- La revue finale avant push confirme que les fichiers exclus `docs/audits/audit-nexus-reussite.md` et `rapport_audit_2_07_2026.md` restent hors staging.
+- Aucune route P1 n'est requalifiee pour le push review.
+
+Decision : `READY_TO_PUSH_BRANCH` seulement apres gates pre-push vertes ; beta elargie et go-live large restent bloques.

--- a/docs/go-live/05_API_SECURITY_MATRIX.md
+++ b/docs/go-live/05_API_SECURITY_MATRIX.md
@@ -1,5 +1,24 @@
 # Matrice API sécurité
 
+## Mise à jour Lot 15 — 2026-07-06
+
+Lot 15 régularise les fichiers non suivis release sans modifier la matrice API et sans requalifier de P1.
+
+| Élément | Statut |
+| --- | --- |
+| Compteurs API | `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178` |
+| 6 P1 | Toujours visibles |
+| Tests release | Commités |
+| Preuves release Lots 9 à 13 | Commitées |
+| Fichiers exclus | `docs/audits/audit-nexus-reussite.md`, `rapport_audit_2_07_2026.md` |
+| Redis/Upstash | Non prouvé |
+| 429 runtime | Non exécuté |
+| ContactLead DB dry-run | Non exécuté |
+
+Décision : `READY_FOR_PUSH_REVIEW`; bêta contrôlée possible avec réserves ; bêta élargie et go-live large bloqués.
+
+---
+
 ## Mise à jour Lot 14 — 2026-07-06
 
 Lot 14 exécute les commits locaux et les gates finales sans requalifier les P1.

--- a/docs/go-live/06_BUSINESS_LOGIC_DECISIONS.md
+++ b/docs/go-live/06_BUSINESS_LOGIC_DECISIONS.md
@@ -1,0 +1,121 @@
+# Décisions métier à figer
+
+## Source de vérité pricing
+
+- Décision proposée : `data/pricing.canonical.json` reste source unique ; accès via `lib/pricing.ts` côté serveur et `lib/pricing-client.ts` côté client.
+- Raison : AGENTS.md et code actuel convergent sur cette règle.
+- Fichiers impactés : `data/pricing.canonical.json`, `lib/pricing.ts`, `lib/pricing-client.ts`, pages publiques.
+- Test attendu : `npm run check:no-hardcoded`, tests pricing.
+- Validation humaine requise : Non, sauf changement d'offre.
+
+## Prix stage affiché
+
+- Décision proposée : utiliser exclusivement les formats de `stage_formats`; prix de base observé `express-vacances` à 420 TND.
+- Raison : audit racine signale l'ancien 350 TND comme obsolète ; canonique 2026/2027 expose 420 TND.
+- Fichiers impactés : `app/stages/*`, `app/offres/page.tsx`, archives.
+- Test attendu : recherche `TND`, `npm run check:no-hardcoded`.
+- Validation humaine requise : Oui pour valider commercialement les formats.
+
+## Promesse groupe maximum
+
+- Décision proposée : promettre `groupes de 5 maximum` quand dérivé de `rules.group_max`.
+- Raison : `data/pricing.canonical.json` indique `group_max: 5`; pages inspectées l'utilisent.
+- Fichiers impactés : pages marketing, `content/marketing/*`.
+- Test attendu : guard texte vs `getRules().group_max`.
+- Validation humaine requise : Oui pour capacité opérationnelle réelle.
+
+## Statut des candidats libres
+
+- Décision proposée : maintenir une niche claire candidat libre avec offres dédiées et prudence administrative.
+- Raison : `/candidat-libre-bac-francais` et `content/marketing/seo-landings.ts` couvrent le statut sans se substituer à Cyclades/IFT.
+- Fichiers impactés : `content/marketing/seo-landings.ts`, `/offres`, `/bilan-gratuit`.
+- Test attendu : smoke landing + liens offres existants.
+- Validation humaine requise : Oui pour conformité session 2027.
+
+## Rôle de la Carte Nexus
+
+- Décision proposée : la Carte Nexus est un droit/avantage produit à expliciter dans le catalogue canonique, pas une promesse générale.
+- Raison : le pricing doit rester source produit.
+- Fichiers impactés : `data/pricing.canonical.json`, `app/offres/page.tsx`.
+- Test attendu : affichage catalogue sans hardcode.
+- Validation humaine requise : Oui.
+
+## Rôle du bilan gratuit
+
+- Décision proposée : adopter l'Option C : `lead_only` pour campagnes et `account_activation` après validation humaine ou inscription confirmée.
+- Raison : UI actuelle ne demande pas de mot de passe, mais `app/api/bilan-gratuit/route.ts` crée `User` parent, `ParentProfile`, `User` élève, `Student`, token d'activation et email d'activation. Pour Meta Ads, cette création implicite n'est pas alignée avec la promesse lead bas-friction.
+- Fichiers impactés : `app/bilan-gratuit/*`, `app/api/bilan-gratuit/route.ts`, CRM.
+- Test attendu : soumission lead en mode campagne sans création de compte, activation différée testée, consentement explicite.
+- Validation humaine requise : Oui.
+
+## Paiement manuel vs ClicToPay
+
+- Décision proposée : virement manuel autorisé en bêta contrôlée ; ClicToPay reste désactivé et masqué du public tant que `501`.
+- Raison : code ClicToPay non configuré ; Lot 0-bis masque la mention publique via `PaymentMethodsNote` sauf opt-in `NEXT_PUBLIC_ENABLE_CLICTOPAY_PUBLIC=true`.
+- Fichiers impactés : `app/api/payments/*`, dashboards paiement, `components/marketing/PaymentMethodsNote.tsx`.
+- Test attendu : paiement manuel complet, ClicToPay non proposé publiquement, ClicToPay 501 assumé côté API.
+- Validation humaine requise : Oui.
+
+## Source de vérité des droits produit
+
+- Décision proposée : cible = `Invoice` payée + `InvoiceItem.productCode` + `Entitlement`; `Subscription` et crédits legacy deviennent projections.
+- Raison : `activateEntitlements` existe mais coexistence legacy crée risque ; Lot 0-bis confirme un écart pricing/entitlement 0/4/8 vs 4/8/16 crédits.
+- Fichiers impactés : `lib/entitlement/*`, `app/api/payments/validate/route.ts`, `prisma/schema.prisma`.
+- Test attendu : test contrat pricing -> entitlement.
+- Validation humaine requise : Oui.
+
+## Consentement analytics
+
+- Décision proposée : GA reste désactivé par défaut ; ne pas activer `NEXT_PUBLIC_ENABLE_GOOGLE_ANALYTICS=true` sans CMP/consent mode.
+- Raison : aucun composant de consentement analytics n'a été trouvé ; `app/layout.tsx` ne charge plus GA sauf opt-in explicite.
+- Fichiers impactés : `app/layout.tsx`, `lib/analytics.ts`, `app/politique-confidentialite/page.tsx`.
+- Test attendu : HTML initial sans `googletagmanager.com/gtag/js` tant que pas de consentement.
+- Validation humaine requise : Oui avant campagne paid.
+
+## Runtime Node de validation
+
+- Décision proposée : considérer Node 20 comme runtime de référence local/CI/Docker pour les validations go-live.
+- Raison : `.github/workflows/ci.yml` cible `20.x`, `Dockerfile.prod` utilise `node:20-alpine`, alors que le shell local par défaut est Node `v22.21.0`. `nvm use 20.20.0` est disponible.
+- Fichiers impactés : `.github/workflows/ci.yml`, `Dockerfile.prod`, `package.json`, documentation QA.
+- Test attendu : typecheck, build et smoke public sous Node 20.
+- Validation humaine requise : Non.
+
+## Statut de la plateforme ARIA
+
+- Décision proposée : ARIA complète l'accompagnement humain et dépend des formules/add-ons.
+- Raison : pages inspectées reprennent cette prudence.
+- Fichiers impactés : `/plateforme-aria`, `/offres`, `app/api/aria/*`.
+- Test attendu : feature guard, copy sans surpromesse.
+- Validation humaine requise : Oui pour offres ARIA.
+
+## Statut de NPC
+
+- Décision proposée : NPC est bêta interne/coach tant que `NPC_LLM_MODE` n'est pas validé `live`.
+- Raison : défaut code à `stub`.
+- Fichiers impactés : `lib/npc/*`, `services/npc-worker/*`, dashboards NPC.
+- Test attendu : affichage mode, worker live/stub/off.
+- Validation humaine requise : Oui.
+
+## Statut des stages de prérentrée
+
+- Décision proposée : prérentrée août 2026 du 24 au 28 août affichable si validée commercialement ; dates précises autres vacances communiquées selon niveau/formule.
+- Raison : `stage_calendar` canonique contient `pre-rentree-2026`.
+- Fichiers impactés : `data/pricing.canonical.json`, `app/stages/*`.
+- Test attendu : page stages + no dates obsolètes printemps 2026.
+- Validation humaine requise : Oui.
+
+## Promesse marketing autorisée
+
+- Décision proposée : groupes réduits, méthode structurée, bilan individualisé, suivi parent, enseignants qualifiés, progression mesurable, cadre exigeant.
+- Raison : conforme AGENTS.md et audit.
+- Fichiers impactés : toutes pages publiques.
+- Test attendu : recherche promesses interdites.
+- Validation humaine requise : Non pour principe, Oui pour preuves enseignants.
+
+## Promesses interdites
+
+- Décision proposée : interdire garantie réussite, 100 % bac ou remboursé, garantie mention, taux non sourcé, chiffres élèves/mentions non prouvés.
+- Raison : risque juridique et crédibilité.
+- Fichiers impactés : pages marketing, archives, emails.
+- Test attendu : recherche `garantie`, `100 %`, `mention`, `remboursé` contextualisée.
+- Validation humaine requise : Non.

--- a/docs/go-live/07_ENV_INFRA_CHECKLIST.md
+++ b/docs/go-live/07_ENV_INFRA_CHECKLIST.md
@@ -1,0 +1,138 @@
+# Checklist environnement et infrastructure
+
+Ne jamais écrire de valeurs de secrets dans ce document. Statut Lot 0 : noms de variables observés par lecture de code uniquement, valeurs non lues.
+
+## Variables obligatoires probables
+
+| Variable | Usage | Statut attendu |
+| --- | --- | --- |
+| `DATABASE_URL` | Prisma/PostgreSQL | Obligatoire production |
+| `NEXTAUTH_SECRET` | Auth sessions | Obligatoire production |
+| `NEXTAUTH_URL` | URL canonique auth | Obligatoire production |
+| `NEXT_PUBLIC_APP_URL` | URL publique client | Obligatoire recommandé |
+| `EMAIL_FROM` ou `SMTP_FROM` | Expéditeur email | Obligatoire si mail actif |
+| `SMTP_HOST` | SMTP | Obligatoire si mail actif |
+| `SMTP_PORT` | SMTP | Obligatoire si mail actif |
+| `SMTP_USER` | SMTP | Obligatoire si mail actif |
+| `SMTP_PASS` ou `SMTP_PASSWORD` | SMTP | Obligatoire si mail actif, nom à harmoniser |
+| `REDIS_URL` ou `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` | Rate limiting distribué | Obligatoire go-live large |
+| `RAG_INGESTOR_URL` | RAG | Obligatoire si ARIA/RAG actif |
+| `RAG_API_TOKEN` | RAG auth | Obligatoire si service protégé |
+| `OPENAI_API_KEY` ou provider IA choisi | ARIA/LLM | Obligatoire si IA live |
+| `NPC_LLM_MODE` | NPC live/stub/off | Obligatoire à expliciter |
+
+## Variables optionnelles / contexte
+
+- `NEXT_PUBLIC_WHATSAPP_NUMBER`
+- `TELEGRAM_BOT_TOKEN`
+- `TELEGRAM_CHAT_ID`
+- `TELEGRAM_DISABLED`
+- `CRM_LEAD_NOTIFICATION_EMAIL`
+- `INTERNAL_NOTIFICATION_EMAIL`
+- `MAIL_DISABLED`
+- `MAIL_FROM`
+- `MAIL_REPLY_TO`
+- `EMAIL_REPLY_TO`
+- `UPLOAD_DIR`
+- `INVOICE_STORAGE_DIR`
+- `GENERATED_REPORTS_DIR`
+- `NPC_UPLOAD_DIR`
+- `NPC_MAX_FILE_SIZE_MB`
+- `NPC_MAX_PAGES_PER_SUBMISSION`
+- `NPC_PDF_DPI`
+- `NPC_IMAGE_QUALITY`
+- `NPC_CONVERTED_FORMAT`
+- `NPC_WORKER_POLL_INTERVAL_MS`
+- `NPC_WORKER_LOCK_DURATION_MS`
+- `NPC_MAX_RETRY_ATTEMPTS`
+- `RAG_SEARCH_TIMEOUT_MS`
+- `RAG_SEARCH_TIMEOUT`
+- `LOG_LEVEL`
+- `PINO_NO_WORKER`
+
+## Secrets à ne jamais exposer
+
+- `DATABASE_URL`
+- `NEXTAUTH_SECRET`
+- `SMTP_PASS` / `SMTP_PASSWORD`
+- `UPSTASH_REDIS_REST_TOKEN`
+- `TELEGRAM_BOT_TOKEN`
+- `OPENAI_API_KEY`
+- `MISTRAL_API_KEY`
+- `CHUTES_API_KEY`
+- `BILAN_TOKEN_SECRET`
+- `PASSWORD_RESET_SECRET`
+- `CLICTOPAY_WEBHOOK_SECRET`
+- `RAG_API_TOKEN`
+
+## DB
+
+- PostgreSQL/Prisma obligatoire.
+- `docker-compose.prod.yml` contient un service postgres avec pgvector.
+- À vérifier : backups, restore, migrations, accès réseau, monitoring taille disque.
+
+## Redis/Upstash
+
+- Code supporte `REDIS_URL` ou Upstash.
+- À vérifier : production n'est pas en mode `memory`.
+- Gate : go-live large interdit si rate limit mémoire.
+
+## SMTP
+
+- Code observe `SMTP_PASS` et `SMTP_PASSWORD` selon zones.
+- À vérifier : harmonisation du nom, envoi test, DKIM/SPF/DMARC.
+
+## Telegram
+
+- Variables présentes dans code.
+- À vérifier : canal, erreurs silencieuses, contenu sans PII excessive.
+
+## OpenAI/ARIA/RAG
+
+- ARIA utilise providers LLM et `lib/rag-client.ts`.
+- À vérifier : backend RAG canonique, token, timeout, fallback, logs.
+
+## ClicToPay
+
+- Variables observées : `NEXT_PUBLIC_CLICTOPAY_API_KEY`, `CLICTOPAY_WEBHOOK_SECRET`.
+- Statut actuel code : init/webhook retournent `501 CLICTOPAY_NOT_CONFIGURED`.
+- Gate : ne pas activer carte sans E2E paiement.
+
+## Nginx
+
+- À vérifier en production réelle : SSL, headers, reverse proxy, taille upload, dotfiles interdits, port app non exposé publiquement.
+
+## PM2 ou Docker
+
+- Dockerfile standalone prêt.
+- `docker-compose.prod.yml` expose app `3001:3000`.
+- À vérifier : choix runtime réel, binding localhost si reverse proxy, politique restart.
+
+## Backup
+
+- À définir : DB, uploads, documents, factures, rapports NPC.
+- Gate : restore testé obligatoire avant go-live large.
+
+## Storage
+
+- Dossiers observés : documents, invoices, NPC uploads, generated reports.
+- À vérifier : hors webroot, permissions, chiffrement, rétention, antivirus.
+
+## Logs
+
+- À vérifier : centralisation, redaction PII, rotation, niveau prod.
+
+## Monitoring
+
+- Health public : `/api/health`.
+- Health interne : `/api/internal/health` avec DB/SMTP/RAG/Redis/disk/NPC.
+- À vérifier : alerte externe et authentification du health interne.
+
+## SSL
+
+- À vérifier production : certificat, renouvellement, HSTS.
+
+## Healthchecks
+
+- Dockerfile appelle `/api/health`.
+- Go-live large exige aussi synthetic checks pages publiques et parcours lead.

--- a/docs/go-live/08_MARKETING_CONTENT_CHECKLIST.md
+++ b/docs/go-live/08_MARKETING_CONTENT_CHECKLIST.md
@@ -1,0 +1,100 @@
+# Checklist marketing et contenu
+
+## Prix affichés
+
+- Statut : PARTIEL OK.
+- Preuve : `/offres`, `/stages`, `/recommandation`, landings SEO utilisent pricing/getters ou contenu centralisé.
+- Risque : `data/Nexus_Reussite_Accueil.html` est archive morte avec anciens montants ; `Nexus_Reussite_Accueil.html` racine est encore inclus dans le tracing standalone ; `components/ui/specialized-packs.tsx` est exporté mais non importé avec prix hardcodés.
+- Action : Lot 2 doit migrer/archiver les composants activables et vérifier exposition production du HTML racine.
+
+## Offres annuelles
+
+- Statut : OK local.
+- Preuve : `data/pricing.canonical.json` version `2026-2027.1`; `/offres` affiche catalogue 2026/2027.
+- Action : validation commerciale humaine avant campagne.
+
+## Stages prérentrée août 2026
+
+- Statut : OK local.
+- Preuve : `stage_calendar` contient `pre-rentree-2026` du 24 au 28 août 2026 ; `/stages` build OK.
+- Action : confirmer capacité opérationnelle et wording des dates non confirmées.
+
+## Candidat libre
+
+- Statut : OK local, à valider juridiquement.
+- Preuve : `/candidat-libre-bac-francais` utilise `content/marketing/seo-landings.ts`; offres libres existent dans pricing.
+- Action : vérifier textes session 2027 et mentions Cyclades/IFT.
+
+## Groupe maximum
+
+- Statut : OK local.
+- Preuve : `rules.group_max` = 5 ; pages inspectées utilisent ce repère.
+- Action : ajouter guard global si nécessaire.
+
+## WhatsApp
+
+- Statut : OK local.
+- Preuve : `lib/whatsapp.ts` centralise `https://wa.me/21699192829`; smoke Lot 0-bis vérifie liens desktop/mobile accessibles.
+- Action : vérifier tracking/UTM et message prérempli.
+
+## Bilan gratuit
+
+- Statut : PARTIEL / bloquant campagne paid.
+- Preuve : UI sans mot de passe et validations Playwright OK ; API crée comptes parent/élève inactifs, token et email d'activation.
+- Action : recommander Option C `lead_only` pour campagne et `account_activation` après validation humaine ; ajouter UTM/source/referrer.
+
+## Mentions légales
+
+- Statut : À vérifier production.
+- Preuve : `lib/legal.ts` centralise identité, siège administratif et centre pédagogique.
+- Action : vérifier RNE, politique commerciale et conformité.
+
+## Politique confidentialité
+
+- Statut : À renforcer.
+- Preuve : page existe dans site map ; GA est désormais désactivé par défaut, mais la politique ne décrit pas encore une CMP/consent mode complet.
+- Action : ajouter consentement analytics et traitements mineurs.
+
+## Consentement analytics
+
+- Statut : P0 partiellement verrouillé.
+- Preuve : `app/layout.tsx` ne charge GA que si `NEXT_PUBLIC_ENABLE_GOOGLE_ANALYTICS=true` et `NEXT_PUBLIC_GA_MEASUREMENT_ID` existe ; aucune CMP complète trouvée.
+- Action : garder GA désactivé ; consent mode/CMP avant tout tracking non essentiel.
+
+## Meta Pixel éventuel
+
+- Statut : Non détecté localement.
+- Preuve : recherche `fbq`, `facebook.net`, `Meta Pixel` sans intégration active.
+- Action : interdire sans consentement.
+
+## Témoignages
+
+- Statut : À vérifier.
+- Preuve : pas d'audit exhaustif contenu témoignages Lot 0.
+- Action : supprimer chiffres/témoignages non sourcés.
+
+## Pages SEO
+
+- Statut : OK partiel.
+- Preuve : `npm run audit:site-map` : 0 link finding ; landings SEO buildent.
+- Action : traiter 13 public orphan entries si pertinent.
+
+## CTA
+
+- Statut : OK partiel.
+- Preuve : pages critiques CTA bilan/offres/WhatsApp.
+- Action : éviter `sécuriser` si perçu comme garantie ; préférer demander bilan, trouver formule, être conseillé.
+
+## Cohérence Nexus premium
+
+- Statut : OK partiel.
+- Preuve : direction visuelle commune sur pages inspectées.
+- Action : harmoniser reliquats `lux-*`, `marketing-*`, `brand-*`, `surface-*`, `nexus-*` en P1.
+
+## Incohérences probables
+
+- Site public Next.js : plutôt aligné 2026/2027.
+- Pricing canonique : solide mais doit être relié au registre entitlement.
+- Anciens fichiers HTML : contiennent prix/mois et stage 350 TND obsolètes ; racine encore à vérifier côté exposition production.
+- Documents marketing : à inventorier avant campagne.
+- Textes de campagne : à relire pour promesses interdites et consentement tracking.

--- a/docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md
+++ b/docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md
@@ -601,6 +601,28 @@ Actions :
 Decision attendue : `READY_FOR_PR_CREATION_REVIEW`; `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`; `BETA_ELARGIE_BLOCKED`; `GO_LIVE_LARGE_BLOCKED`.
 ```
 
+## Prompt Lot 19 — recheck CI PR #58 apres correction E2E bilan gratuit
+
+```md
+Tu travailles dans `nexus-project_v0`, branche `feat/lot4-accessors-runtime`, PR GitHub `#58`.
+
+Objectif : verifier le re-run CI GitHub apres le commit `test(e2e): align bilan gratuit response contract`.
+
+Contraintes :
+- ne pas modifier l'API publique ;
+- ne pas reintroduire `parentId` ou `studentId` dans `/api/bilan-gratuit` ;
+- ne pas lancer de migration locale ;
+- ne pas creer de PR ;
+- ne pas deployer ;
+- ne pas requalifier les 6 P1.
+
+Actions :
+- consulter `gh pr checks 58` ;
+- si `E2E Tests` passe, documenter `READY_FOR_PR_REVIEW_CONTINUATION` ;
+- si `E2E Tests` echoue encore, extraire le log GitHub Actions sans secret et identifier si l'echec est different de l'assertion `parentId/studentId` ;
+- garder beta elargie et go-live large bloques.
+```
+
 ## Prompt Lot 13 — exécution humaine contrôlée des commits
 
 ```md

--- a/docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md
+++ b/docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md
@@ -1,5 +1,34 @@
 # Prompts des prochains lots Codex
 
+## Mise à jour Lot 15 — prompt recommandé suivant
+
+Le prochain lot recommandé est une revue humaine finale avant push. Lot 15 indique `LOCAL_COMMITS_COMPLETE` et `READY_FOR_PUSH_REVIEW`, avec seulement deux exclusions non suivies documentées.
+
+```md
+Tu travailles dans `nexus-project_v0`. Les Lots 0 à 15 sont terminés avec réserves.
+
+Objectif : préparer la revue humaine finale avant push, sans push automatique, sans PR automatique et sans déploiement.
+
+Préconditions :
+- vérifier `git status --short --untracked-files=all` ;
+- vérifier que les seuls fichiers non suivis sont `docs/audits/audit-nexus-reussite.md` et `rapport_audit_2_07_2026.md` ;
+- vérifier `git diff --cached --name-only` vide ;
+- vérifier les 6 P1 dans `docs/go-live/api-security-matrix.full.md`.
+
+Actions :
+- ne pas pousser sans décision humaine explicite ;
+- ne pas créer de PR sans demande explicite ;
+- ne pas déployer et ne lancer aucune migration ;
+- refaire une vérification courte si push demandé : typecheck, lint, P1 matrix, staging vide.
+
+Décisions maintenues :
+- `BETA_CONTROLEE_ALLOWED_WITH_RESERVES` ;
+- `BETA_ELARGIE_BLOCKED` tant que Redis/Upstash et 429 runtime ne sont pas prouvés ;
+- `GO_LIVE_LARGE_BLOCKED`.
+```
+
+---
+
 ## Mise à jour Lot 14 — prompt recommandé suivant
 
 Le prochain lot recommandé est une revue humaine de push/PR, sans push automatique par Codex et sans déploiement. Lot 14 indique `LOCAL_COMMITS_EXECUTED` et `READY_FOR_PUSH_REVIEW`.

--- a/docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md
+++ b/docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md
@@ -1,5 +1,34 @@
 # Prompts des prochains lots Codex
 
+## Mise à jour Lot 14 — prompt recommandé suivant
+
+Le prochain lot recommandé est une revue humaine de push/PR, sans push automatique par Codex et sans déploiement. Lot 14 indique `LOCAL_COMMITS_EXECUTED` et `READY_FOR_PUSH_REVIEW`.
+
+```md
+Tu travailles dans `nexus-project_v0`. Les Lots 0 à 14 sont terminés avec réserves. Les 9 commits locaux du runbook Lot 11 ont été exécutés, plus le commit documentaire Lot 14 si présent localement.
+
+Objectif : préparer la revue humaine avant push, sans push automatique, sans PR automatique et sans déploiement.
+
+Préconditions :
+- vérifier `git log --oneline` et confirmer la séquence de commits locaux ;
+- vérifier `git diff --cached --name-only` vide ;
+- vérifier que `rapport_audit_2_07_2026.md`, `docs/audits/audit-nexus-reussite.md`, `.env*`, `.next`, `node_modules`, `test-results` et `playwright-report` ne sont pas staged ;
+- relire `docs/go-live/28_LOT14_LOCAL_COMMITS_EXECUTION.md` et `docs/go-live/_evidence/lot14-post-commit-go-no-go.md`.
+
+Actions :
+- ne pas pousser sans décision humaine explicite ;
+- si push demandé, refaire une vérification courte : typecheck, lint, P1 matrix, staging vide, statut Git ;
+- préparer une PR uniquement si demandé explicitement ;
+- ne pas déployer, ne pas lancer de migration, ne pas modifier de secret.
+
+Décisions maintenues :
+- `BETA_CONTROLEE_ALLOWED_WITH_RESERVES` ;
+- `BETA_ELARGIE_BLOCKED` tant que Redis/Upstash et 429 runtime ne sont pas prouvés ;
+- `GO_LIVE_LARGE_BLOCKED`.
+```
+
+---
+
 ## Mise à jour Lot 13 — prompt recommandé suivant
 
 Le prochain lot recommandé est l'exécution humaine manuelle des 9 commits du runbook Lot 11. Le Lot 13 a validé le verrou precommit sans `git add` réel, sans commit, sans push et sans PR.

--- a/docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md
+++ b/docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md
@@ -577,6 +577,30 @@ Actions :
 Décision : bêta élargie reste interdite si Redis/Upstash ou 429 runtime ne sont pas prouvés.
 ```
 
+## Prompt Lot 17 — création PR manuelle et revue GitHub
+
+```md
+Tu travailles dans `nexus-project_v0`. Lot 16 a pousse la branche de travail vers `origin` sans PR automatique, sans deploiement et sans migration.
+
+Objectif : preparer la revue PR humaine, sans merge automatique.
+
+Preconditions :
+- relire `AGENTS.md`, `docs/go-live/30_LOT16_FINAL_DIFF_AND_PUSH_REVIEW.md`, `docs/go-live/_evidence/lot16-post-push-status.md` ;
+- verifier que la branche distante correspond au HEAD local pousse ;
+- verifier que seuls `docs/audits/audit-nexus-reussite.md` et `rapport_audit_2_07_2026.md` restent exclus localement ;
+- confirmer les 6 P1 visibles dans `docs/go-live/api-security-matrix.full.md`.
+
+Actions :
+- produire un resume PR humain : perimetre, commits, gates, risques, exclusions ;
+- ne pas creer de PR sauf demande explicite ;
+- ne pas deployer ;
+- ne pas lancer de migration ;
+- ne pas requalifier les P1 ;
+- ne jamais conclure go-live large autorise.
+
+Decision attendue : `READY_FOR_PR_CREATION_REVIEW`; `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`; `BETA_ELARGIE_BLOCKED`; `GO_LIVE_LARGE_BLOCKED`.
+```
+
 ## Prompt Lot 13 — exécution humaine contrôlée des commits
 
 ```md

--- a/docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md
+++ b/docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md
@@ -1,0 +1,618 @@
+# Prompts des prochains lots Codex
+
+## Mise à jour Lot 13 — prompt recommandé suivant
+
+Le prochain lot recommandé est l'exécution humaine manuelle des 9 commits du runbook Lot 11. Le Lot 13 a validé le verrou precommit sans `git add` réel, sans commit, sans push et sans PR.
+
+```md
+Tu travailles dans `nexus-project_v0`. Les Lots 0 à 13 sont terminés avec réserves. Lot 13 indique `READY_TO_EXECUTE_MANUALLY`.
+
+Objectif : exécuter manuellement les 9 commits du runbook Lot 11, sans push ni PR automatique.
+
+Préconditions :
+- relire `docs/go-live/_evidence/lot11-human-commit-runbook.md` ;
+- relire `docs/go-live/_evidence/lot13-human-execution-checklist.md` ;
+- vérifier `git diff --cached --name-only` vide ;
+- confirmer que `docs/audits/audit-nexus-reussite.md` reste exclu ;
+- confirmer qu'aucun `.env*`, `rapport_audit_2_07_2026.md`, `test-results`, `playwright-report`, `.next`, `node_modules` n'est staged.
+
+Actions :
+- exécuter uniquement le bloc `git add -- ...` du commit courant ;
+- vérifier `git diff --cached --name-only` ;
+- relancer les tests recommandés du bloc ;
+- committer uniquement si le staging correspond exactement au bloc ;
+- répéter pour les 9 commits ;
+- ne pas pousser, ne pas créer de PR, ne pas déployer.
+
+Décision : bêta élargie et go-live large restent interdits tant que Redis/Upstash et un vrai `429` runtime ne sont pas prouvés.
+```
+
+---
+
+## Mise à jour Lot 11 — prompt recommandé suivant
+
+Le prochain lot recommandé est l'exécution humaine des commits en suivant le runbook Lot 11, après décision explicite sur le fichier en revue humaine. Codex ne doit pas faire de commit, push ou PR sans demande explicite.
+
+```md
+Tu travailles dans `nexus-project_v0`. Les Lots 0 à 11 sont terminés avec réserves. Ne fais aucun commit automatique sans demande explicite.
+
+Lis d'abord :
+- `docs/go-live/_evidence/lot11-human-commit-runbook.md`
+- `docs/go-live/_evidence/lot11-human-commit-runbook-proof.md`
+- `docs/go-live/_evidence/lot11-human-review-pending-files.md`
+- `docs/go-live/_evidence/lot11-final-human-commit-register.md`
+- `__tests__/scripts/release-candidate-human-commit-runbook.test.ts`
+
+Objectifs :
+1. Faire décider humainement le sort de `docs/audits/audit-nexus-reussite.md`.
+2. Relancer les tests ciblés scripts/manifeste/dry-run/runbook.
+3. Si validation humaine reçue, exécuter les `git add` réels commit par commit en suivant exactement le runbook Lot 11.
+4. Vérifier avant chaque commit qu'aucun fichier exclu, fichier en revue humaine non validé, artefact généré ou configuration locale sensible n'est staged.
+5. Ne jamais pousser ni créer de PR sans demande explicite.
+6. Maintenir les 6 P1 visibles, ClicToPay disabled, bêta élargie et go-live large bloqués tant que Redis/Upstash + 429 runtime ne sont pas prouvés.
+```
+
+---
+
+## Mise à jour Lot 10 — prompt recommandé suivant
+
+Le prochain lot recommandé est l'exécution humaine contrôlée des commits proposés, après validation explicite du fichier en revue humaine. Aucun commit automatique ne doit être fait par Codex sans demande explicite.
+
+```md
+Tu travailles dans `nexus-project_v0`. Les Lots 0 à 10 sont terminés avec réserves. Ne fais aucun commit automatique sans demande explicite.
+
+Lis d'abord :
+- `docs/go-live/_evidence/lot10-git-add-dry-run-plan.md`
+- `docs/go-live/_evidence/lot10-git-add-dry-run-proof.md`
+- `docs/go-live/_evidence/lot10-human-review-pending-files.md`
+- `docs/go-live/_evidence/lot10-final-human-commit-register.md`
+- `docs/go-live/_evidence/lot8-release-candidate-commit-plan-clean.md`
+
+Objectifs :
+1. Faire décider humainement le sort de `docs/audits/audit-nexus-reussite.md`.
+2. Relancer les tests ciblés scripts/manifeste/dry-run.
+3. Si validation humaine reçue, exécuter les `git add` réels commit par commit en suivant exactement le plan Lot 10.
+4. Vérifier avant chaque commit qu'aucun `.env`, `rapport_audit_2_07_2026.md`, artefact généré ou fichier `Needs human review` non validé n'est staged.
+5. Ne jamais pousser ni créer de PR sans demande explicite.
+6. Maintenir les 6 P1 visibles, ClicToPay disabled, bêta élargie et go-live large bloqués tant que Redis/Upstash + 429 runtime ne sont pas prouvés.
+```
+
+---
+
+## Mise à jour Lot 9 — prompt recommandé suivant
+
+Le prochain lot recommandé est une revue humaine RC puis une séquence de commits manuels, sans PR automatique.
+
+```md
+Tu travailles dans `nexus-project_v0`. Les Lots 0 à 9 sont terminés avec réserves. Ne fais aucun commit automatique sans demande explicite.
+
+Lis d'abord :
+- `docs/go-live/_evidence/lot9-human-review-checklist.md`
+- `docs/go-live/_evidence/lot9-rc-manifest-consistency-proof.md`
+- `docs/go-live/_evidence/lot9-final-release-candidate-register.md`
+- `docs/go-live/_evidence/lot8-release-candidate-file-manifest-clean.md`
+- `docs/go-live/_evidence/lot8-release-candidate-commit-plan-clean.md`
+
+Objectifs :
+1. Faire décider humainement le sort de `docs/audits/audit-nexus-reussite.md`.
+2. Rejouer `__tests__/scripts/release-candidate-manifest-consistency.test.ts`.
+3. Si validation humaine reçue, préparer les commits dans l'ordre proposé, sans inclure `rapport_audit_2_07_2026.md` ni `.env*`.
+4. Si `NEXUS_HEALTH_AUTH` est fourni sans afficher sa valeur, exécuter le healthcheck runtime Redis/Upstash.
+5. Si `NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE=true` et fenêtre autorisée, exécuter la probe 429 non destructive.
+6. Si `DATABASE_URL` non production et `NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB=true` sont fournis, exécuter le dry-run ContactLead sans PII.
+7. Ne jamais conclure bêta élargie ou go-live large sans Redis/Upstash et 429 runtime prouvés.
+```
+
+---
+
+## Mise à jour Lot 5 — prompt recommandé suivant
+
+Le prochain lot recommandé est un Lot 6 de preuve staging/production assistée humainement. Il doit partir de `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178`, avec `/api/internal/rate-limit-probe` disponible.
+
+```md
+Tu es le lead senior full-stack, CTO, responsable infra runtime, paiement, RGPD mineurs, sécurité API et garant go-live de Nexus Réussite.
+
+Travaille dans `nexus-project_v0`.
+
+Exécute Lot 6 — validation staging/production assistée humainement et levée go/no-go.
+
+Objectifs :
+- maintenir `P0=0` sans reclassifier artificiellement les 6 P1 ;
+- obtenir un credential healthcheck sécurisé fourni par l'humain sans jamais l'afficher ;
+- prouver `runtime.rateLimit.mode=redis|upstash`, `distributed=true`, `goLiveLarge=allowed` sur staging/production ;
+- exécuter un test 429 réel sur `/api/internal/rate-limit-probe` en staging ou fenêtre production dédiée ;
+- exécuter `scripts/maintenance/contact-leads-retention.ts` en dry-run contre une DB non production puis préparer validation humaine `--apply` ;
+- conserver ClicToPay `DISABLED` ou ouvrir un lot paiement complet séparé ;
+- confirmer BusinessConfig production : `database` ou fallback explicitement autorisé, sinon healthcheck dégradé ;
+- relancer gates Node 20 et Playwright publics.
+
+Contraintes :
+- aucun secret affiché, aucun `.env`, aucune migration destructive, aucun déploiement sans demande explicite ;
+- pas de test 429 bruyant sur production sans fenêtre dédiée ;
+- pas de `--apply` ContactLead en production sans validation humaine ;
+- verdict bêta élargie interdit tant que Redis/Upstash et 429 réel ne sont pas prouvés.
+```
+
+---
+
+## Mise à jour Lot 4 — prompt recommandé suivant
+
+Le prochain lot recommandé est un Lot 5 runtime staging/exploitation. Il doit partir de `P0=0`, `P1=6`, `P2=144`, `OK=27`, total `177`, avec assessment token désormais bindé à un lead/cookie.
+
+```md
+Tu es le lead senior full-stack, CTO, responsable infra runtime, responsable RGPD mineurs, responsable paiement et garant go-live de Nexus Réussite.
+
+Travaille dans `nexus-project_v0`.
+
+Exécute Lot 5 — preuve runtime staging/production, exploitation ContactLead et décision ClicToPay.
+
+Objectifs :
+- maintenir `P0=0` sans maquiller les 6 P1 publics/paiement ;
+- prouver Redis/Upstash sur staging/production via `/api/internal/health` authentifié sans afficher de secret ;
+- exécuter un test 429 réel sur route publique non destructive ou staging dédié ;
+- relancer Playwright public et `e2e/pages-public-bilan-assessment-token.spec.ts` après build ;
+- valider un run `scripts/maintenance/contact-leads-retention.ts --dry-run`, puis préparer un runbook `--apply` validé humainement ;
+- décider ClicToPay : désactivation contractuelle long terme ou lot d'intégration complet ;
+- vérifier que `business_configs` ne masque pas une production non migrée ;
+- régénérer `API_GUARD_INVENTORY.md` et `api-security-matrix.full.md`.
+
+Contraintes :
+- aucun secret affiché, aucun `.env`, aucune migration destructive, aucun déploiement sans demande explicite ;
+- verdict interdit si Redis/Upstash reste non prouvé ou si Playwright assessment échoue après rebuild.
+```
+
+---
+
+## Mise à jour Lot 3 — prompt recommandé suivant
+
+Le prochain lot recommandé est un Lot 4 paiement/facturation/entitlements et preuve runtime finale. Il doit partir de `P0=0`, `P1=6`, `P2=144`, `OK=27`, total `177`, avec `/api/assessments/submit` désormais protégé par token court.
+
+```md
+Tu es le lead senior full-stack, CTO, responsable paiement/facturation, responsable infra runtime, responsable RGPD mineurs, responsable QA et garant go-live de Nexus Réussite.
+
+Travaille dans `nexus-project_v0`.
+
+Exécute Lot 4 — Paiement/facturation/entitlements, purge leads et preuve runtime go-live.
+
+Objectifs :
+- maintenir `P0=0` ;
+- ne pas réactiver ClicToPay sauf intégration complète : signature, idempotence, montant, devise, productCode, invoice reconciliation, entitlement activation, replay protection, audit log et tests E2E ;
+- si ClicToPay reste désactivé, documenter commercialement le paiement manuel uniquement et conserver `init/webhook` sans succès ambigu ;
+- prouver Redis/Upstash sur staging/production via `/api/internal/health` authentifié sans afficher de secret, puis réaliser un test 429 réel non destructif ;
+- implémenter ou planifier de façon exécutable la purge/anonymisation `ContactLead` selon la politique Lot 3 ;
+- vérifier que `/api/assessments/submit` token court reste opérationnel et que la route d'émission staff-only ne fuit aucun secret ;
+- aligner paiement -> facture -> entitlement et pricing canonique.
+
+Contraintes :
+- aucun secret affiché, aucun `.env`, aucune migration destructive, aucun déploiement sans demande explicite ;
+- aucune route P1 ne devient P2/OK sans code, tests et justification route par route ;
+- aucune réponse publique/non staff ne contient `password`, `activationToken`, `activationUrl`, `tokenHash`, `localPath`, `pdfPath`, `filePath`, `contextJson`, `llmJson`, `validatedJson`, `latexSource`, `stack`, `errorDetails`, `metadata` brute, `bankReference`, `rawWebhook`, `rawPayload` ou ID interne non nécessaire.
+
+Commandes finales sous Node 20 :
+`npm run typecheck`, `npm run lint`, `npm run test:unit -- --runInBand`, `npm run build`, `node scripts/security/audit-api-guards.mjs`, `node scripts/go-live/generate-api-security-matrix.mjs`, `npm run audit:site-map`, `npm run check:no-hardcoded`, `npm run check:docs-archive`, `npm run check:bundle-weight`, smoke Playwright public ciblé.
+
+Livrable : rapport Lot 4 avec preuve Redis/Upstash ou blocage, statut ClicToPay, statut entitlement/facture, purge leads, décision bêta contrôlée/élargie/go-live large.
+```
+
+---
+
+## Mise à jour Lot 2 — prompt recommandé suivant
+
+Le prochain lot recommandé est un Lot 3 runtime, RGPD mineurs et parcours pédagogiques publics. Il doit partir des décisions Lot 2 : `/api/bilan-gratuit` est en `lead_only`, ClicToPay webhook reste désactivé, et Redis/Upstash n'est pas prouvé en runtime réel.
+
+```md
+Tu es le lead senior full-stack, CTO, responsable RGPD mineurs, responsable infra runtime, responsable paiement et garant go-live de Nexus Réussite.
+
+Travaille dans `nexus-project_v0`.
+
+Exécute Lot 3 — Preuve runtime Redis/Upstash, tokens courts pédagogiques, RGPD mineurs et préparation paiement.
+
+Objectifs :
+- maintenir `P0=0` ;
+- ne pas réactiver ClicToPay tant que webhook, idempotence, montant, devise, invoice et entitlement ne sont pas complets ;
+- prouver Redis/Upstash en staging/production via `/api/internal/health` authentifié sans exposer de secret, puis réaliser un test 429 réel ;
+- si Redis/Upstash n'est pas prouvé, laisser go-live large interdit ;
+- transformer `/api/assessments/submit` en flux token signé court ou session autorisée si le résultat doit être rattaché à un élève ;
+- statuer `/api/lamis/teacher-report` : public anonyme minimisé ou token/session ;
+- conserver `/api/bilan-gratuit` en `lead_only` et compléter registre RGPD/minimisation/suppression lead ;
+- mettre à jour politique confidentialité et registre traitements mineurs ;
+- définir le plan ClicToPay : désactivation contractuelle durable ou implémentation complète.
+
+Contraintes :
+- aucun secret, aucun `.env`, aucune migration destructive, aucun déploiement ;
+- aucune route publique sensible ne retourne `password`, `activationToken`, `activationUrl`, `tokenHash`, `localPath`, `filePath`, `pdfPath`, `contextJson`, `llmJson`, `validatedJson`, `latexSource`, `stack`, `errorDetails`, `metadata` brute, `bankReference`, `rawWebhook`, `rawPayload` ou ID interne non nécessaire ;
+- toute décision "public" doit être justifiée par finalité, minimisation, consentement, rate limit et tests no-leak.
+
+Commandes finales sous Node 20 :
+`npm run typecheck`, `npm run lint`, `npm run test:unit -- --runInBand`, `npm run build`, `node scripts/security/audit-api-guards.mjs`, `node scripts/go-live/generate-api-security-matrix.mjs`, `npm run audit:site-map`, `npm run check:no-hardcoded`, `npm run check:docs-archive`, `npm run check:bundle-weight`, smoke Playwright public ciblé.
+
+Livrable : preuve runtime ou blocage, décisions token/session, registre RGPD mineurs, statut ClicToPay et décision bêta contrôlée/élargie/go-live large.
+```
+
+---
+
+## Mise à jour Lot 1-quinquies — prompt recommandé suivant
+
+Le prochain lot recommandé est un Lot 2 produit/RGPD et paiement public, après réduction sécurité API à `P0=0`, `P1=6`, `P2=143`, `OK=27`. Il doit arbitrer les P1 restants au lieu de les reclassifier artificiellement.
+
+```md
+Tu es le lead senior full-stack, CTO, responsable produit, RGPD mineurs, paiement, QA et go-live de Nexus Réussite.
+
+Travaille dans `nexus-project_v0`.
+
+Exécute le prochain lot — Arbitrage produit/RGPD des routes publiques P1 et préparation paiement.
+
+Objectifs :
+- maintenir `P0=0` ;
+- traiter route par route les 6 P1 restants : `/api/payments/clictopay/webhook`, `/api/assessments/submit`, `/api/bilan-gratuit`, `/api/lamis/teacher-report`, `/api/stages/[stageSlug]/inscrire`, `/api/student/activate` ;
+- transformer `/api/bilan-gratuit` en mode `lead_only` pour campagnes ou assumer explicitement `account_activation` avec consentement RGPD ;
+- décider si `/api/assessments/submit` et `/api/lamis/teacher-report` restent publics ou passent derrière token/session ;
+- garder ClicToPay désactivé tant que webhook/idempotence/montant/devise/entitlements ne sont pas complets ;
+- prouver Redis/Upstash sur staging/production via healthcheck authentifié ou garder go-live large interdit ;
+- conserver tests no-leak/rate-limit et régénérer `docs/security/API_GUARD_INVENTORY.md` + `docs/go-live/api-security-matrix.full.md`.
+
+Contraintes :
+- aucun secret, aucun `.env`, aucune migration destructive, aucun déploiement ;
+- aucune route P1 ne devient P2/OK sans code, test et décision produit documentée ;
+- aucune réponse publique/non staff ne contient `password`, `activationToken`, `activationUrl`, `tokenHash`, `localPath`, `pdfPath`, `filePath`, `contextJson`, `llmJson`, `validatedJson`, `latexSource`, `stack`, `errorDetails`, `metadata` brute, `bankReference`, `rawWebhook`, `rawPayload`.
+
+Commandes finales sous Node 20 :
+`npm run typecheck`, `npm run lint`, `npm run test:unit -- --runInBand`, `npm run build`, `node scripts/security/audit-api-guards.mjs`, `node scripts/go-live/generate-api-security-matrix.mjs`, `npm run audit:site-map`, `npm run check:no-hardcoded`, `npm run check:docs-archive`, `npm run check:bundle-weight`, smoke Playwright public ciblé.
+
+Livrable : décision route par route, P1 avant/après, preuve runtime Redis/Upstash ou blocage explicite, décision bêta contrôlée/élargie/go-live large.
+```
+
+---
+
+## Mise à jour Lot 1-quater — prompt recommandé suivant
+
+Le prochain lot recommandé est un Lot 1-quinquies ciblé sur les 12 P1 restants et la preuve runtime Redis/Upstash. Il doit partir de `P0=0`, `P1=12`, `P2=137`, `OK=27`.
+
+```md
+Tu es le lead senior full-stack, CTO, responsable sécurité API, responsable RGPD mineurs, responsable QA, responsable infra runtime et garant go-live de Nexus Réussite.
+
+Travaille dans `nexus-project_v0`.
+
+Exécute Lot 1-quinquies — Fermeture des 12 P1 restants et preuve runtime Redis/Upstash.
+
+Objectifs :
+- maintenir `P0=0` ;
+- fermer ou justifier route par route les P1 restants : `/api/payments/clictopay/webhook`, `/api/assessments/submit`, `/api/bilan-gratuit`, `/api/lamis/teacher-report`, `/api/stages/[stageSlug]/inscrire`, `/api/student/activate`, et les 6 routes admin P1 ;
+- ne pas activer ClicToPay sauf intégration complète signature/idempotence/montant/devise/entitlement ;
+- prouver Redis ou Upstash sur staging/production sans lire de secret, ou documenter le blocage go-live large ;
+- ajouter tests no-leak/rate-limit/IDOR ou justification explicite pour chaque P1 restant ;
+- régénérer `docs/security/API_GUARD_INVENTORY.md` et `docs/go-live/api-security-matrix.full.md`.
+
+Contraintes :
+- aucun secret, aucun `.env`, aucune migration destructive, aucun déploiement ;
+- aucune route P1 ne devient P2/OK sans preuve code + test ou justification documentée ;
+- `/api/bilan-gratuit` reste dette produit/RGPD tant que le mode lead-only n'est pas arbitré.
+
+Commandes finales sous Node 20 :
+`npm run typecheck`, `npm run lint`, `npm run test:unit -- --runInBand`, `npm run build`, `node scripts/security/audit-api-guards.mjs`, `node scripts/go-live/generate-api-security-matrix.mjs`, `npm run audit:site-map`, `npm run check:no-hardcoded`, `npm run check:docs-archive`, `npm run check:bundle-weight`, smoke Playwright public ciblé.
+
+Livrable : rapport Lot 1-quinquies avec P1 avant/après, preuve Redis/Upstash ou blocage, décision bêta contrôlée/élargie/go-live large.
+```
+
+---
+
+## Mise à jour Lot 1-ter — prompt recommandé suivant
+
+Le prochain lot recommandé est un Lot 1-quater ciblé sur les P1 restants et la preuve runtime du rate limiting distribué. Il doit partir de `P0=0`, `P1=37`, `P2=112`, `OK=27`.
+
+```md
+Tu es le lead senior full-stack, responsable sécurité API, RGPD mineurs, QA et go-live de Nexus Réussite.
+
+Travaille dans `nexus-project_v0`.
+
+Exécute Lot 1-quater — Fermeture P1 publics/stages/assistante/parent/student et preuve rate limiting distribué.
+
+Objectifs :
+- réduire les 37 P1 restants de `docs/go-live/api-security-matrix.full.md`, en priorité `/api/payments/clictopay/webhook`, `/api/assessments/submit`, `/api/bilan-gratuit`, `/api/stages/[stageSlug]/inscrire`, `/api/assistante/quotes/pdf`, routes assistante crédits/subscriptions, routes parent subscriptions/children, routes student automatismes/survival/trajectory et routes coach notes/survival/trajectory ;
+- ne pas activer ClicToPay : le webhook doit rester `501` ou être entièrement sécurisé avec signature, idempotence, montant/devise, productCode et absence de mutation non signée ;
+- prouver ou bloquer le rate limiting distribué Redis/Upstash en runtime production/staging sans lire de secret ;
+- ajouter Zod strict, rate limit, projections explicites et tests d'accès croisé pour chaque route traitée ;
+- régénérer `docs/security/API_GUARD_INVENTORY.md` et `docs/go-live/api-security-matrix.full.md`.
+
+Contraintes :
+- aucun secret, aucun `.env`, aucune migration destructive, aucun déploiement ;
+- aucune route P1 ne devient P2/OK sans test ou justification route par route ;
+- aucune réponse publique/non staff ne contient `password`, `activationToken`, `activationUrl`, `tokenHash`, `localPath`, `pdfPath`, `filePath`, `contextJson`, `llmJson`, `validatedJson`, `latexSource`, `stack`, `errorDetails`, `metadata` brute, `bankReference`, `rawWebhook`, `rawPayload`.
+
+Commandes finales sous Node 20 :
+`npm run typecheck`, `npm run lint`, `npm run test:unit -- --runInBand`, `npm run build`, `node scripts/security/audit-api-guards.mjs`, `node scripts/go-live/generate-api-security-matrix.mjs`, `npm run audit:site-map`, `npm run check:no-hardcoded`, `npm run check:docs-archive`, `npm run check:bundle-weight`, smoke Playwright public ciblé.
+
+Livrable : rapport Lot 1-quater avec P1 avant/après, tests, routes restantes, décision bêta contrôlée/élargie/go-live large.
+```
+
+---
+
+## Mise à jour Lot 1-bis — prompt recommandé suivant
+
+Le prochain lot recommandé est un Lot 1-ter ciblé P1 paiement/factures/bilans avant de basculer sur un lot produit. Il doit partir de `P0=0`, `P1=54`, `P2=95`, `OK=27`.
+
+```md
+Tu es le lead senior full-stack, responsable sécurité API, paiement/facturation, RGPD mineurs et QA de Nexus Réussite.
+
+Travaille dans `nexus-project_v0`.
+
+Exécute Lot 1-ter — Fermeture P1 paiement, factures, bilans/assessments et routes coach reports.
+
+Objectifs :
+- réduire les P1 de `docs/go-live/api-security-matrix.full.md`, en priorité `/api/admin/invoices`, `/api/payments/clictopay/*`, `/api/assessments/submit`, `/api/bilans*`, routes coach generate/regenerate et NPC documents ;
+- ne jamais activer ClicToPay : garder 501 tant que signature, idempotence, montant/devise et entitlements ne sont pas complets ;
+- ajouter Zod strict/projections explicites/tests IDOR pour chaque route traitée ;
+- régénérer `docs/security/API_GUARD_INVENTORY.md` et `docs/go-live/api-security-matrix.full.md` ;
+- produire `docs/go-live/13_LOT1TER_P1_SECURITY_CLOSURE.md`.
+
+Contraintes :
+- aucun secret, aucun `.env`, aucune migration destructive, aucun déploiement ;
+- aucune route P1 ne devient OK sans test ;
+- aucune réponse publique/non staff ne contient `password`, `activationToken`, `activationUrl`, `tokenHash`, `localPath`, `pdfPath`, `filePath`, `contextJson`, `llmJson`, `validatedJson`, `latexSource`, `stack`, `errorDetails`, `metadata` brute.
+
+Commandes finales sous Node 20 :
+`npm run typecheck`, `npm run lint`, `npm run test:unit -- --runInBand`, `npm run build`, `node scripts/security/audit-api-guards.mjs`, `node scripts/go-live/generate-api-security-matrix.mjs`, `npm run audit:site-map`, `npm run check:no-hardcoded`, `npm run check:docs-archive`, `npm run check:bundle-weight`, smoke Playwright public ciblé.
+```
+
+---
+
+## Prompt Lot 1 — sécurité API, IDOR, rate limiting distribué
+
+```md
+Tu travailles dans `nexus-project_v0`. Exécute le Lot 1 sécurité API.
+
+Contraintes : ne modifie aucun `.env`, ne déploie pas, ne lis aucun secret. Commence par lire `AGENTS.md`, `docs/go-live/00_EXECUTIVE_STATE.md`, `02_P0_P1_BACKLOG.md`, `05_API_SECURITY_MATRIX.md` et `docs/security/API_GUARD_INVENTORY.md`.
+
+Objectif : fermer les P0 API les plus risqués et prouver le rate limiting distribué ou documenter le blocage. Utilise `docs/go-live/api-security-matrix.full.md` comme matrice route par route, pas seulement l'inventaire brut.
+
+Actions :
+1. Traiter en premier le Top 20 Lot 1 : `/api/documents/[id]`, `/api/assistante/students/[studentId]/documents`, `/api/coach/students/[studentId]/documents`, `/api/npc/files/[...path]`, `/api/parent/bilans/[id]/pdf`, `/api/invoices/[id]/pdf`, `/api/invoices/[id]/receipt/pdf`, `/api/admin/invoices/[id]`, `/api/admin/invoices/[id]/send`, `/api/payments/clictopay/webhook`, `/api/assessments/submit`, `/api/bilan-gratuit`, routes coach report `[studentId]`.
+2. Pour chaque route dynamique, vérifier auth, rôle, ownership, Zod, rate limit et données sensibles retournées.
+3. Ajouter tests IDOR parent/élève/coach/assistante/admin avec ressource non propriétaire.
+4. Ne pas refactorer massivement ; utiliser les helpers existants `lib/guards.ts`, `lib/rbac.ts`, `lib/access/*`.
+5. Prouver ou bloquer le rate limiting distribué Redis/Upstash ; interdire fallback mémoire en production.
+6. Régénérer `docs/security/API_GUARD_INVENTORY.md` et `docs/go-live/api-security-matrix.full.md`.
+7. Mettre à jour `docs/go-live/05_API_SECURITY_MATRIX.md` avec les deltas.
+
+Commandes : `npm run typecheck`, `npm run lint`, `npm run test:unit -- --runInBand`, `npm run build`, `node scripts/security/audit-api-guards.mjs`.
+
+Livrable final : routes corrigées, tests, risques restants, P0 encore ouverts.
+```
+
+## Prompt Lot 2 — pricing, offres, pages marketing, prérentrée août 2026
+
+```md
+Tu travailles dans `nexus-project_v0`. Exécute le Lot 2 pricing/offres/conversion publique.
+
+Lis `AGENTS.md`, `docs/go-live/06_BUSINESS_LOGIC_DECISIONS.md`, `08_MARKETING_CONTENT_CHECKLIST.md`, `data/pricing.canonical.json`, `lib/pricing.ts`.
+
+Objectif : garantir que les pages publiques critiques sont cohérentes 2026/2027, sans prix hors canonique ni promesse excessive.
+
+Actions : auditer `/`, `/offres`, `/recommandation`, `/bilan-gratuit`, `/stages`, `/plateforme-aria`, `/accompagnement-scolaire`, `/contact`, pages candidat libre/bac français. Corriger seulement les incohérences de contenu/pricing/CTA. Classer ou neutraliser reliquats activables avec montants obsolètes. Vérifier stage prérentrée août 2026.
+
+Tests : `npm run check:no-hardcoded`, tests marketing, `npm run build`, smoke Playwright mobile si disponible.
+
+Livrable : diff contenu, preuves pricing, risques restants.
+```
+
+## Prompt Lot 3 — CRM admissions, bilan gratuit, WhatsApp, tracking
+
+```md
+Tu travailles dans `nexus-project_v0`. Exécute le Lot 3 CRM admissions.
+
+Lis `AGENTS.md`, `docs/go-live/02_P0_P1_BACKLOG.md`, `08_MARKETING_CONTENT_CHECKLIST.md`, `app/bilan-gratuit/*`, `app/api/bilan-gratuit/route.ts`, `lib/crm/*`, `lib/whatsapp.ts`.
+
+Objectif : transformer le bilan gratuit en tunnel lead bas-friction, traçable et conforme mineurs.
+
+Actions : décider lead pur vs compte différé, ajouter source/UTM/referrer sans collecte excessive, vérifier consentement, anti-spam/rate-limit, emails internes, WhatsApp CTA. Ne pas demander de mot de passe en première intention.
+
+Tests : formulaire, API validation, rate limit, email mock, no PII logs, build.
+
+Livrable : parcours lead fiable et rapport de conformité.
+```
+
+## Prompt Lot 4 — paiement, facturation, entitlements
+
+```md
+Tu travailles dans `nexus-project_v0`. Exécute le Lot 4 paiement/facturation/entitlements.
+
+Lis `AGENTS.md`, `docs/go-live/02_P0_P1_BACKLOG.md`, `06_BUSINESS_LOGIC_DECISIONS.md`, `app/api/payments/*`, `lib/invoice/*`, `lib/entitlement/*`, `prisma/schema.prisma`.
+
+Objectif : fiabiliser la source de vérité paiement -> facture -> entitlement et garder ClicToPay désactivé tant qu'il n'est pas complet.
+
+Actions : aligner registre produit/pricing, idempotence, beneficiary, credits, PDF facture, accès parent/admin. Si ClicToPay non finalisé, le cacher clairement.
+
+Tests : payments validate, invoice pdf, entitlement idempotence, ClicToPay 501 ou E2E complet, build.
+
+Livrable : chaîne achat fiable et décisions restantes.
+```
+
+## Prompt Lot 5 — dashboards par rôle
+
+```md
+Tu travailles dans `nexus-project_v0`. Exécute le Lot 5 dashboards.
+
+Lis `AGENTS.md`, `docs/go-live/01_ACTION_PLAN.md`, `03_RELEASE_GATES.md`, `app/dashboard/**`, API parent/student/coach/assistante/admin.
+
+Objectif : vérifier et corriger les workflows essentiels par rôle sans refonte visuelle massive.
+
+Actions : smoke rôle par rôle, états vides, erreurs sobres, navigation, permissions, mobile. Prioriser parent, élève, coach, assistante, admin.
+
+Tests : unit/API existants, Playwright login par rôle si fixtures disponibles, build.
+
+Livrable : matrice dashboards, corrections, risques.
+```
+
+## Prompt Lot 6 — IA/RAG/NPC
+
+```md
+Tu travailles dans `nexus-project_v0`. Exécute le Lot 6 IA/RAG/NPC.
+
+Lis `AGENTS.md`, `docs/go-live/02_P0_P1_BACKLOG.md`, `lib/aria.ts`, `lib/rag-client.ts`, `docs/RAG_ARCHITECTURE.md`, `lib/npc/*`, `services/npc-worker/*`, `app/api/npc/*`.
+
+Objectif : clarifier backend RAG canonique, feature flags ARIA, mode NPC, uploads et garde-fous pédagogiques.
+
+Actions : aligner docs/code RAG, vérifier health, rendre `NPC_LLM_MODE` visible côté admin/coach si nécessaire, empêcher surpromesse stub, tester ownership fichiers NPC.
+
+Tests : ARIA routes, RAG fallback, NPC uploads/files/submissions, build.
+
+Livrable : IA exploitable en bêta contrôlée.
+```
+
+## Prompt Lot 7 — RGPD, logs, documents, mineurs
+
+```md
+Tu travailles dans `nexus-project_v0`. Exécute le Lot 7 conformité données.
+
+Lis `AGENTS.md`, `docs/go-live/02_P0_P1_BACKLOG.md`, `07_ENV_INFRA_CHECKLIST.md`, routes documents, pages légales, logger/serialize-error.
+
+Objectif : minimiser et protéger données mineurs, documents, bilans, factures et logs.
+
+Actions : consentement analytics, politique confidentialité, logs redaction, accès documents, rétention/suppression, no localPath leak, no PII in errors.
+
+Tests : no-leak, documents IDOR, analytics consent, build.
+
+Livrable : conformité minimale go-live et risques juridiques restants.
+```
+
+## Prompt Lot 8 — infra, backup, monitoring, release
+
+```md
+Tu travailles dans `nexus-project_v0`. Exécute le Lot 8 infra/release.
+
+Lis `AGENTS.md`, `docs/go-live/03_RELEASE_GATES.md`, `07_ENV_INFRA_CHECKLIST.md`, `Dockerfile.prod`, `docker-compose.prod.yml`, `.github/workflows/ci.yml`, health routes.
+
+Objectif : préparer la décision release avec preuves production, sans déployer sans demande explicite.
+
+Actions : audit lecture seule production si autorisé, vérifier Docker/PM2/Nginx/SSL, backup/restore, monitoring, alerting, rollback, curls pages critiques.
+
+Tests : health, smoke production, restore drill, bundle, build, Playwright.
+
+Livrable : rapport release gate A/B/C/D et décision finale.
+```
+# Mise à jour Lot 1 — Prompt suivant recommandé
+
+## Prompt Lot 1-bis — Fermeture P1 API restants
+
+Tu travailles dans `nexus-project_v0`. Lot 1 a ramené `API_GUARD_INVENTORY.md` à `P0=0`, `P1=56`, `P2=93`, `OK=27`. Ne rouvre pas les P0 fermés sans preuve. Ta mission est de traiter les 20 P1 prioritaires listés dans `docs/go-live/api-security-matrix.full.md`, en commençant par sessions, documents admin/assistante, NPC documents, facturation admin, ClicToPay init/webhook, assessments submit et bilan gratuit.
+
+Contraintes : ne lis aucun secret, ne modifie aucun `.env`, ne lance aucune migration destructive, ne déploie rien. Toute route corrigée doit avoir tests négatifs : non authentifié, mauvais rôle, ressource hors scope, payload invalide, champs sensibles absents. Régénère `docs/security/API_GUARD_INVENTORY.md` et `docs/go-live/api-security-matrix.full.md`, puis documente les P1 fermés et les réserves restantes.
+
+## Prompt Lot 7 — preuve humaine runtime et release candidate finale
+
+```md
+Tu travailles dans `nexus-project_v0`. Les Lots 0 à 6 sont terminés avec réserves. N'ajoute pas de fonctionnalité large. Ta mission est d'obtenir les preuves humaines manquantes pour décider bêta élargie.
+
+Préconditions humaines obligatoires :
+- fournir `NEXUS_HEALTH_AUTH` dans le shell sans afficher sa valeur ;
+- autoriser explicitement une fenêtre staging pour `/api/internal/rate-limit-probe` avec `NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE=true` ;
+- fournir une DB non production et `NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB=true` si dry-run ContactLead doit être prouvé.
+
+Actions :
+- exécuter le healthcheck authentifié et vérifier `runtime.rateLimit.mode=redis|upstash`, `distributed=true`, `goLiveLarge=allowed`, `checks.redis.ok=true` ;
+- exécuter un test 429 non destructif sur staging ;
+- exécuter `scripts/maintenance/contact-leads-retention.ts` en dry-run DB non production ;
+- rejouer les gates Node 20 et Playwright critiques ;
+- mettre à jour `docs/go-live/_evidence/lot6-*` ou créer un Lot 7 de preuve runtime ;
+- ne jamais afficher de secret, ne jamais modifier `.env`, ne jamais lancer `--apply` ContactLead.
+
+Décision : bêta élargie reste interdite si Redis/Upstash ou 429 runtime ne sont pas prouvés.
+```
+
+## Prompt Lot 13 — exécution humaine contrôlée des commits
+
+```md
+Tu travailles dans `nexus-project_v0`. Les Lots 0 à 12 sont terminés avec réserves. Lot 12 a arbitré `docs/audits/audit-nexus-reussite.md` : il est exclu des commits standards sauf décision humaine explicite.
+
+Objectif : exécuter les commits humains préparés par le runbook Lot 11, uniquement si le responsable valide le périmètre.
+
+Préconditions :
+- relire `docs/go-live/_evidence/lot11-human-commit-runbook.md` ;
+- relire `docs/go-live/_evidence/lot12-human-review-decision-files.md` ;
+- confirmer que `docs/audits/audit-nexus-reussite.md` reste exclu, ou fournir une décision humaine explicite ;
+- vérifier staging Git vide avant chaque commit ;
+- ne jamais inclure `.env*`, `rapport_audit_2_07_2026.md`, `test-results`, `playwright-report`, `.next`, `node_modules`.
+
+Actions :
+- exécuter les `git add -- ...` du runbook commit par commit ;
+- vérifier `git diff --cached --name-only` après chaque staging ;
+- relancer les tests recommandés par commit ;
+- créer le commit humain si le staging correspond exactement au runbook ;
+- ne pas créer de PR sans demande explicite ;
+- garder les 6 P1 visibles.
+
+Décision : bêta élargie reste interdite tant que Redis/Upstash et un vrai `429` runtime ne sont pas prouvés.
+```
+
+## Prompt Lot 14 — exécution humaine des commits du runbook
+
+```md
+Tu travailles dans `nexus-project_v0`. Les Lots 0 à 13 sont terminés avec réserves. Lot 13 indique `READY_TO_EXECUTE_MANUALLY`.
+
+Objectif : exécuter manuellement les 9 commits du runbook Lot 11, sans push ni PR automatique.
+
+Préconditions :
+- relire `docs/go-live/_evidence/lot11-human-commit-runbook.md` ;
+- relire `docs/go-live/_evidence/lot13-human-execution-checklist.md` ;
+- vérifier `git diff --cached --name-only` vide ;
+- confirmer que `docs/audits/audit-nexus-reussite.md` reste exclu sauf décision humaine explicite ;
+- confirmer qu'aucun `.env*`, `rapport_audit_2_07_2026.md`, `test-results`, `playwright-report`, `.next`, `node_modules` n'est staged.
+
+Actions :
+- exécuter uniquement le bloc `git add -- ...` du commit courant ;
+- vérifier `git diff --cached --name-only` ;
+- relancer les tests recommandés du bloc ;
+- committer uniquement si le staging correspond exactement au bloc ;
+- répéter pour les 9 commits ;
+- ne pas pousser, ne pas créer de PR, ne pas déployer.
+
+Décision : bêta élargie et go-live large restent interdits tant que Redis/Upstash et un vrai `429` runtime ne sont pas prouvés.
+```
+
+## Prompt Lot 9 — commit humain RC et preuves staging
+
+```md
+Tu travailles dans `nexus-project_v0`. Lot 8 a produit un manifest RC propre et un plan de commits, sans commit.
+
+Objectif : revue humaine puis commit par lots, uniquement si le responsable valide les fichiers.
+
+Préconditions :
+- relire `docs/go-live/_evidence/lot8-release-candidate-file-manifest-clean.md` ;
+- relire `docs/go-live/_evidence/lot8-release-candidate-commit-plan-clean.md` ;
+- décider explicitement du sort de `docs/audits/audit-nexus-reussite.md` ;
+- ne jamais inclure `rapport_audit_2_07_2026.md` sans décision humaine explicite ;
+- fournir `NEXUS_HEALTH_AUTH` et une fenêtre staging si les preuves runtime doivent être levées.
+
+Actions :
+- rejouer les gates Node 20 ;
+- exécuter healthcheck Redis/Upstash authentifié si credential disponible ;
+- exécuter `/api/internal/rate-limit-probe` sur staging si autorisé ;
+- exécuter dry-run ContactLead contre DB non production si autorisé ;
+- préparer les commits dans l'ordre du plan Lot 8 ;
+- ne créer aucune PR sans demande explicite.
+
+Décision : go-live large reste interdit tant que les 6 P1 ne sont pas acceptés humainement et que Redis/Upstash + 429 runtime ne sont pas prouvés.
+```
+
+## Prompt Lot 8 — preuve runtime humaine et préparation commit RC
+
+```md
+Tu travailles dans `nexus-project_v0`. Lot 7 a préparé la release candidate et audité les scripts, mais n'a pas levé les blocages runtime.
+
+Objectif : exécuter uniquement les preuves humaines manquantes et préparer la mise en commit, sans ajouter de fonctionnalité.
+
+Préconditions humaines :
+- injecter `NEXUS_HEALTH_AUTH` dans le shell sans afficher sa valeur ;
+- autoriser explicitement le test `/api/internal/rate-limit-probe` sur staging avec `NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE=true` ;
+- fournir une DB non production et `NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB=true` pour dry-run ContactLead.
+
+Actions :
+- vérifier `/api/internal/health` authentifié : `mode=redis|upstash`, `distributed=true`, `goLiveLarge=allowed`, `checks.redis.ok=true` ;
+- exécuter un vrai test `429` non destructif ;
+- exécuter le dry-run DB ContactLead sans PII et sans `--apply` ;
+- rejouer les gates Node 20 et Playwright critiques ;
+- utiliser `docs/go-live/_evidence/lot7-release-candidate-file-manifest.md` et `docs/go-live/_evidence/lot7-release-candidate-commit-plan.md` pour préparer les commits, sans commit automatique ;
+- garder les 6 P1 visibles sauf décision humaine documentée.
+
+Décision : bêta élargie reste interdite si Redis/Upstash ou 429 runtime ne sont pas prouvés.
+```

--- a/docs/go-live/10_LOT0_ACCEPTANCE.md
+++ b/docs/go-live/10_LOT0_ACCEPTANCE.md
@@ -1,0 +1,72 @@
+# Acceptation Lot 0-bis
+
+Date locale : 2026-07-02 18:33 CET  
+Branche : `feat/lot4-accessors-runtime`  
+Commit court : `db8545a19`
+
+## Verdict
+
+Lot 0-bis ACCEPTÉ AVEC RÉSERVES.
+
+Ce verdict signifie que la baseline Lot 0 est maintenant exploitable pour lancer le Lot 1 sécurité. Il ne signifie pas que Nexus Réussite est go-live large.
+
+## Critères Lot 0-bis
+
+| Critère | Statut | Preuve |
+| --- | --- | --- |
+| Échecs Playwright publics corrigés ou requalifiés | OK | `docs/go-live/_evidence/playwright-public-smoke-triage.md` |
+| Smoke Playwright ciblé vert | OK | 24/24 sous Node 20, relance finale 2026-07-02 18:33 CET |
+| Node local vs CI/Docker clarifié | OK | Local par défaut Node 22.21.0 ; CI/Docker Node 20 ; validations rejouées sous `nvm use 20.20.0` |
+| Matrice API exploitable | OK | `docs/go-live/api-security-matrix.full.md`, 176 routes, Top 20 Lot 1 |
+| Occurrences TND classées | OK | `docs/go-live/_evidence/hardcoded-pricing-triage.md` |
+| Pricing vs entitlement prouvé/infirmé | OK | Écart confirmé 0/4/8 vs 4/8/16 |
+| GA/consentement clair | OK avec réserve | GA désactivé par défaut ; aucune CMP complète ; activation interdite sans consentement |
+| Tunnel bilan gratuit clair | OK avec réserve | UI lead, API création comptes inactifs + activation ; décision produit requise |
+| Aucun secret exposé | OK | Aucun `.env` lu ou modifié ; aucune valeur secrète copiée |
+| Aucune migration destructive | OK | Aucune commande Prisma destructive lancée |
+
+## Commandes finales Lot 0-bis
+
+| Statut | Commande | Résultat |
+| --- | --- | --- |
+| OK | `npm run typecheck` sous Node 20.20.0 | `tsc --noEmit` OK |
+| OK | `npm run lint` sous Node 20.20.0 | Code 0, warnings existants sous `--max-warnings 300` |
+| OK | `npm run test:unit -- --runInBand` sous Node 20.20.0 | 504 suites passées, 1 skipped ; 6345 tests passés, 4 skipped |
+| OK | `npm run build` sous Node 20.20.0 | Build Next OK, 143 pages générées, assets standalone copiés |
+| OK | `node scripts/security/audit-api-guards.mjs` | `docs/security/API_GUARD_INVENTORY.md` régénéré avec 176 routes |
+| OK | `node scripts/go-live/generate-api-security-matrix.mjs` | Matrice 176 routes : 44 P0, 42 P1, 62 P2, 28 OK |
+| OK | `npm run audit:site-map` | 290 routes, 412 edges, 0 link finding, 13 public orphan entries |
+| OK | `npm run check:no-hardcoded` | 0 hardcoded values outside canonical sources selon script |
+| OK | `npm run check:docs-archive` | Aucun audit/report historique à `docs/` racine |
+| OK | `npm run check:bundle-weight` | Toutes les routes surveillées dans baseline + 5 kB |
+| OK | `npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` sous Node 20.20.0 | 24 passed |
+
+## Réserves bloquantes go-live large
+
+- 44 P0 API restent ouverts et seulement triés statiquement.
+- Le tunnel `/bilan-gratuit` crée des comptes inactifs alors que la promesse marketing reste un bilan gratuit bas-friction.
+- Aucune CMP complète n'est présente ; GA ne doit pas être activé avant consentement.
+- ClicToPay reste non activable côté API et est masqué des pages publiques, mais la chaîne paiement/facturation/entitlements reste P0.
+- Le delta pricing/entitlement est confirmé.
+- Le fichier HTML historique racine et `components/ui/specialized-packs.tsx` restent à neutraliser/migrer avant campagne large.
+
+## Décisions provisoires
+
+- Campagne marketing payante : NON AUTORISÉE tant que le tunnel bilan n'est pas aligné lead-only ou explicitement assumé avec consentement et copy.
+- Marketing public organique / pré-campagne : AUTORISABLE AVEC RÉSERVES si GA reste désactivé, ClicToPay reste masqué et les formulaires sont surveillés.
+- Bêta contrôlée plateforme : AUTORISABLE AVEC RÉSERVES seulement hors paiement carte, avec comptes sélectionnés et surveillance manuelle.
+- Go-live large : NON AUTORISÉ.
+
+## Prochain lot recommandé
+
+Lot 1 — sécurité API, IDOR, ownership, documents/factures/bilans, rate limiting distribué, avec priorité sur le Top 20 de `api-security-matrix.full.md`.
+# Mise à jour Lot 1 — 2026-07-02
+
+Lot 0-bis reste accepté avec réserves. Lot 1 a fermé les P0 API statiques (`44 -> 0`) et ajouté des tests IDOR/no-leak/rate-limit ciblés. Les réserves structurantes restent :
+
+- rate limiting distribué non prouvé sur production réelle ;
+- 56 P1 API à durcir avant bêta élargie ;
+- `/api/bilan-gratuit` encore ambigu côté produit car création de comptes inactifs ;
+- ClicToPay toujours non activable sans Lot paiement complet.
+
+Voir `docs/go-live/11_LOT1_SECURITY_CLOSURE.md`.

--- a/docs/go-live/11_LOT1_SECURITY_CLOSURE.md
+++ b/docs/go-live/11_LOT1_SECURITY_CLOSURE.md
@@ -1,0 +1,103 @@
+# Lot 1 — Clôture sécurité API
+
+## Mise à jour Lot 1-bis — 2026-07-02
+
+Le contre-audit Lot 1-bis maintient `P0=0` après correction du script d’audit et régénération. Les P1 passent de 56 à 54.
+
+Routes fermées en plus :
+
+- `/api/sessions/video` : rate limit, Zod strict, projection DB explicite.
+- `/api/admin/documents` : MIME/taille, Zod `userId`, réponse sans `localPath`.
+
+Réserves maintenues :
+
+- rate limiting distribué production non prouvé ;
+- ClicToPay maintenu `501`, non activable ;
+- `/api/bilan-gratuit` sécurisé en sortie mais toujours ambigu produit/RGPD car création de comptes inactifs ;
+- 54 P1 restent ouverts.
+
+Preuves : `docs/go-live/12_LOT1BIS_SECURITY_VERIFICATION.md` et `docs/go-live/_evidence/lot1bis-*.md`.
+
+---
+
+## Verdict
+ACCEPTÉ AVEC RÉSERVES.
+
+## Synthèse
+
+Lot 1 a fermé les P0 API statiques issus de la matrice Lot 0-bis : l’inventaire régénéré passe de 44 P0 à 0 P0, avec 56 P1 restants. Cette baisse combine des corrections de code, des tests IDOR/no-leak et une requalification statique plus précise des routes staff-only, publiques fixes, routes 410/501 et réexports.
+
+Les commandes finales Lot 1 sont vertes sous Node 20. Le go-live large reste non autorisé : le rate limiting distribué n’est pas prouvé en production réelle et 56 P1 restent à durcir avant bêta élargie.
+
+## Routes corrigées
+
+| Route | Correction | Preuve |
+| --- | --- | --- |
+| `/api/documents/[id]` | Scope DB avant lecture fichier, 404 non révélateur hors propriétaire, projection explicite, logs sans chemin disque | `__tests__/api/documents.id.route.test.ts` |
+| `/api/coach/students/[studentId]/documents` | Suppression de `localPath` dans les réponses, `select` explicite, rejet JSON `localPath`, validation MIME/taille upload | `__tests__/api/documents-access.test.ts` |
+| `/api/student/documents/[id]/download` | Logs fichier sans erreur brute ni chemin disque | Revue code |
+| `/api/invoices/[id]/pdf` | Scope parent par `beneficiaryUserId` enfant + fallback email legacy | `__tests__/lib/invoice/access-scope.test.ts`, `__tests__/api/invoices.pdf.route.test.ts` |
+| `/api/invoices/[id]/receipt/pdf` | Même scope facture que PDF | `__tests__/api/invoices.receipt.pdf.route.test.ts` |
+| `/api/student/activate` | `guardRateLimitAsync` GET/POST + logs sobres | `__tests__/api/student.activate.route.test.ts` |
+| `/api/lamis/teacher-report` | Zod strict, taille bornée, rate limit GET/POST | `__tests__/api/lamis.teacher-report.route.test.ts` |
+| `/api/stages/[stageSlug]` | Validation Zod du slug public | Revue code |
+| `/api/student/automatismes/series/[id]` | Validation Zod de l’id de contenu | Revue code |
+
+## Routes requalifiées
+
+- `/api/payments/clictopay/webhook` : P1, maintenue en `501` si non configurée et signature HMAC exigée si secret présent.
+- `/api/public-documents/corrige-dnb-maths-2026` : P2, document public fixe servi depuis `public/documents`.
+- `/api/stages` et `/api/stages/[stageSlug]` : P2, catalogue public sans données propriétaire.
+- Routes admin/assistante dynamiques : P1/P2 selon Zod/guard, car staff-only explicite ne relève pas d’un IDOR propriétaire classique.
+- Routes coach avec `assertCoachCanAccessStudent` ou contrôles session/stage : P1/P2 selon couverture restante.
+
+## Routes encore P0
+
+Aucune P0 statique restante dans `docs/security/API_GUARD_INVENTORY.md` généré le 2026-07-02.
+
+## Routes désactivées ou maintenues en 501
+
+- `/api/payments/clictopay/webhook` retourne encore `501 CLICTOPAY_NOT_CONFIGURED` hors activation complète.
+- `/api/payments/clictopay/init` reste P1 à durcir/valider avant activation réelle.
+
+## Tests ajoutés
+
+- `__tests__/lib/invoice/access-scope.test.ts`
+- `__tests__/api/lamis.teacher-report.route.test.ts`
+
+## Tests modifiés
+
+- `__tests__/api/documents.id.route.test.ts`
+- `__tests__/api/documents-access.test.ts`
+- `__tests__/api/invoices.pdf.route.test.ts`
+- `__tests__/api/invoices.receipt.pdf.route.test.ts`
+- `__tests__/api/student.activate.route.test.ts`
+- `__tests__/api/public-rate-limit.coverage.test.ts`
+
+## Rate limiting
+
+Le code empêche `RATE_LIMIT_DISABLE=1` de bypasser la production et le healthcheck expose `redis`, `upstash` ou `memory`. Lot 1 ajoute le rate limiting sur `/api/student/activate` et `/api/lamis/teacher-report`. Réserve bloquante go-live large : le mode distribué n’est pas prouvé sur production réelle.
+
+## Données sensibles / projections
+
+Les réponses documents coach et téléchargement document ne renvoient plus `localPath`. Le scope facture n’utilise plus seulement `customerEmail` quand un `beneficiaryUserId` enfant existe.
+
+## Risques résiduels
+
+- 56 P1 API restent à durcir.
+- `/api/bilan-gratuit` reste P1 produit/sécurité : route sécurisée à poursuivre, mais le flux crée encore des comptes inactifs.
+- ClicToPay reste non activable sans Lot paiement complet.
+- Rate limiting distribué production non prouvé.
+- Smoke Playwright public vert, mais warning runtime local `Prisma P2021` sur table `business_configs` absente pendant le refresh passif de config : à traiter dans le lot infra/DB si reproduit hors environnement local.
+
+## Décision bêta contrôlée
+
+Autorisable avec réserves si environnement isolé, comptes limités, monitoring manuel et ClicToPay désactivé.
+
+## Décision bêta élargie
+
+Non autorisée tant que les P1 documents/factures/bilans/paiements et le rate limiting distribué production ne sont pas fermés.
+
+## Prochain lot recommandé
+
+Lot 2 recommandé : paiement/facturation/entitlements ou Lot 1-bis ciblé P1 API selon priorité direction. Le prochain lot doit traiter en priorité les 20 P1 listés dans `docs/go-live/api-security-matrix.full.md`.

--- a/docs/go-live/12_LOT1BIS_SECURITY_VERIFICATION.md
+++ b/docs/go-live/12_LOT1BIS_SECURITY_VERIFICATION.md
@@ -1,0 +1,120 @@
+# Lot 1-bis — Vérification sécurité API
+
+## Verdict
+
+ACCEPTÉ AVEC RÉSERVES.
+
+## Résumé exécutif
+
+Le contre-audit confirme que `P0=0` tient après durcissement du script d’audit. Le Lot 1-bis a identifié et corrigé un faux signal potentiel dans la détection rate limit, fermé deux P1 (`/api/sessions/video`, `/api/admin/documents`), sécurisé davantage `/api/bilan-gratuit`, renforcé NPC et ajouté un test global de non-exposition de champs sensibles.
+
+La plateforme n’est pas go-live large : 54 P1 restent ouverts, ClicToPay reste désactivé, le rate limiting distribué production n’est pas prouvé et `/api/bilan-gratuit` crée encore des comptes inactifs sans décision produit/RGPD définitive.
+
+## Requalifications P0 vérifiées
+
+- Documents/factures : vérifiées par code + tests IDOR/no-leak.
+- Staff-only admin/assistante : reclassification acceptable en P2/P1, pas OK.
+- Routes publiques fixes : P2 seulement.
+- ClicToPay 501 : P1 maintenu.
+- Public sensible Zod + rate limit : P1, pas OK.
+
+## Requalifications P0 refusées ou insuffisamment prouvées
+
+Aucune route n’a été remise en P0 par le script après durcissement. En revanche, plusieurs requalifications restent insuffisantes pour go-live large et demeurent P1 : `/api/assessments/submit`, `/api/bilan-gratuit`, `/api/admin/invoices`, `/api/bilans*`, ClicToPay, routes coach generate/regenerate, NPC documents.
+
+## P1 traités
+
+Voir `docs/go-live/_evidence/lot1bis-p1-closure.md`.
+
+## P1 fermés
+
+- `/api/sessions/video`
+- `/api/admin/documents`
+
+## P1 restants
+
+54 P1 restent dans `docs/go-live/api-security-matrix.full.md`.
+
+## Corrections code appliquées
+
+- `scripts/security/audit-api-guards.mjs` : détection rate limit stricte.
+- `scripts/go-live/generate-api-security-matrix.mjs` : même détection stricte.
+- `app/api/sessions/video/route.ts` : Zod strict, rate limit, projection DB.
+- `app/api/bilan-gratuit/route.ts` : réponse neutre, pas d’énumération email, pas d’IDs, payload public strict.
+- `app/api/student/activate/route.ts` : 400 validation sans détails `password`.
+- `app/api/admin/documents/route.ts` : MIME/taille, Zod userId, projection sans `localPath`.
+
+## Tests ajoutés
+
+- `__tests__/scripts/audit-api-guards.classification.test.ts`
+- `__tests__/api/bilan-gratuit.security.test.ts`
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+- `__tests__/api/admin.documents.route.test.ts`
+
+## Tests modifiés
+
+- `__tests__/api/bilan-gratuit.test.ts`
+- `__tests__/api/student.activate.route.test.ts`
+- `__tests__/api/sessions.video.route.test.ts`
+- `__tests__/api/npc.files.route.test.ts`
+- `__tests__/api/npc.documents.route.test.ts`
+- `__tests__/api/payments.clictopay.webhook.route.test.ts`
+
+## Script audit-api-guards
+
+Testé par fixtures synthétiques. Le script ne classe plus un commentaire `rateLimit` comme contrôle effectif. Une route dynamique sensible sans ownership reste P0. ClicToPay 501 reste P1.
+
+## Rate limiting
+
+Code/test OK localement. Production distribuée non prouvée : réserve bloquante go-live large.
+
+## ClicToPay
+
+`init` et `webhook` restent non actifs. Webhook signé valide retourne encore 501. Aucune activation entitlement par webhook.
+
+## Bilan gratuit
+
+État actuel sécurisé côté API : pas d’énumération email, pas d’IDs en réponse, pas de token brut. Dette produit/RGPD maintenue : création de comptes inactifs à trancher Lot 3.
+
+## Documents / NPC / fichiers
+
+Documents admin et NPC renforcés par tests. Aucun `localPath/filePath` attendu en réponse testée. Les routes NPC documents restent P1 faute de Zod complet.
+
+## Sessions / coach / parent / élève
+
+`/api/sessions/video` corrigée en P2. Les routes coach report ont des tests d’ownership existants mais plusieurs mutations generate/regenerate restent P1.
+
+## Matrice API avant/après
+
+| Source | P0 | P1 | P2 | OK |
+| --- | ---: | ---: | ---: | ---: |
+| Lot 1 | 0 | 56 | 93 | 27 |
+| Lot 1-bis | 0 | 54 | 95 | 27 |
+
+## Commandes exécutées
+
+Toutes les commandes finales obligatoires ont été exécutées sous Node `v20.20.0`.
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `npm run typecheck` | ÉCHEC puis OK | Échec initial lié aux tests ajoutés, corrigé ; passage final OK. |
+| `npm run lint` | OK | Lint passé avec avertissements existants sous seuil. |
+| `npm run test:unit -- --runInBand` | OK | 509 suites passées, 1 ignorée ; 6383 tests passés, 4 ignorés. |
+| `npm run build` | OK | Build Next.js réussi, 143 pages statiques générées. |
+| `node scripts/security/audit-api-guards.mjs` | OK | Inventaire régénéré, 176 routes. |
+| `node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=54`, `P2=95`, `OK=27`. |
+| `npm run audit:site-map` | OK | 290 routes, 412 edges, 0 link finding. |
+| `npm run check:no-hardcoded` | OK | 0 valeur hardcodée hors sources canoniques. |
+| `npm run check:docs-archive` | OK | Aucun audit historique à la racine de `docs/`. |
+| `npm run check:bundle-weight` | OK | Toutes les routes contrôlées sous baseline + 5 kB. |
+| `npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | OK | 24 tests passés ; avertissement local `business_configs` absent à vérifier hors smoke. |
+
+## Commandes échouées
+
+Le premier `npm run typecheck` a échoué pendant le développement Lot 1-bis après ajout des tests. L’échec a été corrigé puis la commande finale est passée. Aucune commande finale obligatoire ne reste en échec.
+
+## Décisions
+
+- Bêta contrôlée : autorisable avec réserves, périmètre limité, ClicToPay désactivé, monitoring manuel.
+- Bêta élargie : non autorisée tant que P1 critiques paiement/factures/bilans/documents restent ouverts.
+- Go-live large : non autorisé.

--- a/docs/go-live/13_LOT1TER_P1_SECURITY_CLOSURE.md
+++ b/docs/go-live/13_LOT1TER_P1_SECURITY_CLOSURE.md
@@ -1,0 +1,117 @@
+# Lot 1-ter — Fermeture P1 critiques
+
+Date locale : 2026-07-02 22:57:38 CET.
+
+## Verdict
+
+ACCEPTÉ AVEC RÉSERVES.
+
+## Synthèse
+
+Lot 1-ter a réduit les P1 critiques API de `54` à `37` sans modifier le script d'audit pour masquer des risques. Les P0 restent à `0`.
+
+| Priorité | Avant Lot 1-ter | Après Lot 1-ter |
+| --- | ---: | ---: |
+| P0 | 0 | 0 |
+| P1 | 54 | 37 |
+| P2 | 95 | 112 |
+| OK | 27 | 27 |
+| Total | 176 | 176 |
+
+La baisse correspond à des corrections de code sur validation Zod, projections, rôles explicites, refus de paramètres dangereux et tests ciblés. ClicToPay reste non actif : `init` est durci et reste `501`, `webhook` reste P1/501.
+
+## Routes corrigées
+
+- `/api/admin/invoices` : filtres GET bornés, body POST strict, staff-only explicite, projection sans `include` large.
+- `/api/payments/clictopay/init` : rôles autorisés explicites, Zod strict, retour `501` non ambigu.
+- `/api/bilans`, `/api/bilans/[id]`, `/api/bilans/[id]/export`, `/api/bilans/generate` : params/body/query Zod stricts, refus avant DB.
+- `/api/npc/submissions`, `/api/npc/submissions/[submissionId]/documents`, `/api/npc/submissions/[submissionId]/documents/[documentId]`, `/api/npc/submissions/[submissionId]/generate`, `/api/npc/uploads` : params et metadata stricts, refus traversal avant DB/fichier.
+- `/api/sessions/cancel` : body Zod strict.
+- Routes coach reports : `generated-reports/[reportId]/generate`, `generated-reports/[reportId]/regenerate`, `eaf-preparation-report/validate`, `bilan-diagnostic-maths-terminale`, `eaf-stage-printemps/.../regenerate`.
+
+## Routes encore P1
+
+P1 restants principaux :
+
+- Paiement : `/api/payments/clictopay/webhook`.
+- Public sensible : `/api/assessments/submit`, `/api/bilan-gratuit`, `/api/bilan-gratuit/dismiss`, `/api/lamis/teacher-report`, `/api/stages/[stageSlug]/inscrire`, `/api/student/activate`.
+- Documents : `/api/assistante/quotes/pdf`.
+- Coach/élève : notes, survival-mode, trajectory, routes maths-premiere-stage-printemps.
+- Assistante/parent/student : crédits, subscriptions, children, automatismes, survival, trajectory.
+- Admin : config, rollback, stats directeur, recompute SSN, subscriptions, test-email.
+
+## Paiements / ClicToPay
+
+- `init` reste désactivée par `501 CLICTOPAY_NOT_CONFIGURED`, avec validation stricte et refus des rôles non autorisés.
+- `webhook` reste désactivée par `501`; aucune activation de paiement, facture, entitlement ou crédit n'est acceptée.
+- `payments/validate` n'a pas été refondu dans ce lot ; il reste couvert par les tests hérités et doit être consolidé en Lot paiement/entitlements.
+
+## Factures / invoices
+
+`/api/admin/invoices` passe P2 grâce à la validation stricte, aux filtres bornés et à une projection explicite. Les routes `/api/admin/invoices/[id]`, `/send`, `/api/invoices/[id]/pdf` et `/receipt/pdf` restent P2 depuis les lots précédents, avec tests ownership/no-leak hérités.
+
+## Assessments
+
+`/api/assessments/submit` reste P1 : route publique sensible avec données pédagogiques mineur. Elle a Zod et rate limit, mais son mode public/token/session doit être arbitrée avant bêta élargie.
+
+## Bilans
+
+Les routes `Bilan` critiques traitées passent P2. Le correctif a aussi évité qu'une absence de filtre `isPublished` soit interprétée comme `false` dans `GET /api/bilans`.
+
+## NPC documents / fichiers
+
+Les routes NPC traitées refusent les identifiants dangereux avant accès DB/fichier, valident metadata/upload, et ne renvoient pas de chemin local dans les réponses testées.
+
+## Coach reports
+
+Les routes coach reports traitées valident `studentId`/`reportId` avant ownership et ne renvoient pas les champs internes `contextJson`, `llmJson`, `validatedJson`, `latexSource` dans les tests ciblés.
+
+## Bilan gratuit
+
+`/api/bilan-gratuit` n'a pas été refondu dans Lot 1-ter. L'état durci Lot 1-bis reste : pas d'énumération email, pas d'ID/token en réponse, rate limit et no-leak testés. La dette produit/RGPD demeure : la route crée encore des comptes inactifs alors que la promesse marketing est un bilan gratuit.
+
+## Champs sensibles / no-leak
+
+Le test global `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts` couvre désormais 9 routes mockables : bilan gratuit, activation élève, ClicToPay init/webhook, admin invoices, bilans generate, NPC documents, coach generated report regenerate, Lamis teacher report.
+
+## Tests ajoutés / modifiés
+
+Tests Lot 1-ter ciblés passés : 14 suites, 94 tests.
+
+Commandes finales passées sous Node 20 :
+
+- `npm run typecheck`
+- `npm run lint`
+- `npm run test:unit -- --runInBand` : 512 suites passées, 1 ignorée ; 6411 tests passés, 4 ignorés.
+- `npm run build` : 143 pages générées.
+- `node scripts/security/audit-api-guards.mjs`
+- `node scripts/go-live/generate-api-security-matrix.mjs` : `P0=0`, `P1=37`, `P2=112`, `OK=27`.
+- `npm run audit:site-map`
+- `npm run check:no-hardcoded`
+- `npm run check:docs-archive`
+- `npm run check:bundle-weight`
+- Smoke Playwright public ciblé : 24 tests passés.
+
+## Risques résiduels
+
+- Rate limiting distribué production non prouvé.
+- ClicToPay webhook P1/501.
+- `/api/bilan-gratuit` reste ambigu produit/RGPD.
+- 37 P1 restent à traiter avant bêta élargie.
+- Les tests no-leak restent mockés : ils ne remplacent pas un audit dynamique production/staging.
+
+## Décision bêta contrôlée
+
+Autorisable seulement en périmètre limité, sans paiement carte, sans promesse go-live large, avec monitoring manuel et comptes test maîtrisés.
+
+## Décision bêta élargie
+
+Non autorisée tant que les P1 publics/paiement/documents restants et le rate limiting distribué production ne sont pas clos.
+
+## Décision go-live large
+
+Interdit.
+
+## Prochain lot recommandé
+
+Lot 1-quater : fermer les P1 publics/stages/assistante/parent/student restants et prouver le rate limiting distribué en environnement production ou staging.

--- a/docs/go-live/14_LOT1QUATER_PUBLIC_ROLE_SECURITY_CLOSURE.md
+++ b/docs/go-live/14_LOT1QUATER_PUBLIC_ROLE_SECURITY_CLOSURE.md
@@ -1,0 +1,74 @@
+# Lot 1-quater — Fermeture P1 publics et rôles
+
+## Verdict
+
+ACCEPTÉ AVEC RÉSERVES.
+
+## Synthèse
+
+Lot 1-quater maintient `P0=0` et réduit l'inventaire statique de `P1=37` à `P1=12`, sans modification du script `scripts/security/audit-api-guards.mjs`.
+
+La baisse vient de corrections de code : Zod strict, validation de paramètres dynamiques, suppression d'un token brut dans une réponse parent, test d'ownership coach pour `coach/trajectory`, healthcheck rate limiting non ambigu et extension du test global no-leak.
+
+Les commandes finales Node 20 sont passées : typecheck, lint, full unit, build, audit API, matrice, site-map, hardcoded, docs archive, bundle weight et smoke Playwright public ciblé. Une tentative `check:no-hardcoded` avec chemin `nvm` mal saisi a échoué avant exécution du script puis a été relancée correctement avec succès.
+
+Le go-live large reste interdit : le mode Redis/Upstash n'est pas prouvé en staging/production, ClicToPay webhook reste `501/P1`, `/api/bilan-gratuit` crée encore des comptes inactifs, et 12 P1 restent ouverts.
+
+## Matrice API avant/après
+
+| Priorité | Après Lot 1-ter | Après Lot 1-quater | Delta |
+| --- | ---: | ---: | ---: |
+| P0 | 0 | 0 | 0 |
+| P1 | 37 | 12 | -25 |
+| P2 | 112 | 137 | +25 |
+| OK | 27 | 27 | 0 |
+| Total | 176 | 176 | 0 |
+
+## P1 fermés
+
+- Assistante : `/api/assistante/credit-requests`, `/api/assistante/quotes/pdf`, `/api/assistante/students/credits`, `/api/assistante/subscription-requests`, `/api/assistante/subscriptions`.
+- Parent : `/api/parent/children`, `/api/parent/subscription-requests`, `/api/parent/subscriptions`.
+- Student/eleve : `/api/eleve/bilan-diagnostic-maths-terminale`, `/api/student/automatismes/attempts`, `/api/student/automatismes/check-answer`, `/api/student/nexus-index`, `/api/student/survival/*`, `/api/student/trajectory`.
+- Coach : `/api/coach/students/[studentId]/notes`, `/api/coach/students/[studentId]/survival-mode`, `/api/coach/trajectory`, régénérations maths première parent/student.
+- Stages : `/api/stages/[stageSlug]/reservations/[reservationId]/confirm`.
+- Bilan gratuit dashboard : `/api/bilan-gratuit/dismiss`.
+- Programme STMG : `/api/programme/maths-1ere-stmg/stage-progress`.
+
+## P1 restants
+
+- Paiement : `/api/payments/clictopay/webhook` reste `501/P1`.
+- Public sensible : `/api/assessments/submit`, `/api/bilan-gratuit`, `/api/lamis/teacher-report`, `/api/stages/[stageSlug]/inscrire`, `/api/student/activate`.
+- Admin hors priorité Lot 1-quater : `/api/admin/config`, `/api/admin/config/rollback`, `/api/admin/directeur/stats`, `/api/admin/recompute-ssn`, `/api/admin/subscriptions`, `/api/admin/test-email`.
+
+## Rate limiting
+
+- Code : `getRateLimitProductionGate()` ajouté dans `lib/rate-limit/index.ts`.
+- Healthcheck : `/api/internal/health` expose `runtime.rateLimit.mode`, `distributed` et `goLiveLarge`.
+- Tests : `__tests__/lib/rate-limit.production-gate.test.ts`, `__tests__/api/internal.health.rate-limit.test.ts`.
+- Production/staging : À vérifier, aucun secret lu.
+
+## Données sensibles / no-leak
+
+Le test global no-leak passe de 9 à 12 routes mockables et couvre désormais aussi :
+
+- `/api/parent/children`
+- `/api/stages/[stageSlug]/reservations/[reservationId]/confirm`
+- `/api/coach/trajectory`
+
+Le token brut retourné auparavant par `POST /api/parent/children` a été retiré de la réponse.
+
+## Décision bêta contrôlée
+
+Autorisable uniquement en périmètre limité, sans paiement carte actif, sans campagne large, avec surveillance renforcée et avec acceptation explicite des réserves `bilan-gratuit` et rate limiting runtime.
+
+## Décision bêta élargie
+
+Interdite tant que les P1 publics sensibles, ClicToPay webhook, routes admin restantes et preuve Redis/Upstash ne sont pas fermés ou arbitrés.
+
+## Décision go-live large
+
+Interdit.
+
+## Prochain lot recommandé
+
+Lot 1-quinquies : fermer les 12 P1 restants, en priorité routes publiques sensibles, routes admin restantes et preuve runtime Redis/Upstash en staging/production. Ensuite seulement Lot 3 produit/RGPD pour `/api/bilan-gratuit` lead-only vs account activation.

--- a/docs/go-live/15_LOT1QUINQUIES_FINAL_P1_SECURITY_CLOSURE.md
+++ b/docs/go-live/15_LOT1QUINQUIES_FINAL_P1_SECURITY_CLOSURE.md
@@ -1,0 +1,55 @@
+# Lot 1-quinquies — Fermeture finale P1 API
+
+## Verdict
+
+ACCEPTÉ AVEC RÉSERVES.
+
+## Synthèse
+
+Le Lot 1-quinquies maintient `P0=0` et réduit l'inventaire statique de `P1=12` à `P1=6` sur 176 routes. Les six P1 restants sont des routes publiques sensibles ou un webhook paiement volontairement désactivé : ils ne sont pas masqués en P2/OK.
+
+Le rate limiting distribué reste non prouvé en staging/production. Le code local expose `memory`, `redis`, `upstash`, bloque le go-live large en mode `memory`, et le healthcheck production sans secret répond `401 Unauthorized`; aucun mode Redis/Upstash runtime n'a donc été vérifié.
+
+Toutes les commandes finales Node 20 du lot sont vertes : typecheck, lint, unit tests, build, audit API, génération matrice, site-map, hardcoding, archive docs, bundle-weight et smoke Playwright public ciblé.
+
+## Matrice API avant/après
+
+| Priorité | Avant Lot 1-quinquies | Après Lot 1-quinquies |
+| --- | ---: | ---: |
+| P0 | 0 | 0 |
+| P1 | 12 | 6 |
+| P2 | 137 | 143 |
+| OK | 27 | 27 |
+| Total | 176 | 176 |
+
+## P1 fermés
+
+| Route | Statut après | Preuve |
+| --- | --- | --- |
+| `/api/admin/config` | P2 | Zod strict PATCH, tests `admin.config.route` |
+| `/api/admin/config/rollback` | P2 | Zod strict, tests rollback |
+| `/api/admin/directeur/stats` | P2 | `requireRole(UserRole.ADMIN)`, Zod query strict, rate limit, tests |
+| `/api/admin/recompute-ssn` | P2 | `requireRole(UserRole.ADMIN)`, Zod body strict, rate limit, tests |
+| `/api/admin/subscriptions` | P2 | Query/body stricts, pagination bornée, projections explicites, tests |
+| `/api/admin/test-email` | P2 | ADMIN-only, body strict, réponse sans email destinataire, tests |
+
+## P1 restants
+
+| Route | Raison du maintien P1 |
+| --- | --- |
+| `/api/payments/clictopay/webhook` | Route paiement publique maintenue désactivée ; signature requise mais intégration complète non activée |
+| `/api/assessments/submit` | Route publique pédagogique sensible ; Zod/rate limit présents mais décision token/session/auth à arbitrer |
+| `/api/bilan-gratuit` | Route durcie en sortie mais crée encore des comptes inactifs ; dette produit/RGPD Lot 3 |
+| `/api/lamis/teacher-report` | Route publique pédagogique sensible ; flux public à arbitrer |
+| `/api/stages/[stageSlug]/inscrire` | Inscription publique volontaire ; Zod/rate limit présents, réponse doublon sans ID |
+| `/api/student/activate` | Activation publique par token ; Zod/rate limit présents, reste sensible par nature |
+
+## Décisions
+
+- Bêta contrôlée : autorisable uniquement avec routes P1 publiques surveillées et ClicToPay absent du parcours public.
+- Bêta élargie : interdite tant que les six P1 restants ne sont pas arbitrés/fermés et que Redis/Upstash n'est pas prouvé.
+- Go-live large : interdit tant que Redis/Upstash runtime n'est pas prouvé, ClicToPay webhook incomplet, et `/api/bilan-gratuit` crée des comptes sans décision produit/RGPD finale.
+
+## Prochain lot recommandé
+
+Lot 2 produit/RGPD : transformer `/api/bilan-gratuit` en tunnel lead-only ou mode explicite `lead_only/account_activation`, arbitrer les routes publiques pédagogiques, puis Lot paiement pour ClicToPay complet ou suppression durable du parcours carte.

--- a/docs/go-live/16_LOT2_PUBLIC_PRODUCT_RGPD_PAYMENT_DECISIONS.md
+++ b/docs/go-live/16_LOT2_PUBLIC_PRODUCT_RGPD_PAYMENT_DECISIONS.md
@@ -1,0 +1,58 @@
+# Lot 2 — Décisions publiques / RGPD / paiement
+
+## Verdict
+
+ACCEPTÉ AVEC RÉSERVES.
+
+## Synthèse
+
+Lot 2 arbitre les 6 P1 restants comme décisions produit/RGPD/paiement/runtime. `P0=0` doit être maintenu. Les P1 ne sont pas masqués : ils restent visibles lorsque la surface publique ou le runtime réel impose une réserve.
+
+Décision majeure : `/api/bilan-gratuit` passe en `lead_only`. Le formulaire public ne crée plus de `User`, `ParentProfile`, `Student`, token d'activation ou email d'activation. Il crée uniquement un lead CRM minimal avec consentement explicite et réponse neutre.
+
+## Matrice API avant/après
+
+| Priorité | Après Lot 1-quinquies | Après Lot 2 vérifié |
+| --- | ---: | ---: |
+| P0 | 0 | 0 |
+| P1 | 6 | 6 |
+| P2 | 143 | 143 |
+| OK | 27 | 27 |
+| Total | 176 | 176 |
+
+Les 6 P1 restent visibles par décision : ils sont arbitrés et documentés, mais non reclassés artificiellement.
+
+## Décisions route par route
+
+| Route | Décision Lot 2 | Statut produit/RGPD | Statut sécurité |
+| --- | --- | --- | --- |
+| `/api/payments/clictopay/webhook` | ClicToPay reste désactivé | Carte bancaire non disponible | P1 maintenu tant que webhook incomplet |
+| `/api/assessments/submit` | Option A retenue : token signé court à implémenter avant bêta élargie | Public actuel toléré uniquement en parcours contrôlé | P1 maintenu |
+| `/api/bilan-gratuit` | `lead_only` implémenté | Ambiguïté compte supprimée | P1 statique possible, mais dette compte fermée |
+| `/api/lamis/teacher-report` | Public anonyme assumé | Pas de PII ni stockage | P1 statique maintenu par prudence |
+| `/api/stages/[stageSlug]/inscrire` | Public assumé avec consentement explicite API | Lead stage, pas compte | P1 maintenu tant que rate limit runtime non prouvé |
+| `/api/student/activate` | Public par token assumé | Cycle token hashé/expiré/invalidation testé | P1 maintenu par nature |
+
+## Décisions go-live
+
+- Bêta contrôlée : autorisable avec réserves, sans paiement carte, volume limité et supervision.
+- Bêta élargie : interdite tant que Redis/Upstash n'est pas prouvé et que `assessments/submit` n'a pas de token signé.
+- Go-live large : interdit tant que Redis/Upstash runtime n'est pas prouvé et que ClicToPay webhook reste incomplet.
+
+## Tests Lot 2
+
+- `__tests__/api/bilan-gratuit.product-rgpd.test.ts`
+- `__tests__/api/stages.inscrire.product-rgpd.test.ts`
+- `__tests__/api/payments.clictopay.webhook.disabled.test.ts`
+- `__tests__/ui/payment-methods.clictopay-disabled.test.tsx`
+- `__tests__/api/student.activate.lifecycle-security.test.ts`
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+
+Commandes finales Node 20 : typecheck OK, lint OK, test unitaire complet OK, build OK, audit API OK, matrice OK, audit site-map OK, no-hardcoded OK, docs-archive OK, bundle-weight OK, smoke Playwright public OK.
+
+## Réserves
+
+- Redis/Upstash non prouvé en staging/production.
+- ClicToPay webhook volontairement `501`.
+- `assessments/submit` doit passer derrière token signé court avant bêta élargie.
+- `P1=6` reste assumé tant que le runtime Redis/Upstash réel n'est pas prouvé et que ClicToPay webhook n'est pas complet.

--- a/docs/go-live/17_LOT3_RUNTIME_RGPD_ASSESSMENT_TOKEN.md
+++ b/docs/go-live/17_LOT3_RUNTIME_RGPD_ASSESSMENT_TOKEN.md
@@ -1,0 +1,62 @@
+# Lot 3 — Runtime RGPD assessment token
+
+## Verdict
+
+ACCEPTÉ AVEC RÉSERVES.
+
+## Synthèse
+
+Lot 3 maintient `P0=0`, met en place le token signé court pour `assessments/submit`, complète le cadrage RGPD du tunnel `bilan-gratuit` en `lead_only`, garde ClicToPay désactivé contractuellement, et classe le drift local `business_configs`.
+
+## Matrice API
+
+Après régénération : `P0=0`, `P1=6`, `P2=144`, `OK=27`, total `177`.
+
+La nouvelle route `/api/assessments/public-token` est staff-only et classée `P2`. Les 6 P1 publics/paiement restent visibles, dont `/api/assessments/submit`, car la surface publique manipule toujours des données pédagogiques mineur.
+
+## Redis/Upstash
+
+Non prouvé en staging/production. Le healthcheck production répond `401` sans secret. Le mode local observé est `memory`, donc go-live large interdit.
+
+## Assessment public token
+
+Implémenté par HMAC court, TTL 15 minutes, scope `assessment_submit`, `subject`, `grade`, source/campaign optionnelles. Aucune persistance de token brut.
+
+## Bilan gratuit RGPD
+
+`lead_only` confirmé. `studentBirthDate` est retiré du schéma public et refusé si envoyé. Aucun compte ni token d'activation n'est créé.
+
+## ClicToPay
+
+Désactivé. `init` et `webhook` restent sans succès ambigu. Activation future uniquement via intégration complète.
+
+## Business configs
+
+`business_configs` absent est classé comme `static_fallback` optionnel. Le healthcheck expose le statut.
+
+## Tests ciblés
+
+Pack Lot 3 ciblé : `14` suites passées, `99` tests passés.
+
+## Gates finales
+
+Commandes finales Lot 3 sous Node 20 : `typecheck`, `lint`, `test:unit -- --runInBand`, `build`, `audit-api-guards`, `generate-api-security-matrix`, `audit:site-map`, `check:no-hardcoded`, `check:docs-archive`, `check:bundle-weight` et smoke Playwright public ciblé OK.
+
+Résultats clés : tests unitaires `530` suites passées, `6489` tests passés ; Playwright public `24` tests passés.
+
+## Réserves
+
+- Redis/Upstash runtime non prouvé.
+- ClicToPay webhook incomplet et volontairement `501`.
+- Les 6 P1 publics/paiement restent bloquants pour go-live large ; `/api/assessments/submit` est durci mais reste P1 par surface publique mineurs.
+- Job réel de purge/anonymisation `ContactLead` à implémenter avant go-live large.
+
+## Décisions
+
+- Bêta contrôlée : possible avec réserves si environnement opérationnel surveillé et pas de carte bancaire.
+- Bêta élargie : interdite tant que Redis/Upstash n'est pas prouvé.
+- Go-live large : interdit.
+
+## Prochain lot recommandé
+
+Lot 4 — Paiement/facturation/entitlements et runbook runtime : finaliser ou désactiver durablement ClicToPay, prouver Redis/Upstash sur staging/production, et implémenter purge/anonymisation des leads.

--- a/docs/go-live/18_LOT4_RUNTIME_PAYMENT_RETENTION_TOKEN_BINDING.md
+++ b/docs/go-live/18_LOT4_RUNTIME_PAYMENT_RETENTION_TOKEN_BINDING.md
@@ -1,0 +1,79 @@
+# Lot 4 — Runtime, paiement, rétention, token binding
+
+## Verdict
+
+ACCEPTÉ AVEC RÉSERVES.
+
+## Synthèse
+
+Lot 4 ferme l'angle mort principal du Lot 3 : `/bilan-gratuit/assessment` ne génère plus un token assessment depuis de simples query params publics. Le token submit est désormais lié à un contexte lead via cookie HttpOnly signé, hash lead et email assessment pseudonyme.
+
+Le lot ajoute aussi un mécanisme opérationnel de purge/anonymisation ContactLead en dry-run par défaut, durcit la cohérence ClicToPay public/backend, et rend `business_configs` dégradé en production si le fallback statique n'est pas explicitement autorisé.
+
+## Matrice API
+
+Les P1 ne doivent pas baisser artificiellement. Les 6 P1 restent visibles tant que les surfaces publiques/paiement/runtime restent sensibles.
+
+Compteurs attendus après régénération : `P0=0`, `P1=6`, `P2=144`, `OK=27`, total `177`.
+
+## Assessment token binding
+
+- `/api/bilan-gratuit` pose un cookie HttpOnly `nexus_assessment_flow` après création/mise à jour du lead.
+- Le cookie contient un token signé court `assessment_flow`, sans email brut.
+- `/bilan-gratuit/assessment` lit uniquement ce cookie et refuse l'accès sans contexte signé.
+- Les query params `subject`, `grade`, `email` ne peuvent plus être rendus : toute URL avec query params est redirigée vers `/bilan-gratuit/assessment` avant rendu.
+- Le token submit `assessment_submit` contient `binding=lead` et `leadEmailHash`.
+- Le submit vérifie l'email assessment pseudonyme dérivé du hash lead.
+
+## Redis/Upstash
+
+Non prouvé en staging/production. Local observé : `memory`, gate `blocked`. Production sans secret : `/api/internal/health` répond `401`.
+
+Décision : bêta élargie et go-live large interdits tant qu'un healthcheck authentifié ne prouve pas `redis` ou `upstash` et un test 429 réel.
+
+## ContactLead
+
+Script ajouté : `scripts/maintenance/contact-leads-retention.ts`.
+
+Contrat :
+
+- `--dry-run` par défaut.
+- `--apply` explicite requis.
+- Anonymisation des leads non convertis au-delà de la rétention.
+- Support des demandes parentales via hash email.
+- Aucun email/téléphone en clair dans les résultats.
+
+## ClicToPay
+
+ClicToPay reste désactivé. Si `NEXT_PUBLIC_ENABLE_CLICTOPAY_PUBLIC=true` alors que le backend est toujours désactivé, `/api/payments/clictopay/init` échoue en `503 CLICTOPAY_PUBLIC_FLAG_INCONSISTENT`.
+
+## BusinessConfig
+
+`business_configs` absent :
+
+- local/test : `static_fallback_allowed`;
+- production : `static_fallback_unexpected`, `ok=false`, sauf `BUSINESS_CONFIG_STATIC_FALLBACK_ALLOWED=true`.
+
+Aucune migration automatique.
+
+## Tests ciblés
+
+- Token binding : OK.
+- ContactLead retention : OK.
+- BusinessConfig production gate : OK.
+- ClicToPay feature flag consistency : OK.
+- No-leak routes sensibles : OK.
+- E2E `/bilan-gratuit/assessment` : OK après rebuild final.
+
+## Réserves
+
+- Redis/Upstash non prouvé.
+- ClicToPay webhook reste `501`.
+- Application effective du script ContactLead `--apply` requiert validation humaine/runbook.
+- La route assessment est sécurisée par cookie de flux lead-bound, mais le P1 reste visible par nature publique/sensible.
+
+## Décisions go-live
+
+- Bêta contrôlée : possible avec réserves.
+- Bêta élargie : interdite tant que Redis/Upstash n'est pas prouvé.
+- Go-live large : interdit.

--- a/docs/go-live/19_LOT5_RUNTIME_EXPLOITATION_GO_NO_GO.md
+++ b/docs/go-live/19_LOT5_RUNTIME_EXPLOITATION_GO_NO_GO.md
@@ -1,0 +1,87 @@
+# Lot 5 — Runtime exploitation go/no-go
+
+## Verdict
+
+ACCEPTÉ AVEC RÉSERVES.
+
+## Synthèse
+
+Lot 5 transforme les durcissements locaux en décisions d'exploitation. Le lot ajoute une route interne non destructive `/api/internal/rate-limit-probe` pour tester un `429` sans frapper une route métier, confirme que Redis/Upstash n'est toujours pas prouvé, confirme la désactivation contractuelle ClicToPay, et crée le registre go/no-go des 6 P1.
+
+## Matrice API
+
+Après ajout de la probe interne et régénération intermédiaire :
+
+- `P0=0`
+- `P1=6`
+- `P2=144`
+- `OK=28`
+- Total `178`
+
+Les 6 P1 restent visibles. La baisse artificielle de P1 est explicitement évitée.
+
+## Redis/Upstash
+
+Healthcheck authentifié : non exécuté, `NEXUS_HEALTH_AUTH_ABSENT`.
+
+Production sans secret : `/api/internal/health` répond `401`.
+
+Local : `memory`, `goLiveLarge=blocked`.
+
+Décision : bêta élargie et go-live large interdits.
+
+## Test 429
+
+Route dédiée ajoutée : `/api/internal/rate-limit-probe`.
+
+Test local : OK, dépassement -> `429`.
+
+Test staging/production réel : non exécuté faute d'environnement/authentification/fenêtre dédiée. Procédure documentée.
+
+## ContactLead retention
+
+Dry-run réel local : échec non destructif faute de DB locale disponible (`postgres:5432`).
+
+Tests fixture : OK, dry-run par défaut, pas de PII, `--apply` explicite.
+
+## ClicToPay
+
+Décision finale Lot 5 :
+
+- `CLICTOPAY_STATUS = DISABLED`
+- `CARD_PAYMENT_PUBLIC = NO`
+- `MANUAL_PAYMENT_ONLY = YES`
+- `GO_LIVE_CARD_PAYMENT = NO`
+
+## BusinessConfig
+
+Décision confirmée par tests :
+
+- local/test fallback autorisé ;
+- production fallback inattendu = healthcheck dégradé ;
+- pas de migration automatique.
+
+## P1 go/no-go
+
+Registre créé dans `docs/go-live/_evidence/lot5-p1-go-no-go-register.md`.
+
+Résultat : bêta contrôlée possible avec réserves, bêta élargie interdite, go-live large interdit.
+
+## Gates finales
+
+Sous Node 20 :
+
+- typecheck : OK ;
+- lint : OK, warnings existants ;
+- tests unitaires complets : OK, `537` suites passées, `6507` tests passés ;
+- build : OK ;
+- audit API : OK, `178` routes ;
+- matrice API : OK, `P0=0`, `P1=6`, `P2=144`, `OK=28` ;
+- site-map : OK, `0` link findings ;
+- no-hardcoded : OK ;
+- docs archive : OK ;
+- bundle weight : OK ;
+- Playwright public : OK sur port isolé `3012`, `24` tests passés ;
+- Playwright assessment : OK sur port isolé `3012`, `1` test passé.
+
+Tentative Playwright initiale sur `3002` : échec environnement car port occupé par un autre projet local, puis relance isolée OK.

--- a/docs/go-live/20_LOT6_STAGING_RELEASE_CANDIDATE_GO_NO_GO.md
+++ b/docs/go-live/20_LOT6_STAGING_RELEASE_CANDIDATE_GO_NO_GO.md
@@ -1,0 +1,59 @@
+# Lot 6 — Staging, release candidate et go/no-go
+
+## Verdict
+
+ACCEPTÉ AVEC RÉSERVES.
+
+Lot 6 ne ferme pas les réserves runtime majeures. Il confirme que la base locale reste saine, que les preuves d'exploitation sont prêtes à être exécutées, mais que les conditions de bêta élargie et de go-live large ne sont pas réunies sans credential healthcheck, test 429 réel et dry-run ContactLead DB non production.
+
+## Synthèse
+
+- `P0=0` maintenu.
+- `P1=6` maintenus, non maquillés.
+- `P2=144`, `OK=28`, total `178` routes API au démarrage Lot 6.
+- Redis/Upstash staging/production : NON PROUVÉ.
+- Test 429 runtime staging/production : NON EXÉCUTÉ.
+- ContactLead dry-run DB non production : NON EXÉCUTÉ.
+- ClicToPay : `DISABLED`, paiement carte interdit.
+- BusinessConfig : gate production codée/testée, preuve runtime authentifiée non obtenue.
+- Worktree release candidate : audité et classé, aucun diff `.env`.
+- Gates finales Node 20 : OK.
+- Playwright critique public + assessment : OK sur port isolé `3012`.
+
+## Décision
+
+| Périmètre | Décision |
+| --- | --- |
+| Bêta contrôlée | AUTORISÉE AVEC RÉSERVES, volume limité, monitoring humain et paiement manuel |
+| Bêta élargie | INTERDITE tant que Redis/Upstash + 429 runtime + dry-run ContactLead DB ne sont pas prouvés |
+| Go-live large | INTERDIT tant que les 6 P1 ne sont pas acceptés par décision humaine formelle et que les preuves runtime restent absentes |
+
+## Preuves Lot 6
+
+- `docs/go-live/_evidence/lot6-redis-upstash-authenticated-proof.md`
+- `docs/go-live/_evidence/lot6-rate-limit-429-runtime-proof.md`
+- `docs/go-live/_evidence/lot6-contact-lead-retention-db-dry-run.md`
+- `docs/go-live/_evidence/lot6-release-candidate-worktree-audit.md`
+- `docs/go-live/_evidence/lot6-final-go-no-go-register.md`
+- `docs/go-live/_evidence/lot6-staging-release-candidate-command-log.md`
+
+## Gates finales
+
+| Gate | Résultat |
+| --- | --- |
+| Typecheck | OK |
+| Lint | OK, warnings sous seuil |
+| Tests unitaires | OK, `537` suites passées, `6507` tests passés |
+| Build | OK |
+| API guard inventory | OK, `178` routes |
+| Matrice API | OK, `P0=0`, `P1=6`, `P2=144`, `OK=28` |
+| Site map | OK, `292` routes, `0` link finding |
+| Hardcoded pricing | OK |
+| Docs archive | OK |
+| Bundle weight | OK |
+| Playwright public | OK, `24 passed` |
+| Playwright assessment token | OK, `1 passed` |
+
+## Prochain lot recommandé
+
+Lot 7 doit être humainement assisté : fournir un credential healthcheck temporaire, autoriser une fenêtre de test 429 staging, fournir une DB non production pour dry-run ContactLead, puis refaire la décision bêta élargie. Aucun durcissement fonctionnel supplémentaire ne doit remplacer ces preuves.

--- a/docs/go-live/21_LOT7_RELEASE_CANDIDATE_SECURITY_AUDIT.md
+++ b/docs/go-live/21_LOT7_RELEASE_CANDIDATE_SECURITY_AUDIT.md
@@ -1,0 +1,59 @@
+# Lot 7 — Release candidate audit, scripts et decision
+
+## Verdict
+
+`ACCEPTÉ AVEC RÉSERVES`
+
+Le Lot 7 accepte les scripts d'audit comme base de triage statique et prepare la release candidate, mais ne leve pas les blocages runtime. Redis/Upstash, test 429 reel et dry-run DB ContactLead restent non prouves.
+
+## Synthese
+
+- Matrice API courante : `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178`.
+- Les 6 P1 restent visibles et ne sont pas maquilles.
+- Audit scripts : `SECURITY_AUDIT_SCRIPTS_ACCEPTED`.
+- Worktree : trop charge pour commit direct, manifeste et plan de commit requis.
+- Runtime assiste : credentials absents, preuves non executees.
+- ClicToPay : `DISABLED`, paiement carte interdit.
+
+## Decisions release
+
+| Decision | Statut | Raison |
+|---|---|---|
+| Bêta controlee | Autorisee avec reserves | Gates locales vertes attendues, P1 acceptables uniquement en perimetre controle |
+| Bêta elargie | Interdite | Redis/Upstash et 429 runtime non prouves |
+| Go-live large | Interdit | 6 P1 ouverts, runtime non prouve, dry-run DB ContactLead non prouve |
+
+## Artefacts Lot 7
+
+- `docs/go-live/_evidence/lot7-release-candidate-audit-command-log.md`
+- `docs/go-live/_evidence/lot7-security-scripts-audit.md`
+- `docs/go-live/_evidence/lot7-release-candidate-file-manifest.md`
+- `docs/go-live/_evidence/lot7-release-candidate-commit-plan.md`
+- `docs/go-live/_evidence/lot7-runtime-human-assisted-proof.md`
+- `docs/go-live/_evidence/lot7-final-decision-register.md`
+
+## Gates finales
+
+Toutes les gates finales Lot 7 ont été exécutées sous Node 20.20.0 :
+
+| Gate | Statut | Résultat |
+|---|---|---|
+| Typecheck | OK | `tsc --noEmit` |
+| Lint | OK | warnings sous seuil |
+| Unit tests | OK | `538` suites passées, `6510` tests passés |
+| Build | OK | build Next + assets standalone |
+| Audit API | OK | `178` routes |
+| Matrice API | OK | `P0=0`, `P1=6`, `P2=144`, `OK=28` |
+| Site map | OK | `292` routes, `413` edges, `0` link finding |
+| No hardcoded | OK | `0` hardcoded |
+| Docs archive | OK | aucun audit historique mal placé |
+| Bundle weight | OK | baseline + `5 kB` respectée |
+| Playwright public | OK | `24 passed` |
+| Playwright assessment | OK | `1 passed` |
+
+## Limites finales
+
+- Redis/Upstash : non prouvé.
+- `429` runtime réel : non prouvé.
+- ContactLead dry-run DB : non prouvé.
+- Worktree final : `276` entrées, release candidate à revoir avant commit.

--- a/docs/go-live/22_LOT8_RELEASE_CANDIDATE_CLEANUP.md
+++ b/docs/go-live/22_LOT8_RELEASE_CANDIDATE_CLEANUP.md
@@ -1,0 +1,51 @@
+# Lot 8 — Release candidate cleanup
+
+## Verdict
+
+`ACCEPTÉ AVEC RÉSERVES`
+
+## Synthèse
+
+Lot 8 ne modifie pas de fonctionnalité produit. Il corrige la préparation release candidate : manifeste ligne par ligne, plan de commits exploitable, regression scripts renforcée, preuves runtime retentées sans secret et registres de décision.
+
+## Manifeste et plan
+
+- Manifeste propre : `283` entrées.
+- Include RC : `281`.
+- Exclude : `1` (`rapport_audit_2_07_2026.md`).
+- Needs human review : `1` (`docs/audits/audit-nexus-reussite.md`).
+- Tous les chemins `__tests__/**` sont classés `Tests unitaires`.
+- Plan de commits : `9` commits proposés, aucun commit exécuté.
+
+## Décisions
+
+- `P0=0` maintenu.
+- `P1=6` maintenus et visibles.
+- ClicToPay reste `DISABLED`.
+- Bêta contrôlée possible avec réserves.
+- Bêta élargie bloquée.
+- Go-live large bloqué.
+
+## Gates finales
+
+| Gate | Statut | Résultat |
+| --- | --- | --- |
+| `npm run typecheck` | OK | TypeScript sans erreur bloquante |
+| `npm run lint` | OK | Warnings existants dans le seuil configuré |
+| `npm run test:unit -- --runInBand` | OK | `538` suites passées sur `539`, `1` skipped ; `6516` tests passés sur `6520`, `4` skipped |
+| `npm run build` | OK | Build Next.js complet, `142` pages statiques générées, assets standalone copiés |
+| `node scripts/security/audit-api-guards.mjs` | OK | `178` routes écrites dans `docs/security/API_GUARD_INVENTORY.md` |
+| `node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=6`, `P2=144`, `OK=28` |
+| `npm run audit:site-map` | OK | `292` routes, `413` edges, `0` link finding, `13` orphan entries |
+| `npm run check:no-hardcoded` | OK | `0` hardcoded values outside canonical sources |
+| `npm run check:docs-archive` | OK | Aucun audit/report historique à la racine `docs/` |
+| `npm run check:bundle-weight` | OK | Toutes les routes dans baseline + `5 kB` |
+| Playwright public | OK | `24` tests passés |
+| Playwright assessment token | OK | `1` test passé |
+
+## Réserves maintenues
+
+- Redis/Upstash non prouvé : `NEXUS_HEALTH_AUTH_ABSENT`.
+- Test `429` runtime non exécuté : `RL_PROBE_NOT_ALLOWED`.
+- Dry-run DB ContactLead non exécuté : `DATABASE_URL_ABSENT`, `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED`.
+- Les `6` P1 publics/paiement restent visibles et non requalifiés.

--- a/docs/go-live/23_LOT9_RC_MANIFEST_VALIDATION.md
+++ b/docs/go-live/23_LOT9_RC_MANIFEST_VALIDATION.md
@@ -1,0 +1,92 @@
+# Lot 9 — RC manifest validation
+
+## Verdict
+
+`ACCEPTÉ AVEC RÉSERVES`
+
+## Synthèse
+
+Lot 9 ne modifie pas le produit. Il ajoute une validation mécanique du manifeste RC Lot 8 et du plan de commits Lot 8, puis prépare une checklist de revue humaine avant commit.
+
+## Matrice API
+
+- `P0=0`
+- `P1=6`
+- `P2=144`
+- `OK=28`
+- Total : `178` routes
+
+Les 6 P1 restent visibles :
+
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+## Cohérence manifeste / plan de commits
+
+Test ajouté :
+
+```bash
+__tests__/scripts/release-candidate-manifest-consistency.test.ts
+```
+
+Résultat ciblé :
+
+```bash
+npm run test:unit -- --runInBand __tests__/scripts/security-audit-scripts-regression.test.ts __tests__/scripts/release-candidate-manifest-consistency.test.ts
+```
+
+Résultat : `2` suites passées, `14` tests passés.
+
+Points validés :
+
+- chaque fichier `Include RC` est couvert exactement une fois par un commit proposé ;
+- aucun fichier `Exclude` n'est inclus dans un commit ;
+- aucun fichier `Needs human review` n'est inclus dans un commit ;
+- les classifications `__tests__`, `e2e`, `scripts/security`, `scripts/go-live`, `scripts/maintenance` sont verrouillées ;
+- `rapport_audit_2_07_2026.md` reste exclu ;
+- aucun `.env*`, `.next`, `node_modules`, `test-results` ou `playwright-report` n'est inclus ;
+- les 6 P1 restent visibles.
+
+## Runtime
+
+Les preuves runtime restent non exécutées :
+
+- `NEXUS_HEALTH_AUTH_ABSENT`
+- `RL_PROBE_NOT_ALLOWED`
+- `DATABASE_URL_ABSENT`
+- `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED`
+
+## Décision
+
+- Release candidate : `RC_READY_FOR_HUMAN_REVIEW`
+- Bêta contrôlée : `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`
+- Bêta élargie : `BETA_ELARGIE_BLOCKED`
+- Go-live large : `GO_LIVE_LARGE_BLOCKED`
+
+## Gates finales
+
+| Gate | Statut | Résultat |
+| --- | --- | --- |
+| `npm run typecheck` | OK | `tsc --noEmit` sans erreur |
+| `npm run lint` | OK | Commande terminée avec code `0`; warnings existants dans le seuil configuré |
+| `npm run test:unit -- --runInBand` | OK | `539` suites passées sur `540`, `1` skipped ; `6521` tests passés sur `6525`, `4` skipped |
+| `npm run build` | OK | Build Next.js terminé ; `142` pages statiques générées ; assets standalone copiés |
+| `node scripts/security/audit-api-guards.mjs` | OK | `178` routes écrites dans `docs/security/API_GUARD_INVENTORY.md` |
+| `node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=6`, `P2=144`, `OK=28` |
+| `npm run audit:site-map` | OK | `292` routes, `413` edges, `0` link finding, `13` orphan entries |
+| `npm run check:no-hardcoded` | OK | `0` hardcoded values outside canonical sources |
+| `npm run check:docs-archive` | OK | Aucun audit/report historique à la racine `docs/` |
+| `npm run check:bundle-weight` | OK | Toutes les routes dans baseline + `5 kB` |
+| Playwright public | OK | `24` tests passés |
+| Playwright assessment token | OK | `1` test passé |
+
+## Réserves
+
+- Redis/Upstash non prouvé en staging/production.
+- Test `429` runtime non exécuté.
+- Dry-run DB ContactLead non exécuté.
+- Les 6 P1 restent ouverts et doivent faire l'objet d'une décision humaine avant toute ouverture plus large.

--- a/docs/go-live/24_LOT10_HUMAN_COMMIT_DRY_RUN.md
+++ b/docs/go-live/24_LOT10_HUMAN_COMMIT_DRY_RUN.md
@@ -1,0 +1,34 @@
+# Lot 10 — Human commit dry-run
+
+## Verdict
+
+`ACCEPTÉ AVEC RÉSERVES`
+
+## Synthèse
+
+Lot 10 prépare l'exécution humaine des commits sans effectuer de staging réel. Les 9 blocs de commit Lot 8 ont été transformés en commandes `git add --dry-run -- ...`, exécutées en simulation et validées mécaniquement par un test dédié.
+
+## Résultats
+
+- Commits proposés : `9`.
+- Fichiers `Include RC` couverts : `281`.
+- Fichiers non couverts : `0`.
+- Fichiers couverts plusieurs fois : `0`.
+- Fichiers `Exclude` dans le plan : `0`.
+- Fichiers `Needs human review` dans le plan : `0`.
+- Staging avant/après : `VIDE`.
+
+## Décisions
+
+- `READY_FOR_HUMAN_COMMIT`
+- `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`
+- `BETA_ELARGIE_BLOCKED`
+- `GO_LIVE_LARGE_BLOCKED`
+
+## Réserves
+
+- `docs/audits/audit-nexus-reussite.md` reste en décision humaine et n'est pas inclus.
+- Redis/Upstash non prouvé.
+- Test 429 runtime non exécuté.
+- ContactLead dry-run DB non exécuté.
+- 6 P1 restent visibles.

--- a/docs/go-live/25_LOT11_HUMAN_COMMIT_RUNBOOK.md
+++ b/docs/go-live/25_LOT11_HUMAN_COMMIT_RUNBOOK.md
@@ -1,0 +1,48 @@
+# Lot 11 — Human commit runbook
+
+## Verdict
+
+`ACCEPTÉ AVEC RÉSERVES`
+
+## Synthèse
+
+Lot 11 transforme le plan dry-run Lot 10 en runbook humain directement exploitable, sans exécuter de staging réel, commit, push ou PR.
+
+## Résultats
+
+- Commits humains proposés : `9`.
+- Fichiers `Include RC` couverts : `281`.
+- Fichiers non couverts : `0`.
+- Fichiers couverts plusieurs fois : `0`.
+- Fichiers `Exclude` dans les commits standards : `0`.
+- Fichiers `Needs human review` dans les commits standards : `0`.
+- Staging Git observé : `VIDE`.
+
+## Artefacts
+
+- Runbook humain : `docs/go-live/_evidence/lot11-human-commit-runbook.md`.
+- Preuve mécanique : `docs/go-live/_evidence/lot11-human-commit-runbook-proof.md`.
+- Test : `__tests__/scripts/release-candidate-human-commit-runbook.test.ts`.
+
+## Décisions
+
+- `READY_FOR_HUMAN_EXECUTION`.
+- `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`.
+- `BETA_ELARGIE_BLOCKED`.
+- `GO_LIVE_LARGE_BLOCKED`.
+
+## Gates ciblées
+
+- `npm run typecheck` : OK.
+- `npm run lint` : OK avec warnings existants sous le seuil configuré.
+- Tests scripts Lot 11 : OK, `4` suites passées, `24` tests passés.
+- `npm run check:docs-archive` : OK.
+- Staging Git final : vide.
+
+## Réserves
+
+- Redis/Upstash non prouvé.
+- 429 runtime non exécuté.
+- ContactLead dry-run DB non exécuté.
+- 6 P1 restent visibles.
+- `docs/audits/audit-nexus-reussite.md` reste en décision humaine.

--- a/docs/go-live/26_LOT12_AUDIT_NEXUS_DECISION.md
+++ b/docs/go-live/26_LOT12_AUDIT_NEXUS_DECISION.md
@@ -1,0 +1,69 @@
+# Lot 12 — Décision audit Nexus
+
+## Verdict
+
+ACCEPTÉ AVEC RÉSERVES.
+
+## Synthèse
+
+Lot 12 arbitre le fichier `docs/audits/audit-nexus-reussite.md` avant exécution humaine du runbook de commits.
+
+Décision : `EXCLUDE_FROM_STANDARD_COMMITS`.
+
+Le fichier est présent dans le working tree comme fichier non suivi. Il n'est pas inclus dans les commits standards et ne doit pas être considéré comme audit courant de la RC. Il contient des éléments business utiles, mais mentionne `173 routes API` et une sécurité des routes "sans trou", alors que la RC actuelle indique `178` routes et `6` P1 ouverts.
+
+## Matrice actuelle
+
+| Priorité | Nombre |
+|---|---:|
+| P0 | 0 |
+| P1 | 6 |
+| P2 | 144 |
+| OK | 28 |
+| Total | 178 |
+
+Les 6 P1 restent visibles :
+
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+## Décision audit Nexus
+
+`docs/audits/audit-nexus-reussite.md` reste hors commits standards.
+
+Options acceptables après décision humaine explicite :
+
+- l'exclure définitivement de la RC ;
+- l'inclure comme audit historique avec en-tête explicite `HISTORICAL / STALE COUNTS` ;
+- le réécrire avant inclusion pour aligner `178` routes, `6` P1, Redis/Upstash non prouvé, 429 runtime non exécuté et ClicToPay disabled.
+
+## Verrouillage runbook
+
+Le runbook Lot 11 reste exploitable et ne doit pas être modifié pour inclure cet audit dans les commits standards. La décision humaine séparée est documentée dans :
+
+- `docs/go-live/_evidence/lot12-audit-nexus-reussite-review.md`
+- `docs/go-live/_evidence/lot12-human-review-decision-files.md`
+- `docs/go-live/_evidence/lot12-runbook-lock-proof.md`
+
+Gate ciblée Lot 12 : `__tests__/scripts/release-candidate-human-commit-runbook.test.ts` passée, 1 suite / 5 tests.
+
+## Décisions
+
+| Domaine | Décision |
+|---|---|
+| Human execution | READY_FOR_HUMAN_EXECUTION |
+| Bêta contrôlée | BETA_CONTROLEE_ALLOWED_WITH_RESERVES |
+| Bêta élargie | BETA_ELARGIE_BLOCKED |
+| Go-live large | GO_LIVE_LARGE_BLOCKED |
+
+## Réserves
+
+- Redis/Upstash staging/production non prouvé.
+- Test 429 runtime réel non exécuté.
+- ContactLead dry-run DB non production non exécuté.
+- ClicToPay reste disabled.
+- Les 6 P1 publics/paiement restent ouverts et visibles.

--- a/docs/go-live/27_LOT13_FINAL_PRECOMMIT_CHECK.md
+++ b/docs/go-live/27_LOT13_FINAL_PRECOMMIT_CHECK.md
@@ -1,0 +1,74 @@
+# Lot 13 — Final precommit check
+
+## Verdict
+
+ACCEPTÉ AVEC RÉSERVES.
+
+## Synthèse
+
+Date d'exécution : 2026-07-06.
+
+Lot 13 pose le dernier verrou documentaire avant exécution humaine des commits du runbook Lot 11.
+
+Aucun `git add` réel, aucun commit, aucun push, aucune PR, aucune migration et aucune modification métier n'ont été exécutés.
+
+## Matrice actuelle
+
+| Priorité | Nombre |
+|---|---:|
+| P0 | 0 |
+| P1 | 6 |
+| P2 | 144 |
+| OK | 28 |
+| Total | 178 |
+
+Les 6 P1 restent visibles :
+
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+## Runbook humain
+
+Le runbook Lot 11 reste valide pour exécution humaine :
+
+- 9 commits humains.
+- 281 fichiers `Include RC` couverts exactement une fois.
+- Aucun fichier `Exclude` dans les commits standards.
+- Aucun fichier `Needs human review` dans les commits standards.
+- Aucun `.env*`.
+- Aucun `rapport_audit_2_07_2026.md`.
+- Aucun `git push`.
+- Aucune création de PR.
+
+## Audit Nexus
+
+`docs/audits/audit-nexus-reussite.md` reste `PRESENT_UNTRACKED_IN_WORKTREE`.
+
+Décision maintenue : `EXCLUDE_FROM_STANDARD_COMMITS`.
+
+## Runtime
+
+Les preuves runtime restent non levées :
+
+- Redis/Upstash : `NOT_PROVEN`.
+- 429 runtime : `NOT_PROVEN`.
+- ContactLead DB dry-run : `NOT_PROVEN`.
+
+## Décisions
+
+| Domaine | Décision |
+|---|---|
+| Human execution | READY_TO_EXECUTE_MANUALLY |
+| Bêta contrôlée | BETA_CONTROLEE_ALLOWED_WITH_RESERVES |
+| Bêta élargie | BETA_ELARGIE_BLOCKED |
+| Go-live large | GO_LIVE_LARGE_BLOCKED |
+
+## Réserves
+
+- L'exécution humaine doit suivre strictement `docs/go-live/_evidence/lot11-human-commit-runbook.md`.
+- `docs/audits/audit-nexus-reussite.md` ne doit pas être ajouté sans décision humaine explicite.
+- Redis/Upstash, 429 runtime et dry-run DB ContactLead restent bloquants pour bêta élargie/go-live large.

--- a/docs/go-live/28_LOT14_LOCAL_COMMITS_EXECUTION.md
+++ b/docs/go-live/28_LOT14_LOCAL_COMMITS_EXECUTION.md
@@ -1,0 +1,91 @@
+# Lot 14 — Exécution des commits locaux
+
+## Verdict
+
+ACCEPTÉ AVEC RÉSERVES.
+
+## Synthèse
+
+Date d'exécution : 2026-07-06.
+
+Les 9 commits locaux du runbook Lot 11 ont été exécutés dans l'ordre demandé, sans push, sans PR, sans déploiement, sans migration et sans modification `.env`.
+
+## Commits du runbook
+
+| # | Commit | Hash |
+|---:|---|---|
+| 1 | `chore(go-live): update security inventory and matrices` | `48d64a4fd` |
+| 2 | `fix(api-security): close admin and role guard gaps` | `eb0d6630f` |
+| 3 | `fix(public-funnel): lead-only bilan and assessment token binding` | `798f712ae` |
+| 4 | `fix(runtime): rate-limit probe and business-config gate` | `b03d0c37b` |
+| 5 | `fix(payments): keep clictopay disabled and fail closed` | `43be9787b` |
+| 6 | `chore(maintenance): add contact-lead retention dry-run` | `b7d94cf7a` |
+| 7 | `test(security): add no-leak, idor, token and audit regressions` | `eec8430ed` |
+| 8 | `test(e2e): protect public assessment route` | `5b7fe4def` |
+| 9 | `docs(go-live): add evidence and go-no-go registers` | `e92f9f546` |
+
+## Matrice API
+
+| Priorité | Nombre |
+|---|---:|
+| P0 | 0 |
+| P1 | 6 |
+| P2 | 144 |
+| OK | 28 |
+| Total | 178 |
+
+Les 6 P1 restent visibles et non requalifiés :
+
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+## Gates finales
+
+Toutes les gates demandées après les 9 commits sont passées sous Node 20 :
+
+- `npm run typecheck`
+- `npm run lint`
+- `npm run test:unit -- --runInBand`
+- `npm run build`
+- `node scripts/security/audit-api-guards.mjs`
+- `node scripts/go-live/generate-api-security-matrix.mjs`
+- `npm run audit:site-map`
+- `npm run check:no-hardcoded`
+- `npm run check:docs-archive`
+- `npm run check:bundle-weight`
+- Playwright public homepage/offres/bilan : 24 tests passés.
+- Playwright assessment token : 1 test passé.
+
+## Exclusions confirmées
+
+Les fichiers suivants n'ont pas été staged dans les commits standards :
+
+- `rapport_audit_2_07_2026.md`
+- `docs/audits/audit-nexus-reussite.md`
+- `.env*`
+- `.next/**`
+- `node_modules/**`
+- `test-results/**`
+- `playwright-report/**`
+
+## Décisions
+
+| Domaine | Décision |
+|---|---|
+| Local commits | LOCAL_COMMITS_EXECUTED |
+| Push review | READY_FOR_PUSH_REVIEW |
+| Bêta contrôlée | BETA_CONTROLEE_ALLOWED_WITH_RESERVES |
+| Bêta élargie | BETA_ELARGIE_BLOCKED |
+| Go-live large | GO_LIVE_LARGE_BLOCKED |
+
+## Réserves
+
+- Redis/Upstash staging/production reste `NOT_PROVEN`.
+- Le test 429 runtime réel reste `NOT_PROVEN`.
+- Le dry-run DB ContactLead hors production reste `NOT_PROVEN`.
+- ClicToPay reste désactivé.
+- Aucun push, aucune PR et aucun déploiement n'ont été exécutés.

--- a/docs/go-live/29_LOT15_UNTRACKED_FILES_REGULARIZATION.md
+++ b/docs/go-live/29_LOT15_UNTRACKED_FILES_REGULARIZATION.md
@@ -1,0 +1,81 @@
+# Lot 15 — Régularisation des fichiers non suivis
+
+## Verdict
+
+ACCEPTÉ AVEC RÉSERVES.
+
+## Synthèse
+
+Date d'exécution : 2026-07-06.
+
+Lot 15 régularise les 39 fichiers non suivis restés après Lot 14.
+
+Décision d'inventaire :
+
+- 37 fichiers `INCLUDE` commités.
+- 2 fichiers `EXCLUDE` maintenus hors staging.
+- 0 fichier `REVIEW`.
+
+## Fichiers inclus
+
+Les trois tests release manquants ont été commités :
+
+- `__tests__/scripts/release-candidate-manifest-consistency.test.ts`
+- `__tests__/scripts/release-candidate-git-add-dry-run-plan.test.ts`
+- `__tests__/scripts/release-candidate-human-commit-runbook.test.ts`
+
+Les preuves release Lots 9 à 13 ont été commités :
+
+- `docs/go-live/23_LOT9_RC_MANIFEST_VALIDATION.md`
+- `docs/go-live/24_LOT10_HUMAN_COMMIT_DRY_RUN.md`
+- `docs/go-live/25_LOT11_HUMAN_COMMIT_RUNBOOK.md`
+- `docs/go-live/26_LOT12_AUDIT_NEXUS_DECISION.md`
+- `docs/go-live/27_LOT13_FINAL_PRECOMMIT_CHECK.md`
+- `docs/go-live/_evidence/lot9-*`
+- `docs/go-live/_evidence/lot10-*`
+- `docs/go-live/_evidence/lot11-*`
+- `docs/go-live/_evidence/lot12-*`
+- `docs/go-live/_evidence/lot13-*`
+
+## Fichiers exclus
+
+Les fichiers suivants restent hors RC :
+
+- `docs/audits/audit-nexus-reussite.md`
+- `rapport_audit_2_07_2026.md`
+
+## Commits Lot 15
+
+| Message | Hash |
+|---|---|
+| `test(go-live): include release validation tests` | `c774ed34f` |
+| `docs(go-live): include remaining release evidence` | `edcb0faa2` |
+
+## Matrice API
+
+Les 6 P1 restent visibles et non requalifiés :
+
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+## Décisions
+
+| Domaine | Décision |
+|---|---|
+| Local commits | LOCAL_COMMITS_COMPLETE |
+| Push review | READY_FOR_PUSH_REVIEW |
+| Bêta contrôlée | BETA_CONTROLEE_ALLOWED_WITH_RESERVES |
+| Bêta élargie | BETA_ELARGIE_BLOCKED |
+| Go-live large | GO_LIVE_LARGE_BLOCKED |
+
+## Réserves
+
+- Redis/Upstash staging/production reste `NOT_PROVEN`.
+- Le test 429 runtime réel reste `NOT_PROVEN`.
+- Le dry-run DB ContactLead hors production reste `NOT_PROVEN`.
+- ClicToPay reste désactivé.
+- Aucun push, aucune PR, aucun déploiement, aucune migration.

--- a/docs/go-live/29_LOT15_UNTRACKED_FILES_REGULARIZATION.md
+++ b/docs/go-live/29_LOT15_UNTRACKED_FILES_REGULARIZATION.md
@@ -50,6 +50,22 @@ Les fichiers suivants restent hors RC :
 |---|---|
 | `test(go-live): include release validation tests` | `c774ed34f` |
 | `docs(go-live): include remaining release evidence` | `edcb0faa2` |
+| `docs(go-live): record untracked file regularization` | `a775c4e60` |
+
+## Gates finales
+
+Les gates Lot 15 ont été exécutées sous Node 20 :
+
+- `npm run typecheck` : PASSED.
+- `npm run lint` : PASSED.
+- `npm run test:unit -- --runInBand` : PASSED, 541 suites passées, 1 skipped ; 6531 tests passés, 4 skipped.
+- `npm run build` : PASSED.
+- `node scripts/security/audit-api-guards.mjs` : PASSED, 178 routes.
+- `node scripts/go-live/generate-api-security-matrix.mjs` : PASSED, `P0=0`, `P1=6`, `P2=144`, `OK=28`.
+- `npm run audit:site-map` : PASSED.
+- `npm run check:no-hardcoded` : PASSED.
+- `npm run check:docs-archive` : PASSED.
+- `npm run check:bundle-weight` : PASSED.
 
 ## Matrice API
 

--- a/docs/go-live/30_LOT16_FINAL_DIFF_AND_PUSH_REVIEW.md
+++ b/docs/go-live/30_LOT16_FINAL_DIFF_AND_PUSH_REVIEW.md
@@ -1,0 +1,65 @@
+# Lot 16 — Revue finale du diff et push review
+
+## Date
+
+2026-07-06.
+
+## Objectif
+
+Effectuer la derniere revue locale avant push de la branche de travail, sans PR, sans deploiement et sans migration.
+
+## Contexte
+
+Les Lots 0 a 15 sont termines avec reserves. Lot 15 a regularise les fichiers non suivis utiles a la release candidate :
+
+- tests release utiles commites ;
+- preuves release utiles commitees ;
+- staging Git vide ;
+- seuls fichiers non suivis restants : `docs/audits/audit-nexus-reussite.md` et `rapport_audit_2_07_2026.md`.
+
+## Revue finale
+
+Base de comparaison locale : `main...HEAD`, avec merge-base `db8545a19`.
+
+Synthese pre-push :
+
+- Branche : `feat/lot4-accessors-runtime`.
+- HEAD avant documentation Lot 16 : `9cfdbb7a6`.
+- Diff local depuis `main` : `329 files changed, 21339 insertions(+), 1258 deletions(-)`.
+- Staging initial : vide.
+- Diff tracked initial : vide.
+- Fichiers non suivis : uniquement les deux exclusions Lot 15.
+- P1 visibles : `6`.
+
+## Gates pre-push
+
+Les gates minimales Lot 16 ont ete relancees sous Node 20 avant le push :
+
+- `npm run typecheck` : PASSED.
+- `npm run lint` : PASSED avec warnings existants sous seuil.
+- `npm run test:unit -- --runInBand __tests__/scripts/release-candidate-human-commit-runbook.test.ts` : PASSED, 1 suite, 5 tests.
+- `npm run check:docs-archive` : PASSED.
+
+## Exclusions maintenues
+
+Les fichiers suivants restent hors push review :
+
+- `docs/audits/audit-nexus-reussite.md`
+- `rapport_audit_2_07_2026.md`
+
+## Decisions
+
+- `READY_TO_PUSH_BRANCH`.
+- `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`.
+- `BETA_ELARGIE_BLOCKED`.
+- `GO_LIVE_LARGE_BLOCKED`.
+
+## Interdits respectes
+
+- Aucune lecture de secret.
+- Aucun `.env*` modifie.
+- Aucun push force.
+- Aucune PR.
+- Aucun deploiement.
+- Aucune migration.
+- Aucun push vers `main` ou `master`.

--- a/docs/go-live/31_LOT18_CI_E2E_BILAN_GRATUIT_FIX.md
+++ b/docs/go-live/31_LOT18_CI_E2E_BILAN_GRATUIT_FIX.md
@@ -1,0 +1,68 @@
+# Lot 18 — Correction CI E2E bilan gratuit
+
+## Date
+
+2026-07-07.
+
+## Contexte
+
+La PR GitHub `#58` est une draft sur la branche `feat/lot4-accessors-runtime`.
+
+Le check GitHub `E2E Tests` echouait sur le fichier CI `e2e/real/pages/04-bilan-gratuit.spec.ts`, test `Soumission complète — crée parent + élève en DB`.
+
+Le rapport Playwright montrait que l'API publique `/api/bilan-gratuit` retournait le contrat securise attendu :
+
+```json
+{
+  "success": true,
+  "message": "Votre demande a bien été enregistrée. Notre équipe vous recontactera pour la suite."
+}
+```
+
+Le test attendait encore `parentId` et `studentId`, ce qui contredit la decision RGPD/securite Lot 2-3 : une API publique ne doit pas exposer d'identifiants internes parent/eleve.
+
+## Correction
+
+Le test E2E a ete aligne sur le contrat public :
+
+- `success === true`.
+- `message` present.
+- absence de `parentId`.
+- absence de `studentId`.
+- absence de `token`.
+- absence de `assessmentToken`.
+- absence de `leadEmailHash`.
+- regression anti-leak via recherche globale sur le JSON.
+- verification de la redirection vers `/bilan-gratuit/confirmation`.
+- verification du H1 de confirmation.
+
+## Decision securite
+
+Ne pas modifier l'API publique pour reintroduire `parentId` ou `studentId`.
+
+La verification de persistance reste cote serveur/test integration. Le test unitaire `__tests__/api/bilan-gratuit.product-rgpd.test.ts` confirme :
+
+- creation CRM lead-only ;
+- aucune creation de compte parent/eleve inactive ;
+- cookie assessment HttpOnly ;
+- aucun token ou ID interne dans le JSON public.
+
+## Verifications locales
+
+- `npm run typecheck` : PASSED.
+- `npm run lint` : PASSED avec warnings existants sous seuil.
+- `npm run test:unit -- --runInBand __tests__/api/bilan-gratuit.product-rgpd.test.ts` : PASSED, 8 tests.
+- `PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium --reporter=line` : PASSED, 1 test.
+- `PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/04-bilan-gratuit.spec.ts --project=chromium --reporter=line` : FAILED, `No tests found`, car ce chemin n'existe pas dans le repo.
+- `NEXTAUTH_URL=http://127.0.0.1:3012 REUSE_EXISTING_SERVER=true npx playwright test --config=playwright.ci.config.ts e2e/real/pages/04-bilan-gratuit.spec.ts --project=chromium --reporter=line` : 6 passed, 1 failed localement car la DB E2E `127.0.0.1:5435` est absente. L'echec n'est plus l'assertion `parentId/studentId`.
+
+## Limite locale
+
+Aucune migration n'a ete lancee et aucune DB n'a ete creee. Le run local complet du test de soumission reste dependant d'une DB E2E disponible, comme en CI GitHub.
+
+## Decisions
+
+- `READY_FOR_PR_RECHECK`.
+- `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`.
+- `BETA_ELARGIE_BLOCKED`.
+- `GO_LIVE_LARGE_BLOCKED`.

--- a/docs/go-live/_evidence/entitlement-pricing-delta.md
+++ b/docs/go-live/_evidence/entitlement-pricing-delta.md
@@ -1,0 +1,57 @@
+# Delta pricing canonique vs entitlement registry
+
+Date locale : 2026-07-02 18:20 CET
+
+## Fichiers lus
+
+- `data/pricing.canonical.json`
+- `lib/entitlement/types.ts`
+- `lib/entitlement/engine.ts`
+- `lib/operational-catalog.ts`
+- `app/api/payments/validate/route.ts`
+
+## Produits pricing opérationnels
+
+| Produit pricing | Prix | Crédits annoncés | Source |
+| --- | ---: | ---: | --- |
+| `ACCES_PLATEFORME` | 150 TND/mois | 0 | `data/pricing.canonical.json` `operational_subscription_plans` |
+| `HYBRIDE` | 450 TND/mois | 4 | `data/pricing.canonical.json` `operational_subscription_plans` |
+| `IMMERSION` | 750 TND/mois | 8 | `data/pricing.canonical.json` `operational_subscription_plans` |
+
+## Produits entitlement
+
+| ProductCode entitlement | Label | Crédits accordés | Source |
+| --- | --- | ---: | --- |
+| `ABONNEMENT_ESSENTIEL` | Abonnement Essentiel | 4 | `lib/entitlement/types.ts` `PRODUCT_REGISTRY` |
+| `ABONNEMENT_HYBRIDE` | Abonnement Hybride | 8 | `lib/entitlement/types.ts` `PRODUCT_REGISTRY` |
+| `ABONNEMENT_IMMERSION` | Abonnement Immersion | 16 | `lib/entitlement/types.ts` `PRODUCT_REGISTRY` |
+
+## Écarts prouvés
+
+| Mapping paiement | Pricing | Entitlement | Écart |
+| --- | ---: | ---: | --- |
+| `ACCES_PLATEFORME` -> `ABONNEMENT_ESSENTIEL` | 0 crédit | 4 crédits | +4 crédits |
+| `HYBRIDE` -> `ABONNEMENT_HYBRIDE` | 4 crédits | 8 crédits | +4 crédits |
+| `IMMERSION` -> `ABONNEMENT_IMMERSION` | 8 crédits | 16 crédits | +8 crédits |
+
+## Risques
+
+- Sur-crédit potentiel lors de `activateEntitlements()` après validation paiement.
+- Double projection possible : `activateEntitlements()` incrémente les crédits sur `Student`, puis la logique legacy `Subscription` crée aussi une `CreditTransaction` mensuelle si `creditsPerMonth > 0`.
+- Le paiement validé peut créer une facture et des droits incohérents avec l'offre achetée.
+- Les tests actuels ne prouvent pas le contrat pricing -> invoice item -> entitlement -> credits.
+
+## Décision recommandée
+
+- Source cible : `data/pricing.canonical.json` pour les prix et crédits opérationnels.
+- `PRODUCT_REGISTRY` doit être aligné automatiquement ou généré depuis la source canonique, ou bien ne porter que les droits techniques sans quantité commerciale.
+- Ne pas corriger toute la chaîne dans Lot 0-bis ; traiter en Lot 4 avec tests de contrat et migration contrôlée.
+
+## Test à créer dans Lot 4
+
+Créer un test de contrat qui vérifie pour chaque plan opérationnel :
+
+1. le `productCode` résolu par `app/api/payments/validate/route.ts` ;
+2. le nombre de crédits accordés par `activateEntitlements()`;
+3. l'absence de double allocation entre `Entitlement`, `Student.credits` et `CreditTransaction`;
+4. l'idempotence sur validation concurrente ou retry.

--- a/docs/go-live/_evidence/hardcoded-pricing-triage.md
+++ b/docs/go-live/_evidence/hardcoded-pricing-triage.md
@@ -1,0 +1,41 @@
+# Triage montants TND hors pricing canonique
+
+Date locale : 2026-07-02 18:20 CET
+
+## Commandes
+
+| Statut | Objectif | Commande exacte | Résultat |
+| --- | --- | --- | --- |
+| PARTIEL | Rechercher montants et textes tarifaires | `rg -n "TND|DT|dès [0-9]|[0-9][0-9][0-9]\\s*TND|[0-9][0-9][0-9]\\s*DT|prix|tarif|montant" app components data lib content docs --glob '!docs/archive/**'` | Nombreuses occurrences ; plusieurs faux positifs docs, pédagogie, dashboards et sources canoniques. |
+| OK | Vérifier le guard officiel | `npm run check:no-hardcoded` | OK : 0 hardcoded values outside canonical sources. |
+
+## Classification principale
+
+| Fichier / zone | Classification | Preuve | Décision Lot 0-bis |
+| --- | --- | --- | --- |
+| `data/pricing.canonical.json` | CANONIQUE | Source de vérité déclarée ; contient `currency`, offres, crédits opérationnels, repères. | OK. |
+| `data/pricing-client-data.generated.json` | DÉRIVÉE DU PRICING | Fichier généré depuis le canonique pour le client. | OK si régénéré après tout changement pricing. |
+| `app/HomePageClient.tsx` | DÉRIVÉE DU PRICING | Utilise `getReperesTarifaires()` depuis `lib/pricing-client`. | OK. |
+| `app/offres/page.tsx` et `components/marketing/OfferDetailDialog.tsx` | DÉRIVÉE DU PRICING | Affichage via `fmtTND`, `getRules()`, `getAllOffers()` et données offre. | OK local. |
+| `components/marketing/LandingNiche.tsx` | DÉRIVÉE DU PRICING | Prix formatés via `fmtTND(offer.price)`. | OK local, vérifier source des offres landings en Lot 2. |
+| `data/Nexus_Reussite_Accueil.html` | ARCHIVE MORTE dans `data/` | Aucune importation runtime trouvée ; contient anciens repères `220`, `250`, `290`, `490`, `390`, `720`, stage `350 TND`. | Ne pas utiliser comme source ; garder P1 de nettoyage/archivage. |
+| `Nexus_Reussite_Accueil.html` racine | FICHIER ACTIVABLE / DETTE À CORRIGER | `next.config.mjs` l'inclut dans `outputFileTracingIncludes`; le fichier contient liens et anciens repères HTML. | P1 : retirer du tracing ou archiver proprement après vérification production/Nginx. |
+| `components/ui/specialized-packs.tsx` | FICHIER ACTIVABLE / DETTE À CORRIGER | Non importé par `rg`, mais exporte un composant avec `300 TND`, `1200 TND`, `450 TND`. | P1 Lot 2 : migrer vers pricing canonique ou archiver le composant. |
+| `app/dashboard/parent/abonnements/page.tsx` | DÉRIVÉE DU PRICING | Prix venant de `getOperationalSubscriptionPlans()`, `getAriaAddonCatalog()`, `getSpecialPackCatalog()`. | OK. |
+| `app/dashboard/assistante/subscriptions/page.tsx` | DÉRIVÉE DU PRICING / runtime DB | Affiche prix catalogue ou champs subscription existants. | À couvrir dans Lot 4/5. |
+| `app/dashboard/admin/facturation/page.tsx` | FICHIER ACTIVABLE | Montants saisis par admin et presets facture ; conversion millimes. | Hors pricing public ; audit facturation Lot 4. |
+| `docs/incidents/*`, `docs/audits/*` | ARCHIVE / DOCUMENTATION HISTORIQUE | Montants de tests ou rapports datés. | Faux positifs runtime, ne pas traiter comme source commerciale. |
+| `data/automatismes/*`, `content/stage-eam-stmg/*`, `components/EAMPrep/*` | FAUX POSITIF | Exercices pédagogiques sur prix en euros ou variables. | OK. |
+| `lib/email.ts` | DÉRIVÉE D'ARGUMENT | Affiche `${price} TND`; le montant est fourni par l'appelant. | Vérifier appelants en Lot 4/CRM. |
+
+## Limites du guard actuel
+
+- `scripts/check-no-hardcoded.sh` passe, mais sa recherche TND client repose sur une expression `grep` avec `\s`, peu robuste en basic regex.
+- Le script ne couvre pas la racine ni `data/`.
+- Le script ne détecte pas les composants exportés mais non importés si la regex ne matche pas selon le grep local.
+
+## Action recommandée
+
+- Lot 2 : corriger ou archiver `components/ui/specialized-packs.tsx`.
+- Lot 2/8 : vérifier si `Nexus_Reussite_Accueil.html` racine peut être servi en production ; retirer du tracing standalone si obsolète.
+- Lot 2 : renforcer `check:no-hardcoded` après classification des exceptions pour éviter de transformer une dette connue en build rouge non exploitable.

--- a/docs/go-live/_evidence/lot0-command-log.md
+++ b/docs/go-live/_evidence/lot0-command-log.md
@@ -1,0 +1,109 @@
+# Lot 0 command log
+
+## Date / contexte
+
+- Date locale : 2026-07-02 14:46:53 CET
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Statut initial Git : fichiers non suivis préexistants `docs/audits/audit-nexus-reussite.md`, `rapport_audit_2_07_2026.md`
+- Rapport d'audit racine utilisé : `rapport_audit_2_07_2026.md`
+- Audit secondaire lu : `docs/audits/audit-nexus-reussite.md`
+
+## Commandes exécutées
+
+| Statut | Objectif | Commande exacte | Résultat résumé |
+| --- | --- | --- | --- |
+| OK | Confirmer répertoire | `pwd` | `/home/alaeddine/Bureau/nexus-project_v0` |
+| OK | Branche courante | `git rev-parse --abbrev-ref HEAD` | `feat/lot4-accessors-runtime` |
+| OK | Commit court | `git rev-parse --short HEAD` | `db8545a19` |
+| OK | État Git initial | `git status --short` | 2 fichiers non suivis préexistants |
+| OK | Version Node | `node -v` | `v22.21.0` |
+| OK | Version npm | `npm -v` | `11.6.3` |
+| OK | TypeScript | `npm run typecheck` | `tsc --noEmit` OK |
+| OK | Lint | `npm run lint` | OK avec warnings ; `next lint` déprécié |
+| OK | Tests unitaires | `npm run test:unit -- --runInBand` | 504 suites passées, 1 skipped ; 6345 tests passés, 4 skipped |
+| OK | Build production local | `npm run build` | Next build OK, 143 pages générées, assets standalone copiés |
+| OK | Inventaire API guards | `node scripts/security/audit-api-guards.mjs` | A écrit `docs/security/API_GUARD_INVENTORY.md` avec 176 routes |
+| OK | Site map | `npm run audit:site-map` | 290 routes, 412 edges, 0 link finding, 13 public orphan entries |
+| OK | Hardcoded values | `npm run check:no-hardcoded` | 0 hardcoded values outside canonical sources |
+| OK | Archives docs | `npm run check:docs-archive` | OK, pas de fichiers audit/report historiques à la racine de `docs/` |
+| OK | Bundle public | `npm run check:bundle-weight` | Toutes les routes surveillées dans baseline + 5 kB |
+| ÉCHEC | Smoke public Playwright ciblé | `npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | 18 tests passés, 4 échoués |
+
+## Erreurs et limites observées
+
+- `npm run lint` passe mais remonte de nombreux warnings : `any`, variables inutilisées, hooks, props React dans tests.
+- `npm run build` passe mais indique que le lint est sauté ; preuve dans `next.config.mjs` avec `eslint.ignoreDuringBuilds`.
+- Les tests unitaires passent mais produisent beaucoup de logs console sur chemins d'erreur simulés DB/SMTP/API. Les logs complets ne sont pas recopiés pour éviter bruit et données sensibles.
+- Le smoke Playwright public ciblé échoue sur trois attentes de messages validation `/bilan-gratuit` (`Prénom requis`, `Email invalide`) et une attente homepage de nombre de liens WhatsApp (`2` attendus, `3` reçus).
+- L'inventaire API est statique : il détecte des indices de guards, pas une preuve d'absence de vulnérabilité.
+- La production réelle n'a pas été interrogée dans ce lot.
+- Aucun fichier `.env` n'a été lu ou modifié.
+- Aucune migration DB, `db:push`, `prisma migrate dev` ou commande destructive n'a été lancée.
+
+## Addendum Lot 0-bis — 2026-07-02 18:33 CET
+
+Contexte : le Lot 0-bis a requalifié l'échec Playwright initial, aligné les validations sur Node 20 et régénéré une matrice API exploitable.
+
+### Baseline environnement Lot 0-bis
+
+- Répertoire : `/home/alaeddine/Bureau/nexus-project_v0`
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Node local par défaut : `v22.21.0`
+- npm local par défaut : `11.6.3`
+- Runtime CI/Docker : Node 20 (`.github/workflows/ci.yml`, `Dockerfile.prod`)
+- Runtime de validation Lot 0-bis : `nvm use 20.20.0`, npm `10.8.2`
+
+### Commandes finales Lot 0-bis
+
+| Statut | Objectif | Commande exacte | Résultat résumé |
+| --- | --- | --- | --- |
+| OK | TypeScript sous runtime cible | `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run typecheck` | `tsc --noEmit` OK |
+| OK | Lint sous runtime cible | `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run lint` | Code 0 ; warnings existants sous `--max-warnings 300` |
+| OK | Tests unitaires sous runtime cible | `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand` | 504 suites passées, 1 skipped ; 6345 tests passés, 4 skipped |
+| OK | Build production sous runtime cible | `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run build` | Next build OK ; 143 pages statiques générées ; assets standalone copiés |
+| OK | Régénérer inventaire API guards | `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/security/audit-api-guards.mjs` | `docs/security/API_GUARD_INVENTORY.md` écrit avec 176 routes |
+| OK | Régénérer matrice API go-live | `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/go-live/generate-api-security-matrix.mjs` | 176 routes : 44 P0, 42 P1, 62 P2, 28 OK |
+| OK | Site-map | `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run audit:site-map` | 290 routes, 412 edges, 0 link finding, 13 public orphan entries |
+| OK | Hardcoded pricing officiel | `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:no-hardcoded` | 0 hardcoded values outside canonical sources selon script |
+| OK | Placement archives docs | `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:docs-archive` | OK, aucun audit/report historique à `docs/` racine |
+| OK | Poids bundle | `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:bundle-weight` | Toutes les routes surveillées dans baseline + 5 kB |
+| OK | Smoke public ciblé | `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | 24 passed |
+
+### Réserves Lot 0-bis
+
+- Le smoke Playwright final a loggé un warning Prisma `P2021` : table locale `public.business_configs` absente pendant le refresh passif de configuration. Le smoke public n'échoue pas, mais la baseline DB e2e doit être traitée avant Gate B.
+- `npm run audit:site-map` passe mais remonte 13 entrées publiques orphelines à qualifier.
+- `npm run check:no-hardcoded` passe, mais le triage manuel confirme des reliquats activables à traiter : HTML historique racine et `components/ui/specialized-packs.tsx`.
+- L'inventaire API et la matrice sont statiques : les 44 P0 restent ouverts pour le Lot 1.
+- Aucun fichier `.env` n'a été lu ou modifié ; aucune migration destructive n'a été lancée.
+
+## Fichiers modifiés par commandes
+
+- `docs/security/API_GUARD_INVENTORY.md` régénéré par `node scripts/security/audit-api-guards.mjs`.
+- `docs/architecture/SITE_MAP.md`, `docs/architecture/SITE_GRAPH.mmd`, `docs/architecture/SSOT_MAP.md` ont été générés par `npm run audit:site-map`; Git ne signale pas de delta suivi au moment de la vérification intermédiaire.
+
+## Fichiers créés Lot 0
+
+- `docs/go-live/00_EXECUTIVE_STATE.md`
+- `docs/go-live/01_ACTION_PLAN.md`
+- `docs/go-live/02_P0_P1_BACKLOG.md`
+- `docs/go-live/03_RELEASE_GATES.md`
+- `docs/go-live/04_TEST_MATRIX.md`
+- `docs/go-live/05_API_SECURITY_MATRIX.md`
+- `docs/go-live/api-security-matrix.full.md`
+- `docs/go-live/06_BUSINESS_LOGIC_DECISIONS.md`
+- `docs/go-live/07_ENV_INFRA_CHECKLIST.md`
+- `docs/go-live/08_MARKETING_CONTENT_CHECKLIST.md`
+- `docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md`
+- `docs/go-live/_evidence/lot0-command-log.md`
+
+## Limites de l'audit Lot 0
+
+- Pas de smoke production réel.
+- Pas de Playwright exécuté.
+- Pas de test de restauration backup.
+- Pas de vérification Redis/Upstash runtime.
+- Pas de vérification SMTP/Telegram/RAG/ClicToPay avec secrets réels.
+- Pas de correction fonctionnelle volontairement, sauf régénération documentaire demandée.

--- a/docs/go-live/_evidence/lot1-api-route-triage.md
+++ b/docs/go-live/_evidence/lot1-api-route-triage.md
@@ -1,0 +1,32 @@
+# Lot 1 — Triage routes API
+
+Date locale : 2026-07-02.
+
+## Synthèse avant/après
+
+| Source | P0 | P1 | P2 | OK | Total |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Lot 0-bis | 44 | 42 | 62 | 28 | 176 |
+| Lot 1 après régénération | 0 | 56 | 93 | 27 | 176 |
+
+## P0 fermés par correction de code
+
+- Documents : `/api/documents/[id]`, `/api/coach/students/[studentId]/documents`, `/api/student/documents/[id]/download`.
+- Factures PDF : `/api/invoices/[id]/pdf`, `/api/invoices/[id]/receipt/pdf`.
+- Activation élève : `/api/student/activate`.
+- Lamis teacher report : `/api/lamis/teacher-report`.
+
+## P0 requalifiés par preuve existante
+
+- Routes coach avec assignation : `assertCoachCanAccessStudent`, contrôle `sessionBooking.coachId`, contrôle stage coach.
+- Routes stage staff-only : `requireAnyRole(['ADMIN', 'ASSISTANTE'])`.
+- ClicToPay webhook : `501` tant que non configuré, signature HMAC si secret présent.
+- Documents publics fixes : PDF public statique, sans donnée mineur propriétaire.
+
+## P1 prioritaires restants
+
+La liste exploitable est dans `docs/go-live/api-security-matrix.full.md`, section `Top 20 à corriger en priorité (P1)`.
+
+## Limites
+
+La matrice reste une lecture statique. Les P1 ne sont pas déclarés go-live ready ; ils sont seulement sortis du niveau P0 après preuve de guard, requalification de domaine ou correction ciblée.

--- a/docs/go-live/_evidence/lot1-command-log.md
+++ b/docs/go-live/_evidence/lot1-command-log.md
@@ -1,0 +1,61 @@
+# Lot 1 — Journal de commandes
+
+Date locale initiale : 2026-07-02 21:45:22 CET.
+
+## État initial
+
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Node utilisé : `v20.20.0`
+- npm utilisé : `10.8.2`
+- État git initial : dépôt déjà modifié par Lot 0-bis et docs go-live non suivis.
+
+## Commandes baseline exécutées
+
+| Commande | Statut | Résultat résumé |
+| --- | --- | --- |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node -v` | OK | `v20.20.0` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm -v` | OK | `10.8.2` |
+| `git rev-parse --abbrev-ref HEAD` | OK | `feat/lot4-accessors-runtime` |
+| `git rev-parse --short HEAD` | OK | `db8545a19` |
+| `git status --short` | OK | Modifications Lot 0-bis existantes + docs non suivis |
+
+## Commandes ciblées exécutées
+
+| Commande | Statut | Résultat résumé |
+| --- | --- | --- |
+| `npm run test:unit -- --runInBand __tests__/api/documents.id.route.test.ts __tests__/api/documents-access.test.ts __tests__/lib/invoice/access-scope.test.ts` | ÉCHEC attendu TDD | Helper facture absent, fuite `localPath`, 403 révélateur |
+| `npm run test:unit -- --runInBand __tests__/api/documents.id.route.test.ts __tests__/api/documents-access.test.ts __tests__/lib/invoice/access-scope.test.ts __tests__/api/invoices.pdf.route.test.ts __tests__/api/invoices.receipt.pdf.route.test.ts` | OK | 5 suites, 43 tests OK |
+| `npm run test:unit -- --runInBand __tests__/api/student.activate.route.test.ts __tests__/api/public-rate-limit.coverage.test.ts` | OK | 2 suites, 17 tests OK |
+| `npm run test:unit -- --runInBand __tests__/api/lamis.teacher-report.route.test.ts __tests__/api/public-rate-limit.coverage.test.ts __tests__/api/stages/stages-list.test.ts __tests__/api/stages.reservations.access.test.ts __tests__/api/coach.sessions.report.route.test.ts` | OK | 5 suites, 45 tests OK |
+| `node scripts/security/audit-api-guards.mjs` | OK | Inventaire régénéré, 176 routes |
+| `node scripts/go-live/generate-api-security-matrix.mjs` | OK | Matrice régénérée, P0=0, P1=56, P2=93, OK=27 |
+
+## Commandes finales obligatoires
+
+| Commande | Statut | Résultat résumé |
+| --- | --- | --- |
+| `npm run typecheck` | OK | `tsc --noEmit` sans erreur |
+| `npm run lint` | OK | Warnings ESLint existants sous `--max-warnings 300` |
+| `npm run test:unit -- --runInBand` | OK | 506 suites passées, 1 suite ignorée ; 6360 tests passés, 4 ignorés |
+| `npm run build` | OK | Build Next réussi, 143 pages statiques générées, assets standalone copiés |
+| `node scripts/security/audit-api-guards.mjs` | OK | `docs/security/API_GUARD_INVENTORY.md`, 176 routes |
+| `node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=56`, `P2=93`, `OK=27` |
+| `npm run audit:site-map` | OK | 290 routes, 412 edges, 0 link findings, 13 public orphan entries |
+| `npm run check:no-hardcoded` | OK | 0 hardcoded values outside canonical sources |
+| `npm run check:docs-archive` | OK | no historical audit/report files at docs root |
+| `npm run check:bundle-weight` | OK | all tracked routes within baseline + 5 kB |
+| `npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | OK | 24 tests passed |
+
+## Warnings observés
+
+- `npm run lint` : nombreux warnings préexistants `no-explicit-any`, `no-unused-vars`, hooks, sous le seuil configuré.
+- `npm run test:unit` : logs de tests simulant des erreurs DB/RAG/SMTP/jsdom ; statut final OK.
+- Smoke Playwright : warning WebServer `PrismaClientKnownRequestError P2021`, table `public.business_configs` absente pendant refresh passif de config. Le smoke public reste vert, mais ce point doit être vérifié dans le lot infra/DB.
+
+## Limites
+
+- Pas de lecture de `.env`.
+- Pas de migration Prisma.
+- Pas de déploiement.
+- Le mode Redis/Upstash de production n’est pas prouvé localement.

--- a/docs/go-live/_evidence/lot1-idor-tests.md
+++ b/docs/go-live/_evidence/lot1-idor-tests.md
@@ -1,0 +1,60 @@
+# Lot 1 — Preuves tests IDOR / no-leak
+
+## Tests documents
+
+- `__tests__/api/documents.id.route.test.ts`
+  - non authentifié → 401 ;
+  - document absent → 404 ;
+  - utilisateur non propriétaire → 404 non révélateur ;
+  - propriétaire/admin/assistante → 200 ;
+  - fichier manquant → 404 sans log de chemin local ;
+  - erreur DB → 500.
+
+- `__tests__/api/documents-access.test.ts`
+  - coach assigné peut lire/créer ;
+  - coach non assigné → 403 ;
+  - rôle non coach → 403 ;
+  - réponses coach sans `localPath` ;
+  - assistante/admin gardés staff-only.
+
+## Tests factures
+
+- `__tests__/lib/invoice/access-scope.test.ts`
+  - admin/assistante scope `{ id }` ;
+  - parent scope par `beneficiaryUserId` enfant + fallback `customerEmail` legacy ;
+  - parent sans scope → null ;
+  - élève/coach/role inconnu → null.
+
+- `__tests__/api/invoices.pdf.route.test.ts`
+  - token invalide/mismatch → 404 ;
+  - token valide → PDF ;
+  - session non autorisée → 404 ;
+  - admin → PDF ;
+  - facture hors scope → 404.
+
+- `__tests__/api/invoices.receipt.pdf.route.test.ts`
+  - non authentifié/role interdit/facture absente → 404 ;
+  - facture non payée → 409 ;
+  - facture payée → PDF.
+
+## Tests rate limit publics
+
+- `__tests__/api/student.activate.route.test.ts`
+  - GET/POST rate-limited → 429 avant service ;
+  - token manquant/invalide ;
+  - activation valide ;
+  - erreur service sobre.
+
+- `__tests__/api/lamis.teacher-report.route.test.ts`
+  - payload valide → 200 ;
+  - champ inattendu ou tentative malformée → 400 ;
+  - GET/POST rate-limited → 429.
+
+- `__tests__/api/public-rate-limit.coverage.test.ts`
+  - couverture statique `guardRateLimitAsync` pour routes publiques sensibles listées.
+
+## Résultat ciblé
+
+Commande ciblée exécutée sous Node 20 : `npm run test:unit -- --runInBand ...`
+
+Résultat observé : 5 suites / 45 tests OK pour le dernier lot ciblé, et 5 suites / 43 tests OK pour documents/factures.

--- a/docs/go-live/_evidence/lot1-rate-limit-runtime.md
+++ b/docs/go-live/_evidence/lot1-rate-limit-runtime.md
@@ -1,0 +1,31 @@
+# Lot 1 — Rate limiting runtime
+
+## Code vérifié
+
+- `lib/rate-limit/index.ts`
+- `lib/rate-limit/redis-store.ts`
+- `lib/rate-limit/upstash-store.ts`
+- `app/api/internal/health/route.ts`
+- `__tests__/lib/rate-limit.distributed.test.ts`
+
+## Constats
+
+- `RATE_LIMIT_DISABLE=1` est ignoré en `NODE_ENV=production`.
+- Le runtime choisit `redis` si `REDIS_URL` est présent, sinon `upstash` si les variables REST Upstash sont présentes, sinon `memory`.
+- Le healthcheck interne expose le mode dans `checks.redis.detail`.
+- Le mode `memory` rend le healthcheck dégradé et reste bloquant pour go-live large.
+
+## Routes renforcées dans Lot 1
+
+- `/api/student/activate` : `guardRateLimitAsync`, preset `auth`, suffixe `student-activate`.
+- `/api/lamis/teacher-report` : `guardRateLimitAsync`, preset `api`, suffixe `lamis-teacher-report`.
+
+## Tests
+
+- `__tests__/lib/rate-limit.distributed.test.ts` couvre production + `RATE_LIMIT_DISABLE=1`, Redis, Upstash et fallback mémoire.
+- `__tests__/api/student.activate.route.test.ts` couvre 429 GET/POST.
+- `__tests__/api/lamis.teacher-report.route.test.ts` couvre 429 GET/POST.
+
+## Réserve
+
+Le rate limiting distribué n’est pas prouvé sur production réelle dans Lot 1. Aucune valeur de secret Redis/Upstash n’a été lue ni affichée.

--- a/docs/go-live/_evidence/lot10-final-human-commit-register.md
+++ b/docs/go-live/_evidence/lot10-final-human-commit-register.md
@@ -1,0 +1,18 @@
+# Lot 10 — Registre final human commit
+
+| Domaine | Statut | Preuve | Décision |
+|---|---|---|---|
+| P0 | 0 | matrice | OK |
+| P1 | 6 | matrice | bêta contrôlée seulement |
+| Manifest consistency | PASSED | test Lot 9 | OK |
+| Git add dry-run plan | PASSED | test Lot 10 + dry-runs | READY_FOR_HUMAN_COMMIT |
+| Excluded files | OK | proof Lot 10 | Exclusions maintenues |
+| Human review files | PENDING | `docs/audits/audit-nexus-reussite.md` absent des commits standards | Décision humaine requise |
+| Runtime Redis | NOT_PROVEN | variables absentes | BETA_ELARGIE_BLOCKED |
+| 429 runtime | NOT_PROVEN | probe non autorisée | BETA_ELARGIE_BLOCKED |
+| ContactLead DB dry-run | NOT_PROVEN | DB/autorisation absentes | GO_LIVE_LARGE_BLOCKED |
+| RC commit readiness | READY_FOR_HUMAN_COMMIT | plan dry-run + test | READY_FOR_HUMAN_COMMIT |
+| Gates ciblées | PASSED | typecheck, lint, tests scripts, docs-archive | READY_FOR_HUMAN_COMMIT |
+| Staging Git | EMPTY | `git diff --cached --name-only` sans sortie | Aucun `git add` réel |
+
+Décisions : `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`, `BETA_ELARGIE_BLOCKED`, `GO_LIVE_LARGE_BLOCKED`.

--- a/docs/go-live/_evidence/lot10-git-add-dry-run-plan.md
+++ b/docs/go-live/_evidence/lot10-git-add-dry-run-plan.md
@@ -1,0 +1,857 @@
+# Lot 10 — Plan git add dry-run par commit humain
+
+Aucun commit n'est exécuté. Aucun `git add` réel n'est exécuté. Les sorties ci-dessous proviennent uniquement de `git add --dry-run -- ...`.
+
+- Staging Git avant dry-run : `VIDE`
+- Staging Git après dry-run : `VIDE`
+- Fichiers `Include RC` couverts : `281`
+- Fichiers `Exclude` : `1`
+- Fichiers `Needs human review` : `1`
+
+## Commit 1 — chore(go-live): update security inventory and matrices
+
+### Intention
+
+Versionner les inventaires et scripts de génération nécessaires au suivi RC.
+
+### Fichiers à ajouter
+
+```bash
+git add --dry-run -- \
+  "docs/go-live/api-security-matrix.full.md" \
+  "docs/security/API_GUARD_INVENTORY.md" \
+  "scripts/check-bundle-weight.sh" \
+  "scripts/go-live/generate-api-security-matrix.mjs" \
+  "scripts/security/audit-api-guards.mjs"
+```
+
+### Résultat dry-run observé
+
+```txt
+add 'docs/security/API_GUARD_INVENTORY.md'
+add 'scripts/check-bundle-weight.sh'
+add 'scripts/security/audit-api-guards.mjs'
+add 'docs/go-live/api-security-matrix.full.md'
+add 'scripts/go-live/generate-api-security-matrix.mjs'
+```
+
+### Commande de commit proposée, NON EXÉCUTÉE
+
+```bash
+git commit -m "chore(go-live): update security inventory and matrices"
+```
+
+### Tests à relancer avant commit
+
+`node scripts/security/audit-api-guards.mjs`, `node scripts/go-live/generate-api-security-matrix.mjs`, `npm run check:bundle-weight`
+
+### Risques
+
+Revue code standard requise ; ne pas inclure de fichiers exclus ou en décision humaine.
+
+## Commit 2 — fix(api-security): close admin and role guard gaps
+
+### Intention
+
+Regrouper les durcissements API, guards, ownership et projections hors flux publics/paiement.
+
+### Fichiers à ajouter
+
+```bash
+git add --dry-run -- \
+  "app/api/admin/config/rollback/route.ts" \
+  "app/api/admin/config/route.ts" \
+  "app/api/admin/directeur/stats/route.ts" \
+  "app/api/admin/documents/route.ts" \
+  "app/api/admin/invoices/route.ts" \
+  "app/api/admin/recompute-ssn/route.ts" \
+  "app/api/admin/subscriptions/route.ts" \
+  "app/api/admin/test-email/route.ts" \
+  "app/api/assistante/credit-requests/route.ts" \
+  "app/api/assistante/quotes/pdf/route.ts" \
+  "app/api/assistante/students/credits/route.ts" \
+  "app/api/assistante/subscription-requests/route.ts" \
+  "app/api/assistante/subscriptions/route.ts" \
+  "app/api/bilans/[id]/export/route.ts" \
+  "app/api/bilans/[id]/route.ts" \
+  "app/api/bilans/generate/route.ts" \
+  "app/api/bilans/route.ts" \
+  "app/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate/route.ts" \
+  "app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent/route.ts" \
+  "app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student/route.ts" \
+  "app/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale/route.ts" \
+  "app/api/coach/students/[studentId]/documents/route.ts" \
+  "app/api/coach/students/[studentId]/eaf-preparation-report/validate/route.ts" \
+  "app/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate/route.ts" \
+  "app/api/coach/students/[studentId]/notes/route.ts" \
+  "app/api/coach/students/[studentId]/survival-mode/route.ts" \
+  "app/api/coach/trajectory/route.ts" \
+  "app/api/documents/[id]/route.ts" \
+  "app/api/eleve/bilan-diagnostic-maths-terminale/route.ts" \
+  "app/api/invoices/[id]/pdf/route.ts" \
+  "app/api/invoices/[id]/receipt/pdf/route.ts" \
+  "app/api/lamis/teacher-report/route.ts" \
+  "app/api/npc/submissions/[submissionId]/documents/[documentId]/route.ts" \
+  "app/api/npc/submissions/[submissionId]/documents/route.ts" \
+  "app/api/npc/submissions/[submissionId]/generate/route.ts" \
+  "app/api/npc/submissions/route.ts" \
+  "app/api/npc/uploads/route.ts" \
+  "app/api/parent/children/route.ts" \
+  "app/api/parent/subscription-requests/route.ts" \
+  "app/api/parent/subscriptions/route.ts" \
+  "app/api/programme/maths-1ere-stmg/stage-progress/route.ts" \
+  "app/api/sessions/cancel/route.ts" \
+  "app/api/sessions/video/route.ts" \
+  "app/api/stages/[stageSlug]/inscrire/route.ts" \
+  "app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts" \
+  "app/api/stages/[stageSlug]/route.ts" \
+  "app/api/student/activate/route.ts" \
+  "app/api/student/automatismes/attempts/route.ts" \
+  "app/api/student/automatismes/check-answer/route.ts" \
+  "app/api/student/automatismes/series/[id]/route.ts" \
+  "app/api/student/documents/[id]/download/route.ts" \
+  "app/api/student/nexus-index/route.ts" \
+  "app/api/student/survival/phrases/[phraseId]/copied/route.ts" \
+  "app/api/student/survival/progress/route.ts" \
+  "app/api/student/survival/qcm/attempt/route.ts" \
+  "app/api/student/survival/reflexes/[reflexId]/attempt/route.ts" \
+  "app/api/student/trajectory/route.ts" \
+  "lib/invoice/index.ts" \
+  "lib/invoice/not-found.ts" \
+  "lib/stages/inscription-schema.ts" \
+  "lib/validations.ts"
+```
+
+### Résultat dry-run observé
+
+```txt
+add 'app/api/admin/config/rollback/route.ts'
+add 'app/api/admin/config/route.ts'
+add 'app/api/admin/directeur/stats/route.ts'
+add 'app/api/admin/documents/route.ts'
+add 'app/api/admin/invoices/route.ts'
+add 'app/api/admin/recompute-ssn/route.ts'
+add 'app/api/admin/subscriptions/route.ts'
+add 'app/api/admin/test-email/route.ts'
+add 'app/api/assistante/credit-requests/route.ts'
+add 'app/api/assistante/quotes/pdf/route.ts'
+add 'app/api/assistante/students/credits/route.ts'
+add 'app/api/assistante/subscription-requests/route.ts'
+add 'app/api/assistante/subscriptions/route.ts'
+add 'app/api/bilans/[id]/export/route.ts'
+add 'app/api/bilans/[id]/route.ts'
+add 'app/api/bilans/generate/route.ts'
+add 'app/api/bilans/route.ts'
+add 'app/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate/route.ts'
+add 'app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent/route.ts'
+add 'app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student/route.ts'
+add 'app/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale/route.ts'
+add 'app/api/coach/students/[studentId]/documents/route.ts'
+add 'app/api/coach/students/[studentId]/eaf-preparation-report/validate/route.ts'
+add 'app/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate/route.ts'
+add 'app/api/coach/students/[studentId]/notes/route.ts'
+add 'app/api/coach/students/[studentId]/survival-mode/route.ts'
+add 'app/api/coach/trajectory/route.ts'
+add 'app/api/documents/[id]/route.ts'
+add 'app/api/eleve/bilan-diagnostic-maths-terminale/route.ts'
+add 'app/api/invoices/[id]/pdf/route.ts'
+add 'app/api/invoices/[id]/receipt/pdf/route.ts'
+add 'app/api/lamis/teacher-report/route.ts'
+add 'app/api/npc/submissions/[submissionId]/documents/[documentId]/route.ts'
+add 'app/api/npc/submissions/[submissionId]/documents/route.ts'
+add 'app/api/npc/submissions/[submissionId]/generate/route.ts'
+add 'app/api/npc/submissions/route.ts'
+add 'app/api/npc/uploads/route.ts'
+add 'app/api/parent/children/route.ts'
+add 'app/api/parent/subscription-requests/route.ts'
+add 'app/api/parent/subscriptions/route.ts'
+add 'app/api/programme/maths-1ere-stmg/stage-progress/route.ts'
+add 'app/api/sessions/cancel/route.ts'
+add 'app/api/sessions/video/route.ts'
+add 'app/api/stages/[stageSlug]/inscrire/route.ts'
+add 'app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts'
+add 'app/api/stages/[stageSlug]/route.ts'
+add 'app/api/student/activate/route.ts'
+add 'app/api/student/automatismes/attempts/route.ts'
+add 'app/api/student/automatismes/check-answer/route.ts'
+add 'app/api/student/automatismes/series/[id]/route.ts'
+add 'app/api/student/documents/[id]/download/route.ts'
+add 'app/api/student/nexus-index/route.ts'
+add 'app/api/student/survival/phrases/[phraseId]/copied/route.ts'
+add 'app/api/student/survival/progress/route.ts'
+add 'app/api/student/survival/qcm/attempt/route.ts'
+add 'app/api/student/survival/reflexes/[reflexId]/attempt/route.ts'
+add 'app/api/student/trajectory/route.ts'
+add 'lib/invoice/index.ts'
+add 'lib/invoice/not-found.ts'
+add 'lib/stages/inscription-schema.ts'
+add 'lib/validations.ts'
+```
+
+### Commande de commit proposée, NON EXÉCUTÉE
+
+```bash
+git commit -m "fix(api-security): close admin and role guard gaps"
+```
+
+### Tests à relancer avant commit
+
+`npm run test:unit -- --runInBand __tests__/api/admin.config.route.test.ts __tests__/api/admin.documents.route.test.ts __tests__/api/bilans.id.route.test.ts`
+
+### Risques
+
+Revue code standard requise ; ne pas inclure de fichiers exclus ou en décision humaine.
+
+## Commit 3 — fix(public-funnel): lead-only bilan and assessment token binding
+
+### Intention
+
+Regrouper le passage bilan lead-only et le binding du token assessment au flux autorisé.
+
+### Fichiers à ajouter
+
+```bash
+git add --dry-run -- \
+  "app/api/assessments/public-token/route.ts" \
+  "app/api/assessments/submit/route.ts" \
+  "app/api/assessments/submit/types.ts" \
+  "app/api/bilan-gratuit/dismiss/route.ts" \
+  "app/api/bilan-gratuit/route.ts" \
+  "app/bilan-gratuit/assessment/AssessmentClient.tsx" \
+  "app/bilan-gratuit/assessment/page.tsx" \
+  "app/layout.tsx" \
+  "components/assessments/AssessmentRunner.tsx" \
+  "components/stages/StageInscriptionForm.tsx" \
+  "lib/assessments/public-token.ts" \
+  "lib/crm/contact-leads.ts"
+```
+
+### Résultat dry-run observé
+
+```txt
+add 'app/api/assessments/submit/route.ts'
+add 'app/api/assessments/submit/types.ts'
+add 'app/api/bilan-gratuit/dismiss/route.ts'
+add 'app/api/bilan-gratuit/route.ts'
+add 'app/bilan-gratuit/assessment/page.tsx'
+add 'app/layout.tsx'
+add 'components/assessments/AssessmentRunner.tsx'
+add 'components/stages/StageInscriptionForm.tsx'
+add 'lib/crm/contact-leads.ts'
+add 'app/api/assessments/public-token/route.ts'
+add 'app/bilan-gratuit/assessment/AssessmentClient.tsx'
+add 'lib/assessments/public-token.ts'
+```
+
+### Commande de commit proposée, NON EXÉCUTÉE
+
+```bash
+git commit -m "fix(public-funnel): lead-only bilan and assessment token binding"
+```
+
+### Tests à relancer avant commit
+
+`npm run test:unit -- --runInBand __tests__/api/bilan-gratuit.product-rgpd.test.ts __tests__/api/assessments.submit.token-binding.test.ts __tests__/app/bilan-gratuit.assessment-page-token.test.tsx`
+
+### Risques
+
+Flux public critique mineurs ; relancer tests token, bilan et Playwright assessment avant commit humain.
+
+## Commit 4 — fix(runtime): rate-limit probe and business-config gate
+
+### Intention
+
+Regrouper les garde-fous runtime : healthcheck, rate-limit probe et BusinessConfig.
+
+### Fichiers à ajouter
+
+```bash
+git add --dry-run -- \
+  "app/api/internal/health/route.ts" \
+  "app/api/internal/rate-limit-probe/route.ts" \
+  "lib/config/snapshot.ts" \
+  "lib/rate-limit/index.ts"
+```
+
+### Résultat dry-run observé
+
+```txt
+add 'app/api/internal/health/route.ts'
+add 'lib/config/snapshot.ts'
+add 'lib/rate-limit/index.ts'
+add 'app/api/internal/rate-limit-probe/route.ts'
+```
+
+### Commande de commit proposée, NON EXÉCUTÉE
+
+```bash
+git commit -m "fix(runtime): rate-limit probe and business-config gate"
+```
+
+### Tests à relancer avant commit
+
+`npm run test:unit -- --runInBand __tests__/api/internal.rate-limit-probe.test.ts __tests__/api/internal.business-config.health.test.ts __tests__/lib/rate-limit.production-gate.test.ts`
+
+### Risques
+
+Preuves Redis/Upstash externes encore absentes ; ne pas lever les réserves runtime.
+
+## Commit 5 — fix(payments): keep clictopay disabled and fail closed
+
+### Intention
+
+Maintenir ClicToPay désactivé et fail-closed côté API/UI.
+
+### Fichiers à ajouter
+
+```bash
+git add --dry-run -- \
+  "app/api/payments/clictopay/init/route.ts" \
+  "app/api/payments/clictopay/webhook/route.ts" \
+  "components/marketing/PaymentMethodsNote.tsx"
+```
+
+### Résultat dry-run observé
+
+```txt
+add 'app/api/payments/clictopay/init/route.ts'
+add 'app/api/payments/clictopay/webhook/route.ts'
+add 'components/marketing/PaymentMethodsNote.tsx'
+```
+
+### Commande de commit proposée, NON EXÉCUTÉE
+
+```bash
+git commit -m "fix(payments): keep clictopay disabled and fail closed"
+```
+
+### Tests à relancer avant commit
+
+`npm run test:unit -- --runInBand __tests__/api/payments.clictopay.disabled-contract.test.ts __tests__/api/payments.clictopay.feature-flag-consistency.test.ts __tests__/ui/payment-methods.clictopay-disabled.test.tsx`
+
+### Risques
+
+Paiement carte doit rester désactivé ; vérifier ClicToPay disabled avant commit humain.
+
+## Commit 6 — chore(maintenance): add contact-lead retention dry-run
+
+### Intention
+
+Ajouter le script de rétention ContactLead en dry-run par défaut.
+
+### Fichiers à ajouter
+
+```bash
+git add --dry-run -- \
+  "scripts/maintenance/contact-leads-retention.ts"
+```
+
+### Résultat dry-run observé
+
+```txt
+add 'scripts/maintenance/contact-leads-retention.ts'
+```
+
+### Commande de commit proposée, NON EXÉCUTÉE
+
+```bash
+git commit -m "chore(maintenance): add contact-lead retention dry-run"
+```
+
+### Tests à relancer avant commit
+
+`npm run test:unit -- --runInBand __tests__/scripts/contact-leads-retention.test.ts __tests__/lib/crm/contact-leads.retention.test.ts`
+
+### Risques
+
+Revue code standard requise ; ne pas inclure de fichiers exclus ou en décision humaine.
+
+## Commit 7 — test(security): add no-leak, idor, token and audit regressions
+
+### Intention
+
+Ajouter les tests unitaires de non-régression sécurité, no-leak, IDOR, tokens et scripts.
+
+### Fichiers à ajouter
+
+```bash
+git add --dry-run -- \
+  "__tests__/api/admin.config.route.test.ts" \
+  "__tests__/api/admin.directeur.stats.route.test.ts" \
+  "__tests__/api/admin.documents.route.test.ts" \
+  "__tests__/api/admin.invoices.route.test.ts" \
+  "__tests__/api/admin.recompute-ssn.route.test.ts" \
+  "__tests__/api/admin.subscriptions.route.test.ts" \
+  "__tests__/api/admin.test-email.route.test.ts" \
+  "__tests__/api/assessments-rbac.test.ts" \
+  "__tests__/api/assessments-submit.test.ts" \
+  "__tests__/api/assessments.public-token.binding.test.ts" \
+  "__tests__/api/assessments.public-token.route.test.ts" \
+  "__tests__/api/assessments.submit.token-binding.test.ts" \
+  "__tests__/api/assessments.submit.token-security.test.ts" \
+  "__tests__/api/assistant.credit-requests.route.test.ts" \
+  "__tests__/api/assistant.students.credits.route.test.ts" \
+  "__tests__/api/assistant.subscription-requests.route.test.ts" \
+  "__tests__/api/assistant.subscriptions.route.test.ts" \
+  "__tests__/api/assistante.quotes.pdf.route.test.ts" \
+  "__tests__/api/bilan-gratuit.product-rgpd.test.ts" \
+  "__tests__/api/bilan-gratuit.rgpd-minimization.test.ts" \
+  "__tests__/api/bilan-gratuit.security.test.ts" \
+  "__tests__/api/bilan-gratuit.test.ts" \
+  "__tests__/api/bilans.id.route.test.ts" \
+  "__tests__/api/bilans.idor.test.ts" \
+  "__tests__/api/bilans/crud.test.ts" \
+  "__tests__/api/bilans/generate.test.ts" \
+  "__tests__/api/coach.bilan-diagnostic-maths-terminale.security.test.ts" \
+  "__tests__/api/coach.eaf-preparation-report.validate.test.ts" \
+  "__tests__/api/coach.eaf-stage-regenerate.security.test.ts" \
+  "__tests__/api/coach.generated-reports.route.test.ts" \
+  "__tests__/api/coach.trajectory.security.test.ts" \
+  "__tests__/api/documents-access.test.ts" \
+  "__tests__/api/documents.id.route.test.ts" \
+  "__tests__/api/eleve.bilan-diagnostic-maths-terminale.security.test.ts" \
+  "__tests__/api/internal.business-config.health.test.ts" \
+  "__tests__/api/internal.health.rate-limit.test.ts" \
+  "__tests__/api/internal.rate-limit-probe.test.ts" \
+  "__tests__/api/invoices.pdf.route.test.ts" \
+  "__tests__/api/invoices.receipt.pdf.route.test.ts" \
+  "__tests__/api/lamis.teacher-report.route.test.ts" \
+  "__tests__/api/npc.documents.route.test.ts" \
+  "__tests__/api/npc.files.route.test.ts" \
+  "__tests__/api/npc.generate.test.ts" \
+  "__tests__/api/npc.submissions.security.test.ts" \
+  "__tests__/api/npc.uploads.route.test.ts" \
+  "__tests__/api/parent.children.activation.route.test.ts" \
+  "__tests__/api/parent.children.route.test.ts" \
+  "__tests__/api/parent.subscription-requests.route.test.ts" \
+  "__tests__/api/parent.subscriptions.route.test.ts" \
+  "__tests__/api/payments.clictopay.disabled-contract.test.ts" \
+  "__tests__/api/payments.clictopay.feature-flag-consistency.test.ts" \
+  "__tests__/api/payments.clictopay.init.route.test.ts" \
+  "__tests__/api/payments.clictopay.webhook.disabled.test.ts" \
+  "__tests__/api/payments.clictopay.webhook.route.test.ts" \
+  "__tests__/api/payments.clictopay.webhook.security.test.ts" \
+  "__tests__/api/programme.maths-1ere-stmg.stage-progress.test.ts" \
+  "__tests__/api/public-rate-limit.coverage.test.ts" \
+  "__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts" \
+  "__tests__/api/sessions.cancel.route.test.ts" \
+  "__tests__/api/sessions.video.route.test.ts" \
+  "__tests__/api/stages.inscrire.product-rgpd.test.ts" \
+  "__tests__/api/stages.inscrire.security.test.ts" \
+  "__tests__/api/stages/confirm.test.ts" \
+  "__tests__/api/stages/inscriptions.test.ts" \
+  "__tests__/api/student.activate.lifecycle-security.test.ts" \
+  "__tests__/api/student.activate.route.test.ts" \
+  "__tests__/app/bilan-gratuit.assessment-page-token.test.tsx" \
+  "__tests__/components/offer-detail-dialog.test.tsx" \
+  "__tests__/components/offres-page.test.tsx" \
+  "__tests__/lib/assessments/public-token.test.ts" \
+  "__tests__/lib/bilan-gratuit-form.test.tsx" \
+  "__tests__/lib/business-config.fallback.test.ts" \
+  "__tests__/lib/business-config.production-gate.test.ts" \
+  "__tests__/lib/crm/contact-leads.retention.test.ts" \
+  "__tests__/lib/invoice/access-scope.test.ts" \
+  "__tests__/lib/rate-limit.production-gate.test.ts" \
+  "__tests__/lib/validations.test.ts" \
+  "__tests__/scripts/audit-api-guards.classification.test.ts" \
+  "__tests__/scripts/contact-leads-retention.test.ts" \
+  "__tests__/scripts/security-audit-scripts-regression.test.ts" \
+  "__tests__/ui/payment-methods.clictopay-disabled.test.tsx"
+```
+
+### Résultat dry-run observé
+
+```txt
+add '__tests__/api/admin.config.route.test.ts'
+add '__tests__/api/admin.directeur.stats.route.test.ts'
+add '__tests__/api/admin.documents.route.test.ts'
+add '__tests__/api/admin.invoices.route.test.ts'
+add '__tests__/api/admin.recompute-ssn.route.test.ts'
+add '__tests__/api/admin.subscriptions.route.test.ts'
+add '__tests__/api/admin.test-email.route.test.ts'
+add '__tests__/api/assessments-rbac.test.ts'
+add '__tests__/api/assessments-submit.test.ts'
+add '__tests__/api/assistant.credit-requests.route.test.ts'
+add '__tests__/api/assistant.students.credits.route.test.ts'
+add '__tests__/api/assistant.subscription-requests.route.test.ts'
+add '__tests__/api/assistant.subscriptions.route.test.ts'
+add '__tests__/api/assistante.quotes.pdf.route.test.ts'
+add '__tests__/api/bilan-gratuit.test.ts'
+add '__tests__/api/bilans.id.route.test.ts'
+add '__tests__/api/bilans.idor.test.ts'
+add '__tests__/api/bilans/crud.test.ts'
+add '__tests__/api/bilans/generate.test.ts'
+add '__tests__/api/coach.eaf-preparation-report.validate.test.ts'
+add '__tests__/api/coach.generated-reports.route.test.ts'
+add '__tests__/api/documents-access.test.ts'
+add '__tests__/api/documents.id.route.test.ts'
+add '__tests__/api/invoices.pdf.route.test.ts'
+add '__tests__/api/invoices.receipt.pdf.route.test.ts'
+add '__tests__/api/npc.documents.route.test.ts'
+add '__tests__/api/npc.files.route.test.ts'
+add '__tests__/api/npc.generate.test.ts'
+add '__tests__/api/npc.uploads.route.test.ts'
+add '__tests__/api/parent.children.activation.route.test.ts'
+add '__tests__/api/parent.children.route.test.ts'
+add '__tests__/api/parent.subscription-requests.route.test.ts'
+add '__tests__/api/parent.subscriptions.route.test.ts'
+add '__tests__/api/payments.clictopay.init.route.test.ts'
+add '__tests__/api/payments.clictopay.webhook.route.test.ts'
+add '__tests__/api/programme.maths-1ere-stmg.stage-progress.test.ts'
+add '__tests__/api/public-rate-limit.coverage.test.ts'
+add '__tests__/api/sessions.cancel.route.test.ts'
+add '__tests__/api/sessions.video.route.test.ts'
+add '__tests__/api/stages.inscrire.security.test.ts'
+add '__tests__/api/stages/confirm.test.ts'
+add '__tests__/api/stages/inscriptions.test.ts'
+add '__tests__/api/student.activate.route.test.ts'
+add '__tests__/components/offer-detail-dialog.test.tsx'
+add '__tests__/components/offres-page.test.tsx'
+add '__tests__/lib/bilan-gratuit-form.test.tsx'
+add '__tests__/lib/validations.test.ts'
+add '__tests__/api/assessments.public-token.binding.test.ts'
+add '__tests__/api/assessments.public-token.route.test.ts'
+add '__tests__/api/assessments.submit.token-binding.test.ts'
+add '__tests__/api/assessments.submit.token-security.test.ts'
+add '__tests__/api/bilan-gratuit.product-rgpd.test.ts'
+add '__tests__/api/bilan-gratuit.rgpd-minimization.test.ts'
+add '__tests__/api/bilan-gratuit.security.test.ts'
+add '__tests__/api/coach.bilan-diagnostic-maths-terminale.security.test.ts'
+add '__tests__/api/coach.eaf-stage-regenerate.security.test.ts'
+add '__tests__/api/coach.trajectory.security.test.ts'
+add '__tests__/api/eleve.bilan-diagnostic-maths-terminale.security.test.ts'
+add '__tests__/api/internal.business-config.health.test.ts'
+add '__tests__/api/internal.health.rate-limit.test.ts'
+add '__tests__/api/internal.rate-limit-probe.test.ts'
+add '__tests__/api/lamis.teacher-report.route.test.ts'
+add '__tests__/api/npc.submissions.security.test.ts'
+add '__tests__/api/payments.clictopay.disabled-contract.test.ts'
+add '__tests__/api/payments.clictopay.feature-flag-consistency.test.ts'
+add '__tests__/api/payments.clictopay.webhook.disabled.test.ts'
+add '__tests__/api/payments.clictopay.webhook.security.test.ts'
+add '__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts'
+add '__tests__/api/stages.inscrire.product-rgpd.test.ts'
+add '__tests__/api/student.activate.lifecycle-security.test.ts'
+add '__tests__/app/bilan-gratuit.assessment-page-token.test.tsx'
+add '__tests__/lib/assessments/public-token.test.ts'
+add '__tests__/lib/business-config.fallback.test.ts'
+add '__tests__/lib/business-config.production-gate.test.ts'
+add '__tests__/lib/crm/contact-leads.retention.test.ts'
+add '__tests__/lib/invoice/access-scope.test.ts'
+add '__tests__/lib/rate-limit.production-gate.test.ts'
+add '__tests__/scripts/audit-api-guards.classification.test.ts'
+add '__tests__/scripts/contact-leads-retention.test.ts'
+add '__tests__/scripts/security-audit-scripts-regression.test.ts'
+add '__tests__/ui/payment-methods.clictopay-disabled.test.tsx'
+```
+
+### Commande de commit proposée, NON EXÉCUTÉE
+
+```bash
+git commit -m "test(security): add no-leak, idor, token and audit regressions"
+```
+
+### Tests à relancer avant commit
+
+`npm run test:unit -- --runInBand`
+
+### Risques
+
+Risque faible, mais les tests doivent rester verts isolément et dans la suite ciblée.
+
+## Commit 8 — test(e2e): protect public assessment route
+
+### Intention
+
+Ajouter et ajuster les smokes E2E publics liés au tunnel assessment.
+
+### Fichiers à ajouter
+
+```bash
+git add --dry-run -- \
+  "e2e/pages-public-bilan-assessment-token.spec.ts" \
+  "e2e/pages-public-bilan-gratuit.spec.ts" \
+  "e2e/pages-public-homepage.spec.ts" \
+  "e2e/pages-public-offres.spec.ts" \
+  "playwright.config.ts"
+```
+
+### Résultat dry-run observé
+
+```txt
+add 'e2e/pages-public-bilan-gratuit.spec.ts'
+add 'e2e/pages-public-homepage.spec.ts'
+add 'e2e/pages-public-offres.spec.ts'
+add 'playwright.config.ts'
+add 'e2e/pages-public-bilan-assessment-token.spec.ts'
+```
+
+### Commande de commit proposée, NON EXÉCUTÉE
+
+```bash
+git commit -m "test(e2e): protect public assessment route"
+```
+
+### Tests à relancer avant commit
+
+`PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium`
+
+### Risques
+
+Risque faible, mais les tests doivent rester verts isolément et dans la suite ciblée.
+
+## Commit 9 — docs(go-live): add evidence and go-no-go registers
+
+### Intention
+
+Versionner les documents go-live et preuves de décision RC.
+
+### Fichiers à ajouter
+
+```bash
+git add --dry-run -- \
+  "docs/go-live/00_EXECUTIVE_STATE.md" \
+  "docs/go-live/01_ACTION_PLAN.md" \
+  "docs/go-live/02_P0_P1_BACKLOG.md" \
+  "docs/go-live/03_RELEASE_GATES.md" \
+  "docs/go-live/04_TEST_MATRIX.md" \
+  "docs/go-live/05_API_SECURITY_MATRIX.md" \
+  "docs/go-live/06_BUSINESS_LOGIC_DECISIONS.md" \
+  "docs/go-live/07_ENV_INFRA_CHECKLIST.md" \
+  "docs/go-live/08_MARKETING_CONTENT_CHECKLIST.md" \
+  "docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md" \
+  "docs/go-live/10_LOT0_ACCEPTANCE.md" \
+  "docs/go-live/11_LOT1_SECURITY_CLOSURE.md" \
+  "docs/go-live/12_LOT1BIS_SECURITY_VERIFICATION.md" \
+  "docs/go-live/13_LOT1TER_P1_SECURITY_CLOSURE.md" \
+  "docs/go-live/14_LOT1QUATER_PUBLIC_ROLE_SECURITY_CLOSURE.md" \
+  "docs/go-live/15_LOT1QUINQUIES_FINAL_P1_SECURITY_CLOSURE.md" \
+  "docs/go-live/16_LOT2_PUBLIC_PRODUCT_RGPD_PAYMENT_DECISIONS.md" \
+  "docs/go-live/17_LOT3_RUNTIME_RGPD_ASSESSMENT_TOKEN.md" \
+  "docs/go-live/18_LOT4_RUNTIME_PAYMENT_RETENTION_TOKEN_BINDING.md" \
+  "docs/go-live/19_LOT5_RUNTIME_EXPLOITATION_GO_NO_GO.md" \
+  "docs/go-live/20_LOT6_STAGING_RELEASE_CANDIDATE_GO_NO_GO.md" \
+  "docs/go-live/21_LOT7_RELEASE_CANDIDATE_SECURITY_AUDIT.md" \
+  "docs/go-live/22_LOT8_RELEASE_CANDIDATE_CLEANUP.md" \
+  "docs/go-live/_evidence/entitlement-pricing-delta.md" \
+  "docs/go-live/_evidence/hardcoded-pricing-triage.md" \
+  "docs/go-live/_evidence/lot0-command-log.md" \
+  "docs/go-live/_evidence/lot1-api-route-triage.md" \
+  "docs/go-live/_evidence/lot1-command-log.md" \
+  "docs/go-live/_evidence/lot1-idor-tests.md" \
+  "docs/go-live/_evidence/lot1-rate-limit-runtime.md" \
+  "docs/go-live/_evidence/lot1bis-audit-script-review.md" \
+  "docs/go-live/_evidence/lot1bis-command-log.md" \
+  "docs/go-live/_evidence/lot1bis-p0-reclassification-audit.md" \
+  "docs/go-live/_evidence/lot1bis-p1-closure.md" \
+  "docs/go-live/_evidence/lot1bis-rate-limit-production-gate.md" \
+  "docs/go-live/_evidence/lot1quater-assistante.md" \
+  "docs/go-live/_evidence/lot1quater-coach.md" \
+  "docs/go-live/_evidence/lot1quater-command-log.md" \
+  "docs/go-live/_evidence/lot1quater-p1-before-after.md" \
+  "docs/go-live/_evidence/lot1quater-parent-student.md" \
+  "docs/go-live/_evidence/lot1quater-public-routes.md" \
+  "docs/go-live/_evidence/lot1quater-rate-limit-runtime-proof.md" \
+  "docs/go-live/_evidence/lot1quater-sensitive-fields-coverage.md" \
+  "docs/go-live/_evidence/lot1quater-stages.md" \
+  "docs/go-live/_evidence/lot1quinquies-admin-routes.md" \
+  "docs/go-live/_evidence/lot1quinquies-clictopay-webhook.md" \
+  "docs/go-live/_evidence/lot1quinquies-command-log.md" \
+  "docs/go-live/_evidence/lot1quinquies-p1-before-after.md" \
+  "docs/go-live/_evidence/lot1quinquies-public-sensitive-routes.md" \
+  "docs/go-live/_evidence/lot1quinquies-rate-limit-runtime-proof.md" \
+  "docs/go-live/_evidence/lot1quinquies-sensitive-fields-coverage.md" \
+  "docs/go-live/_evidence/lot1ter-bilans-assessments.md" \
+  "docs/go-live/_evidence/lot1ter-coach-reports.md" \
+  "docs/go-live/_evidence/lot1ter-command-log.md" \
+  "docs/go-live/_evidence/lot1ter-npc-documents.md" \
+  "docs/go-live/_evidence/lot1ter-p1-before-after.md" \
+  "docs/go-live/_evidence/lot1ter-payments-invoices.md" \
+  "docs/go-live/_evidence/lot1ter-sensitive-fields-coverage.md" \
+  "docs/go-live/_evidence/lot2-assessments-submit-decision.md" \
+  "docs/go-live/_evidence/lot2-bilan-gratuit-product-rgpd.md" \
+  "docs/go-live/_evidence/lot2-clictopay-payment-decision.md" \
+  "docs/go-live/_evidence/lot2-lamis-teacher-report-decision.md" \
+  "docs/go-live/_evidence/lot2-public-product-rgpd-command-log.md" \
+  "docs/go-live/_evidence/lot2-rate-limit-runtime-decision.md" \
+  "docs/go-live/_evidence/lot2-sensitive-fields-success-error-coverage.md" \
+  "docs/go-live/_evidence/lot2-stages-inscrire-product-rgpd.md" \
+  "docs/go-live/_evidence/lot2-student-activate-token-lifecycle.md" \
+  "docs/go-live/_evidence/lot3-assessments-public-token.md" \
+  "docs/go-live/_evidence/lot3-bilan-gratuit-rgpd-register.md" \
+  "docs/go-live/_evidence/lot3-business-configs-db-drift.md" \
+  "docs/go-live/_evidence/lot3-clictopay-disabled-contract.md" \
+  "docs/go-live/_evidence/lot3-contact-lead-retention-policy.md" \
+  "docs/go-live/_evidence/lot3-no-leak-success-error-runtime-coverage.md" \
+  "docs/go-live/_evidence/lot3-redis-upstash-runtime-proof.md" \
+  "docs/go-live/_evidence/lot3-runtime-rgpd-assessment-command-log.md" \
+  "docs/go-live/_evidence/lot4-assessment-token-binding.md" \
+  "docs/go-live/_evidence/lot4-business-config-production-gate.md" \
+  "docs/go-live/_evidence/lot4-clictopay-disabled-runbook.md" \
+  "docs/go-live/_evidence/lot4-contact-lead-retention-job.md" \
+  "docs/go-live/_evidence/lot4-no-leak-e2e-runtime-coverage.md" \
+  "docs/go-live/_evidence/lot4-redis-upstash-runtime-proof.md" \
+  "docs/go-live/_evidence/lot4-token-runtime-payment-command-log.md" \
+  "docs/go-live/_evidence/lot5-business-config-runtime-decision.md" \
+  "docs/go-live/_evidence/lot5-clictopay-final-disabled-decision.md" \
+  "docs/go-live/_evidence/lot5-contact-lead-retention-dry-run.md" \
+  "docs/go-live/_evidence/lot5-p1-go-no-go-register.md" \
+  "docs/go-live/_evidence/lot5-public-e2e-critical-paths.md" \
+  "docs/go-live/_evidence/lot5-rate-limit-429-proof.md" \
+  "docs/go-live/_evidence/lot5-redis-upstash-authenticated-healthcheck.md" \
+  "docs/go-live/_evidence/lot5-runtime-exploitation-command-log.md" \
+  "docs/go-live/_evidence/lot6-contact-lead-retention-db-dry-run.md" \
+  "docs/go-live/_evidence/lot6-final-go-no-go-register.md" \
+  "docs/go-live/_evidence/lot6-rate-limit-429-runtime-proof.md" \
+  "docs/go-live/_evidence/lot6-redis-upstash-authenticated-proof.md" \
+  "docs/go-live/_evidence/lot6-release-candidate-worktree-audit.md" \
+  "docs/go-live/_evidence/lot6-staging-release-candidate-command-log.md" \
+  "docs/go-live/_evidence/lot7-final-decision-register.md" \
+  "docs/go-live/_evidence/lot7-release-candidate-audit-command-log.md" \
+  "docs/go-live/_evidence/lot7-release-candidate-commit-plan.md" \
+  "docs/go-live/_evidence/lot7-release-candidate-file-manifest.md" \
+  "docs/go-live/_evidence/lot7-runtime-human-assisted-proof.md" \
+  "docs/go-live/_evidence/lot7-security-scripts-audit.md" \
+  "docs/go-live/_evidence/lot8-final-release-candidate-register.md" \
+  "docs/go-live/_evidence/lot8-release-candidate-clean-manifest-command-log.md" \
+  "docs/go-live/_evidence/lot8-release-candidate-commit-plan-clean.md" \
+  "docs/go-live/_evidence/lot8-release-candidate-file-manifest-clean.md" \
+  "docs/go-live/_evidence/lot8-runtime-proof-status.md" \
+  "docs/go-live/_evidence/lot8-security-scripts-regression-audit.md" \
+  "docs/go-live/_evidence/playwright-public-smoke-triage.md"
+```
+
+### Résultat dry-run observé
+
+```txt
+add 'docs/go-live/00_EXECUTIVE_STATE.md'
+add 'docs/go-live/01_ACTION_PLAN.md'
+add 'docs/go-live/02_P0_P1_BACKLOG.md'
+add 'docs/go-live/03_RELEASE_GATES.md'
+add 'docs/go-live/04_TEST_MATRIX.md'
+add 'docs/go-live/05_API_SECURITY_MATRIX.md'
+add 'docs/go-live/06_BUSINESS_LOGIC_DECISIONS.md'
+add 'docs/go-live/07_ENV_INFRA_CHECKLIST.md'
+add 'docs/go-live/08_MARKETING_CONTENT_CHECKLIST.md'
+add 'docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md'
+add 'docs/go-live/10_LOT0_ACCEPTANCE.md'
+add 'docs/go-live/11_LOT1_SECURITY_CLOSURE.md'
+add 'docs/go-live/12_LOT1BIS_SECURITY_VERIFICATION.md'
+add 'docs/go-live/13_LOT1TER_P1_SECURITY_CLOSURE.md'
+add 'docs/go-live/14_LOT1QUATER_PUBLIC_ROLE_SECURITY_CLOSURE.md'
+add 'docs/go-live/15_LOT1QUINQUIES_FINAL_P1_SECURITY_CLOSURE.md'
+add 'docs/go-live/16_LOT2_PUBLIC_PRODUCT_RGPD_PAYMENT_DECISIONS.md'
+add 'docs/go-live/17_LOT3_RUNTIME_RGPD_ASSESSMENT_TOKEN.md'
+add 'docs/go-live/18_LOT4_RUNTIME_PAYMENT_RETENTION_TOKEN_BINDING.md'
+add 'docs/go-live/19_LOT5_RUNTIME_EXPLOITATION_GO_NO_GO.md'
+add 'docs/go-live/20_LOT6_STAGING_RELEASE_CANDIDATE_GO_NO_GO.md'
+add 'docs/go-live/21_LOT7_RELEASE_CANDIDATE_SECURITY_AUDIT.md'
+add 'docs/go-live/22_LOT8_RELEASE_CANDIDATE_CLEANUP.md'
+add 'docs/go-live/_evidence/entitlement-pricing-delta.md'
+add 'docs/go-live/_evidence/hardcoded-pricing-triage.md'
+add 'docs/go-live/_evidence/lot0-command-log.md'
+add 'docs/go-live/_evidence/lot1-api-route-triage.md'
+add 'docs/go-live/_evidence/lot1-command-log.md'
+add 'docs/go-live/_evidence/lot1-idor-tests.md'
+add 'docs/go-live/_evidence/lot1-rate-limit-runtime.md'
+add 'docs/go-live/_evidence/lot1bis-audit-script-review.md'
+add 'docs/go-live/_evidence/lot1bis-command-log.md'
+add 'docs/go-live/_evidence/lot1bis-p0-reclassification-audit.md'
+add 'docs/go-live/_evidence/lot1bis-p1-closure.md'
+add 'docs/go-live/_evidence/lot1bis-rate-limit-production-gate.md'
+add 'docs/go-live/_evidence/lot1quater-assistante.md'
+add 'docs/go-live/_evidence/lot1quater-coach.md'
+add 'docs/go-live/_evidence/lot1quater-command-log.md'
+add 'docs/go-live/_evidence/lot1quater-p1-before-after.md'
+add 'docs/go-live/_evidence/lot1quater-parent-student.md'
+add 'docs/go-live/_evidence/lot1quater-public-routes.md'
+add 'docs/go-live/_evidence/lot1quater-rate-limit-runtime-proof.md'
+add 'docs/go-live/_evidence/lot1quater-sensitive-fields-coverage.md'
+add 'docs/go-live/_evidence/lot1quater-stages.md'
+add 'docs/go-live/_evidence/lot1quinquies-admin-routes.md'
+add 'docs/go-live/_evidence/lot1quinquies-clictopay-webhook.md'
+add 'docs/go-live/_evidence/lot1quinquies-command-log.md'
+add 'docs/go-live/_evidence/lot1quinquies-p1-before-after.md'
+add 'docs/go-live/_evidence/lot1quinquies-public-sensitive-routes.md'
+add 'docs/go-live/_evidence/lot1quinquies-rate-limit-runtime-proof.md'
+add 'docs/go-live/_evidence/lot1quinquies-sensitive-fields-coverage.md'
+add 'docs/go-live/_evidence/lot1ter-bilans-assessments.md'
+add 'docs/go-live/_evidence/lot1ter-coach-reports.md'
+add 'docs/go-live/_evidence/lot1ter-command-log.md'
+add 'docs/go-live/_evidence/lot1ter-npc-documents.md'
+add 'docs/go-live/_evidence/lot1ter-p1-before-after.md'
+add 'docs/go-live/_evidence/lot1ter-payments-invoices.md'
+add 'docs/go-live/_evidence/lot1ter-sensitive-fields-coverage.md'
+add 'docs/go-live/_evidence/lot2-assessments-submit-decision.md'
+add 'docs/go-live/_evidence/lot2-bilan-gratuit-product-rgpd.md'
+add 'docs/go-live/_evidence/lot2-clictopay-payment-decision.md'
+add 'docs/go-live/_evidence/lot2-lamis-teacher-report-decision.md'
+add 'docs/go-live/_evidence/lot2-public-product-rgpd-command-log.md'
+add 'docs/go-live/_evidence/lot2-rate-limit-runtime-decision.md'
+add 'docs/go-live/_evidence/lot2-sensitive-fields-success-error-coverage.md'
+add 'docs/go-live/_evidence/lot2-stages-inscrire-product-rgpd.md'
+add 'docs/go-live/_evidence/lot2-student-activate-token-lifecycle.md'
+add 'docs/go-live/_evidence/lot3-assessments-public-token.md'
+add 'docs/go-live/_evidence/lot3-bilan-gratuit-rgpd-register.md'
+add 'docs/go-live/_evidence/lot3-business-configs-db-drift.md'
+add 'docs/go-live/_evidence/lot3-clictopay-disabled-contract.md'
+add 'docs/go-live/_evidence/lot3-contact-lead-retention-policy.md'
+add 'docs/go-live/_evidence/lot3-no-leak-success-error-runtime-coverage.md'
+add 'docs/go-live/_evidence/lot3-redis-upstash-runtime-proof.md'
+add 'docs/go-live/_evidence/lot3-runtime-rgpd-assessment-command-log.md'
+add 'docs/go-live/_evidence/lot4-assessment-token-binding.md'
+add 'docs/go-live/_evidence/lot4-business-config-production-gate.md'
+add 'docs/go-live/_evidence/lot4-clictopay-disabled-runbook.md'
+add 'docs/go-live/_evidence/lot4-contact-lead-retention-job.md'
+add 'docs/go-live/_evidence/lot4-no-leak-e2e-runtime-coverage.md'
+add 'docs/go-live/_evidence/lot4-redis-upstash-runtime-proof.md'
+add 'docs/go-live/_evidence/lot4-token-runtime-payment-command-log.md'
+add 'docs/go-live/_evidence/lot5-business-config-runtime-decision.md'
+add 'docs/go-live/_evidence/lot5-clictopay-final-disabled-decision.md'
+add 'docs/go-live/_evidence/lot5-contact-lead-retention-dry-run.md'
+add 'docs/go-live/_evidence/lot5-p1-go-no-go-register.md'
+add 'docs/go-live/_evidence/lot5-public-e2e-critical-paths.md'
+add 'docs/go-live/_evidence/lot5-rate-limit-429-proof.md'
+add 'docs/go-live/_evidence/lot5-redis-upstash-authenticated-healthcheck.md'
+add 'docs/go-live/_evidence/lot5-runtime-exploitation-command-log.md'
+add 'docs/go-live/_evidence/lot6-contact-lead-retention-db-dry-run.md'
+add 'docs/go-live/_evidence/lot6-final-go-no-go-register.md'
+add 'docs/go-live/_evidence/lot6-rate-limit-429-runtime-proof.md'
+add 'docs/go-live/_evidence/lot6-redis-upstash-authenticated-proof.md'
+add 'docs/go-live/_evidence/lot6-release-candidate-worktree-audit.md'
+add 'docs/go-live/_evidence/lot6-staging-release-candidate-command-log.md'
+add 'docs/go-live/_evidence/lot7-final-decision-register.md'
+add 'docs/go-live/_evidence/lot7-release-candidate-audit-command-log.md'
+add 'docs/go-live/_evidence/lot7-release-candidate-commit-plan.md'
+add 'docs/go-live/_evidence/lot7-release-candidate-file-manifest.md'
+add 'docs/go-live/_evidence/lot7-runtime-human-assisted-proof.md'
+add 'docs/go-live/_evidence/lot7-security-scripts-audit.md'
+add 'docs/go-live/_evidence/lot8-final-release-candidate-register.md'
+add 'docs/go-live/_evidence/lot8-release-candidate-clean-manifest-command-log.md'
+add 'docs/go-live/_evidence/lot8-release-candidate-commit-plan-clean.md'
+add 'docs/go-live/_evidence/lot8-release-candidate-file-manifest-clean.md'
+add 'docs/go-live/_evidence/lot8-runtime-proof-status.md'
+add 'docs/go-live/_evidence/lot8-security-scripts-regression-audit.md'
+add 'docs/go-live/_evidence/playwright-public-smoke-triage.md'
+```
+
+### Commande de commit proposée, NON EXÉCUTÉE
+
+```bash
+git commit -m "docs(go-live): add evidence and go-no-go registers"
+```
+
+### Tests à relancer avant commit
+
+`npm run check:docs-archive` + relecture docs go-live
+
+### Risques
+
+Volume documentaire important ; revue humaine recommandée avant commit.
+
+## Contrôles d'exclusion
+
+- `rapport_audit_2_07_2026.md` : non inclus.
+- `.env*` : aucun fichier inclus.
+- `docs/audits/audit-nexus-reussite.md` : non inclus, décision humaine séparée.
+- Artefacts `.next/**`, `node_modules/**`, `test-results/**`, `playwright-report/**` : non inclus.

--- a/docs/go-live/_evidence/lot10-git-add-dry-run-proof.md
+++ b/docs/go-live/_evidence/lot10-git-add-dry-run-proof.md
@@ -1,0 +1,78 @@
+# Lot 10 — Git add dry-run proof
+
+## Résultat
+
+`PASSED`
+
+## Commits proposés
+
+`9`
+
+## Fichiers Include RC couverts
+
+`281`
+
+## Fichiers non couverts
+
+Aucun.
+
+## Fichiers couverts plusieurs fois
+
+Aucun.
+
+## Fichiers Exclude détectés dans le plan
+
+Aucun.
+
+## Fichiers Needs human review détectés dans le plan
+
+Aucun.
+
+## Fichiers .env détectés dans le plan
+
+Aucun.
+
+## Rapport racine détecté dans le plan
+
+Aucun.
+
+## Artefacts générés détectés dans le plan
+
+Aucun.
+
+## Staging Git avant dry-run
+
+```txt
+(vide)
+```
+
+## Staging Git après dry-run
+
+```txt
+(vide)
+```
+
+## P1 visibles
+
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+## Décision
+
+`READY_FOR_HUMAN_COMMIT`
+
+## Test de validation exécuté
+
+```bash
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand __tests__/scripts/security-audit-scripts-regression.test.ts __tests__/scripts/release-candidate-manifest-consistency.test.ts __tests__/scripts/release-candidate-git-add-dry-run-plan.test.ts
+```
+
+Résultat : `3` suites passées, `19` tests passés.
+
+## Vérification staging finale
+
+`git diff --cached --name-only` : aucune sortie.

--- a/docs/go-live/_evidence/lot10-human-commit-dry-run-command-log.md
+++ b/docs/go-live/_evidence/lot10-human-commit-dry-run-command-log.md
@@ -1,0 +1,69 @@
+# Lot 10 — Journal human commit dry-run
+
+## Baseline
+
+- Date locale : 03/07/2026 18:03:25 CET
+- Node : `v22.21.0`
+- npm : `11.6.3`
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Entrées `git status --short --untracked-files=all` avant artefacts Lot 10 : `290`
+- Fichiers suivis modifiés : `130`
+- Fichiers non suivis avant artefacts Lot 10 : `160`
+- Diff `.env` : aucune sortie observée.
+- Staging Git avant dry-runs : `VIDE`.
+- Staging Git après dry-runs : `VIDE`.
+
+## Dry-runs exécutés
+
+- `9` commandes `git add --dry-run -- ...` exécutées.
+- Aucun `git add` réel exécuté.
+- Aucun `git commit` exécuté.
+- Aucun `git push` exécuté.
+- Aucune PR créée.
+
+## Runtime optionnel
+
+- `NEXUS_HEALTH_AUTH_ABSENT`
+- `RL_PROBE_NOT_ALLOWED`
+- `DATABASE_URL_ABSENT`
+- `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED`
+
+## Commandes ciblées
+
+- Baseline Node/npm/Git exécutée sous Node 20.
+- P1 confirmés avec `rg -n "^\| P1 \|" docs/go-live/api-security-matrix.full.md`.
+- Test RED exécuté avant génération du plan : échec attendu `ENOENT lot10-git-add-dry-run-plan.md`.
+- Dry-runs générés depuis le manifeste et le plan Lot 8.
+
+## Limites
+
+- Aucun secret lu.
+- Aucun `.env` modifié.
+- Aucun staging réel.
+- Aucun commit ni PR.
+- Redis/Upstash non prouvé.
+- 429 runtime non exécuté.
+- ContactLead dry-run DB non exécuté.
+
+## Gates finales Lot 10
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `npm run typecheck` | OK | `tsc --noEmit` sans erreur |
+| `npm run lint` | OK | Commande terminée avec code `0`; warnings existants sous le seuil configuré |
+| `npm run test:unit -- --runInBand __tests__/scripts/security-audit-scripts-regression.test.ts __tests__/scripts/release-candidate-manifest-consistency.test.ts __tests__/scripts/release-candidate-git-add-dry-run-plan.test.ts` | OK | `3` suites passées, `19` tests passés |
+| `npm run check:docs-archive` | OK | Aucun audit/report historique à la racine `docs/` |
+| `git diff --cached --name-only` | OK | Aucune sortie, staging vide |
+| `git diff --name-only \| rg '(^\|/)\\.env($\|\\.)' \|\| true` | OK | Aucune sortie |
+| `rg -n "^\\| P1 \\|" docs/go-live/api-security-matrix.full.md` | OK | `6` P1 visibles |
+
+## État final observé
+
+- Entrées `git status --short --untracked-files=all` après Lot 10 : `298`
+- Fichiers suivis modifiés : `130`
+- Fichiers non suivis après Lot 10 : `168`
+- Staging Git final : `VIDE`
+- Aucun `git add` réel exécuté.
+- Aucun commit exécuté.
+- Aucune PR créée.

--- a/docs/go-live/_evidence/lot10-human-review-pending-files.md
+++ b/docs/go-live/_evidence/lot10-human-review-pending-files.md
@@ -1,0 +1,7 @@
+# Lot 10 — Fichiers en décision humaine
+
+| Fichier | Statut | Décision actuelle | Options | Recommandation |
+|---|---|---|---|---|
+| `docs/audits/audit-nexus-reussite.md` | Needs human review | Non inclus par défaut | Inclure / Exclure / Reporter | REPORTER tant que non validé humainement |
+
+Ce fichier n'apparaît dans aucun bloc de commit standard du plan dry-run Lot 10.

--- a/docs/go-live/_evidence/lot10-runtime-proof-status.md
+++ b/docs/go-live/_evidence/lot10-runtime-proof-status.md
@@ -1,0 +1,10 @@
+# Lot 10 — Runtime proof status
+
+| Variable / autorisation | Résultat | Décision |
+|---|---|---|
+| `NEXUS_HEALTH_AUTH` | `ABSENT` | Redis/Upstash non prouvé |
+| `NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE` | `NOT_ALLOWED` | 429 runtime non exécuté |
+| `DATABASE_URL` | `ABSENT` | ContactLead DB dry-run non prouvé |
+| `NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB` | `NOT_ALLOWED` | Dry-run DB non exécuté |
+
+Aucune valeur secrète n'a été lue ni écrite.

--- a/docs/go-live/_evidence/lot11-final-human-commit-register.md
+++ b/docs/go-live/_evidence/lot11-final-human-commit-register.md
@@ -1,0 +1,18 @@
+# Lot 11 — Registre final human commit runbook
+
+| Domaine | Statut | Preuve | Décision |
+|---|---|---|---|
+| P0 | 0 | matrice | OK |
+| P1 | 6 | matrice | bêta contrôlée seulement |
+| Dry-run plan | PASSED | Lot 10 | OK |
+| Human commit runbook | PASSED | test Lot 11 | READY_FOR_HUMAN_EXECUTION |
+| Excluded files | OK | preuve Lot 11 | Exclusions maintenues |
+| Human review files | PENDING | `docs/audits/audit-nexus-reussite.md` absent des commits standards | Décision humaine requise |
+| Runtime Redis | NOT_PROVEN | variables absentes | BETA_ELARGIE_BLOCKED |
+| 429 runtime | NOT_PROVEN | probe non autorisée | BETA_ELARGIE_BLOCKED |
+| ContactLead DB dry-run | NOT_PROVEN | DB/autorisation absentes | GO_LIVE_LARGE_BLOCKED |
+| Human commit readiness | READY_FOR_HUMAN_EXECUTION | runbook + test | READY_FOR_HUMAN_EXECUTION |
+| Gates ciblées | PASSED | typecheck, lint, tests scripts, docs-archive | READY_FOR_HUMAN_EXECUTION |
+| Staging Git | EMPTY | `git diff --cached --name-only` sans sortie | Aucun staging réel |
+
+Décisions : `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`, `BETA_ELARGIE_BLOCKED`, `GO_LIVE_LARGE_BLOCKED`.

--- a/docs/go-live/_evidence/lot11-human-commit-runbook-command-log.md
+++ b/docs/go-live/_evidence/lot11-human-commit-runbook-command-log.md
@@ -1,0 +1,52 @@
+# Lot 11 — Journal human commit runbook
+
+## Baseline
+
+- Date locale : 2026-07-03 23:18:25 CET
+- Node : `v20.20.0`
+- npm : `10.8.2`
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Entrées `git status --short --untracked-files=all` au moment du journal : `300`
+- Fichiers suivis modifiés : `130`
+- Fichiers non suivis : `170`
+- Diff de fichiers de configuration locale sensibles : aucune sortie observée
+- Staging Git initial : `VIDE`
+
+## Commandes et actions Lot 11
+
+- P1 confirmés via `rg -n "^\| P1 \|" docs/go-live/api-security-matrix.full.md`.
+- Test RED exécuté avant création du runbook : échec attendu `ENOENT lot11-human-commit-runbook.md`.
+- Runbook humain généré depuis le plan dry-run Lot 10.
+- Aucun `git add` réel exécuté.
+- Aucun commit exécuté.
+- Aucune PR créée.
+
+## Runtime optionnel
+
+- `NEXUS_HEALTH_AUTH_ABSENT`.
+- `RL_PROBE_NOT_ALLOWED`.
+- `DATABASE_URL_ABSENT`.
+- `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED`.
+
+## Gates finales Lot 11
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `npm run typecheck` | OK | `tsc --noEmit` sans erreur |
+| `npm run lint` | OK | Commande terminée avec code `0`; warnings existants sous le seuil configuré |
+| `npm run test:unit -- --runInBand __tests__/scripts/security-audit-scripts-regression.test.ts __tests__/scripts/release-candidate-manifest-consistency.test.ts __tests__/scripts/release-candidate-git-add-dry-run-plan.test.ts __tests__/scripts/release-candidate-human-commit-runbook.test.ts` | OK | `4` suites passées, `24` tests passés |
+| `npm run check:docs-archive` | OK | Aucun audit/report historique à la racine `docs/` |
+| `git diff --cached --name-only` | OK | Aucune sortie, staging vide |
+| `git diff --name-only \| rg '(^\|/)\\.env($\|\\.)' \|\| true` | OK | Aucune sortie |
+| `rg -n "^\\| P1 \\|" docs/go-live/api-security-matrix.full.md` | OK | `6` P1 visibles |
+
+## État final observé
+
+- Entrées `git status --short --untracked-files=all` après Lot 11 : `306`
+- Fichiers suivis modifiés : `130`
+- Fichiers non suivis après Lot 11 : `176`
+- Fichiers staged : `0`
+- Aucun `git add` réel exécuté.
+- Aucun commit exécuté.
+- Aucune PR créée.

--- a/docs/go-live/_evidence/lot11-human-commit-runbook-proof.md
+++ b/docs/go-live/_evidence/lot11-human-commit-runbook-proof.md
@@ -1,0 +1,72 @@
+# Lot 11 — Human commit runbook proof
+
+## Résultat
+
+`PASSED`
+
+## Commits proposés
+
+`9`
+
+## Fichiers Include RC couverts
+
+`281`
+
+## Fichiers non couverts
+
+Aucun.
+
+## Fichiers couverts plusieurs fois
+
+Aucun.
+
+## Fichiers Exclude détectés dans les commits standards
+
+Aucun.
+
+## Fichiers Needs human review détectés dans les commits standards
+
+Aucun.
+
+## Staging Git avant vérification Lot 11
+
+```txt
+(vide)
+```
+
+## Staging Git après génération du runbook
+
+```txt
+(vide)
+```
+
+## P1 visibles
+
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/payments/clictopay/webhook`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+## Décision
+
+`READY_FOR_HUMAN_EXECUTION`
+
+## Test de validation exécuté
+
+```bash
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand __tests__/scripts/security-audit-scripts-regression.test.ts __tests__/scripts/release-candidate-manifest-consistency.test.ts __tests__/scripts/release-candidate-git-add-dry-run-plan.test.ts __tests__/scripts/release-candidate-human-commit-runbook.test.ts
+```
+
+Résultat : `4` suites passées, `24` tests passés.
+
+## Vérification staging finale
+
+`git diff --cached --name-only` : aucune sortie.

--- a/docs/go-live/_evidence/lot11-human-commit-runbook.md
+++ b/docs/go-live/_evidence/lot11-human-commit-runbook.md
@@ -1,0 +1,947 @@
+# Lot 11 — Runbook humain de commits
+
+Ce runbook transforme le plan Lot 10 en instructions humaines. Les commandes ci-dessous sont a executer par un humain uniquement. Codex ne les a pas executees.
+
+- Aucun staging reel effectue par Codex pendant ce lot.
+- Aucun commit execute par Codex pendant ce lot.
+- Aucune creation de PR par Codex pendant ce lot.
+- Le fichier en decision humaine `docs/audits/audit-nexus-reussite.md` reste hors commits standards.
+
+## Commit 1 — chore(go-live): update security inventory and matrices
+
+### Objectif
+
+Versionner les inventaires et scripts de génération nécessaires au suivi RC.
+
+### Fichiers concernés
+
+- `docs/go-live/api-security-matrix.full.md`
+- `docs/security/API_GUARD_INVENTORY.md`
+- `scripts/check-bundle-weight.sh`
+- `scripts/go-live/generate-api-security-matrix.mjs`
+- `scripts/security/audit-api-guards.mjs`
+
+### Commande de staging à exécuter par l’humain
+
+```bash
+git add -- \
+  "docs/go-live/api-security-matrix.full.md" \
+  "docs/security/API_GUARD_INVENTORY.md" \
+  "scripts/check-bundle-weight.sh" \
+  "scripts/go-live/generate-api-security-matrix.mjs" \
+  "scripts/security/audit-api-guards.mjs"
+```
+
+### Commande de vérification du staging
+
+```bash
+git diff --cached --name-only
+```
+
+### Commande de commit à exécuter par l’humain
+
+```bash
+git commit -m "chore(go-live): update security inventory and matrices"
+```
+
+### Tests recommandés avant ce commit
+
+`node scripts/security/audit-api-guards.mjs`, `node scripts/go-live/generate-api-security-matrix.mjs`, `npm run check:bundle-weight`
+
+### Vérifications après ce commit
+
+- Relancer `git status --short --untracked-files=all`.
+- Vérifier que le staging est vide après le commit humain.
+- Vérifier que les 6 P1 restent visibles dans la matrice API.
+
+### Risques à accepter
+
+Revue code standard requise ; ne pas inclure de fichiers exclus ou en décision humaine.
+
+## Commit 2 — fix(api-security): close admin and role guard gaps
+
+### Objectif
+
+Regrouper les durcissements API, guards, ownership et projections hors flux publics/paiement.
+
+### Fichiers concernés
+
+- `app/api/admin/config/rollback/route.ts`
+- `app/api/admin/config/route.ts`
+- `app/api/admin/directeur/stats/route.ts`
+- `app/api/admin/documents/route.ts`
+- `app/api/admin/invoices/route.ts`
+- `app/api/admin/recompute-ssn/route.ts`
+- `app/api/admin/subscriptions/route.ts`
+- `app/api/admin/test-email/route.ts`
+- `app/api/assistante/credit-requests/route.ts`
+- `app/api/assistante/quotes/pdf/route.ts`
+- `app/api/assistante/students/credits/route.ts`
+- `app/api/assistante/subscription-requests/route.ts`
+- `app/api/assistante/subscriptions/route.ts`
+- `app/api/bilans/[id]/export/route.ts`
+- `app/api/bilans/[id]/route.ts`
+- `app/api/bilans/generate/route.ts`
+- `app/api/bilans/route.ts`
+- `app/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate/route.ts`
+- `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent/route.ts`
+- `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student/route.ts`
+- `app/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale/route.ts`
+- `app/api/coach/students/[studentId]/documents/route.ts`
+- `app/api/coach/students/[studentId]/eaf-preparation-report/validate/route.ts`
+- `app/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate/route.ts`
+- `app/api/coach/students/[studentId]/notes/route.ts`
+- `app/api/coach/students/[studentId]/survival-mode/route.ts`
+- `app/api/coach/trajectory/route.ts`
+- `app/api/documents/[id]/route.ts`
+- `app/api/eleve/bilan-diagnostic-maths-terminale/route.ts`
+- `app/api/invoices/[id]/pdf/route.ts`
+- `app/api/invoices/[id]/receipt/pdf/route.ts`
+- `app/api/lamis/teacher-report/route.ts`
+- `app/api/npc/submissions/[submissionId]/documents/[documentId]/route.ts`
+- `app/api/npc/submissions/[submissionId]/documents/route.ts`
+- `app/api/npc/submissions/[submissionId]/generate/route.ts`
+- `app/api/npc/submissions/route.ts`
+- `app/api/npc/uploads/route.ts`
+- `app/api/parent/children/route.ts`
+- `app/api/parent/subscription-requests/route.ts`
+- `app/api/parent/subscriptions/route.ts`
+- `app/api/programme/maths-1ere-stmg/stage-progress/route.ts`
+- `app/api/sessions/cancel/route.ts`
+- `app/api/sessions/video/route.ts`
+- `app/api/stages/[stageSlug]/inscrire/route.ts`
+- `app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts`
+- `app/api/stages/[stageSlug]/route.ts`
+- `app/api/student/activate/route.ts`
+- `app/api/student/automatismes/attempts/route.ts`
+- `app/api/student/automatismes/check-answer/route.ts`
+- `app/api/student/automatismes/series/[id]/route.ts`
+- `app/api/student/documents/[id]/download/route.ts`
+- `app/api/student/nexus-index/route.ts`
+- `app/api/student/survival/phrases/[phraseId]/copied/route.ts`
+- `app/api/student/survival/progress/route.ts`
+- `app/api/student/survival/qcm/attempt/route.ts`
+- `app/api/student/survival/reflexes/[reflexId]/attempt/route.ts`
+- `app/api/student/trajectory/route.ts`
+- `lib/invoice/index.ts`
+- `lib/invoice/not-found.ts`
+- `lib/stages/inscription-schema.ts`
+- `lib/validations.ts`
+
+### Commande de staging à exécuter par l’humain
+
+```bash
+git add -- \
+  "app/api/admin/config/rollback/route.ts" \
+  "app/api/admin/config/route.ts" \
+  "app/api/admin/directeur/stats/route.ts" \
+  "app/api/admin/documents/route.ts" \
+  "app/api/admin/invoices/route.ts" \
+  "app/api/admin/recompute-ssn/route.ts" \
+  "app/api/admin/subscriptions/route.ts" \
+  "app/api/admin/test-email/route.ts" \
+  "app/api/assistante/credit-requests/route.ts" \
+  "app/api/assistante/quotes/pdf/route.ts" \
+  "app/api/assistante/students/credits/route.ts" \
+  "app/api/assistante/subscription-requests/route.ts" \
+  "app/api/assistante/subscriptions/route.ts" \
+  "app/api/bilans/[id]/export/route.ts" \
+  "app/api/bilans/[id]/route.ts" \
+  "app/api/bilans/generate/route.ts" \
+  "app/api/bilans/route.ts" \
+  "app/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate/route.ts" \
+  "app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent/route.ts" \
+  "app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student/route.ts" \
+  "app/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale/route.ts" \
+  "app/api/coach/students/[studentId]/documents/route.ts" \
+  "app/api/coach/students/[studentId]/eaf-preparation-report/validate/route.ts" \
+  "app/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate/route.ts" \
+  "app/api/coach/students/[studentId]/notes/route.ts" \
+  "app/api/coach/students/[studentId]/survival-mode/route.ts" \
+  "app/api/coach/trajectory/route.ts" \
+  "app/api/documents/[id]/route.ts" \
+  "app/api/eleve/bilan-diagnostic-maths-terminale/route.ts" \
+  "app/api/invoices/[id]/pdf/route.ts" \
+  "app/api/invoices/[id]/receipt/pdf/route.ts" \
+  "app/api/lamis/teacher-report/route.ts" \
+  "app/api/npc/submissions/[submissionId]/documents/[documentId]/route.ts" \
+  "app/api/npc/submissions/[submissionId]/documents/route.ts" \
+  "app/api/npc/submissions/[submissionId]/generate/route.ts" \
+  "app/api/npc/submissions/route.ts" \
+  "app/api/npc/uploads/route.ts" \
+  "app/api/parent/children/route.ts" \
+  "app/api/parent/subscription-requests/route.ts" \
+  "app/api/parent/subscriptions/route.ts" \
+  "app/api/programme/maths-1ere-stmg/stage-progress/route.ts" \
+  "app/api/sessions/cancel/route.ts" \
+  "app/api/sessions/video/route.ts" \
+  "app/api/stages/[stageSlug]/inscrire/route.ts" \
+  "app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts" \
+  "app/api/stages/[stageSlug]/route.ts" \
+  "app/api/student/activate/route.ts" \
+  "app/api/student/automatismes/attempts/route.ts" \
+  "app/api/student/automatismes/check-answer/route.ts" \
+  "app/api/student/automatismes/series/[id]/route.ts" \
+  "app/api/student/documents/[id]/download/route.ts" \
+  "app/api/student/nexus-index/route.ts" \
+  "app/api/student/survival/phrases/[phraseId]/copied/route.ts" \
+  "app/api/student/survival/progress/route.ts" \
+  "app/api/student/survival/qcm/attempt/route.ts" \
+  "app/api/student/survival/reflexes/[reflexId]/attempt/route.ts" \
+  "app/api/student/trajectory/route.ts" \
+  "lib/invoice/index.ts" \
+  "lib/invoice/not-found.ts" \
+  "lib/stages/inscription-schema.ts" \
+  "lib/validations.ts"
+```
+
+### Commande de vérification du staging
+
+```bash
+git diff --cached --name-only
+```
+
+### Commande de commit à exécuter par l’humain
+
+```bash
+git commit -m "fix(api-security): close admin and role guard gaps"
+```
+
+### Tests recommandés avant ce commit
+
+`npm run test:unit -- --runInBand __tests__/api/admin.config.route.test.ts __tests__/api/admin.documents.route.test.ts __tests__/api/bilans.id.route.test.ts`
+
+### Vérifications après ce commit
+
+- Relancer `git status --short --untracked-files=all`.
+- Vérifier que le staging est vide après le commit humain.
+- Vérifier que les 6 P1 restent visibles dans la matrice API.
+
+### Risques à accepter
+
+Revue code standard requise ; ne pas inclure de fichiers exclus ou en décision humaine.
+
+## Commit 3 — fix(public-funnel): lead-only bilan and assessment token binding
+
+### Objectif
+
+Regrouper le passage bilan lead-only et le binding du token assessment au flux autorisé.
+
+### Fichiers concernés
+
+- `app/api/assessments/public-token/route.ts`
+- `app/api/assessments/submit/route.ts`
+- `app/api/assessments/submit/types.ts`
+- `app/api/bilan-gratuit/dismiss/route.ts`
+- `app/api/bilan-gratuit/route.ts`
+- `app/bilan-gratuit/assessment/AssessmentClient.tsx`
+- `app/bilan-gratuit/assessment/page.tsx`
+- `app/layout.tsx`
+- `components/assessments/AssessmentRunner.tsx`
+- `components/stages/StageInscriptionForm.tsx`
+- `lib/assessments/public-token.ts`
+- `lib/crm/contact-leads.ts`
+
+### Commande de staging à exécuter par l’humain
+
+```bash
+git add -- \
+  "app/api/assessments/public-token/route.ts" \
+  "app/api/assessments/submit/route.ts" \
+  "app/api/assessments/submit/types.ts" \
+  "app/api/bilan-gratuit/dismiss/route.ts" \
+  "app/api/bilan-gratuit/route.ts" \
+  "app/bilan-gratuit/assessment/AssessmentClient.tsx" \
+  "app/bilan-gratuit/assessment/page.tsx" \
+  "app/layout.tsx" \
+  "components/assessments/AssessmentRunner.tsx" \
+  "components/stages/StageInscriptionForm.tsx" \
+  "lib/assessments/public-token.ts" \
+  "lib/crm/contact-leads.ts"
+```
+
+### Commande de vérification du staging
+
+```bash
+git diff --cached --name-only
+```
+
+### Commande de commit à exécuter par l’humain
+
+```bash
+git commit -m "fix(public-funnel): lead-only bilan and assessment token binding"
+```
+
+### Tests recommandés avant ce commit
+
+`npm run test:unit -- --runInBand __tests__/api/bilan-gratuit.product-rgpd.test.ts __tests__/api/assessments.submit.token-binding.test.ts __tests__/app/bilan-gratuit.assessment-page-token.test.tsx`
+
+### Vérifications après ce commit
+
+- Relancer `git status --short --untracked-files=all`.
+- Vérifier que le staging est vide après le commit humain.
+- Vérifier que les 6 P1 restent visibles dans la matrice API.
+
+### Risques à accepter
+
+Flux public critique mineurs ; relancer tests token, bilan et Playwright assessment avant commit humain.
+
+## Commit 4 — fix(runtime): rate-limit probe and business-config gate
+
+### Objectif
+
+Regrouper les garde-fous runtime : healthcheck, rate-limit probe et BusinessConfig.
+
+### Fichiers concernés
+
+- `app/api/internal/health/route.ts`
+- `app/api/internal/rate-limit-probe/route.ts`
+- `lib/config/snapshot.ts`
+- `lib/rate-limit/index.ts`
+
+### Commande de staging à exécuter par l’humain
+
+```bash
+git add -- \
+  "app/api/internal/health/route.ts" \
+  "app/api/internal/rate-limit-probe/route.ts" \
+  "lib/config/snapshot.ts" \
+  "lib/rate-limit/index.ts"
+```
+
+### Commande de vérification du staging
+
+```bash
+git diff --cached --name-only
+```
+
+### Commande de commit à exécuter par l’humain
+
+```bash
+git commit -m "fix(runtime): rate-limit probe and business-config gate"
+```
+
+### Tests recommandés avant ce commit
+
+`npm run test:unit -- --runInBand __tests__/api/internal.rate-limit-probe.test.ts __tests__/api/internal.business-config.health.test.ts __tests__/lib/rate-limit.production-gate.test.ts`
+
+### Vérifications après ce commit
+
+- Relancer `git status --short --untracked-files=all`.
+- Vérifier que le staging est vide après le commit humain.
+- Vérifier que les 6 P1 restent visibles dans la matrice API.
+
+### Risques à accepter
+
+Preuves Redis/Upstash externes encore absentes ; ne pas lever les réserves runtime.
+
+## Commit 5 — fix(payments): keep clictopay disabled and fail closed
+
+### Objectif
+
+Maintenir ClicToPay désactivé et fail-closed côté API/UI.
+
+### Fichiers concernés
+
+- `app/api/payments/clictopay/init/route.ts`
+- `app/api/payments/clictopay/webhook/route.ts`
+- `components/marketing/PaymentMethodsNote.tsx`
+
+### Commande de staging à exécuter par l’humain
+
+```bash
+git add -- \
+  "app/api/payments/clictopay/init/route.ts" \
+  "app/api/payments/clictopay/webhook/route.ts" \
+  "components/marketing/PaymentMethodsNote.tsx"
+```
+
+### Commande de vérification du staging
+
+```bash
+git diff --cached --name-only
+```
+
+### Commande de commit à exécuter par l’humain
+
+```bash
+git commit -m "fix(payments): keep clictopay disabled and fail closed"
+```
+
+### Tests recommandés avant ce commit
+
+`npm run test:unit -- --runInBand __tests__/api/payments.clictopay.disabled-contract.test.ts __tests__/api/payments.clictopay.feature-flag-consistency.test.ts __tests__/ui/payment-methods.clictopay-disabled.test.tsx`
+
+### Vérifications après ce commit
+
+- Relancer `git status --short --untracked-files=all`.
+- Vérifier que le staging est vide après le commit humain.
+- Vérifier que les 6 P1 restent visibles dans la matrice API.
+
+### Risques à accepter
+
+Paiement carte doit rester désactivé ; vérifier ClicToPay disabled avant commit humain.
+
+## Commit 6 — chore(maintenance): add contact-lead retention dry-run
+
+### Objectif
+
+Ajouter le script de rétention ContactLead en dry-run par défaut.
+
+### Fichiers concernés
+
+- `scripts/maintenance/contact-leads-retention.ts`
+
+### Commande de staging à exécuter par l’humain
+
+```bash
+git add -- \
+  "scripts/maintenance/contact-leads-retention.ts"
+```
+
+### Commande de vérification du staging
+
+```bash
+git diff --cached --name-only
+```
+
+### Commande de commit à exécuter par l’humain
+
+```bash
+git commit -m "chore(maintenance): add contact-lead retention dry-run"
+```
+
+### Tests recommandés avant ce commit
+
+`npm run test:unit -- --runInBand __tests__/scripts/contact-leads-retention.test.ts __tests__/lib/crm/contact-leads.retention.test.ts`
+
+### Vérifications après ce commit
+
+- Relancer `git status --short --untracked-files=all`.
+- Vérifier que le staging est vide après le commit humain.
+- Vérifier que les 6 P1 restent visibles dans la matrice API.
+
+### Risques à accepter
+
+Revue code standard requise ; ne pas inclure de fichiers exclus ou en décision humaine.
+
+## Commit 7 — test(security): add no-leak, idor, token and audit regressions
+
+### Objectif
+
+Ajouter les tests unitaires de non-régression sécurité, no-leak, IDOR, tokens et scripts.
+
+### Fichiers concernés
+
+- `__tests__/api/admin.config.route.test.ts`
+- `__tests__/api/admin.directeur.stats.route.test.ts`
+- `__tests__/api/admin.documents.route.test.ts`
+- `__tests__/api/admin.invoices.route.test.ts`
+- `__tests__/api/admin.recompute-ssn.route.test.ts`
+- `__tests__/api/admin.subscriptions.route.test.ts`
+- `__tests__/api/admin.test-email.route.test.ts`
+- `__tests__/api/assessments-rbac.test.ts`
+- `__tests__/api/assessments-submit.test.ts`
+- `__tests__/api/assessments.public-token.binding.test.ts`
+- `__tests__/api/assessments.public-token.route.test.ts`
+- `__tests__/api/assessments.submit.token-binding.test.ts`
+- `__tests__/api/assessments.submit.token-security.test.ts`
+- `__tests__/api/assistant.credit-requests.route.test.ts`
+- `__tests__/api/assistant.students.credits.route.test.ts`
+- `__tests__/api/assistant.subscription-requests.route.test.ts`
+- `__tests__/api/assistant.subscriptions.route.test.ts`
+- `__tests__/api/assistante.quotes.pdf.route.test.ts`
+- `__tests__/api/bilan-gratuit.product-rgpd.test.ts`
+- `__tests__/api/bilan-gratuit.rgpd-minimization.test.ts`
+- `__tests__/api/bilan-gratuit.security.test.ts`
+- `__tests__/api/bilan-gratuit.test.ts`
+- `__tests__/api/bilans.id.route.test.ts`
+- `__tests__/api/bilans.idor.test.ts`
+- `__tests__/api/bilans/crud.test.ts`
+- `__tests__/api/bilans/generate.test.ts`
+- `__tests__/api/coach.bilan-diagnostic-maths-terminale.security.test.ts`
+- `__tests__/api/coach.eaf-preparation-report.validate.test.ts`
+- `__tests__/api/coach.eaf-stage-regenerate.security.test.ts`
+- `__tests__/api/coach.generated-reports.route.test.ts`
+- `__tests__/api/coach.trajectory.security.test.ts`
+- `__tests__/api/documents-access.test.ts`
+- `__tests__/api/documents.id.route.test.ts`
+- `__tests__/api/eleve.bilan-diagnostic-maths-terminale.security.test.ts`
+- `__tests__/api/internal.business-config.health.test.ts`
+- `__tests__/api/internal.health.rate-limit.test.ts`
+- `__tests__/api/internal.rate-limit-probe.test.ts`
+- `__tests__/api/invoices.pdf.route.test.ts`
+- `__tests__/api/invoices.receipt.pdf.route.test.ts`
+- `__tests__/api/lamis.teacher-report.route.test.ts`
+- `__tests__/api/npc.documents.route.test.ts`
+- `__tests__/api/npc.files.route.test.ts`
+- `__tests__/api/npc.generate.test.ts`
+- `__tests__/api/npc.submissions.security.test.ts`
+- `__tests__/api/npc.uploads.route.test.ts`
+- `__tests__/api/parent.children.activation.route.test.ts`
+- `__tests__/api/parent.children.route.test.ts`
+- `__tests__/api/parent.subscription-requests.route.test.ts`
+- `__tests__/api/parent.subscriptions.route.test.ts`
+- `__tests__/api/payments.clictopay.disabled-contract.test.ts`
+- `__tests__/api/payments.clictopay.feature-flag-consistency.test.ts`
+- `__tests__/api/payments.clictopay.init.route.test.ts`
+- `__tests__/api/payments.clictopay.webhook.disabled.test.ts`
+- `__tests__/api/payments.clictopay.webhook.route.test.ts`
+- `__tests__/api/payments.clictopay.webhook.security.test.ts`
+- `__tests__/api/programme.maths-1ere-stmg.stage-progress.test.ts`
+- `__tests__/api/public-rate-limit.coverage.test.ts`
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+- `__tests__/api/sessions.cancel.route.test.ts`
+- `__tests__/api/sessions.video.route.test.ts`
+- `__tests__/api/stages.inscrire.product-rgpd.test.ts`
+- `__tests__/api/stages.inscrire.security.test.ts`
+- `__tests__/api/stages/confirm.test.ts`
+- `__tests__/api/stages/inscriptions.test.ts`
+- `__tests__/api/student.activate.lifecycle-security.test.ts`
+- `__tests__/api/student.activate.route.test.ts`
+- `__tests__/app/bilan-gratuit.assessment-page-token.test.tsx`
+- `__tests__/components/offer-detail-dialog.test.tsx`
+- `__tests__/components/offres-page.test.tsx`
+- `__tests__/lib/assessments/public-token.test.ts`
+- `__tests__/lib/bilan-gratuit-form.test.tsx`
+- `__tests__/lib/business-config.fallback.test.ts`
+- `__tests__/lib/business-config.production-gate.test.ts`
+- `__tests__/lib/crm/contact-leads.retention.test.ts`
+- `__tests__/lib/invoice/access-scope.test.ts`
+- `__tests__/lib/rate-limit.production-gate.test.ts`
+- `__tests__/lib/validations.test.ts`
+- `__tests__/scripts/audit-api-guards.classification.test.ts`
+- `__tests__/scripts/contact-leads-retention.test.ts`
+- `__tests__/scripts/security-audit-scripts-regression.test.ts`
+- `__tests__/ui/payment-methods.clictopay-disabled.test.tsx`
+
+### Commande de staging à exécuter par l’humain
+
+```bash
+git add -- \
+  "__tests__/api/admin.config.route.test.ts" \
+  "__tests__/api/admin.directeur.stats.route.test.ts" \
+  "__tests__/api/admin.documents.route.test.ts" \
+  "__tests__/api/admin.invoices.route.test.ts" \
+  "__tests__/api/admin.recompute-ssn.route.test.ts" \
+  "__tests__/api/admin.subscriptions.route.test.ts" \
+  "__tests__/api/admin.test-email.route.test.ts" \
+  "__tests__/api/assessments-rbac.test.ts" \
+  "__tests__/api/assessments-submit.test.ts" \
+  "__tests__/api/assessments.public-token.binding.test.ts" \
+  "__tests__/api/assessments.public-token.route.test.ts" \
+  "__tests__/api/assessments.submit.token-binding.test.ts" \
+  "__tests__/api/assessments.submit.token-security.test.ts" \
+  "__tests__/api/assistant.credit-requests.route.test.ts" \
+  "__tests__/api/assistant.students.credits.route.test.ts" \
+  "__tests__/api/assistant.subscription-requests.route.test.ts" \
+  "__tests__/api/assistant.subscriptions.route.test.ts" \
+  "__tests__/api/assistante.quotes.pdf.route.test.ts" \
+  "__tests__/api/bilan-gratuit.product-rgpd.test.ts" \
+  "__tests__/api/bilan-gratuit.rgpd-minimization.test.ts" \
+  "__tests__/api/bilan-gratuit.security.test.ts" \
+  "__tests__/api/bilan-gratuit.test.ts" \
+  "__tests__/api/bilans.id.route.test.ts" \
+  "__tests__/api/bilans.idor.test.ts" \
+  "__tests__/api/bilans/crud.test.ts" \
+  "__tests__/api/bilans/generate.test.ts" \
+  "__tests__/api/coach.bilan-diagnostic-maths-terminale.security.test.ts" \
+  "__tests__/api/coach.eaf-preparation-report.validate.test.ts" \
+  "__tests__/api/coach.eaf-stage-regenerate.security.test.ts" \
+  "__tests__/api/coach.generated-reports.route.test.ts" \
+  "__tests__/api/coach.trajectory.security.test.ts" \
+  "__tests__/api/documents-access.test.ts" \
+  "__tests__/api/documents.id.route.test.ts" \
+  "__tests__/api/eleve.bilan-diagnostic-maths-terminale.security.test.ts" \
+  "__tests__/api/internal.business-config.health.test.ts" \
+  "__tests__/api/internal.health.rate-limit.test.ts" \
+  "__tests__/api/internal.rate-limit-probe.test.ts" \
+  "__tests__/api/invoices.pdf.route.test.ts" \
+  "__tests__/api/invoices.receipt.pdf.route.test.ts" \
+  "__tests__/api/lamis.teacher-report.route.test.ts" \
+  "__tests__/api/npc.documents.route.test.ts" \
+  "__tests__/api/npc.files.route.test.ts" \
+  "__tests__/api/npc.generate.test.ts" \
+  "__tests__/api/npc.submissions.security.test.ts" \
+  "__tests__/api/npc.uploads.route.test.ts" \
+  "__tests__/api/parent.children.activation.route.test.ts" \
+  "__tests__/api/parent.children.route.test.ts" \
+  "__tests__/api/parent.subscription-requests.route.test.ts" \
+  "__tests__/api/parent.subscriptions.route.test.ts" \
+  "__tests__/api/payments.clictopay.disabled-contract.test.ts" \
+  "__tests__/api/payments.clictopay.feature-flag-consistency.test.ts" \
+  "__tests__/api/payments.clictopay.init.route.test.ts" \
+  "__tests__/api/payments.clictopay.webhook.disabled.test.ts" \
+  "__tests__/api/payments.clictopay.webhook.route.test.ts" \
+  "__tests__/api/payments.clictopay.webhook.security.test.ts" \
+  "__tests__/api/programme.maths-1ere-stmg.stage-progress.test.ts" \
+  "__tests__/api/public-rate-limit.coverage.test.ts" \
+  "__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts" \
+  "__tests__/api/sessions.cancel.route.test.ts" \
+  "__tests__/api/sessions.video.route.test.ts" \
+  "__tests__/api/stages.inscrire.product-rgpd.test.ts" \
+  "__tests__/api/stages.inscrire.security.test.ts" \
+  "__tests__/api/stages/confirm.test.ts" \
+  "__tests__/api/stages/inscriptions.test.ts" \
+  "__tests__/api/student.activate.lifecycle-security.test.ts" \
+  "__tests__/api/student.activate.route.test.ts" \
+  "__tests__/app/bilan-gratuit.assessment-page-token.test.tsx" \
+  "__tests__/components/offer-detail-dialog.test.tsx" \
+  "__tests__/components/offres-page.test.tsx" \
+  "__tests__/lib/assessments/public-token.test.ts" \
+  "__tests__/lib/bilan-gratuit-form.test.tsx" \
+  "__tests__/lib/business-config.fallback.test.ts" \
+  "__tests__/lib/business-config.production-gate.test.ts" \
+  "__tests__/lib/crm/contact-leads.retention.test.ts" \
+  "__tests__/lib/invoice/access-scope.test.ts" \
+  "__tests__/lib/rate-limit.production-gate.test.ts" \
+  "__tests__/lib/validations.test.ts" \
+  "__tests__/scripts/audit-api-guards.classification.test.ts" \
+  "__tests__/scripts/contact-leads-retention.test.ts" \
+  "__tests__/scripts/security-audit-scripts-regression.test.ts" \
+  "__tests__/ui/payment-methods.clictopay-disabled.test.tsx"
+```
+
+### Commande de vérification du staging
+
+```bash
+git diff --cached --name-only
+```
+
+### Commande de commit à exécuter par l’humain
+
+```bash
+git commit -m "test(security): add no-leak, idor, token and audit regressions"
+```
+
+### Tests recommandés avant ce commit
+
+`npm run test:unit -- --runInBand`
+
+### Vérifications après ce commit
+
+- Relancer `git status --short --untracked-files=all`.
+- Vérifier que le staging est vide après le commit humain.
+- Vérifier que les 6 P1 restent visibles dans la matrice API.
+
+### Risques à accepter
+
+Risque faible, mais les tests doivent rester verts isolément et dans la suite ciblée.
+
+## Commit 8 — test(e2e): protect public assessment route
+
+### Objectif
+
+Ajouter et ajuster les smokes E2E publics liés au tunnel assessment.
+
+### Fichiers concernés
+
+- `e2e/pages-public-bilan-assessment-token.spec.ts`
+- `e2e/pages-public-bilan-gratuit.spec.ts`
+- `e2e/pages-public-homepage.spec.ts`
+- `e2e/pages-public-offres.spec.ts`
+- `playwright.config.ts`
+
+### Commande de staging à exécuter par l’humain
+
+```bash
+git add -- \
+  "e2e/pages-public-bilan-assessment-token.spec.ts" \
+  "e2e/pages-public-bilan-gratuit.spec.ts" \
+  "e2e/pages-public-homepage.spec.ts" \
+  "e2e/pages-public-offres.spec.ts" \
+  "playwright.config.ts"
+```
+
+### Commande de vérification du staging
+
+```bash
+git diff --cached --name-only
+```
+
+### Commande de commit à exécuter par l’humain
+
+```bash
+git commit -m "test(e2e): protect public assessment route"
+```
+
+### Tests recommandés avant ce commit
+
+`PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium`
+
+### Vérifications après ce commit
+
+- Relancer `git status --short --untracked-files=all`.
+- Vérifier que le staging est vide après le commit humain.
+- Vérifier que les 6 P1 restent visibles dans la matrice API.
+
+### Risques à accepter
+
+Risque faible, mais les tests doivent rester verts isolément et dans la suite ciblée.
+
+## Commit 9 — docs(go-live): add evidence and go-no-go registers
+
+### Objectif
+
+Versionner les documents go-live et preuves de décision RC.
+
+### Fichiers concernés
+
+- `docs/go-live/00_EXECUTIVE_STATE.md`
+- `docs/go-live/01_ACTION_PLAN.md`
+- `docs/go-live/02_P0_P1_BACKLOG.md`
+- `docs/go-live/03_RELEASE_GATES.md`
+- `docs/go-live/04_TEST_MATRIX.md`
+- `docs/go-live/05_API_SECURITY_MATRIX.md`
+- `docs/go-live/06_BUSINESS_LOGIC_DECISIONS.md`
+- `docs/go-live/07_ENV_INFRA_CHECKLIST.md`
+- `docs/go-live/08_MARKETING_CONTENT_CHECKLIST.md`
+- `docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md`
+- `docs/go-live/10_LOT0_ACCEPTANCE.md`
+- `docs/go-live/11_LOT1_SECURITY_CLOSURE.md`
+- `docs/go-live/12_LOT1BIS_SECURITY_VERIFICATION.md`
+- `docs/go-live/13_LOT1TER_P1_SECURITY_CLOSURE.md`
+- `docs/go-live/14_LOT1QUATER_PUBLIC_ROLE_SECURITY_CLOSURE.md`
+- `docs/go-live/15_LOT1QUINQUIES_FINAL_P1_SECURITY_CLOSURE.md`
+- `docs/go-live/16_LOT2_PUBLIC_PRODUCT_RGPD_PAYMENT_DECISIONS.md`
+- `docs/go-live/17_LOT3_RUNTIME_RGPD_ASSESSMENT_TOKEN.md`
+- `docs/go-live/18_LOT4_RUNTIME_PAYMENT_RETENTION_TOKEN_BINDING.md`
+- `docs/go-live/19_LOT5_RUNTIME_EXPLOITATION_GO_NO_GO.md`
+- `docs/go-live/20_LOT6_STAGING_RELEASE_CANDIDATE_GO_NO_GO.md`
+- `docs/go-live/21_LOT7_RELEASE_CANDIDATE_SECURITY_AUDIT.md`
+- `docs/go-live/22_LOT8_RELEASE_CANDIDATE_CLEANUP.md`
+- `docs/go-live/_evidence/entitlement-pricing-delta.md`
+- `docs/go-live/_evidence/hardcoded-pricing-triage.md`
+- `docs/go-live/_evidence/lot0-command-log.md`
+- `docs/go-live/_evidence/lot1-api-route-triage.md`
+- `docs/go-live/_evidence/lot1-command-log.md`
+- `docs/go-live/_evidence/lot1-idor-tests.md`
+- `docs/go-live/_evidence/lot1-rate-limit-runtime.md`
+- `docs/go-live/_evidence/lot1bis-audit-script-review.md`
+- `docs/go-live/_evidence/lot1bis-command-log.md`
+- `docs/go-live/_evidence/lot1bis-p0-reclassification-audit.md`
+- `docs/go-live/_evidence/lot1bis-p1-closure.md`
+- `docs/go-live/_evidence/lot1bis-rate-limit-production-gate.md`
+- `docs/go-live/_evidence/lot1quater-assistante.md`
+- `docs/go-live/_evidence/lot1quater-coach.md`
+- `docs/go-live/_evidence/lot1quater-command-log.md`
+- `docs/go-live/_evidence/lot1quater-p1-before-after.md`
+- `docs/go-live/_evidence/lot1quater-parent-student.md`
+- `docs/go-live/_evidence/lot1quater-public-routes.md`
+- `docs/go-live/_evidence/lot1quater-rate-limit-runtime-proof.md`
+- `docs/go-live/_evidence/lot1quater-sensitive-fields-coverage.md`
+- `docs/go-live/_evidence/lot1quater-stages.md`
+- `docs/go-live/_evidence/lot1quinquies-admin-routes.md`
+- `docs/go-live/_evidence/lot1quinquies-clictopay-webhook.md`
+- `docs/go-live/_evidence/lot1quinquies-command-log.md`
+- `docs/go-live/_evidence/lot1quinquies-p1-before-after.md`
+- `docs/go-live/_evidence/lot1quinquies-public-sensitive-routes.md`
+- `docs/go-live/_evidence/lot1quinquies-rate-limit-runtime-proof.md`
+- `docs/go-live/_evidence/lot1quinquies-sensitive-fields-coverage.md`
+- `docs/go-live/_evidence/lot1ter-bilans-assessments.md`
+- `docs/go-live/_evidence/lot1ter-coach-reports.md`
+- `docs/go-live/_evidence/lot1ter-command-log.md`
+- `docs/go-live/_evidence/lot1ter-npc-documents.md`
+- `docs/go-live/_evidence/lot1ter-p1-before-after.md`
+- `docs/go-live/_evidence/lot1ter-payments-invoices.md`
+- `docs/go-live/_evidence/lot1ter-sensitive-fields-coverage.md`
+- `docs/go-live/_evidence/lot2-assessments-submit-decision.md`
+- `docs/go-live/_evidence/lot2-bilan-gratuit-product-rgpd.md`
+- `docs/go-live/_evidence/lot2-clictopay-payment-decision.md`
+- `docs/go-live/_evidence/lot2-lamis-teacher-report-decision.md`
+- `docs/go-live/_evidence/lot2-public-product-rgpd-command-log.md`
+- `docs/go-live/_evidence/lot2-rate-limit-runtime-decision.md`
+- `docs/go-live/_evidence/lot2-sensitive-fields-success-error-coverage.md`
+- `docs/go-live/_evidence/lot2-stages-inscrire-product-rgpd.md`
+- `docs/go-live/_evidence/lot2-student-activate-token-lifecycle.md`
+- `docs/go-live/_evidence/lot3-assessments-public-token.md`
+- `docs/go-live/_evidence/lot3-bilan-gratuit-rgpd-register.md`
+- `docs/go-live/_evidence/lot3-business-configs-db-drift.md`
+- `docs/go-live/_evidence/lot3-clictopay-disabled-contract.md`
+- `docs/go-live/_evidence/lot3-contact-lead-retention-policy.md`
+- `docs/go-live/_evidence/lot3-no-leak-success-error-runtime-coverage.md`
+- `docs/go-live/_evidence/lot3-redis-upstash-runtime-proof.md`
+- `docs/go-live/_evidence/lot3-runtime-rgpd-assessment-command-log.md`
+- `docs/go-live/_evidence/lot4-assessment-token-binding.md`
+- `docs/go-live/_evidence/lot4-business-config-production-gate.md`
+- `docs/go-live/_evidence/lot4-clictopay-disabled-runbook.md`
+- `docs/go-live/_evidence/lot4-contact-lead-retention-job.md`
+- `docs/go-live/_evidence/lot4-no-leak-e2e-runtime-coverage.md`
+- `docs/go-live/_evidence/lot4-redis-upstash-runtime-proof.md`
+- `docs/go-live/_evidence/lot4-token-runtime-payment-command-log.md`
+- `docs/go-live/_evidence/lot5-business-config-runtime-decision.md`
+- `docs/go-live/_evidence/lot5-clictopay-final-disabled-decision.md`
+- `docs/go-live/_evidence/lot5-contact-lead-retention-dry-run.md`
+- `docs/go-live/_evidence/lot5-p1-go-no-go-register.md`
+- `docs/go-live/_evidence/lot5-public-e2e-critical-paths.md`
+- `docs/go-live/_evidence/lot5-rate-limit-429-proof.md`
+- `docs/go-live/_evidence/lot5-redis-upstash-authenticated-healthcheck.md`
+- `docs/go-live/_evidence/lot5-runtime-exploitation-command-log.md`
+- `docs/go-live/_evidence/lot6-contact-lead-retention-db-dry-run.md`
+- `docs/go-live/_evidence/lot6-final-go-no-go-register.md`
+- `docs/go-live/_evidence/lot6-rate-limit-429-runtime-proof.md`
+- `docs/go-live/_evidence/lot6-redis-upstash-authenticated-proof.md`
+- `docs/go-live/_evidence/lot6-release-candidate-worktree-audit.md`
+- `docs/go-live/_evidence/lot6-staging-release-candidate-command-log.md`
+- `docs/go-live/_evidence/lot7-final-decision-register.md`
+- `docs/go-live/_evidence/lot7-release-candidate-audit-command-log.md`
+- `docs/go-live/_evidence/lot7-release-candidate-commit-plan.md`
+- `docs/go-live/_evidence/lot7-release-candidate-file-manifest.md`
+- `docs/go-live/_evidence/lot7-runtime-human-assisted-proof.md`
+- `docs/go-live/_evidence/lot7-security-scripts-audit.md`
+- `docs/go-live/_evidence/lot8-final-release-candidate-register.md`
+- `docs/go-live/_evidence/lot8-release-candidate-clean-manifest-command-log.md`
+- `docs/go-live/_evidence/lot8-release-candidate-commit-plan-clean.md`
+- `docs/go-live/_evidence/lot8-release-candidate-file-manifest-clean.md`
+- `docs/go-live/_evidence/lot8-runtime-proof-status.md`
+- `docs/go-live/_evidence/lot8-security-scripts-regression-audit.md`
+- `docs/go-live/_evidence/playwright-public-smoke-triage.md`
+
+### Commande de staging à exécuter par l’humain
+
+```bash
+git add -- \
+  "docs/go-live/00_EXECUTIVE_STATE.md" \
+  "docs/go-live/01_ACTION_PLAN.md" \
+  "docs/go-live/02_P0_P1_BACKLOG.md" \
+  "docs/go-live/03_RELEASE_GATES.md" \
+  "docs/go-live/04_TEST_MATRIX.md" \
+  "docs/go-live/05_API_SECURITY_MATRIX.md" \
+  "docs/go-live/06_BUSINESS_LOGIC_DECISIONS.md" \
+  "docs/go-live/07_ENV_INFRA_CHECKLIST.md" \
+  "docs/go-live/08_MARKETING_CONTENT_CHECKLIST.md" \
+  "docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md" \
+  "docs/go-live/10_LOT0_ACCEPTANCE.md" \
+  "docs/go-live/11_LOT1_SECURITY_CLOSURE.md" \
+  "docs/go-live/12_LOT1BIS_SECURITY_VERIFICATION.md" \
+  "docs/go-live/13_LOT1TER_P1_SECURITY_CLOSURE.md" \
+  "docs/go-live/14_LOT1QUATER_PUBLIC_ROLE_SECURITY_CLOSURE.md" \
+  "docs/go-live/15_LOT1QUINQUIES_FINAL_P1_SECURITY_CLOSURE.md" \
+  "docs/go-live/16_LOT2_PUBLIC_PRODUCT_RGPD_PAYMENT_DECISIONS.md" \
+  "docs/go-live/17_LOT3_RUNTIME_RGPD_ASSESSMENT_TOKEN.md" \
+  "docs/go-live/18_LOT4_RUNTIME_PAYMENT_RETENTION_TOKEN_BINDING.md" \
+  "docs/go-live/19_LOT5_RUNTIME_EXPLOITATION_GO_NO_GO.md" \
+  "docs/go-live/20_LOT6_STAGING_RELEASE_CANDIDATE_GO_NO_GO.md" \
+  "docs/go-live/21_LOT7_RELEASE_CANDIDATE_SECURITY_AUDIT.md" \
+  "docs/go-live/22_LOT8_RELEASE_CANDIDATE_CLEANUP.md" \
+  "docs/go-live/_evidence/entitlement-pricing-delta.md" \
+  "docs/go-live/_evidence/hardcoded-pricing-triage.md" \
+  "docs/go-live/_evidence/lot0-command-log.md" \
+  "docs/go-live/_evidence/lot1-api-route-triage.md" \
+  "docs/go-live/_evidence/lot1-command-log.md" \
+  "docs/go-live/_evidence/lot1-idor-tests.md" \
+  "docs/go-live/_evidence/lot1-rate-limit-runtime.md" \
+  "docs/go-live/_evidence/lot1bis-audit-script-review.md" \
+  "docs/go-live/_evidence/lot1bis-command-log.md" \
+  "docs/go-live/_evidence/lot1bis-p0-reclassification-audit.md" \
+  "docs/go-live/_evidence/lot1bis-p1-closure.md" \
+  "docs/go-live/_evidence/lot1bis-rate-limit-production-gate.md" \
+  "docs/go-live/_evidence/lot1quater-assistante.md" \
+  "docs/go-live/_evidence/lot1quater-coach.md" \
+  "docs/go-live/_evidence/lot1quater-command-log.md" \
+  "docs/go-live/_evidence/lot1quater-p1-before-after.md" \
+  "docs/go-live/_evidence/lot1quater-parent-student.md" \
+  "docs/go-live/_evidence/lot1quater-public-routes.md" \
+  "docs/go-live/_evidence/lot1quater-rate-limit-runtime-proof.md" \
+  "docs/go-live/_evidence/lot1quater-sensitive-fields-coverage.md" \
+  "docs/go-live/_evidence/lot1quater-stages.md" \
+  "docs/go-live/_evidence/lot1quinquies-admin-routes.md" \
+  "docs/go-live/_evidence/lot1quinquies-clictopay-webhook.md" \
+  "docs/go-live/_evidence/lot1quinquies-command-log.md" \
+  "docs/go-live/_evidence/lot1quinquies-p1-before-after.md" \
+  "docs/go-live/_evidence/lot1quinquies-public-sensitive-routes.md" \
+  "docs/go-live/_evidence/lot1quinquies-rate-limit-runtime-proof.md" \
+  "docs/go-live/_evidence/lot1quinquies-sensitive-fields-coverage.md" \
+  "docs/go-live/_evidence/lot1ter-bilans-assessments.md" \
+  "docs/go-live/_evidence/lot1ter-coach-reports.md" \
+  "docs/go-live/_evidence/lot1ter-command-log.md" \
+  "docs/go-live/_evidence/lot1ter-npc-documents.md" \
+  "docs/go-live/_evidence/lot1ter-p1-before-after.md" \
+  "docs/go-live/_evidence/lot1ter-payments-invoices.md" \
+  "docs/go-live/_evidence/lot1ter-sensitive-fields-coverage.md" \
+  "docs/go-live/_evidence/lot2-assessments-submit-decision.md" \
+  "docs/go-live/_evidence/lot2-bilan-gratuit-product-rgpd.md" \
+  "docs/go-live/_evidence/lot2-clictopay-payment-decision.md" \
+  "docs/go-live/_evidence/lot2-lamis-teacher-report-decision.md" \
+  "docs/go-live/_evidence/lot2-public-product-rgpd-command-log.md" \
+  "docs/go-live/_evidence/lot2-rate-limit-runtime-decision.md" \
+  "docs/go-live/_evidence/lot2-sensitive-fields-success-error-coverage.md" \
+  "docs/go-live/_evidence/lot2-stages-inscrire-product-rgpd.md" \
+  "docs/go-live/_evidence/lot2-student-activate-token-lifecycle.md" \
+  "docs/go-live/_evidence/lot3-assessments-public-token.md" \
+  "docs/go-live/_evidence/lot3-bilan-gratuit-rgpd-register.md" \
+  "docs/go-live/_evidence/lot3-business-configs-db-drift.md" \
+  "docs/go-live/_evidence/lot3-clictopay-disabled-contract.md" \
+  "docs/go-live/_evidence/lot3-contact-lead-retention-policy.md" \
+  "docs/go-live/_evidence/lot3-no-leak-success-error-runtime-coverage.md" \
+  "docs/go-live/_evidence/lot3-redis-upstash-runtime-proof.md" \
+  "docs/go-live/_evidence/lot3-runtime-rgpd-assessment-command-log.md" \
+  "docs/go-live/_evidence/lot4-assessment-token-binding.md" \
+  "docs/go-live/_evidence/lot4-business-config-production-gate.md" \
+  "docs/go-live/_evidence/lot4-clictopay-disabled-runbook.md" \
+  "docs/go-live/_evidence/lot4-contact-lead-retention-job.md" \
+  "docs/go-live/_evidence/lot4-no-leak-e2e-runtime-coverage.md" \
+  "docs/go-live/_evidence/lot4-redis-upstash-runtime-proof.md" \
+  "docs/go-live/_evidence/lot4-token-runtime-payment-command-log.md" \
+  "docs/go-live/_evidence/lot5-business-config-runtime-decision.md" \
+  "docs/go-live/_evidence/lot5-clictopay-final-disabled-decision.md" \
+  "docs/go-live/_evidence/lot5-contact-lead-retention-dry-run.md" \
+  "docs/go-live/_evidence/lot5-p1-go-no-go-register.md" \
+  "docs/go-live/_evidence/lot5-public-e2e-critical-paths.md" \
+  "docs/go-live/_evidence/lot5-rate-limit-429-proof.md" \
+  "docs/go-live/_evidence/lot5-redis-upstash-authenticated-healthcheck.md" \
+  "docs/go-live/_evidence/lot5-runtime-exploitation-command-log.md" \
+  "docs/go-live/_evidence/lot6-contact-lead-retention-db-dry-run.md" \
+  "docs/go-live/_evidence/lot6-final-go-no-go-register.md" \
+  "docs/go-live/_evidence/lot6-rate-limit-429-runtime-proof.md" \
+  "docs/go-live/_evidence/lot6-redis-upstash-authenticated-proof.md" \
+  "docs/go-live/_evidence/lot6-release-candidate-worktree-audit.md" \
+  "docs/go-live/_evidence/lot6-staging-release-candidate-command-log.md" \
+  "docs/go-live/_evidence/lot7-final-decision-register.md" \
+  "docs/go-live/_evidence/lot7-release-candidate-audit-command-log.md" \
+  "docs/go-live/_evidence/lot7-release-candidate-commit-plan.md" \
+  "docs/go-live/_evidence/lot7-release-candidate-file-manifest.md" \
+  "docs/go-live/_evidence/lot7-runtime-human-assisted-proof.md" \
+  "docs/go-live/_evidence/lot7-security-scripts-audit.md" \
+  "docs/go-live/_evidence/lot8-final-release-candidate-register.md" \
+  "docs/go-live/_evidence/lot8-release-candidate-clean-manifest-command-log.md" \
+  "docs/go-live/_evidence/lot8-release-candidate-commit-plan-clean.md" \
+  "docs/go-live/_evidence/lot8-release-candidate-file-manifest-clean.md" \
+  "docs/go-live/_evidence/lot8-runtime-proof-status.md" \
+  "docs/go-live/_evidence/lot8-security-scripts-regression-audit.md" \
+  "docs/go-live/_evidence/playwright-public-smoke-triage.md"
+```
+
+### Commande de vérification du staging
+
+```bash
+git diff --cached --name-only
+```
+
+### Commande de commit à exécuter par l’humain
+
+```bash
+git commit -m "docs(go-live): add evidence and go-no-go registers"
+```
+
+### Tests recommandés avant ce commit
+
+`npm run check:docs-archive` + relecture docs go-live
+
+### Vérifications après ce commit
+
+- Relancer `git status --short --untracked-files=all`.
+- Vérifier que le staging est vide après le commit humain.
+- Vérifier que les 6 P1 restent visibles dans la matrice API.
+
+### Risques à accepter
+
+Volume documentaire important ; revue humaine recommandée avant commit.
+
+## Décision humaine requise
+
+| Fichier | Statut | Décision actuelle | Options | Recommandation |
+|---|---|---|---|---|
+| `docs/audits/audit-nexus-reussite.md` | Needs human review | Non inclus dans les commits standards | Inclure / Exclure / Reporter | Reporter tant que non valide humainement |
+
+Ce fichier ne doit etre ajoute a aucun commit standard sans decision humaine explicite.

--- a/docs/go-live/_evidence/lot11-human-review-pending-files.md
+++ b/docs/go-live/_evidence/lot11-human-review-pending-files.md
@@ -1,0 +1,5 @@
+# Lot 11 — Fichiers en décision humaine
+
+| Fichier | Statut | Décision actuelle | Options | Recommandation |
+|---|---|---|---|---|
+| `docs/audits/audit-nexus-reussite.md` | Needs human review | Non inclus dans les commits standards | Inclure / Exclure / Reporter | Reporter tant que non validé humainement |

--- a/docs/go-live/_evidence/lot11-runtime-proof-status.md
+++ b/docs/go-live/_evidence/lot11-runtime-proof-status.md
@@ -1,0 +1,10 @@
+# Lot 11 — Runtime proof status
+
+| Variable / autorisation | Résultat | Décision |
+|---|---|---|
+| `NEXUS_HEALTH_AUTH` | `ABSENT` | Redis/Upstash non prouvé |
+| `NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE` | `NOT_ALLOWED` | 429 runtime non exécuté |
+| `DATABASE_URL` | `ABSENT` | ContactLead DB dry-run non prouvé |
+| `NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB` | `NOT_ALLOWED` | Dry-run DB non exécuté |
+
+Aucune valeur secrète n'a été lue ni écrite.

--- a/docs/go-live/_evidence/lot12-audit-nexus-human-decision-command-log.md
+++ b/docs/go-live/_evidence/lot12-audit-nexus-human-decision-command-log.md
@@ -1,0 +1,153 @@
+# Lot 12 — Command log audit Nexus decision
+
+## Baseline
+
+- Date locale : 2026-07-03 23:38:18 CET
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Node : `v20.20.0`
+- npm : `10.8.2`
+- Entrées `git status --short --untracked-files=all` : 306
+- Fichiers suivis modifiés : 130
+- Fichiers non suivis : 176
+- Staging Git initial : vide (`git diff --cached --name-only` = 0 fichier)
+- Diff `.env` : aucune sortie
+
+## Fichiers lus
+
+- `AGENTS.md`
+- `docs/go-live/25_LOT11_HUMAN_COMMIT_RUNBOOK.md`
+- `docs/go-live/24_LOT10_HUMAN_COMMIT_DRY_RUN.md`
+- `docs/go-live/23_LOT9_RC_MANIFEST_VALIDATION.md`
+- `docs/go-live/api-security-matrix.full.md`
+- `docs/go-live/05_API_SECURITY_MATRIX.md`
+- `docs/go-live/02_P0_P1_BACKLOG.md`
+- `docs/go-live/04_TEST_MATRIX.md`
+- `docs/go-live/_evidence/lot11-human-commit-runbook.md`
+- `docs/go-live/_evidence/lot11-human-commit-runbook-proof.md`
+- `docs/go-live/_evidence/lot11-human-review-pending-files.md`
+- `docs/go-live/_evidence/lot11-final-human-commit-register.md`
+- `docs/go-live/_evidence/lot10-final-human-commit-register.md`
+- `docs/go-live/_evidence/lot8-release-candidate-file-manifest-clean.md`
+- `docs/go-live/_evidence/lot8-release-candidate-commit-plan-clean.md`
+- `__tests__/scripts/release-candidate-human-commit-runbook.test.ts`
+- `docs/audits/audit-nexus-reussite.md`
+
+## Commandes exécutées
+
+```bash
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node -v
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm -v
+git rev-parse --abbrev-ref HEAD
+git rev-parse --short HEAD
+git status --short --untracked-files=all
+git diff --name-only
+git diff --stat
+git diff --cached --name-only
+git diff --name-only | rg '(^|/)\\.env($|\\.)' || true
+rg -n "^\\| P1 \\|" docs/go-live/api-security-matrix.full.md
+git ls-files --error-unmatch docs/audits/audit-nexus-reussite.md >/dev/null 2>&1 && echo TRACKED_IN_GIT || if test -f docs/audits/audit-nexus-reussite.md; then echo PRESENT_UNTRACKED_IN_WORKTREE; else echo ABSENT; fi
+rg -n "173|178|route|P0|P1|P2|OK|sécur|secur|faille|trou|go-live|ready|prêt|pret|ClicToPay|Redis|Upstash|429|ContactLead" docs/audits/audit-nexus-reussite.md
+sed -n '1,130p' docs/audits/audit-nexus-reussite.md
+sed -n '130,235p' docs/audits/audit-nexus-reussite.md
+if [ -n "${NEXUS_HEALTH_AUTH:-}" ]; then echo "NEXUS_HEALTH_AUTH_PRESENT"; else echo "NEXUS_HEALTH_AUTH_ABSENT"; fi
+if [ "${NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE:-}" = "true" ]; then echo "RL_PROBE_ALLOWED"; else echo "RL_PROBE_NOT_ALLOWED"; fi
+if [ -n "${DATABASE_URL:-}" ]; then echo "DATABASE_URL_PRESENT"; else echo "DATABASE_URL_ABSENT"; fi
+if [ "${NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB:-}" = "true" ]; then echo "CONTACT_LEAD_DRY_RUN_ALLOWED"; else echo "CONTACT_LEAD_DRY_RUN_NOT_ALLOWED"; fi
+```
+
+## Résultats clés
+
+- `docs/audits/audit-nexus-reussite.md` : `PRESENT_UNTRACKED_IN_WORKTREE`.
+- Le fichier est présent dans le working tree comme fichier non suivi. Il n'est pas inclus dans les commits standards et ne doit pas être considéré comme audit courant de la RC.
+- Audit nexus : mentionne `173 routes API`.
+- Audit nexus : mentionne une sécurité des routes classée "sans trou".
+- RC actuelle : `178` routes, `6` P1 ouverts.
+- Runtime : `NEXUS_HEALTH_AUTH_ABSENT`, `RL_PROBE_NOT_ALLOWED`, `DATABASE_URL_ABSENT`, `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED`.
+
+## Gates Lot 12
+
+```bash
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run typecheck
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run lint
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand __tests__/scripts/release-candidate-human-commit-runbook.test.ts
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:docs-archive
+git diff --cached --name-only
+git diff --name-only | rg '(^|/)\\.env($|\\.)' || true
+rg -n "^\\| P1 \\|" docs/go-live/api-security-matrix.full.md
+```
+
+Résultats :
+
+- `typecheck` : OK.
+- `lint` : OK avec warnings existants sous seuil `--max-warnings 300`.
+- Test runbook : OK, 1 suite passée, 5 tests passés.
+- `check:docs-archive` : OK.
+- Staging Git final : vide.
+- Diff `.env` final : aucune sortie.
+- P1 final : 6 routes visibles.
+- Entrées `git status --short --untracked-files=all` après création des preuves Lot 12 : 313.
+
+## Correction documentaire — 2026-07-03 23:47:03 CET
+
+Fichiers corrigés :
+
+- `docs/go-live/04_TEST_MATRIX.md`
+- `docs/go-live/26_LOT12_AUDIT_NEXUS_DECISION.md`
+- `docs/go-live/_evidence/lot12-audit-nexus-human-decision-command-log.md`
+- `docs/go-live/_evidence/lot12-audit-nexus-reussite-review.md`
+- `docs/go-live/_evidence/lot12-human-review-decision-files.md`
+
+Commandes de correction/vérification :
+
+```bash
+git ls-files --error-unmatch docs/audits/audit-nexus-reussite.md >/dev/null 2>&1 && echo TRACKED_IN_GIT || if test -f docs/audits/audit-nexus-reussite.md; then echo PRESENT_UNTRACKED_IN_WORKTREE; else echo ABSENT; fi
+rg -n "PRESENT_UNTRACKED_IN_WORKTREE|1 suite passée, 5 tests passés|Ne remplace pas les preuves runtime Redis/Upstash, 429 et ContactLead DB" docs/go-live/04_TEST_MATRIX.md docs/go-live/26_LOT12_AUDIT_NEXUS_DECISION.md docs/go-live/_evidence/lot12-audit-nexus-human-decision-command-log.md docs/go-live/_evidence/lot12-audit-nexus-reussite-review.md docs/go-live/_evidence/lot12-human-review-decision-files.md
+```
+
+Résultats :
+
+- `docs/audits/audit-nexus-reussite.md` : `PRESENT_UNTRACKED_IN_WORKTREE`.
+- `04_TEST_MATRIX.md` aligné : statut `OK`, résultat `1 suite passée, 5 tests passés`.
+- Formulation ambiguë supprimée des documents Lot 12 concernés.
+- Staging Git resté vide.
+- Audit Nexus maintenu hors commits standards.
+
+## Validation correction — 2026-07-03 23:49:08 CET
+
+Commandes exécutées sous Node 20 :
+
+```bash
+source /home/alaeddine/.nvm/nvm.sh
+nvm use 20.20.0 >/dev/null
+
+npm run typecheck
+npm run lint
+npm run test:unit -- --runInBand __tests__/scripts/release-candidate-human-commit-runbook.test.ts
+npm run check:docs-archive
+git diff --cached --name-only
+git diff --name-only | rg '(^|/)\\.env($|\\.)' || true
+rg -n "^\\| P1 \\|" docs/go-live/api-security-matrix.full.md
+rg -n "EXISTS_IN_REP[O]|existe dans le dépôt comme fichier non suiv[i]|existe comme fichier non suiv[i]|À relancer Lot 1[2]" docs/go-live/04_TEST_MATRIX.md docs/go-live/26_LOT12_AUDIT_NEXUS_DECISION.md docs/go-live/_evidence/lot12-audit-nexus-human-decision-command-log.md docs/go-live/_evidence/lot12-audit-nexus-reussite-review.md docs/go-live/_evidence/lot12-human-review-decision-files.md || true
+```
+
+Résultats :
+
+- `typecheck` : OK.
+- `lint` : OK avec warnings existants sous seuil `--max-warnings 300`.
+- Test runbook : OK, 1 suite passée, 5 tests passés.
+- `check:docs-archive` : OK.
+- Staging Git : vide.
+- Diff `.env` : aucune sortie.
+- P1 : 6 visibles.
+- Anciennes formulations ambiguës : aucune sortie.
+- Aucun `git add` réel, aucun commit, aucune PR.
+
+## Limites
+
+- Aucun secret lu.
+- Aucun `.env` modifié.
+- Aucun `git add` réel.
+- Aucun commit.
+- Aucune PR.
+- Aucune preuve Redis/Upstash ou 429 runtime exécutée faute de variables/autorisation.

--- a/docs/go-live/_evidence/lot12-audit-nexus-reussite-review.md
+++ b/docs/go-live/_evidence/lot12-audit-nexus-reussite-review.md
@@ -1,0 +1,60 @@
+# Lot 12 — Revue de `audit-nexus-reussite.md`
+
+## Statut du fichier
+
+PRESENT_UNTRACKED_IN_WORKTREE.
+
+Le fichier est présent dans le working tree comme fichier non suivi : `docs/audits/audit-nexus-reussite.md`.
+
+Il n'est pas inclus dans les commits standards et ne doit pas être considéré comme audit courant de la RC.
+
+## Résumé
+
+Le document contient un audit utile comme contexte business, pricing, conversion, SEO, UX et dette de gestion. Il ne correspond pas à l'état release candidate courant sur les compteurs API et la sécurité API.
+
+Décision recommandée : `EXCLUDE_FROM_STANDARD_COMMITS`.
+
+## Points utiles
+
+- `USEFUL_BUSINESS_CONTEXT` : analyse des incohérences pricing/crédits et de l'impact marge/confiance.
+- `USEFUL_BUSINESS_CONTEXT` : rappel que ClicToPay/paiement carte n'est pas actif.
+- `USEFUL_BUSINESS_CONTEXT` : priorisation business autour de preuve sociale, conversion, bundle, gestion admin/assistante.
+- `USEFUL_TECH_CONTEXT` : signale la dépendance forte aux handlers API puisque `/api` est exclu du middleware global.
+- `USEFUL_RELEASE_CONTEXT` : rappelle la discipline de gates et de migrations non destructives.
+
+## Points obsolètes ou contradictoires
+
+- `STALE_COUNT` : le fichier indique `173 routes API`; la RC actuelle indique `178`.
+- `STALE_SECURITY_STATUS` : le fichier parle de sécurité des routes classée "sans trou"; la RC actuelle maintient `6` P1 publics/paiement visibles.
+- `STALE_RUNTIME_STATUS` : le fichier ne reflète pas les blocages Redis/Upstash non prouvé et test `429` runtime non exécuté.
+- `STALE_PAYMENT_STATUS` : le paiement carte est cité comme priorité, mais la RC actuelle a une décision contractuelle `CLICTOPAY_STATUS = DISABLED`.
+- `STALE_RC_CONTEXT` : le document se présente comme audit courant du dépôt audité sur `main`, alors que la RC courante est préparée sur `feat/lot4-accessors-runtime` avec de nombreux lots de sécurité/release postérieurs.
+
+## Contradictions avec la RC actuelle
+
+| Sujet | Audit nexus | RC actuelle | Décision |
+|---|---|---|---|
+| Routes API | `173 routes API` | `178` routes | `STALE_COUNT`, ne pas inclure comme audit courant |
+| P1 | sécurité "sans trou", seulement un concern route stage | `6` P1 visibles | `STALE_SECURITY_STATUS`, ne pas masquer les P1 |
+| Go-live/security | base technique durcie, finalisation par incohérences métier | bêta élargie et go-live large bloqués | Ajouter en-tête historique ou réécrire avant inclusion |
+| Paiement | paiement carte à activer comme P0 business | ClicToPay disabled, paiement carte interdit | Garder comme contexte business historique uniquement |
+| Runtime | pas de preuve Redis/Upstash/429 runtime | Redis/Upstash non prouvé, 429 non exécuté | Non acceptable comme état exploitation |
+
+## Décision recommandée
+
+EXCLUDE_FROM_STANDARD_COMMITS.
+
+## Condition d’inclusion
+
+Une inclusion future est acceptable seulement avec décision humaine explicite et l'une des corrections suivantes :
+
+1. `INCLUDE_AS_HISTORICAL_AUDIT` avec un en-tête visible indiquant que les compteurs et le statut sécurité sont historiques/stale.
+2. `REWRITE_BEFORE_INCLUDE` en alignant le document avec `178` routes, `6` P1, ClicToPay disabled, Redis/Upstash non prouvé, `429` runtime non exécuté et ContactLead dry-run DB non prouvé.
+
+## Risque si inclus sans correction
+
+- Le reviewer peut croire que la RC n'a aucun trou sécurité API.
+- Le compteur `173 routes` contredit les matrices Lot 8 à Lot 12.
+- Les `6` P1 publics/paiement peuvent être minimisés.
+- Les blocages runtime Redis/Upstash et `429` peuvent être invisibilisés.
+- La décision go/no-go serait moins fiable.

--- a/docs/go-live/_evidence/lot12-final-audit-decision-register.md
+++ b/docs/go-live/_evidence/lot12-final-audit-decision-register.md
@@ -1,0 +1,19 @@
+# Lot 12 — Final audit decision register
+
+| Domaine | Statut | Preuve | Décision |
+|---|---|---|---|
+| P0 | 0 | `docs/go-live/api-security-matrix.full.md` | OK |
+| P1 | 6 | `docs/go-live/api-security-matrix.full.md` | bêta contrôlée seulement |
+| Runbook humain | PASSED | `__tests__/scripts/release-candidate-human-commit-runbook.test.ts` : 1 suite passée, 5 tests passés | OK |
+| Audit nexus file | EXCLUDED | `docs/go-live/_evidence/lot12-audit-nexus-reussite-review.md` | EXCLUDE_FROM_STANDARD_COMMITS |
+| Runtime Redis | NOT_PROVEN | `docs/go-live/_evidence/lot12-runtime-proof-status.md` | BETA_ELARGIE_BLOCKED |
+| 429 runtime | NOT_PROVEN | `docs/go-live/_evidence/lot12-runtime-proof-status.md` | BETA_ELARGIE_BLOCKED |
+| ContactLead DB dry-run | NOT_PROVEN | `docs/go-live/_evidence/lot12-runtime-proof-status.md` | GO_LIVE_LARGE_BLOCKED |
+| Human execution readiness | READY_FOR_HUMAN_EXECUTION | runbook Lot 11 + décision audit Lot 12 | READY_FOR_HUMAN_EXECUTION |
+
+## Décisions finales
+
+- `READY_FOR_HUMAN_EXECUTION`
+- `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`
+- `BETA_ELARGIE_BLOCKED`
+- `GO_LIVE_LARGE_BLOCKED`

--- a/docs/go-live/_evidence/lot12-human-review-decision-files.md
+++ b/docs/go-live/_evidence/lot12-human-review-decision-files.md
@@ -1,0 +1,15 @@
+# Lot 12 — Fichiers en décision humaine
+
+| Fichier | Statut | Décision actuelle | Options | Recommandation | Décision finale |
+|---|---|---|---|---|---|
+| `docs/audits/audit-nexus-reussite.md` | PRESENT_UNTRACKED_IN_WORKTREE / Needs human review | Non inclus par défaut | Exclure / Inclure historique / Réécrire / Reporter | Exclure des commits standards ; réécrire ou marquer historique avant inclusion | EXCLUDE_FROM_STANDARD_COMMITS |
+
+## Justification
+
+Le fichier contient des éléments utiles mais partiellement obsolètes pour la RC actuelle :
+
+- `STALE_COUNT` : `173 routes API` vs `178` routes actuelles.
+- `STALE_SECURITY_STATUS` : formulation "sans trou" vs `6` P1 visibles.
+- `STALE_RUNTIME_STATUS` : Redis/Upstash et `429` runtime non prouvés dans la RC.
+
+Le fichier est présent dans le working tree comme fichier non suivi. Il reste hors commits standards jusqu'à décision humaine explicite et ne doit pas être considéré comme audit courant de la RC.

--- a/docs/go-live/_evidence/lot12-runbook-lock-proof.md
+++ b/docs/go-live/_evidence/lot12-runbook-lock-proof.md
@@ -1,0 +1,52 @@
+# Lot 12 — Runbook lock proof
+
+## Résumé
+
+Le runbook humain Lot 11 reste verrouillé. `docs/audits/audit-nexus-reussite.md` n'est pas dans les commandes de staging des commits standards ; il apparaît seulement dans l'introduction et la section de décision humaine.
+
+## Vérifications statiques
+
+| Contrôle | Résultat |
+|---|---|
+| `docs/audits/audit-nexus-reussite.md` dans commits standards | Absent des commandes `git add --` des commits standards |
+| `docs/audits/audit-nexus-reussite.md` dans runbook | Présent uniquement comme décision humaine |
+| `rapport_audit_2_07_2026.md` | Absent |
+| `.env*` | Absent |
+| `git push` | Absent |
+| `gh pr create` | Absent |
+| `git add --dry-run` | Absent |
+| `git diff --cached --name-only` | Vide avant gates |
+| P1 visibles | 6 P1 dans `docs/go-live/api-security-matrix.full.md` |
+
+## P1 visibles
+
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+## Test de verrouillage
+
+Commande relancée dans les gates Lot 12 :
+
+```bash
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand __tests__/scripts/release-candidate-human-commit-runbook.test.ts
+```
+
+Résultat observé :
+
+- `PASS __tests__/scripts/release-candidate-human-commit-runbook.test.ts`
+- 1 suite passée.
+- 5 tests passés.
+
+## Vérifications Git finales
+
+- `git diff --cached --name-only` : aucune sortie.
+- `git diff --name-only | rg '(^|/)\\.env($|\\.)' || true` : aucune sortie.
+- `rg -n "^\\| P1 \\|" docs/go-live/api-security-matrix.full.md` : 6 P1 visibles.
+
+## Décision
+
+READY_FOR_HUMAN_EXECUTION avec réserves runtime.

--- a/docs/go-live/_evidence/lot12-runtime-proof-status.md
+++ b/docs/go-live/_evidence/lot12-runtime-proof-status.md
@@ -1,0 +1,26 @@
+# Lot 12 — Runtime proof status
+
+## Présence des variables
+
+| Variable / autorisation | Statut |
+|---|---|
+| `NEXUS_HEALTH_AUTH` | ABSENT |
+| `NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE=true` | NOT_ALLOWED |
+| `DATABASE_URL` | ABSENT |
+| `NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB=true` | NOT_ALLOWED |
+
+## Décision
+
+- Redis/Upstash : NOT_PROVEN.
+- 429 runtime : NOT_PROVEN.
+- ContactLead DB dry-run : NOT_PROVEN.
+
+## Impact
+
+- `BETA_ELARGIE_BLOCKED`.
+- `GO_LIVE_LARGE_BLOCKED`.
+
+## Limite
+
+Aucune preuve runtime n'a été forcée et aucun secret n'a été lu.
+

--- a/docs/go-live/_evidence/lot13-audit-nexus-final-status.md
+++ b/docs/go-live/_evidence/lot13-audit-nexus-final-status.md
@@ -1,0 +1,39 @@
+# Lot 13 — Audit Nexus final status
+
+## Statut
+
+PRESENT_UNTRACKED_IN_WORKTREE.
+
+Date de vérification : 2026-07-06.
+
+Commande exécutée :
+
+```bash
+git ls-files --error-unmatch docs/audits/audit-nexus-reussite.md >/dev/null 2>&1 && echo TRACKED_IN_GIT || if test -f docs/audits/audit-nexus-reussite.md; then echo PRESENT_UNTRACKED_IN_WORKTREE; else echo ABSENT; fi
+```
+
+Résultat :
+
+```txt
+PRESENT_UNTRACKED_IN_WORKTREE
+```
+
+## Décision obligatoire
+
+EXCLUDE_FROM_STANDARD_COMMITS.
+
+## Justification
+
+Le fichier contient du contexte business utile mais reste obsolète pour la RC actuelle :
+
+- il mentionne `173 routes API` ;
+- il parle d'une sécurité des routes "sans trou" ;
+- la RC actuelle indique `178` routes et `6` P1 ouverts ;
+- Redis/Upstash, 429 runtime et ContactLead dry-run DB restent non prouvés.
+
+## Condition d'inclusion future
+
+Inclusion uniquement après décision humaine explicite :
+
+- soit comme audit historique avec en-tête indiquant les compteurs stale ;
+- soit après réécriture alignée avec la RC actuelle.

--- a/docs/go-live/_evidence/lot13-final-human-execution-register.md
+++ b/docs/go-live/_evidence/lot13-final-human-execution-register.md
@@ -1,0 +1,22 @@
+# Lot 13 — Final human execution register
+
+Date de décision : 2026-07-06.
+
+| Domaine | Statut | Preuve | Décision |
+|---|---|---|---|
+| P0 | 0 | `docs/go-live/api-security-matrix.full.md` | OK |
+| P1 | 6 | `docs/go-live/api-security-matrix.full.md` | bêta contrôlée seulement |
+| Runbook humain | PASSED | `__tests__/scripts/release-candidate-human-commit-runbook.test.ts` : 1 suite passée, 5 tests passés | READY_TO_EXECUTE_MANUALLY |
+| Audit Nexus | EXCLUDED | `docs/go-live/_evidence/lot13-audit-nexus-final-status.md` | EXCLUDE_FROM_STANDARD_COMMITS |
+| Staging Git | EMPTY | `git diff --cached --name-only` | OK |
+| Runtime Redis | NOT_PROVEN | `docs/go-live/_evidence/lot13-runtime-proof-status.md` | BETA_ELARGIE_BLOCKED |
+| 429 runtime | NOT_PROVEN | `docs/go-live/_evidence/lot13-runtime-proof-status.md` | BETA_ELARGIE_BLOCKED |
+| ContactLead DB dry-run | NOT_PROVEN | `docs/go-live/_evidence/lot13-runtime-proof-status.md` | GO_LIVE_LARGE_BLOCKED |
+| Human execution | READY_TO_EXECUTE_MANUALLY | runbook Lot 11 + preuve Lot 13 | READY_TO_EXECUTE_MANUALLY |
+
+## Décisions finales
+
+- `READY_TO_EXECUTE_MANUALLY`
+- `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`
+- `BETA_ELARGIE_BLOCKED`
+- `GO_LIVE_LARGE_BLOCKED`

--- a/docs/go-live/_evidence/lot13-final-precommit-command-log.md
+++ b/docs/go-live/_evidence/lot13-final-precommit-command-log.md
@@ -1,0 +1,94 @@
+# Lot 13 — Final precommit command log
+
+## Baseline
+
+- Date locale : 2026-07-06 21:36:54 CET
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Node : `v20.20.0`
+- npm : `10.8.2`
+- Entrées `git status --short --untracked-files=all` : 320
+- Fichiers suivis modifiés : 130
+- Fichiers non suivis : 190
+- Staging Git initial : vide (`git diff --cached --name-only` = 0 fichier)
+- Diff `.env` : aucune sortie
+
+## Fichiers lus
+
+- `AGENTS.md`
+- `docs/go-live/26_LOT12_AUDIT_NEXUS_DECISION.md`
+- `docs/go-live/25_LOT11_HUMAN_COMMIT_RUNBOOK.md`
+- `docs/go-live/24_LOT10_HUMAN_COMMIT_DRY_RUN.md`
+- `docs/go-live/23_LOT9_RC_MANIFEST_VALIDATION.md`
+- `docs/go-live/api-security-matrix.full.md`
+- `docs/go-live/05_API_SECURITY_MATRIX.md`
+- `docs/go-live/02_P0_P1_BACKLOG.md`
+- `docs/go-live/04_TEST_MATRIX.md`
+- `docs/go-live/_evidence/lot11-human-commit-runbook.md`
+- `docs/go-live/_evidence/lot11-human-commit-runbook-proof.md`
+- `docs/go-live/_evidence/lot12-audit-nexus-reussite-review.md`
+- `docs/go-live/_evidence/lot12-human-review-decision-files.md`
+- `docs/go-live/_evidence/lot12-final-audit-decision-register.md`
+- `__tests__/scripts/release-candidate-human-commit-runbook.test.ts`
+
+## Commandes exécutées
+
+```bash
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node -v
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm -v
+git rev-parse --abbrev-ref HEAD
+git rev-parse --short HEAD
+git status --short --untracked-files=all
+git diff --name-only
+git diff --stat
+git diff --cached --name-only
+git diff --name-only | rg '(^|/)\\.env($|\\.)' || true
+rg -n "^\\| P1 \\|" docs/go-live/api-security-matrix.full.md
+git ls-files --error-unmatch docs/audits/audit-nexus-reussite.md >/dev/null 2>&1 && echo TRACKED_IN_GIT || if test -f docs/audits/audit-nexus-reussite.md; then echo PRESENT_UNTRACKED_IN_WORKTREE; else echo ABSENT; fi
+if [ -n "${NEXUS_HEALTH_AUTH:-}" ]; then echo "NEXUS_HEALTH_AUTH_PRESENT"; else echo "NEXUS_HEALTH_AUTH_ABSENT"; fi
+if [ "${NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE:-}" = "true" ]; then echo "RL_PROBE_ALLOWED"; else echo "RL_PROBE_NOT_ALLOWED"; fi
+if [ -n "${DATABASE_URL:-}" ]; then echo "DATABASE_URL_PRESENT"; else echo "DATABASE_URL_ABSENT"; fi
+if [ "${NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB:-}" = "true" ]; then echo "CONTACT_LEAD_DRY_RUN_ALLOWED"; else echo "CONTACT_LEAD_DRY_RUN_NOT_ALLOWED"; fi
+npm run test:unit -- --runInBand __tests__/scripts/release-candidate-human-commit-runbook.test.ts
+npm run typecheck
+npm run lint
+npm run test:unit -- --runInBand __tests__/scripts/release-candidate-human-commit-runbook.test.ts
+npm run check:docs-archive
+git diff --cached --name-only
+git diff --name-only | rg '(^|/)\\.env($|\\.)' || true
+rg -n "^\\| P1 \\|" docs/go-live/api-security-matrix.full.md
+```
+
+## Résultats intermédiaires
+
+- Runbook test : OK, 1 suite passée, 5 tests passés.
+- Commits humains détectés dans le runbook : 9.
+- Fichiers `Include RC` du manifeste Lot 8 : 281.
+- Fichiers `Exclude` : 1.
+- Fichiers `Needs human review` : 1.
+- `docs/audits/audit-nexus-reussite.md` : `PRESENT_UNTRACKED_IN_WORKTREE`.
+- Runtime : `NEXUS_HEALTH_AUTH_ABSENT`, `RL_PROBE_NOT_ALLOWED`, `DATABASE_URL_ABSENT`, `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED`.
+- Deux commandes exploratoires de comptage `rg` avec backticks shell non échappés ont échoué sans effet de bord ; elles ont été relancées avec motif échappé et ont confirmé `1` fichier `Exclude` et `1` fichier `Needs human review`.
+
+## Gates finales
+
+- Date/heure de correction finale : 2026-07-06 21:36:54 CET à 2026-07-06 21:43 CET.
+- `npm run typecheck` : OK, `tsc --noEmit` en code 0.
+- `npm run lint` : OK en code 0, avertissements ESLint existants sous le seuil `--max-warnings 300`.
+- `npm run test:unit -- --runInBand __tests__/scripts/release-candidate-human-commit-runbook.test.ts` : OK, 1 suite passée, 5 tests passés.
+- `npm run check:docs-archive` : OK, aucun audit/rapport historique à la racine `docs/`.
+- Staging Git final : vide (`git diff --cached --name-only` sans sortie).
+- Diff `.env` final : aucune sortie.
+- P1 finaux : 6 routes visibles dans `docs/go-live/api-security-matrix.full.md`.
+- Audit Nexus : reste `PRESENT_UNTRACKED_IN_WORKTREE` et exclu des commits standards.
+- Confirmation : aucun `git add` réel, aucun commit, aucun push, aucune PR.
+
+## Limites
+
+- Aucun secret lu.
+- Aucun `.env` modifié.
+- Aucun `git add` réel.
+- Aucun commit.
+- Aucun push.
+- Aucune PR.
+- Aucune preuve Redis/Upstash ou 429 runtime exécutée faute de variables/autorisation.

--- a/docs/go-live/_evidence/lot13-human-execution-checklist.md
+++ b/docs/go-live/_evidence/lot13-human-execution-checklist.md
@@ -1,0 +1,21 @@
+# Lot 13 — Checklist avant exécution humaine
+
+## Avant chaque commit
+
+- [ ] Exécuter uniquement la commande `git add -- ...` du bloc concerné.
+- [ ] Exécuter `git diff --cached --name-only`.
+- [ ] Vérifier qu’aucun fichier Exclude n’est staged.
+- [ ] Vérifier qu’aucun fichier Needs human review non validé n’est staged.
+- [ ] Vérifier qu’aucun `.env*` n’est staged.
+- [ ] Vérifier que `rapport_audit_2_07_2026.md` n’est pas staged.
+- [ ] Vérifier que `docs/audits/audit-nexus-reussite.md` n’est pas staged.
+- [ ] Exécuter les tests recommandés du bloc.
+- [ ] Committer uniquement si le staging correspond exactement au bloc.
+- [ ] Après commit, vérifier `git status --short`.
+
+## Interdits
+
+- [ ] Aucun `git push`.
+- [ ] Aucune PR.
+- [ ] Aucun déploiement.
+- [ ] Aucune migration.

--- a/docs/go-live/_evidence/lot13-runbook-still-valid-proof.md
+++ b/docs/go-live/_evidence/lot13-runbook-still-valid-proof.md
@@ -1,0 +1,47 @@
+# Lot 13 — Runbook still valid proof
+
+## Résultat
+
+PASSED.
+
+Date d'exécution : 2026-07-06.
+
+## Test exécuté
+
+```bash
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand __tests__/scripts/release-candidate-human-commit-runbook.test.ts
+```
+
+Résultat observé :
+
+- 1 suite passée.
+- 5 tests passés.
+- 0 échec.
+
+## Preuves mécaniques
+
+| Contrôle | Résultat |
+|---|---|
+| Commits humains présents | 9 |
+| Fichiers `Include RC` couverts exactement une fois | 281 |
+| Fichiers `Exclude` inclus | 0 |
+| Fichiers `Needs human review` inclus dans commits standards | 0 |
+| `docs/audits/audit-nexus-reussite.md` dans commits standards | Non |
+| `rapport_audit_2_07_2026.md` | Absent |
+| `.env*` | Absent |
+| `git push` | Absent |
+| `gh pr create` | Absent |
+| Staging Git | Vide |
+
+## P1 visibles
+
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+## Décision
+
+READY_TO_EXECUTE_MANUALLY.

--- a/docs/go-live/_evidence/lot13-runtime-proof-status.md
+++ b/docs/go-live/_evidence/lot13-runtime-proof-status.md
@@ -1,0 +1,27 @@
+# Lot 13 — Runtime proof status
+
+## Présence des variables
+
+Date de vérification : 2026-07-06.
+
+| Variable / autorisation | Statut |
+|---|---|
+| `NEXUS_HEALTH_AUTH` | ABSENT |
+| `NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE=true` | NOT_ALLOWED |
+| `DATABASE_URL` | ABSENT |
+| `NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB=true` | NOT_ALLOWED |
+
+## Décision
+
+- Redis/Upstash : NOT_PROVEN.
+- 429 runtime : NOT_PROVEN.
+- ContactLead DB dry-run : NOT_PROVEN.
+
+## Impact
+
+- `BETA_ELARGIE_BLOCKED`.
+- `GO_LIVE_LARGE_BLOCKED`.
+
+## Limite
+
+Aucune preuve runtime n'a été forcée et aucun secret n'a été lu.

--- a/docs/go-live/_evidence/lot14-commit-hashes.md
+++ b/docs/go-live/_evidence/lot14-commit-hashes.md
@@ -1,0 +1,29 @@
+# Lot 14 — Hashes des commits locaux
+
+Branche : `feat/lot4-accessors-runtime`.
+
+Commit initial avant Lot 14 : `db8545a19`.
+
+## Runbook Lot 11
+
+| # | Message | Hash |
+|---:|---|---|
+| 1 | `chore(go-live): update security inventory and matrices` | `48d64a4fd` |
+| 2 | `fix(api-security): close admin and role guard gaps` | `eb0d6630f` |
+| 3 | `fix(public-funnel): lead-only bilan and assessment token binding` | `798f712ae` |
+| 4 | `fix(runtime): rate-limit probe and business-config gate` | `b03d0c37b` |
+| 5 | `fix(payments): keep clictopay disabled and fail closed` | `43be9787b` |
+| 6 | `chore(maintenance): add contact-lead retention dry-run` | `b7d94cf7a` |
+| 7 | `test(security): add no-leak, idor, token and audit regressions` | `eec8430ed` |
+| 8 | `test(e2e): protect public assessment route` | `5b7fe4def` |
+| 9 | `docs(go-live): add evidence and go-no-go registers` | `e92f9f546` |
+
+## Interdits respectés
+
+- Aucun push.
+- Aucune PR.
+- Aucun déploiement.
+- Aucune migration.
+- Aucun fichier `.env*` staged.
+- `rapport_audit_2_07_2026.md` non staged.
+- `docs/audits/audit-nexus-reussite.md` non staged.

--- a/docs/go-live/_evidence/lot14-final-gates-after-commits.md
+++ b/docs/go-live/_evidence/lot14-final-gates-after-commits.md
@@ -1,0 +1,38 @@
+# Lot 14 — Gates finales après commits locaux
+
+Date : 2026-07-06.
+
+## Résultats
+
+| Commande | Statut | Résultat |
+|---|---|---|
+| `npm run typecheck` | PASSED | `tsc --noEmit` OK |
+| `npm run lint` | PASSED | Next lint OK sous `--max-warnings 300`; warnings existants |
+| `npm run test:unit -- --runInBand` | PASSED | 541 suites passées, 1 skipped ; 6531 tests passés, 4 skipped ; 7 snapshots passés |
+| `npm run build` | PASSED | Next build OK, 142 pages statiques générées |
+| `node scripts/security/audit-api-guards.mjs` | PASSED | Inventaire régénéré : 178 routes |
+| `node scripts/go-live/generate-api-security-matrix.mjs` | PASSED | `P0=0`, `P1=6`, `P2=144`, `OK=28`, total 178 |
+| `npm run audit:site-map` | PASSED | 292 routes, 413 edges, 0 link finding, 13 public orphan entries |
+| `npm run check:no-hardcoded` | PASSED | 0 valeur hardcodée hors sources canoniques |
+| `npm run check:docs-archive` | PASSED | Aucun audit/rapport historique à la racine `docs/` |
+| `npm run check:bundle-weight` | PASSED | Toutes les routes dans baseline + 5 kB |
+| `PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | PASSED | 24 tests passés |
+| `PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium` | PASSED | 1 test passé |
+
+## Observations
+
+- Les commandes Playwright ont affiché un avertissement serveur `NO_COLOR`/`FORCE_COLOR` et un refresh passif Prisma non bloquant.
+- Les tests unitaires complets affichent des logs d'erreurs simulées attendues ; aucun échec.
+- `audit-api-guards` et `generate-api-security-matrix` ont régénéré uniquement les timestamps des documents générés.
+
+## Décision
+
+`LOCAL_COMMITS_EXECUTED`.
+
+`READY_FOR_PUSH_REVIEW`.
+
+`BETA_CONTROLEE_ALLOWED_WITH_RESERVES`.
+
+`BETA_ELARGIE_BLOCKED`.
+
+`GO_LIVE_LARGE_BLOCKED`.

--- a/docs/go-live/_evidence/lot14-local-commits-command-log.md
+++ b/docs/go-live/_evidence/lot14-local-commits-command-log.md
@@ -1,0 +1,83 @@
+# Lot 14 — Local commits command log
+
+## Baseline
+
+- Date locale : 2026-07-06 21:46:09 CET
+- Branche : `feat/lot4-accessors-runtime`
+- Commit initial : `db8545a19`
+- Node : `v20.20.0`
+- npm : `10.8.2`
+- Staging initial : vide
+- Diff `.env` initial : aucune sortie
+- Entrées `git status --short --untracked-files=all` : `320`
+- Fichiers suivis modifiés : `130`
+- Fichiers non suivis : `190`
+
+## P1 confirmés avant commits
+
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+## Fichiers interdits / exclus
+
+- `rapport_audit_2_07_2026.md` : exclu du staging.
+- `docs/audits/audit-nexus-reussite.md` : exclu du staging.
+- `.env*` : exclu du staging.
+- `.next/**`, `node_modules/**`, `test-results/**`, `playwright-report/**` : exclus du staging.
+
+## Commits exécutés
+
+| # | Message | Hash | Tests du bloc | Notes |
+|---:|---|---|---|---|
+| 1 | `chore(go-live): update security inventory and matrices` | `48d64a4fd` | `node scripts/security/audit-api-guards.mjs`; `node scripts/go-live/generate-api-security-matrix.mjs`; `npm run check:bundle-weight` | Générateurs relancés, `P0=0`, `P1=6`, staging vide après commit. |
+| 2 | `fix(api-security): close admin and role guard gaps` | `eb0d6630f` | `npm run test:unit -- --runInBand __tests__/api/admin.config.route.test.ts __tests__/api/admin.documents.route.test.ts __tests__/api/bilans.id.route.test.ts` | 3 suites passées, 27 tests passés, staging exact 61 fichiers, staging vide après commit. |
+| 3 | `fix(public-funnel): lead-only bilan and assessment token binding` | `798f712ae` | `npm run test:unit -- --runInBand __tests__/api/bilan-gratuit.product-rgpd.test.ts __tests__/api/assessments.submit.token-binding.test.ts __tests__/app/bilan-gratuit.assessment-page-token.test.tsx` | 3 suites passées, 13 tests passés, staging exact 12 fichiers, staging vide après commit. |
+| 4 | `fix(runtime): rate-limit probe and business-config gate` | `b03d0c37b` | `npm run test:unit -- --runInBand __tests__/api/internal.rate-limit-probe.test.ts __tests__/api/internal.business-config.health.test.ts __tests__/lib/rate-limit.production-gate.test.ts` | 3 suites passées, 8 tests passés, staging exact 4 fichiers, staging vide après commit. |
+| 5 | `fix(payments): keep clictopay disabled and fail closed` | `43be9787b` | `npm run test:unit -- --runInBand __tests__/api/payments.clictopay.disabled-contract.test.ts __tests__/api/payments.clictopay.feature-flag-consistency.test.ts __tests__/ui/payment-methods.clictopay-disabled.test.tsx` | 3 suites passées, 5 tests passés, staging exact 3 fichiers, staging vide après commit. |
+| 6 | `chore(maintenance): add contact-lead retention dry-run` | `b7d94cf7a` | `npm run test:unit -- --runInBand __tests__/scripts/contact-leads-retention.test.ts __tests__/lib/crm/contact-leads.retention.test.ts` | 2 suites passées, 4 tests passés, staging exact 1 fichier, staging vide après commit. |
+| 7 | `test(security): add no-leak, idor, token and audit regressions` | `eec8430ed` | `npm run test:unit -- --runInBand` | 541 suites passées, 1 suite skipped, 6531 tests passés, 4 tests skipped, staging exact 81 fichiers, staging vide après commit. |
+| 8 | `test(e2e): protect public assessment route` | `5b7fe4def` | `PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium` | 1 test Chromium passé, staging exact 5 fichiers, staging vide après commit. |
+| 9 | `docs(go-live): add evidence and go-no-go registers` | `e92f9f546` | `npm run check:docs-archive` | Check archive OK, staging exact 109 fichiers, staging vide après commit. |
+
+## Tests exécutés
+
+- Commit 1 : inventaire API OK (`178` routes), matrice OK (`P0=0`, `P1=6`, `P2=144`, `OK=28`), bundle weight OK.
+- Commit 2 : tests ciblés API admin/documents/bilans OK (`3` suites, `27` tests).
+- Commit 3 : tests ciblés bilan/token/page assessment OK (`3` suites, `13` tests). Un `console.error` attendu apparaît sur un chemin de validation simulé sans échec.
+- Commit 4 : tests ciblés runtime/probe/business config OK (`3` suites, `8` tests).
+- Commit 5 : tests ciblés ClicToPay disabled OK (`3` suites, `5` tests).
+- Commit 6 : tests ciblés rétention ContactLead OK (`2` suites, `4` tests).
+- Commit 7 : suite unitaire complète OK (`541` suites passées, `1` suite skipped, `6531` tests passés, `4` tests skipped).
+- Commit 8 : Playwright assessment token OK (`1` test passé). Avertissements serveur observés sans échec : `NO_COLOR` ignoré avec `FORCE_COLOR`, refresh passif Prisma non bloquant.
+- Commit 9 : `check:docs-archive` OK.
+
+## Gates finales après les 9 commits
+
+| Commande | Statut | Résultat |
+|---|---|---|
+| `npm run typecheck` | PASSED | `tsc --noEmit` OK |
+| `npm run lint` | PASSED | Next lint OK sous seuil `--max-warnings 300` |
+| `npm run test:unit -- --runInBand` | PASSED | 541 suites passées, 1 skipped ; 6531 tests passés, 4 skipped |
+| `npm run build` | PASSED | Next build OK, 142 pages statiques générées |
+| `node scripts/security/audit-api-guards.mjs` | PASSED | `178` routes |
+| `node scripts/go-live/generate-api-security-matrix.mjs` | PASSED | `P0=0`, `P1=6`, `P2=144`, `OK=28` |
+| `npm run audit:site-map` | PASSED | 292 routes, 413 edges, 0 link finding |
+| `npm run check:no-hardcoded` | PASSED | 0 valeur hardcodée hors sources canoniques |
+| `npm run check:docs-archive` | PASSED | OK |
+| `npm run check:bundle-weight` | PASSED | Toutes les routes dans baseline + 5 kB |
+| Playwright public homepage/offres/bilan | PASSED | 24 tests passés |
+| Playwright assessment token | PASSED | 1 test passé |
+
+## État final
+
+- Les 9 commits du runbook Lot 11 ont été exécutés localement.
+- Aucun push, aucune PR, aucun déploiement, aucune migration.
+- `git diff --cached --name-only` vide après les 9 commits et après les gates finales.
+- Les 6 P1 restent visibles.
+- `docs/audits/audit-nexus-reussite.md` et `rapport_audit_2_07_2026.md` restent hors staging.
+- Les générateurs de gates finales ont modifié uniquement les timestamps de `docs/security/API_GUARD_INVENTORY.md` et `docs/go-live/api-security-matrix.full.md`.
+- Documentation Lot 14 préparée pour commit documentaire local additionnel.

--- a/docs/go-live/_evidence/lot14-post-commit-go-no-go.md
+++ b/docs/go-live/_evidence/lot14-post-commit-go-no-go.md
@@ -1,0 +1,32 @@
+# Lot 14 — Post-commit go/no-go
+
+Date : 2026-07-06.
+
+## Registre
+
+| Domaine | Statut | Preuve | Décision |
+|---|---|---|---|
+| Local commits | EXECUTED | 9 hashes Lot 11 | LOCAL_COMMITS_EXECUTED |
+| P0 | 0 | `docs/go-live/api-security-matrix.full.md` | OK |
+| P1 | 6 | `docs/go-live/api-security-matrix.full.md` | BETA_CONTROLEE_ALLOWED_WITH_RESERVES |
+| Staging Git | EMPTY | `git diff --cached --name-only` | OK |
+| Fichiers exclus | EXCLUDED | vérifications avant chaque commit | OK |
+| Gates finales | PASSED | `docs/go-live/_evidence/lot14-final-gates-after-commits.md` | READY_FOR_PUSH_REVIEW |
+| Redis/Upstash | NOT_PROVEN | preuve runtime absente | BETA_ELARGIE_BLOCKED |
+| 429 runtime | NOT_PROVEN | preuve runtime absente | BETA_ELARGIE_BLOCKED |
+| ContactLead DB dry-run | NOT_PROVEN | preuve DB hors production absente | GO_LIVE_LARGE_BLOCKED |
+| ClicToPay | DISABLED | tests contrat + matrice | OK paiement manuel seulement |
+
+## Décisions finales
+
+- `READY_FOR_PUSH_REVIEW`
+- `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`
+- `BETA_ELARGIE_BLOCKED`
+- `GO_LIVE_LARGE_BLOCKED`
+
+## Réserves non levées
+
+- Aucune preuve Redis/Upstash staging/production authentifiée.
+- Aucun test 429 runtime réel sur environnement partagé.
+- Aucun dry-run DB ContactLead hors production.
+- Aucun push, aucune PR et aucun déploiement exécutés dans ce lot.

--- a/docs/go-live/_evidence/lot15-final-status.md
+++ b/docs/go-live/_evidence/lot15-final-status.md
@@ -1,0 +1,36 @@
+# Lot 15 — Final status
+
+Date : 2026-07-06.
+
+## Statut
+
+| Domaine | Statut | Preuve | Décision |
+|---|---|---|---|
+| Fichiers non suivis initiaux | 39 | `git ls-files --others --exclude-standard` | Inventoriés |
+| INCLUDE | 37 | `docs/go-live/_evidence/lot15-untracked-files-inventory.md` | Commités |
+| EXCLUDE | 2 | `docs/go-live/_evidence/lot15-untracked-files-decision-proof.md` | Maintenus hors staging |
+| REVIEW | 0 | `docs/go-live/_evidence/lot15-untracked-files-review-leftovers.md` | NONE |
+| Tests release | COMMITTED | `c774ed34f` | OK |
+| Preuves release | COMMITTED | `edcb0faa2` | OK |
+| P1 | 6 | `docs/go-live/api-security-matrix.full.md` | Non requalifiés |
+| Staging Git | EMPTY | `git diff --cached --name-only` | OK |
+
+## Fichiers restants hors staging
+
+- `docs/audits/audit-nexus-reussite.md`
+- `rapport_audit_2_07_2026.md`
+
+## Décisions finales
+
+- `LOCAL_COMMITS_COMPLETE`
+- `READY_FOR_PUSH_REVIEW`
+- `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`
+- `BETA_ELARGIE_BLOCKED`
+- `GO_LIVE_LARGE_BLOCKED`
+
+## Réserves maintenues
+
+- Redis/Upstash runtime non prouvé.
+- 429 runtime réel non prouvé.
+- ContactLead DB dry-run non prouvé.
+- ClicToPay disabled.

--- a/docs/go-live/_evidence/lot15-final-status.md
+++ b/docs/go-live/_evidence/lot15-final-status.md
@@ -12,6 +12,8 @@ Date : 2026-07-06.
 | REVIEW | 0 | `docs/go-live/_evidence/lot15-untracked-files-review-leftovers.md` | NONE |
 | Tests release | COMMITTED | `c774ed34f` | OK |
 | Preuves release | COMMITTED | `edcb0faa2` | OK |
+| Documentation Lot 15 | COMMITTED | `a775c4e60` | OK |
+| Gates finales | PASSED | typecheck, lint, unit, build, audit API, matrice, site-map, no-hardcoded, docs-archive, bundle-weight | OK |
 | P1 | 6 | `docs/go-live/api-security-matrix.full.md` | Non requalifiés |
 | Staging Git | EMPTY | `git diff --cached --name-only` | OK |
 
@@ -19,6 +21,19 @@ Date : 2026-07-06.
 
 - `docs/audits/audit-nexus-reussite.md`
 - `rapport_audit_2_07_2026.md`
+
+## Gates finales
+
+- `npm run typecheck` : PASSED.
+- `npm run lint` : PASSED avec warnings existants sous seuil.
+- `npm run test:unit -- --runInBand` : PASSED, 541 suites passées, 1 skipped ; 6531 tests passés, 4 skipped.
+- `npm run build` : PASSED.
+- `node scripts/security/audit-api-guards.mjs` : PASSED, 178 routes.
+- `node scripts/go-live/generate-api-security-matrix.mjs` : PASSED, `P0=0`, `P1=6`, `P2=144`, `OK=28`.
+- `npm run audit:site-map` : PASSED.
+- `npm run check:no-hardcoded` : PASSED.
+- `npm run check:docs-archive` : PASSED.
+- `npm run check:bundle-weight` : PASSED.
 
 ## Décisions finales
 

--- a/docs/go-live/_evidence/lot15-untracked-files-decision-proof.md
+++ b/docs/go-live/_evidence/lot15-untracked-files-decision-proof.md
@@ -1,0 +1,81 @@
+# Lot 15 — Preuve de décision sur fichiers non suivis
+
+Date : 2026-07-06.
+
+## Comptage
+
+- Total fichiers non suivis au départ : 39.
+- `INCLUDE` : 37.
+- `EXCLUDE` : 2.
+- `REVIEW` : 0.
+
+## Fichiers INCLUDE
+
+- `__tests__/scripts/release-candidate-git-add-dry-run-plan.test.ts`
+- `__tests__/scripts/release-candidate-human-commit-runbook.test.ts`
+- `__tests__/scripts/release-candidate-manifest-consistency.test.ts`
+- `docs/go-live/23_LOT9_RC_MANIFEST_VALIDATION.md`
+- `docs/go-live/24_LOT10_HUMAN_COMMIT_DRY_RUN.md`
+- `docs/go-live/25_LOT11_HUMAN_COMMIT_RUNBOOK.md`
+- `docs/go-live/26_LOT12_AUDIT_NEXUS_DECISION.md`
+- `docs/go-live/27_LOT13_FINAL_PRECOMMIT_CHECK.md`
+- `docs/go-live/_evidence/lot10-final-human-commit-register.md`
+- `docs/go-live/_evidence/lot10-git-add-dry-run-plan.md`
+- `docs/go-live/_evidence/lot10-git-add-dry-run-proof.md`
+- `docs/go-live/_evidence/lot10-human-commit-dry-run-command-log.md`
+- `docs/go-live/_evidence/lot10-human-review-pending-files.md`
+- `docs/go-live/_evidence/lot10-runtime-proof-status.md`
+- `docs/go-live/_evidence/lot11-final-human-commit-register.md`
+- `docs/go-live/_evidence/lot11-human-commit-runbook-command-log.md`
+- `docs/go-live/_evidence/lot11-human-commit-runbook-proof.md`
+- `docs/go-live/_evidence/lot11-human-commit-runbook.md`
+- `docs/go-live/_evidence/lot11-human-review-pending-files.md`
+- `docs/go-live/_evidence/lot11-runtime-proof-status.md`
+- `docs/go-live/_evidence/lot12-audit-nexus-human-decision-command-log.md`
+- `docs/go-live/_evidence/lot12-audit-nexus-reussite-review.md`
+- `docs/go-live/_evidence/lot12-final-audit-decision-register.md`
+- `docs/go-live/_evidence/lot12-human-review-decision-files.md`
+- `docs/go-live/_evidence/lot12-runbook-lock-proof.md`
+- `docs/go-live/_evidence/lot12-runtime-proof-status.md`
+- `docs/go-live/_evidence/lot13-audit-nexus-final-status.md`
+- `docs/go-live/_evidence/lot13-final-human-execution-register.md`
+- `docs/go-live/_evidence/lot13-final-precommit-command-log.md`
+- `docs/go-live/_evidence/lot13-human-execution-checklist.md`
+- `docs/go-live/_evidence/lot13-runbook-still-valid-proof.md`
+- `docs/go-live/_evidence/lot13-runtime-proof-status.md`
+- `docs/go-live/_evidence/lot9-final-release-candidate-register.md`
+- `docs/go-live/_evidence/lot9-human-review-checklist.md`
+- `docs/go-live/_evidence/lot9-rc-manifest-consistency-proof.md`
+- `docs/go-live/_evidence/lot9-rc-manifest-validation-command-log.md`
+- `docs/go-live/_evidence/lot9-runtime-proof-status.md`
+
+## Fichiers EXCLUDE
+
+- `docs/audits/audit-nexus-reussite.md`
+- `rapport_audit_2_07_2026.md`
+
+## Preuve d'exclusion obligatoire
+
+Les fichiers suivants ne doivent pas être inclus dans les commits Lot 15 :
+
+- `.env*`
+- `rapport_audit_2_07_2026.md`
+- `docs/audits/audit-nexus-reussite.md`
+- `.next/**`
+- `node_modules/**`
+- `test-results/**`
+- `playwright-report/**`
+
+La vérification avant chaque commit utilise :
+
+```bash
+git diff --cached --name-only | rg '(^|/)\.env($|\.)|rapport_audit_2_07_2026.md|docs/audits/audit-nexus-reussite.md|(^|/)\.next/|(^|/)node_modules/|(^|/)test-results/|(^|/)playwright-report/' || true
+```
+
+## Décision finale
+
+`INCLUDE_RELEASE_TESTS_AND_EVIDENCE`.
+
+`EXCLUDE_STALE_AUDIT_AND_HISTORICAL_REPORT`.
+
+`REVIEW_NONE`.

--- a/docs/go-live/_evidence/lot15-untracked-files-inventory.md
+++ b/docs/go-live/_evidence/lot15-untracked-files-inventory.md
@@ -1,0 +1,52 @@
+# Lot 15 — Inventaire des fichiers non suivis
+
+Date : 2026-07-06.
+
+| Fichier | Type | Décision | Raison |
+|---|---|---|---|
+| `__tests__/scripts/release-candidate-git-add-dry-run-plan.test.ts` | test | INCLUDE | Test release utile pour verrouiller le dry-run humain Lot 10. |
+| `__tests__/scripts/release-candidate-human-commit-runbook.test.ts` | test | INCLUDE | Test release utile pour valider le runbook humain Lot 11. |
+| `__tests__/scripts/release-candidate-manifest-consistency.test.ts` | test | INCLUDE | Test release utile pour valider la cohérence manifeste RC. |
+| `docs/audits/audit-nexus-reussite.md` | stale audit | EXCLUDE | Décision Lot 12/13 maintenue : contexte business obsolète comme audit courant, hors commits standards. |
+| `docs/go-live/23_LOT9_RC_MANIFEST_VALIDATION.md` | release evidence | INCLUDE | Rapport Lot 9 utile à la traçabilité RC. |
+| `docs/go-live/24_LOT10_HUMAN_COMMIT_DRY_RUN.md` | release evidence | INCLUDE | Rapport Lot 10 utile à la traçabilité RC. |
+| `docs/go-live/25_LOT11_HUMAN_COMMIT_RUNBOOK.md` | release evidence | INCLUDE | Rapport Lot 11 utile à la traçabilité RC. |
+| `docs/go-live/26_LOT12_AUDIT_NEXUS_DECISION.md` | release evidence | INCLUDE | Rapport Lot 12 utile à la décision d'exclusion audit Nexus. |
+| `docs/go-live/27_LOT13_FINAL_PRECOMMIT_CHECK.md` | release evidence | INCLUDE | Rapport Lot 13 utile au verrou precommit. |
+| `docs/go-live/_evidence/lot10-final-human-commit-register.md` | release evidence | INCLUDE | Preuve Lot 10 utile. |
+| `docs/go-live/_evidence/lot10-git-add-dry-run-plan.md` | release evidence | INCLUDE | Preuve Lot 10 utile. |
+| `docs/go-live/_evidence/lot10-git-add-dry-run-proof.md` | release evidence | INCLUDE | Preuve Lot 10 utile. |
+| `docs/go-live/_evidence/lot10-human-commit-dry-run-command-log.md` | release evidence | INCLUDE | Journal Lot 10 utile. |
+| `docs/go-live/_evidence/lot10-human-review-pending-files.md` | release evidence | INCLUDE | Preuve Lot 10 utile. |
+| `docs/go-live/_evidence/lot10-runtime-proof-status.md` | release evidence | INCLUDE | Statut runtime Lot 10 utile. |
+| `docs/go-live/_evidence/lot11-final-human-commit-register.md` | release evidence | INCLUDE | Preuve Lot 11 utile. |
+| `docs/go-live/_evidence/lot11-human-commit-runbook-command-log.md` | release evidence | INCLUDE | Journal Lot 11 utile. |
+| `docs/go-live/_evidence/lot11-human-commit-runbook-proof.md` | release evidence | INCLUDE | Preuve mécanique Lot 11 utile. |
+| `docs/go-live/_evidence/lot11-human-commit-runbook.md` | release evidence | INCLUDE | Runbook Lot 11 utile. |
+| `docs/go-live/_evidence/lot11-human-review-pending-files.md` | release evidence | INCLUDE | Preuve Lot 11 utile. |
+| `docs/go-live/_evidence/lot11-runtime-proof-status.md` | release evidence | INCLUDE | Statut runtime Lot 11 utile. |
+| `docs/go-live/_evidence/lot12-audit-nexus-human-decision-command-log.md` | release evidence | INCLUDE | Journal Lot 12 utile. |
+| `docs/go-live/_evidence/lot12-audit-nexus-reussite-review.md` | release evidence | INCLUDE | Revue Lot 12 utile sans inclure l'audit source obsolète. |
+| `docs/go-live/_evidence/lot12-final-audit-decision-register.md` | release evidence | INCLUDE | Registre Lot 12 utile. |
+| `docs/go-live/_evidence/lot12-human-review-decision-files.md` | release evidence | INCLUDE | Décision Lot 12 utile. |
+| `docs/go-live/_evidence/lot12-runbook-lock-proof.md` | release evidence | INCLUDE | Preuve Lot 12 utile. |
+| `docs/go-live/_evidence/lot12-runtime-proof-status.md` | release evidence | INCLUDE | Statut runtime Lot 12 utile. |
+| `docs/go-live/_evidence/lot13-audit-nexus-final-status.md` | release evidence | INCLUDE | Statut final audit Nexus Lot 13 utile. |
+| `docs/go-live/_evidence/lot13-final-human-execution-register.md` | release evidence | INCLUDE | Registre Lot 13 utile. |
+| `docs/go-live/_evidence/lot13-final-precommit-command-log.md` | release evidence | INCLUDE | Journal Lot 13 utile. |
+| `docs/go-live/_evidence/lot13-human-execution-checklist.md` | release evidence | INCLUDE | Checklist d'exécution humaine utile. |
+| `docs/go-live/_evidence/lot13-runbook-still-valid-proof.md` | release evidence | INCLUDE | Preuve Lot 13 utile. |
+| `docs/go-live/_evidence/lot13-runtime-proof-status.md` | release evidence | INCLUDE | Statut runtime Lot 13 utile. |
+| `docs/go-live/_evidence/lot9-final-release-candidate-register.md` | release evidence | INCLUDE | Registre Lot 9 utile. |
+| `docs/go-live/_evidence/lot9-human-review-checklist.md` | release evidence | INCLUDE | Checklist Lot 9 utile. |
+| `docs/go-live/_evidence/lot9-rc-manifest-consistency-proof.md` | release evidence | INCLUDE | Preuve Lot 9 utile. |
+| `docs/go-live/_evidence/lot9-rc-manifest-validation-command-log.md` | release evidence | INCLUDE | Journal Lot 9 utile. |
+| `docs/go-live/_evidence/lot9-runtime-proof-status.md` | release evidence | INCLUDE | Statut runtime Lot 9 utile. |
+| `rapport_audit_2_07_2026.md` | stale audit | EXCLUDE | Rapport historique hors RC, explicitement exclu. |
+
+## Synthèse
+
+- Total initial : 39 fichiers.
+- `INCLUDE` : 37 fichiers.
+- `EXCLUDE` : 2 fichiers.
+- `REVIEW` : 0 fichier.

--- a/docs/go-live/_evidence/lot15-untracked-files-regularization-command-log.md
+++ b/docs/go-live/_evidence/lot15-untracked-files-regularization-command-log.md
@@ -1,0 +1,52 @@
+# Lot 15 — Untracked files regularization command log
+
+## Baseline
+
+- Date locale : 2026-07-06 22:19:40 CET
+- Branche : `feat/lot4-accessors-runtime`
+- Commit initial : `61d54a8eb`
+- Node : `v20.20.0`
+- npm : `10.8.2`
+- `git diff --name-only` : aucune sortie
+- `git diff --cached --name-only` : aucune sortie
+- `git diff --name-only | rg '(^|/)\.env($|\.)' || true` : aucune sortie
+- Fichiers non suivis au départ : 39
+
+## P1 confirmés
+
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+## Décision d'inventaire
+
+- `INCLUDE` : 37 fichiers.
+- `EXCLUDE` : 2 fichiers.
+- `REVIEW` : 0 fichier.
+
+## Commandes Lot 15
+
+| Étape | Commande | Statut | Résultat |
+|---|---|---|---|
+| Baseline | `git ls-files --others --exclude-standard` | PASSED | 39 fichiers non suivis |
+| Tests release | `npm run test:unit -- --runInBand __tests__/scripts/release-candidate-manifest-consistency.test.ts __tests__/scripts/release-candidate-git-add-dry-run-plan.test.ts __tests__/scripts/release-candidate-human-commit-runbook.test.ts` | PASSED | 3 suites passées, 15 tests passés |
+| Commit tests | `git commit -m "test(go-live): include release validation tests"` | PASSED | `c774ed34f` |
+| Docs archive preuves | `npm run check:docs-archive` | PASSED | OK |
+| Runbook preuves | `npm run test:unit -- --runInBand __tests__/scripts/release-candidate-human-commit-runbook.test.ts` | PASSED | 1 suite passée, 5 tests passés |
+| Commit preuves | `git commit -m "docs(go-live): include remaining release evidence"` | PASSED | `edcb0faa2` |
+
+## Exclusions vérifiées
+
+Avant chaque commit, la commande suivante a retourné une sortie vide :
+
+```bash
+git diff --cached --name-only | rg '(^|/)\.env($|\.)|rapport_audit_2_07_2026.md|docs/audits/audit-nexus-reussite.md|(^|/)\.next/|(^|/)node_modules/|(^|/)test-results/|(^|/)playwright-report/' || true
+```
+
+## État avant commit documentaire Lot 15
+
+- Staging Git : vide.
+- Fichiers restants non suivis métier/release : uniquement documentation Lot 15 et deux fichiers `EXCLUDE`.

--- a/docs/go-live/_evidence/lot15-untracked-files-regularization-command-log.md
+++ b/docs/go-live/_evidence/lot15-untracked-files-regularization-command-log.md
@@ -37,6 +37,7 @@
 | Docs archive preuves | `npm run check:docs-archive` | PASSED | OK |
 | Runbook preuves | `npm run test:unit -- --runInBand __tests__/scripts/release-candidate-human-commit-runbook.test.ts` | PASSED | 1 suite passée, 5 tests passés |
 | Commit preuves | `git commit -m "docs(go-live): include remaining release evidence"` | PASSED | `edcb0faa2` |
+| Commit documentation Lot 15 | `git commit -m "docs(go-live): record untracked file regularization"` | PASSED | `a775c4e60` |
 
 ## Exclusions vérifiées
 
@@ -50,3 +51,27 @@ git diff --cached --name-only | rg '(^|/)\.env($|\.)|rapport_audit_2_07_2026.md|
 
 - Staging Git : vide.
 - Fichiers restants non suivis métier/release : uniquement documentation Lot 15 et deux fichiers `EXCLUDE`.
+
+## Gates finales Lot 15
+
+| Commande | Statut | Résultat |
+|---|---|---|
+| `npm run typecheck` | PASSED | `tsc --noEmit` OK |
+| `npm run lint` | PASSED | Next lint OK sous seuil `--max-warnings 300` |
+| `npm run test:unit -- --runInBand` | PASSED | 541 suites passées, 1 skipped ; 6531 tests passés, 4 skipped |
+| `npm run build` | PASSED | Next build OK, 142 pages statiques générées |
+| `node scripts/security/audit-api-guards.mjs` | PASSED | 178 routes |
+| `node scripts/go-live/generate-api-security-matrix.mjs` | PASSED | `P0=0`, `P1=6`, `P2=144`, `OK=28` |
+| `npm run audit:site-map` | PASSED | 292 routes, 413 edges, 0 link finding |
+| `npm run check:no-hardcoded` | PASSED | 0 valeur hardcodée hors sources canoniques |
+| `npm run check:docs-archive` | PASSED | OK |
+| `npm run check:bundle-weight` | PASSED | Toutes les routes dans baseline + 5 kB |
+
+## Régularisation post-gates
+
+Les gates `audit-api-guards` et `generate-api-security-matrix` ont modifié uniquement les timestamps de :
+
+- `docs/security/API_GUARD_INVENTORY.md`
+- `docs/go-live/api-security-matrix.full.md`
+
+Ces changements générés sont intégrés au dernier commit documentaire Lot 15 afin de conserver un worktree propre hors exclusions.

--- a/docs/go-live/_evidence/lot15-untracked-files-review-leftovers.md
+++ b/docs/go-live/_evidence/lot15-untracked-files-review-leftovers.md
@@ -1,0 +1,14 @@
+# Lot 15 — Fichiers restants en REVIEW
+
+Date : 2026-07-06.
+
+## REVIEW
+
+NONE.
+
+## Notes
+
+Les seuls fichiers prévus pour rester non suivis après régularisation sont les fichiers `EXCLUDE` :
+
+- `docs/audits/audit-nexus-reussite.md`
+- `rapport_audit_2_07_2026.md`

--- a/docs/go-live/_evidence/lot16-final-diff-review-command-log.md
+++ b/docs/go-live/_evidence/lot16-final-diff-review-command-log.md
@@ -1,0 +1,85 @@
+# Lot 16 — Final diff review command log
+
+Date locale : 2026-07-06 22:47:53 CET.
+
+## Contexte lu
+
+- `AGENTS.md` : lu.
+- `docs/go-live/29_LOT15_UNTRACKED_FILES_REGULARIZATION.md` : lu.
+- `docs/go-live/28_LOT14_LOCAL_COMMITS_EXECUTION.md` : lu.
+- `docs/go-live/27_LOT13_FINAL_PRECOMMIT_CHECK.md` : lu.
+- `docs/go-live/_evidence/lot15-final-status.md` : lu.
+- `docs/go-live/_evidence/lot15-untracked-files-inventory.md` : lu.
+- `docs/go-live/_evidence/lot15-untracked-files-decision-proof.md` : lu.
+- `docs/go-live/_evidence/lot15-untracked-files-review-leftovers.md` : lu.
+- `docs/go-live/_evidence/lot14-commit-hashes.md` : lu.
+- `docs/go-live/api-security-matrix.full.md` : lu.
+
+## Baseline
+
+| Commande | Resultat |
+|---|---|
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node -v` | `v20.20.0` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm -v` | `10.8.2` |
+| `git rev-parse --abbrev-ref HEAD` | `feat/lot4-accessors-runtime` |
+| `git rev-parse --short HEAD` | `9cfdbb7a6` |
+| `git status --short --untracked-files=all` | `?? docs/audits/audit-nexus-reussite.md`; `?? rapport_audit_2_07_2026.md` |
+| `git diff --cached --name-only` | sortie vide |
+| `git diff --name-only` | sortie vide |
+| `git ls-files --others --exclude-standard` | `docs/audits/audit-nexus-reussite.md`; `rapport_audit_2_07_2026.md` |
+| `git diff --name-only \| rg '(^\|/)\\.env($\|\\.)' \|\| true` | sortie vide |
+
+## P1
+
+Commande :
+
+```bash
+rg -n "^\\| P1 \\|" docs/go-live/api-security-matrix.full.md
+```
+
+Resultat :
+
+- Synthese : `P1 = 6`.
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+## Revue diff
+
+| Commande | Resultat |
+|---|---|
+| `git log --oneline -20` | 20 derniers commits consultes, HEAD initial `9cfdbb7a6` |
+| `git diff --stat main...HEAD` | `329 files changed, 21339 insertions(+), 1258 deletions(-)` |
+| `git diff --name-only main...HEAD` | 329 fichiers |
+| `git status --short --untracked-files=all` | deux exclusions seulement |
+| `git diff --cached --name-only` | sortie vide |
+| `git ls-files --others --exclude-standard` | deux exclusions seulement |
+| `git merge-base --short main HEAD` | commande echouee : option non supportee par cette version Git |
+| `git merge-base main HEAD \| cut -c1-9` | `db8545a19` |
+| `git rev-parse --short main` | `db8545a19` |
+| `git rev-list --count main..HEAD` | `14` |
+
+## Gates pre-push
+
+| Commande | Resultat |
+|---|---|
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run typecheck` | PASSED |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run lint` | PASSED avec warnings existants sous seuil |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand __tests__/scripts/release-candidate-human-commit-runbook.test.ts` | PASSED, 1 suite, 5 tests |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:docs-archive` | PASSED |
+
+## Verifications post-gates
+
+| Commande | Resultat |
+|---|---|
+| `rg -n "^\\| P1 \\|" docs/go-live/api-security-matrix.full.md` | 6 P1 visibles |
+| `git diff --cached --name-only` | sortie vide |
+| `git diff --name-only \| rg '(^\|/)\\.env($\|\\.)' \|\| true` | sortie vide |
+| `git status --short --untracked-files=all` | docs Lot 16 modifies/non suivis, plus les deux exclusions attendues avant commit documentaire |
+
+## Push
+
+Statut : `PENDING`. Aucun push execute au moment de creation initiale du document.

--- a/docs/go-live/_evidence/lot16-final-diff-summary.md
+++ b/docs/go-live/_evidence/lot16-final-diff-summary.md
@@ -1,0 +1,73 @@
+# Lot 16 — Final diff summary
+
+## Branche
+
+`feat/lot4-accessors-runtime`
+
+## Commit HEAD local
+
+HEAD au moment de la revue avant documentation Lot 16 : `9cfdbb7a6`.
+
+## Base de comparaison
+
+`main...HEAD`.
+
+Merge-base local : `db8545a19`.
+
+## Résumé des commits
+
+La branche contient 14 commits locaux au-dessus de `main` avant le commit documentaire Lot 16 :
+
+```txt
+9cfdbb7a6 docs(go-live): record final lot15 gates
+a775c4e60 docs(go-live): record untracked file regularization
+edcb0faa2 docs(go-live): include remaining release evidence
+c774ed34f test(go-live): include release validation tests
+61d54a8eb docs(go-live): record local commit execution
+e92f9f546 docs(go-live): add evidence and go-no-go registers
+5b7fe4def test(e2e): protect public assessment route
+eec8430ed test(security): add no-leak, idor, token and audit regressions
+b7d94cf7a chore(maintenance): add contact-lead retention dry-run
+43be9787b fix(payments): keep clictopay disabled and fail closed
+b03d0c37b fix(runtime): rate-limit probe and business-config gate
+798f712ae fix(public-funnel): lead-only bilan and assessment token binding
+eb0d6630f fix(api-security): close admin and role guard gaps
+48d64a4fd chore(go-live): update security inventory and matrices
+```
+
+## Diff stat
+
+`329 files changed, 21339 insertions(+), 1258 deletions(-)`.
+
+## Fichiers sensibles vérifiés
+
+- Staging Git : vide.
+- Diff tracked local avant docs Lot 16 : vide.
+- `.env*` dans diff tracked : aucun.
+- Fichiers interdits en staging : aucun.
+- Push force : non execute.
+- PR : non creee.
+- Deploiement : non execute.
+- Migration : non executee.
+
+## Fichiers exclus restants
+
+- `docs/audits/audit-nexus-reussite.md`
+- `rapport_audit_2_07_2026.md`
+
+## P1 visibles
+
+Les 6 P1 sont visibles dans `docs/go-live/api-security-matrix.full.md` :
+
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+## Décision
+
+`READY_TO_PUSH_BRANCH`.
+
+Gates pre-push minimales : PASSED.

--- a/docs/go-live/_evidence/lot16-post-push-status.md
+++ b/docs/go-live/_evidence/lot16-post-push-status.md
@@ -1,0 +1,22 @@
+# Lot 16 — Post-push status
+
+Date : 2026-07-06.
+
+## Statut
+
+`PENDING_PUSH`.
+
+Ce fichier est cree avant push pour etre inclus dans le commit documentaire Lot 16. Il devra etre mis a jour localement apres le push, sans second commit sauf decision humaine explicite.
+
+## Post-push checks prevus
+
+- `git status --short --untracked-files=all`
+- `git log --oneline -5`
+- remote origin masque si l'URL contient une information sensible.
+
+## Interdits maintenus
+
+- Pas de PR automatique.
+- Pas de deploiement.
+- Pas de migration.
+- Pas de push force.

--- a/docs/go-live/_evidence/lot16-push-review-readiness.md
+++ b/docs/go-live/_evidence/lot16-push-review-readiness.md
@@ -1,0 +1,42 @@
+# Lot 16 — Push review readiness
+
+Date : 2026-07-06.
+
+## Statut pre-gates
+
+| Domaine | Statut | Preuve | Decision |
+|---|---|---|---|
+| Branche | `feat/lot4-accessors-runtime` | `git rev-parse --abbrev-ref HEAD` | OK, pas `main`/`master` |
+| HEAD initial Lot 16 | `9cfdbb7a6` | `git rev-parse --short HEAD` | OK |
+| Staging | EMPTY | `git diff --cached --name-only` | OK |
+| Diff tracked | EMPTY | `git diff --name-only` | OK |
+| Untracked | 2 exclusions | `git ls-files --others --exclude-standard` | OK |
+| `.env*` diff | NONE | `rg` sur diff tracked | OK |
+| P1 | 6 | matrice API | OK, non requalifies |
+| PR automatique | NOT_CREATED | regle Lot 16 | OK |
+| Deploiement | NOT_EXECUTED | regle Lot 16 | OK |
+| Migration | NOT_EXECUTED | regle Lot 16 | OK |
+
+## Fichiers exclus restants
+
+- `docs/audits/audit-nexus-reussite.md`
+- `rapport_audit_2_07_2026.md`
+
+## Gates pre-push
+
+| Commande | Statut |
+|---|---|
+| `npm run typecheck` | PASSED |
+| `npm run lint` | PASSED |
+| `npm run test:unit -- --runInBand __tests__/scripts/release-candidate-human-commit-runbook.test.ts` | PASSED |
+| `npm run check:docs-archive` | PASSED |
+
+## Decision
+
+`READY_TO_PUSH_BRANCH` si la re-verification juste avant push confirme :
+
+- branche differente de `main` et `master` ;
+- staging vide ;
+- seuls untracked : les deux exclusions ci-dessus ;
+- 6 P1 visibles ;
+- aucune trace `.env` dans le diff.

--- a/docs/go-live/_evidence/lot18-ci-e2e-bilan-gratuit-command-log.md
+++ b/docs/go-live/_evidence/lot18-ci-e2e-bilan-gratuit-command-log.md
@@ -1,0 +1,71 @@
+# Lot 18 — CI E2E bilan gratuit command log
+
+Date locale : 2026-07-07.
+
+## Baseline
+
+| Commande | Resultat |
+|---|---|
+| `git branch --show-current` | `feat/lot4-accessors-runtime` |
+| `git rev-parse --short HEAD` | `8aec67023` |
+| `git status --short --untracked-files=all` | deux exclusions connues + reliquat local Lot 16 restaure avant correction |
+| `git diff --cached --name-only` | sortie vide |
+| `git diff --name-only \| rg '(^\|/)\\.env($\|\\.)' \|\| true` | sortie vide |
+| `rg -n "parentId\|studentId\|/api/bilan-gratuit\|Soumission complète" e2e __tests__ app lib scripts` | test obsolète localise dans `e2e/real/pages/04-bilan-gratuit.spec.ts` |
+| `rg -n "^\\| P1 \\|" docs/go-live/api-security-matrix.full.md` | 6 P1 visibles |
+
+## GitHub PR #58
+
+| Commande | Resultat |
+|---|---|
+| `gh pr view 58 --json number,title,state,isDraft,headRefName,headRefOid,baseRefName,url` | PR `#58`, draft, branche `feat/lot4-accessors-runtime`, HEAD `8aec67023` |
+| `gh pr checks 58` | `E2E Tests` failed, `CI Success` failed par synthese ; autres checks principaux passent |
+| `gh pr view 58 --json statusCheckRollup` | confirme `E2E Tests = FAILURE`, `Security Scan/Lint/TypeScript/Integration/Build/Unit = SUCCESS` |
+| helper `gh-fix-ci` `inspect_pr_checks.py --json` | non utilisable localement : ce `gh` ne supporte pas `gh pr checks --json` |
+
+## Analyse source
+
+Fichier CI reel :
+
+- `e2e/real/pages/04-bilan-gratuit.spec.ts`
+
+Le chemin `e2e/04-bilan-gratuit.spec.ts` n'existe pas dans ce repo.
+
+Assertions obsoletes supprimees :
+
+- `expect(body.parentId).toBeTruthy()`
+- `expect(body.studentId).toBeTruthy()`
+
+Assertions ajoutees :
+
+- `expect(body.success).toBe(true)`
+- `expect(body.message).toBeTruthy()`
+- `expect(body).not.toHaveProperty('parentId')`
+- `expect(body).not.toHaveProperty('studentId')`
+- `expect(body).not.toHaveProperty('token')`
+- `expect(body).not.toHaveProperty('assessmentToken')`
+- `expect(body).not.toHaveProperty('leadEmailHash')`
+- `expect(JSON.stringify(body)).not.toMatch(/parentId|studentId|token|assessmentToken|leadEmailHash/i)`
+
+## Verifications executees
+
+| Commande | Resultat |
+|---|---|
+| `npm run typecheck` sous Node 20 | PASSED |
+| `npm run lint` sous Node 20 | PASSED avec warnings existants sous seuil |
+| `npm run test:unit -- --runInBand __tests__/api/bilan-gratuit.product-rgpd.test.ts` sous Node 20 | PASSED, 8 tests |
+| `PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium --reporter=line` sous Node 20 | PASSED, 1 test |
+| `PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/04-bilan-gratuit.spec.ts --project=chromium --reporter=line` sous Node 20 | FAILED, `No tests found` car ce chemin n'existe pas dans le repo |
+| `NEXTAUTH_URL=http://127.0.0.1:3012 REUSE_EXISTING_SERVER=true npx playwright test --config=playwright.ci.config.ts e2e/real/pages/04-bilan-gratuit.spec.ts --project=chromium --reporter=line` sous Node 20 | 6 passed, 1 failed car DB E2E locale absente |
+
+## Echec local non bloquant pour le correctif
+
+Le run local CI-config du fichier `04-bilan-gratuit` atteint la soumission et retourne `HTTP 500` parce que le serveur local ne peut pas joindre `127.0.0.1:5435`.
+
+Preuve serveur :
+
+```txt
+Can't reach database server at `127.0.0.1:5435`
+```
+
+Decision : ne pas lancer de migration, ne pas creer de DB, ne pas modifier l'API. La correction cible l'assertion obsolete qui faisait echouer GitHub CI avec une DB E2E disponible.

--- a/docs/go-live/_evidence/lot18-github-ci-failure-analysis.md
+++ b/docs/go-live/_evidence/lot18-github-ci-failure-analysis.md
@@ -1,0 +1,52 @@
+# Lot 18 — GitHub CI failure analysis
+
+## PR
+
+- PR : `#58`
+- URL : `https://github.com/cyranoaladin/nexus-project_v0/pull/58`
+- Branche : `feat/lot4-accessors-runtime`
+- Etat : draft
+
+## Checks GitHub
+
+Le check `E2E Tests` echoue sur GitHub Actions.
+
+Les checks suivants passent :
+
+- Security Scan
+- Lint
+- TypeScript Type Check
+- Integration Tests
+- Production Build
+- Unit Tests
+
+`CI Success` echoue comme job de synthese car `E2E Tests` echoue.
+
+## Cause racine
+
+Le test `e2e/real/pages/04-bilan-gratuit.spec.ts` attendait encore :
+
+```ts
+expect(body.parentId).toBeTruthy();
+expect(body.studentId).toBeTruthy();
+```
+
+Ces assertions sont obsoletes depuis la decision lead-only/RGPD : l'API publique `/api/bilan-gratuit` ne doit pas exposer d'IDs internes parent/eleve.
+
+## Correction retenue
+
+Ne pas modifier l'API.
+
+Corriger le test E2E pour verifier :
+
+- `success === true`.
+- `message` present.
+- absence des champs sensibles.
+- redirection vers `/bilan-gratuit/confirmation`.
+- chargement visible de la confirmation.
+
+## Verification locale
+
+Le test unitaire API/RGPD passe et prouve le contrat serveur.
+
+Le test E2E CI-config local ne peut pas terminer la soumission sans DB E2E locale ; il echoue sur `HTTP 500` cause `PrismaClientInitializationError` vers `127.0.0.1:5435`, pas sur l'ancienne assertion `parentId/studentId`.

--- a/docs/go-live/_evidence/lot18-public-api-contract-proof.md
+++ b/docs/go-live/_evidence/lot18-public-api-contract-proof.md
@@ -1,0 +1,45 @@
+# Lot 18 — Public API contract proof
+
+## Route
+
+`POST /api/bilan-gratuit`
+
+## Contrat public attendu
+
+La reponse JSON publique de succes est volontairement minimale :
+
+```json
+{
+  "success": true,
+  "message": "Votre demande a bien été enregistrée. Notre équipe vous recontactera pour la suite."
+}
+```
+
+## Donnees interdites dans la reponse publique
+
+- `parentId`
+- `studentId`
+- `token`
+- `assessmentToken`
+- `leadEmailHash`
+
+## Preuves code/tests
+
+- `app/api/bilan-gratuit/route.ts` retourne `neutralSuccessBody`.
+- `__tests__/api/bilan-gratuit.product-rgpd.test.ts` verifie que le JSON ne contient pas d'identifiants publics internes.
+- `e2e/real/pages/04-bilan-gratuit.spec.ts` verifie maintenant le contrat public et la redirection confirmation.
+
+## Assertions anti-leak E2E
+
+```ts
+expect(body).not.toHaveProperty('parentId');
+expect(body).not.toHaveProperty('studentId');
+expect(body).not.toHaveProperty('token');
+expect(body).not.toHaveProperty('assessmentToken');
+expect(body).not.toHaveProperty('leadEmailHash');
+expect(JSON.stringify(body)).not.toMatch(/parentId|studentId|token|assessmentToken|leadEmailHash/i);
+```
+
+## Decision
+
+`DO_NOT_EXPOSE_INTERNAL_PUBLIC_IDS`.

--- a/docs/go-live/_evidence/lot1bis-audit-script-review.md
+++ b/docs/go-live/_evidence/lot1bis-audit-script-review.md
@@ -1,0 +1,103 @@
+# Lot 1-bis — Revue du script `audit-api-guards.mjs`
+
+## Synthèse
+
+Le script a été contre-audité parce que la baisse `P0=44 -> 0` dépend en partie de ses heuristiques. Un faux positif/faux négatif potentiel a été trouvé : la détection de rate limit acceptait le simple mot `rateLimit`, donc un commentaire pouvait suffire.
+
+Correction appliquée :
+
+- ajout de `hasRateLimitGuard(source)` dans `scripts/security/audit-api-guards.mjs` ;
+- même durcissement dans `scripts/go-live/generate-api-security-matrix.mjs` ;
+- ajout de `__tests__/scripts/audit-api-guards.classification.test.ts`.
+
+## Règle : `staffOnlyRoute`
+
+- Motif regex ou logique : route sous `app/api/admin|assistante` ou `requireAnyRole(['ADMIN','ASSISTANTE'])`, avec auth + role.
+- Risque de faux négatif : staff-only réel non détecté si guard custom.
+- Risque de faux positif : route admin avec role guard insuffisant.
+- Routes impactées : admin/assistante dynamiques.
+- Test de script existant : staff-only sensible mutation n’est pas P0 et n’est pas OK.
+- Test de script à ajouter : couverture par fixture réelle possible si le script devient plus complexe.
+- Verdict : acceptable pour triage statique, pas preuve go-live.
+
+## Règle : routes publiques fixes
+
+- Motif regex ou logique : `app/api/public-documents/*` GET avec `FILE_NAME`.
+- Risque de faux négatif : document fixe autre pattern.
+- Risque de faux positif : document public qui contiendrait une donnée personnelle.
+- Routes impactées : `/api/public-documents/corrige-dnb-maths-2026`.
+- Test de script existant : route fixe publique devient P2, pas OK.
+- Verdict : acceptable si fichier public est validé comme contenu marketing/pédagogique non propriétaire.
+
+## Règle : routes `410`
+
+- Motif regex ou logique : présence de `status: 410`.
+- Risque de faux négatif : 410 construit indirectement.
+- Risque de faux positif : route partiellement active avec un 410 dans un seul cas.
+- Routes impactées : aucune P0 critique observée dans le Top 20 courant.
+- Test de script existant : non ajouté dans Lot 1-bis.
+- Verdict : à surveiller ; ne pas utiliser seul pour déclarer OK.
+
+## Règle : routes `501`
+
+- Motif regex ou logique : route webhook + `status: 501` + texte not configured.
+- Risque de faux négatif : service désactivé par helper externe.
+- Risque de faux positif : route avec chemin de succès alternatif.
+- Routes impactées : `/api/payments/clictopay/webhook`.
+- Test de script existant : route 501 ClicToPay devient P1, pas OK.
+- Verdict : acceptable. ClicToPay reste P1 tant que non complet.
+
+## Règle : réexports
+
+- Motif regex ou logique : `export { ... } from '...'` lu via `sourceFor(file)`.
+- Risque de faux négatif : réexport indirect ou barrel plus complexe.
+- Risque de faux positif : collision de méthodes source/route.
+- Routes impactées : routes générées/réexportées coach reports.
+- Test de script existant : réexport suit la source et conserve `POST`, sans P0 artificiel.
+- Verdict : amélioration utile, pas preuve métier.
+
+## Règle : `ownership`
+
+- Motif regex ou logique : helpers `buildDocumentOwnershipWhere`, `assertCoachCanAccessStudent`, `buildInvoiceAccessWhere`, `buildBilanReadWhere`, `canReadSubmission`, etc.
+- Risque de faux négatif : ownership réel non listé dans les motifs.
+- Risque de faux positif : helper appelé mais résultat non appliqué correctement.
+- Routes impactées : documents, factures, bilans, coach, NPC.
+- Test de script existant : route dynamique sensible sans ownership reste P0.
+- Verdict : indicateur de triage seulement. Les tests IDOR restent requis.
+
+## Règle : `roleGuard`
+
+- Motif regex ou logique : `requireRole`, `requireAnyRole`, `enforcePolicy`, `UserRole`, `session.user.role`.
+- Risque de faux négatif : guard custom.
+- Risque de faux positif : simple référence au rôle sans enforcement.
+- Routes impactées : admin/assistante/coach/parent/student.
+- Test de script existant : staff-only mutation non P0/non OK.
+- Verdict : acceptable pour priorité, pas pour preuve finale.
+
+## Règle : `authGuard`
+
+- Motif regex ou logique : `auth()`, `requireAuth`, `requireRole`, `requireAnyRole`, `enforcePolicy`, `getActor`.
+- Risque de faux négatif : auth dans wrapper non détecté.
+- Risque de faux positif : `auth()` appelé mais non vérifié.
+- Routes impactées : toutes routes sensibles.
+- Test de script existant : public sensible sans auth/rate/ownership reste P0.
+- Verdict : à compléter par tests route.
+
+## Règle : `zod`
+
+- Motif regex ou logique : `zod`, `z.`, `.parse`, `.safeParse`.
+- Risque de faux négatif : validation non-Zod correcte.
+- Risque de faux positif : Zod importé mais pas utilisé sur le payload.
+- Routes impactées : public sensible, mutations.
+- Test de script existant : public sensible avec Zod + rate limit devient P1, pas OK.
+- Verdict : indicateur faible mais utile.
+
+## Règle : `rateLimit`
+
+- Ancien motif : `guardRateLimitAsync|checkRateLimitAsync|rateLimit`.
+- Nouveau motif : appels explicites `guardRateLimitAsync(`, `guardRateLimit(`, `checkRateLimitAsync(`, `checkRateLimit(`, `RateLimitPresets.*(`, etc.
+- Risque de faux négatif : wrapper custom non listé.
+- Risque de faux positif : fortement réduit ; un commentaire ne suffit plus.
+- Routes impactées : routes publiques sensibles.
+- Test de script existant : commentaire `// TODO: add rateLimit` reste P0.
+- Verdict : correction validée.

--- a/docs/go-live/_evidence/lot1bis-command-log.md
+++ b/docs/go-live/_evidence/lot1bis-command-log.md
@@ -1,0 +1,65 @@
+# Lot 1-bis — Journal de commandes
+
+Date locale : 2026-07-02 22:14:54 CET.
+
+## État initial
+
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Runtime Node : `v20.20.0`
+- npm : `10.8.2`
+- État Git : worktree déjà modifié par Lots 0-bis/Lot 1, plus ajouts Lot 1-bis.
+
+## Fichiers hérités déjà modifiés avant Lot 1-bis
+
+Voir `git status --short` : documents go-live non suivis, inventaire API modifié, routes Lot 1 documents/factures/activation/Lamis/stages/automatismes, tests publics et Playwright issus des lots précédents.
+
+## Commandes baseline
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node -v` | OK | `v20.20.0` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm -v` | OK | `10.8.2` |
+| `git rev-parse --abbrev-ref HEAD` | OK | `feat/lot4-accessors-runtime` |
+| `git rev-parse --short HEAD` | OK | `db8545a19` |
+| `git status --short --untracked-files=all` | OK | worktree sale, aucun `.env` modifié |
+
+## Commandes ciblées exécutées
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `npm run test:unit -- --runInBand __tests__/scripts/audit-api-guards.classification.test.ts` | ÉCHEC attendu puis OK | Rouge avant correction rate limit commentaire, vert après patch |
+| `npm run test:unit -- --runInBand __tests__/api/sessions.video.route.test.ts` | ÉCHEC attendu puis OK | Rouge avant rate limit/Zod, vert après patch |
+| `npm run test:unit -- --runInBand __tests__/api/bilan-gratuit.test.ts __tests__/api/bilan-gratuit.security.test.ts` | OK | 13 tests passés |
+| `npm run test:unit -- --runInBand __tests__/api/payments.clictopay.init.route.test.ts __tests__/api/payments.clictopay.webhook.route.test.ts` | OK | 5 tests passés |
+| `npm run test:unit -- --runInBand __tests__/api/student.activate.route.test.ts __tests__/api/security/no-sensitive-fields-in-api-responses.test.ts` | OK | 16 tests passés |
+| `npm run test:unit -- --runInBand __tests__/api/npc.files.route.test.ts __tests__/api/npc.documents.route.test.ts` | OK | 15 tests passés |
+| `npm run test:unit -- --runInBand __tests__/api/admin.documents.route.test.ts` | ÉCHEC attendu puis OK | Rouge avant validation/projection, vert après patch |
+| `node scripts/security/audit-api-guards.mjs && node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=54`, `P2=95`, `OK=27` |
+
+## Commandes finales complètes
+
+Exécutées sous Node `v20.20.0`, finalisées le 2026-07-02 22:25:00 CET.
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run typecheck` | ÉCHEC puis OK | Premier passage rouge après ajout de tests (`process.env.NODE_ENV` readonly, typage `safeErrorSummary`), corrigé. Passage final OK. |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run lint` | OK | Lint passé avec avertissements existants sous seuil. |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand` | OK | 509 suites passées, 1 ignorée ; 6383 tests passés, 4 ignorés ; 7 snapshots passés. |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run build` | OK | Build Next.js réussi ; 143 pages statiques générées ; assets standalone copiés. |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/security/audit-api-guards.mjs` | OK | `docs/security/API_GUARD_INVENTORY.md` régénéré, 176 routes. |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=54`, `P2=95`, `OK=27`. |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run audit:site-map` | OK | 290 routes, 412 edges, 0 link finding, 13 public orphan entries ; docs architecture régénérées. |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:no-hardcoded` | OK | 0 hardcoded values outside canonical sources. |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:docs-archive` | OK | Aucun ancien audit/report à la racine de `docs/`. |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:bundle-weight` | OK | Toutes les routes contrôlées restent dans baseline + 5 kB. |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | OK | 24 tests passés. Avertissement runtime local : table `business_configs` absente pendant le refresh passif de config. |
+
+## Limites
+
+- Aucune valeur secrète lue ou affichée.
+- Aucun fichier `.env` modifié.
+- Aucune migration lancée.
+- Rate limiting distribué production non vérifié localement : `À vérifier en production`.
+- `/api/bilan-gratuit` reste à arbitrer produit/RGPD : création de comptes inactifs maintenue mais réponse API durcie.
+- ClicToPay reste désactivé/non complet : routes maintenues en statut non actif.

--- a/docs/go-live/_evidence/lot1bis-p0-reclassification-audit.md
+++ b/docs/go-live/_evidence/lot1bis-p0-reclassification-audit.md
@@ -1,0 +1,107 @@
+# Lot 1-bis — Audit des requalifications P0
+
+## Synthèse
+
+Le contre-audit ne valide pas les requalifications par confiance aveugle dans le script. La vérification combine :
+
+- revue du diff du script `scripts/security/audit-api-guards.mjs` ;
+- test de classification synthétique `__tests__/scripts/audit-api-guards.classification.test.ts` ;
+- revue des routes corrigées Lot 1 ;
+- tests IDOR/no-leak existants Lot 1 ;
+- régénération de `docs/security/API_GUARD_INVENTORY.md` et `docs/go-live/api-security-matrix.full.md`.
+
+Résultat après Lot 1-bis : `P0=0`, `P1=54`, `P2=95`, `OK=27` sur 176 routes.
+
+## Avant / après
+
+| Priorité | Lot 0-bis | Lot 1 | Lot 1-bis |
+|---|---:|---:|---:|
+| P0 | 44 | 0 | 0 |
+| P1 | 42 | 56 | 54 |
+| P2 | 62 | 93 | 95 |
+| OK | 28 | 27 | 27 |
+
+Limite factuelle : l’inventaire complet Lot 0-bis exact n’est pas versionné séparément. Le snapshot versionné récupérable via `git show HEAD:docs/security/API_GUARD_INVENTORY.md` contient 42 P0/164 routes ; les documents Lot 1-bis/Lot 1 indiquent l’état opérationnel Lot 0-bis à 44 P0/176 routes. Cette limite est documentée, pas comblée par hypothèse.
+
+## Méthodologie
+
+1. Comparaison du snapshot versionné pré-Lot 1 avec l’inventaire régénéré Lot 1-bis.
+2. Vérification de chaque famille de fermeture : correction code, test, staff-only, public fixe, 501.
+3. Ajout d’un test de script pour empêcher les faux OK/P1 : commentaire `rateLimit` seul, route publique sensible sans contrôle, route 501, route fixe publique, réexport.
+4. Durcissement de la détection `rateLimit` : seuls les appels explicites aux helpers sont comptés.
+
+## Routes P0 fermées par correction de code
+
+| Route | Ancien statut | Nouveau statut | Preuve |
+| --- | --- | --- | --- |
+| `/api/documents/[id]` | P0 | P2 | `app/api/documents/[id]/route.ts`, `__tests__/api/documents.id.route.test.ts` |
+| `/api/coach/students/[studentId]/documents` | P0 | P2 | `app/api/coach/students/[studentId]/documents/route.ts`, `__tests__/api/documents-access.test.ts` |
+| `/api/student/documents/[id]/download` | P0/P2 selon inventaire | P2 | `app/api/student/documents/[id]/download/route.ts`, logs sans chemin |
+| `/api/invoices/[id]/pdf` | P0 | P2 | `lib/invoice/not-found.ts`, `__tests__/lib/invoice/access-scope.test.ts`, `__tests__/api/invoices.pdf.route.test.ts` |
+| `/api/invoices/[id]/receipt/pdf` | P0 | P2 | `__tests__/api/invoices.receipt.pdf.route.test.ts` |
+| `/api/student/activate` | P0 | P1 | `guardRateLimitAsync`, erreurs sobres, `__tests__/api/student.activate.route.test.ts` |
+| `/api/lamis/teacher-report` | P0 opérationnel Lot 0-bis | P1 | Zod strict, rate limit, `__tests__/api/lamis.teacher-report.route.test.ts` |
+| `/api/bilan-gratuit` | P0 | P1 | réponse neutre, strict public payload, no enumeration, `__tests__/api/bilan-gratuit.security.test.ts` |
+| `/api/sessions/video` | P1 | P2 | Zod strict, rate limit, projection DB, `__tests__/api/sessions.video.route.test.ts` |
+| `/api/admin/documents` | P1 | P2 | MIME/taille, projection sans `localPath`, `__tests__/api/admin.documents.route.test.ts` |
+
+## Routes P0 fermées par tests ajoutés
+
+- Documents : IDOR propriétaire, staff autorisé, non propriétaire sans lecture fichier.
+- Factures : parent non bénéficiaire/non email legacy => 404 canonical ; admin/staff autorisés.
+- Coach documents : coach non assigné => 403.
+- NPC : traversal, document absent, coach non assigné sans lecture disque.
+- Script audit : route dynamique sensible sans ownership reste P0 ; public sensible sans vrai rate limit reste P0.
+
+## Routes P0 requalifiées par script
+
+Acceptable seulement quand la requalification correspond à une preuve lisible :
+
+- staff-only dynamique avec auth + role guard : P2/P1, pas P0 IDOR propriétaire ;
+- route publique fixe sans donnée propriétaire : P2, pas OK ;
+- route `501` ClicToPay : P1, pas OK ;
+- route publique sensible avec Zod + rate limit : P1, pas OK ;
+- réexport : classé selon la source réexportée.
+
+## Routes P0 requalifiées staff-only
+
+| Route | Ancien | Nouveau | Verdict |
+| --- | --- | --- | --- |
+| `/api/admin/stages/[stageId]` et sous-routes | P0 | P2 | Acceptable comme staff-only, mais tests métier stage encore P2/P1. |
+| `/api/admin/invoices/[id]`, `/send` | P0 | P2 | Acceptable staff-only avec Zod ; `/api/admin/invoices` reste P1. |
+| `/api/assistante/assignments/[id]` | P0 | P2 | Acceptable staff-only ; audit métier assistante à poursuivre. |
+| `/api/assistante/students/[studentId]/documents` | P0 | P2 | Acceptable staff-only, no public ownership ; reste sensible mineurs. |
+
+## Routes P0 requalifiées publiques fixes
+
+| Route | Ancien | Nouveau | Verdict |
+| --- | --- | --- | --- |
+| `/api/public-documents/corrige-dnb-maths-2026` | P0 opérationnel Lot 0-bis | P2 | Acceptable : document public fixe, sans ressource propriétaire. Pas OK. |
+| `/api/stages` | P0 | P2 | Acceptable catalogue public ; pas de donnée propriétaire. |
+| `/api/stages/[stageSlug]` | P0 | P2 | Acceptable catalogue public par slug validé ; pas de réservation exposée. |
+
+## Routes P0 requalifiées 410/501
+
+| Route | Ancien | Nouveau | Verdict |
+| --- | --- | --- | --- |
+| `/api/payments/clictopay/webhook` | P0 | P1 | Acceptable seulement si ClicToPay reste désactivé. Test valide : signature invalide 401, signature valide 501. |
+| `/api/payments/clictopay/init` | P1 | P1 | Maintenue non active, ne doit pas devenir OK. |
+
+## Routes dont la requalification est acceptable
+
+Les familles suivantes sont acceptables en Lot 1-bis : documents, factures PDF/reçus, admin/staff-only dynamiques, catalogues publics fixes, activation étudiant durcie, Lamis, sessions vidéo, admin documents.
+
+## Routes dont la requalification est insuffisamment prouvée
+
+Ces routes ne sont plus P0 statiques mais restent P1 critiques :
+
+- `/api/assessments/submit` : public sensible, retourne encore `assessmentId` et `redirectUrl`; décision token/session à trancher.
+- `/api/bilan-gratuit` : sécurisé en sortie, mais crée encore des comptes inactifs ; décision `lead_only` Lot 3 requise.
+- `/api/payments/clictopay/*` : intégration non active ; pas go-live paiement.
+- `/api/admin/invoices` : création/liste factures encore P1, schéma Zod/projection GET à durcir.
+- `/api/bilans*` et routes coach report/generate : ownership détecté mais nombreux P1 sans Zod complet.
+- `/api/npc/submissions/[submissionId]/documents*` : tests renforcés, mais restent P1 faute de Zod sur PATCH/DELETE/POST selon inventaire.
+
+## Décision
+
+La fermeture P0 statique est acceptée avec réserves. Elle ne vaut pas feu vert go-live large. Les P1 critiques doivent rester bloquants pour bêta élargie/go-live large tant que paiement, bilans, factures, rate limiting distribué production et flux bilan gratuit ne sont pas clos.

--- a/docs/go-live/_evidence/lot1bis-p1-closure.md
+++ b/docs/go-live/_evidence/lot1bis-p1-closure.md
@@ -1,0 +1,67 @@
+# Lot 1-bis — Fermeture P1 critiques
+
+## Synthèse
+
+Après correction et régénération :
+
+- Lot 1 : `P0=0`, `P1=56`, `P2=93`, `OK=27`.
+- Lot 1-bis : `P0=0`, `P1=54`, `P2=95`, `OK=27`.
+
+Deux P1 ont été fermés en P2 : `/api/sessions/video` et `/api/admin/documents`.
+
+## P1 traités
+
+| Route | Avant | Après | Traitement | Test |
+| --- | --- | --- | --- | --- |
+| `/api/sessions/video` | P1 | P2 | Zod strict, rate limit async, projection DB explicite, rejet champs inattendus | `__tests__/api/sessions.video.route.test.ts` |
+| `/api/admin/documents` | P1 | P2 | MIME/taille, Zod `userId`, projection sans `localPath`, pas d’écriture fichier invalide | `__tests__/api/admin.documents.route.test.ts` |
+| `/api/bilan-gratuit` | P1 | P1 | Réponse neutre, pas d’énumération email, pas d’IDs, payload public strict sans `parentPassword` | `__tests__/api/bilan-gratuit.security.test.ts` |
+| `/api/payments/clictopay/init` | P1 | P1 | Maintenue 501 non configurée | `__tests__/api/payments.clictopay.init.route.test.ts` |
+| `/api/payments/clictopay/webhook` | P1 | P1 | Signature invalide 401 si secret ; signature valide reste 501 | `__tests__/api/payments.clictopay.webhook.route.test.ts` |
+| `/api/npc/files/[...path]` | P2 | P2 | Test coach non assigné sans lecture disque ajouté | `__tests__/api/npc.files.route.test.ts` |
+| `/api/npc/submissions/[submissionId]/documents*` | P1 | P1 | Tests coach non assigné GET/POST/DELETE ajoutés ; reste P1 faute de Zod complet | `__tests__/api/npc.documents.route.test.ts` |
+| `/api/student/activate` | P1 | P1 | 400 public sans `details.password` | `__tests__/api/student.activate.route.test.ts`, `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts` |
+| `/api/lamis/teacher-report` | P1 | P1 | Déjà durcie Lot 1 ; couverte par non-exposition globale | `__tests__/api/lamis.teacher-report.route.test.ts` |
+| `/api/assessments/submit` | P1 | P1 | Revue : Zod + rate limit présents, mais réponse et modèle public à traiter séparément | À créer Lot suivant |
+| `/api/admin/invoices` | P1 | P1 | Revue : staff-only, mais schéma/projection GET/POST insuffisants pour fermeture | À créer Lot suivant |
+| `/api/bilans*` | P1 | P1 | Revue : ownership helpers présents, mais mutations/exports sans Zod complet | À créer Lot suivant |
+| routes coach generated reports | P1 | P1 | Revue : assignment détecté, mais routes generate/regenerate restent P1 | Tests existants partiels |
+| `/api/sessions/cancel` | P1 | P1 | Revue : Zod via `parseBody`, rate limit facade, ownership tests existants ; script reste P1 par heuristique | `__tests__/api/sessions.cancel.route.test.ts` |
+
+## P1 fermés
+
+- `/api/sessions/video`
+- `/api/admin/documents`
+
+## P1 requalifiés
+
+Aucune route paiement ou ClicToPay n’a été requalifiée en OK. Les routes 501 restent P1.
+
+## P1 restants
+
+54 P1 restent ouverts. Les plus critiques sont :
+
+- `/api/payments/clictopay/init`
+- `/api/payments/clictopay/webhook`
+- `/api/admin/invoices`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/bilans`, `/api/bilans/[id]`, `/api/bilans/[id]/export`
+- routes coach generate/regenerate report
+- `/api/npc/submissions/[submissionId]/documents*`
+- `/api/assistante/quotes/pdf`
+
+## Tests associés
+
+- `__tests__/scripts/audit-api-guards.classification.test.ts`
+- `__tests__/api/admin.documents.route.test.ts`
+- `__tests__/api/bilan-gratuit.security.test.ts`
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+- `__tests__/api/sessions.video.route.test.ts`
+- `__tests__/api/npc.files.route.test.ts`
+- `__tests__/api/npc.documents.route.test.ts`
+- tests Lot 1 existants documents/factures/activation/Lamis.
+
+## Risques résiduels
+
+La baisse P1 est réelle mais limitée. Les P1 restants touchent paiement, facturation, bilans, documents NPC, reports coach et flux public bilan gratuit. Ils interdisent bêta élargie et go-live large.

--- a/docs/go-live/_evidence/lot1bis-rate-limit-production-gate.md
+++ b/docs/go-live/_evidence/lot1bis-rate-limit-production-gate.md
@@ -1,0 +1,35 @@
+# Gate rate limiting production
+
+## État local
+
+Le code expose `getRateLimitRuntimeMode()` avec modes `redis`, `upstash`, `memory`. Les tests `__tests__/lib/rate-limit.distributed.test.ts` prouvent :
+
+- `RATE_LIMIT_DISABLE=1` ne bypass pas en `NODE_ENV=production` ;
+- Upstash est utilisé si `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` sont présents ;
+- Redis est utilisé si `REDIS_URL` est présent ;
+- Redis prime sur Upstash si les deux sont présents ;
+- fallback mémoire existe si Redis échoue.
+
+## État production
+
+À vérifier, aucun secret lu.
+
+## Variables attendues
+
+- `REDIS_URL` ou
+- `UPSTASH_REDIS_REST_URL`
+- `UPSTASH_REDIS_REST_TOKEN`
+
+Ne jamais afficher les valeurs.
+
+## Healthcheck attendu
+
+`GET /api/internal/health` doit retourner `checks.redis.detail = redis` ou `upstash`. Si `detail = memory`, le go-live large est interdit.
+
+## Test 429 attendu
+
+Sur une route publique sensible (`/api/bilan-gratuit`, `/api/assessments/submit`, `/api/student/activate`), envoyer plus de requêtes que le preset autorisé depuis la même IP/test key doit retourner `429 RATE_LIMIT_EXCEEDED`.
+
+## Décision
+
+Go-live large interdit tant que le mode distribué n’est pas prouvé en production réelle par healthcheck et test 429. Bêta contrôlée possible uniquement avec volume limité, monitoring manuel et réserve formelle.

--- a/docs/go-live/_evidence/lot1quater-assistante.md
+++ b/docs/go-live/_evidence/lot1quater-assistante.md
@@ -1,0 +1,23 @@
+# Lot 1-quater — Assistante
+
+## Routes traitées
+
+| Route | Avant | Après | Preuve |
+| --- | --- | --- | --- |
+| `/api/assistante/credit-requests` | P1 | P2 | Body Zod strict |
+| `/api/assistante/quotes/pdf` | P1 | P2 | Payload devis Zod strict, rate limit existant |
+| `/api/assistante/students/credits` | P1 | P2 | Query/body Zod, montant borné |
+| `/api/assistante/subscription-requests` | P1 | P2 | Query/body Zod, pagination bornée |
+| `/api/assistante/subscriptions` | P1 | P2 | Body Zod strict |
+
+## Tests
+
+- `__tests__/api/assistant.credit-requests.route.test.ts`
+- `__tests__/api/assistant.students.credits.route.test.ts`
+- `__tests__/api/assistant.subscription-requests.route.test.ts`
+- `__tests__/api/assistant.subscriptions.route.test.ts`
+- `__tests__/api/assistante.quotes.pdf.route.test.ts`
+
+## Réserves
+
+Les réponses assistante restent staff-only. La réduction P1 ne vaut pas preuve RGPD complète sur minimisation PII ; elle prouve validation stricte et absence de mutation sur payload invalide.

--- a/docs/go-live/_evidence/lot1quater-coach.md
+++ b/docs/go-live/_evidence/lot1quater-coach.md
@@ -1,0 +1,21 @@
+# Lot 1-quater — Coach
+
+## Routes traitées
+
+| Route | Avant | Après | Preuve |
+| --- | --- | --- | --- |
+| `/api/coach/students/[studentId]/notes` | P1 | P2 | Params/body Zod strict, assignment conservé |
+| `/api/coach/students/[studentId]/survival-mode` | P1 | P2 | Params/body Zod strict, assignment conservé |
+| `/api/coach/trajectory` | P1 | P2 | Body Zod strict + refus coach non assigné |
+| `/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent` | P1 | P2 | Params Zod strict |
+| `/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student` | P1 | P2 | Params Zod strict |
+
+## Tests
+
+- `__tests__/api/coach.trajectory.security.test.ts`
+- Tests coach reports hérités Lot 1-ter
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+
+## Réserves
+
+Les routes coach passent P2 statique, mais un audit E2E rôle coach reste requis avant bêta élargie.

--- a/docs/go-live/_evidence/lot1quater-command-log.md
+++ b/docs/go-live/_evidence/lot1quater-command-log.md
@@ -1,0 +1,61 @@
+# Lot 1-quater — Journal de commandes
+
+Date locale initiale : 2026-07-02 23:19:30 CET.
+
+## Baseline
+
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Node : `v20.20.0`
+- npm : `10.8.2`
+- État Git initial : worktree déjà chargé par les lots 0-bis, 1, 1-bis et 1-ter ; nombreux fichiers modifiés/non suivis hérités. Aucun fichier `.env` listé comme modifié.
+
+## Commandes baseline exécutées
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node -v` | OK | `v20.20.0` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm -v` | OK | `10.8.2` |
+| `git rev-parse --abbrev-ref HEAD` | OK | `feat/lot4-accessors-runtime` |
+| `git rev-parse --short HEAD` | OK | `db8545a19` |
+| `git status --short --untracked-files=all` | OK | Worktree dirty hérité, voir sortie terminal locale |
+
+## Commandes ciblées exécutées
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `node scripts/security/audit-api-guards.mjs && node scripts/go-live/generate-api-security-matrix.mjs` | OK | Après corrections : `P0=0`, `P1=12`, `P2=137`, `OK=27` |
+| `npm run typecheck` | ÉCHEC puis OK | Échec initial sur typage Zod `eleve/bilan-diagnostic`; corrigé avec schémas métier. Relance OK. |
+| `npm run test:unit -- <13 suites ciblées> --runInBand` | OK | 13 suites passées, 77 tests passés |
+
+## Limites
+
+- Aucune production/staging consultée.
+- Aucun secret lu.
+- Aucun `.env` modifié.
+- Aucun déploiement.
+- Aucune migration destructive.
+- La preuve Redis/Upstash reste locale côté code/tests ; runtime réel marqué `À vérifier`.
+
+## Commandes finales
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run typecheck` | OK | `tsc --noEmit` sans erreur |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run lint` | OK | `next lint --max-warnings 300` OK, warnings existants sous seuil |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand` | OK | 516 suites passées, 1 ignorée ; 6425 tests passés, 4 ignorés |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run build` | OK | Next build OK, 143 pages générées, assets standalone copiés |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/security/audit-api-guards.mjs` | OK | `docs/security/API_GUARD_INVENTORY.md` régénéré, 176 routes |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=12`, `P2=137`, `OK=27` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run audit:site-map` | OK | `docs/architecture/SITE_MAP.md`, `SITE_GRAPH.mmd`, `SSOT_MAP.md` régénérés ; 290 routes, 412 edges, 0 link finding |
+| `source /home/alaeddine/.nvm/nvm use 20.20.0 >/dev/null && npm run check:no-hardcoded` | ÉCHEC | Erreur de saisie locale : chemin `/home/alaeddine/.nvm/nvm` inexistant. Le script projet n'a pas été exécuté sur cette tentative. |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:no-hardcoded` | OK | `0 hardcoded values outside canonical sources` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:docs-archive` | OK | Aucun ancien audit/rapport à la racine de `docs/` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:bundle-weight` | OK | Toutes les routes dans la baseline + 5 kB |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | OK | 24 tests passés ; warning runtime connu sur table `business_configs` absente en DB locale |
+
+## Synthèse finale
+
+- Gates bloquants locaux : OK sous Node 20.
+- Inventaire final : `P0=0`, `P1=12`, `P2=137`, `OK=27`.
+- Réserve runtime : Redis/Upstash non vérifié hors local ; go-live large interdit.

--- a/docs/go-live/_evidence/lot1quater-p1-before-after.md
+++ b/docs/go-live/_evidence/lot1quater-p1-before-after.md
@@ -1,0 +1,53 @@
+# Lot 1-quater — P1 avant / après
+
+## Synthèse
+
+| Priorité | Avant Lot 1-quater | Après Lot 1-quater | Delta |
+| --- | ---: | ---: | ---: |
+| P0 | 0 | 0 | 0 |
+| P1 | 37 | 12 | -25 |
+| P2 | 112 | 137 | +25 |
+| OK | 27 | 27 | 0 |
+| Total | 176 | 176 | 0 |
+
+## P1 fermés par correction de code
+
+| Route | Correction | Tests |
+| --- | --- | --- |
+| `/api/assistante/credit-requests` | Zod strict décision approve/reject | `assistant.credit-requests.route.test.ts` |
+| `/api/assistante/quotes/pdf` | Zod strict devis PDF | `assistante.quotes.pdf.route.test.ts` |
+| `/api/assistante/students/credits` | Zod strict query/body, montant borné | `assistant.students.credits.route.test.ts` |
+| `/api/assistante/subscription-requests` | Query/body Zod, pagination bornée | `assistant.subscription-requests.route.test.ts` |
+| `/api/assistante/subscriptions` | Body Zod strict | `assistant.subscriptions.route.test.ts` |
+| `/api/parent/children` | Zod strict + retrait token brut réponse | `parent.children.route.test.ts`, `parent.children.activation.route.test.ts`, no-leak |
+| `/api/parent/subscription-requests` | Query/body Zod strict | Tests existants parent subscriptions à couvrir plus largement |
+| `/api/parent/subscriptions` | Body Zod strict | Tests existants parent subscriptions à couvrir plus largement |
+| `/api/eleve/bilan-diagnostic-maths-terminale` | Body Zod aligné types métier | `eleve.bilan-diagnostic-maths-terminale.security.test.ts` |
+| `/api/student/automatismes/attempts` | Body Zod strict | Couverture à renforcer |
+| `/api/student/automatismes/check-answer` | Body Zod strict | Couverture à renforcer |
+| `/api/student/nexus-index` | Query Zod + rôle explicite | Couverture existante route student nexus-index |
+| `/api/student/survival/*` | Params/body Zod strict | Couverture à renforcer |
+| `/api/student/trajectory` | Query Zod + rôle explicite | `student.trajectory.route.test.ts` existant |
+| `/api/coach/students/[studentId]/notes` | Params/body Zod strict | Tests route notes existants + no-leak indirect |
+| `/api/coach/students/[studentId]/survival-mode` | Params/body Zod strict | Tests route survival-mode existants |
+| `/api/coach/trajectory` | Body Zod + assignment coach | `coach.trajectory.security.test.ts`, no-leak |
+| `/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-*` | Params Zod strict | Tests régénération hérités |
+| `/api/stages/[stageSlug]/reservations/[reservationId]/confirm` | Params Zod strict avant DB | `stages/confirm.test.ts`, no-leak |
+| `/api/bilan-gratuit/dismiss` | Payload optionnel strict | Couverture à compléter |
+| `/api/programme/maths-1ere-stmg/stage-progress` | Rôle ELEVE explicite + body Zod | Tests programme existants |
+
+## P1 restants
+
+| Route | Raison |
+| --- | --- |
+| `/api/payments/clictopay/webhook` | Intégration volontairement désactivée, `501`, reste P1 tant que webhook complet non implémenté |
+| `/api/assessments/submit` | Route publique sensible ; token/session produit à arbitrer |
+| `/api/bilan-gratuit` | Route publique sensible ; crée encore comptes inactifs |
+| `/api/lamis/teacher-report` | Route publique/pédagogique sensible, à requalifier produit |
+| `/api/stages/[stageSlug]/inscrire` | Route publique sensible malgré Zod/rate limit |
+| `/api/student/activate` | Activation publique sensible par token |
+| Routes admin P1 restantes | Hors priorité fonctionnelle Lot 1-quater, à fermer Lot 1-quinquies |
+
+## Décision
+
+La baisse P1 est réelle et provient de code/tests. Les P1 restants bloquent bêta élargie et go-live large.

--- a/docs/go-live/_evidence/lot1quater-parent-student.md
+++ b/docs/go-live/_evidence/lot1quater-parent-student.md
@@ -1,0 +1,27 @@
+# Lot 1-quater — Parent / Student
+
+## Routes traitées
+
+| Route | Avant | Après | Preuve |
+| --- | --- | --- | --- |
+| `/api/parent/children` | P1 | P2 | Zod strict, suppression token brut réponse |
+| `/api/parent/subscription-requests` | P1 | P2 | Query/body Zod strict |
+| `/api/parent/subscriptions` | P1 | P2 | Body Zod strict |
+| `/api/eleve/bilan-diagnostic-maths-terminale` | P1 | P2 | Body Zod aligné types métier |
+| `/api/student/automatismes/attempts` | P1 | P2 | Body Zod strict |
+| `/api/student/automatismes/check-answer` | P1 | P2 | Body Zod strict |
+| `/api/student/nexus-index` | P1 | P2 | Query Zod + rôle explicite |
+| `/api/student/survival/*` | P1 | P2 | Params/body Zod strict |
+| `/api/student/trajectory` | P1 | P2 | Query Zod + rôle explicite |
+
+## Tests
+
+- `__tests__/api/parent.children.route.test.ts`
+- `__tests__/api/parent.children.activation.route.test.ts`
+- `__tests__/api/eleve.bilan-diagnostic-maths-terminale.security.test.ts`
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+- Tests student existants conservés.
+
+## Réserves
+
+`/api/student/activate` reste P1 car activation publique par token. `/api/bilan-gratuit` crée encore des comptes inactifs et doit être arbitré en Lot 3.

--- a/docs/go-live/_evidence/lot1quater-public-routes.md
+++ b/docs/go-live/_evidence/lot1quater-public-routes.md
@@ -1,0 +1,16 @@
+# Lot 1-quater — Routes publiques sensibles
+
+## Routes revues
+
+| Route | Statut après lot | Décision |
+| --- | --- | --- |
+| `/api/assessments/submit` | P1 | Zod + rate limit présents ; reste public sensible tant que token/session non arbitré |
+| `/api/bilan-gratuit` | P1 | Sortie durcie par lots précédents ; dette produit/RGPD car création de comptes inactifs |
+| `/api/bilan-gratuit/dismiss` | P2 | Payload optionnel strict, auth parent |
+| `/api/stages/[stageSlug]/inscrire` | P1 | Params/body Zod + rate limit ; reste public sensible |
+| `/api/student/activate` | P1 | Activation publique sensible par token |
+| `/api/lamis/teacher-report` | P1 | Zod + rate limit ; statut public pédagogique à requalifier |
+
+## Réserves
+
+Les routes publiques sensibles ne doivent pas être déclarées OK par statique. Elles requièrent une décision produit/RGPD et, pour certaines, token signé/session ou mécanisme anti-abus renforcé.

--- a/docs/go-live/_evidence/lot1quater-rate-limit-runtime-proof.md
+++ b/docs/go-live/_evidence/lot1quater-rate-limit-runtime-proof.md
@@ -1,0 +1,35 @@
+# Lot 1-quater — Preuve rate limiting distribué
+
+## État code
+
+- `lib/rate-limit/index.ts` expose `getRateLimitRuntimeMode()` : `redis`, `upstash`, `memory`.
+- `getRateLimitProductionGate()` ajoute une décision explicite : `memory` => `blocked`, `redis/upstash` => `allowed`.
+- `RATE_LIMIT_DISABLE=1` reste ignoré en production par le code existant et les tests hérités.
+
+## État tests
+
+- `__tests__/lib/rate-limit.distributed.test.ts` couvre `RATE_LIMIT_DISABLE=1` en production, Redis, Upstash et fallback mémoire.
+- `__tests__/lib/rate-limit.production-gate.test.ts` couvre la décision `memory` bloquante.
+- `__tests__/api/internal.health.rate-limit.test.ts` couvre le healthcheck interne : `memory` => 503/degraded, `redis` => mode explicite.
+
+## État production/staging
+
+À vérifier. Aucun secret lu, aucun accès runtime externe utilisé dans ce lot.
+
+## Healthcheck attendu
+
+`GET /api/internal/health` doit retourner :
+
+- `runtime.rateLimit.mode = redis` ou `upstash` pour go-live large ;
+- `runtime.rateLimit.distributed = true` ;
+- `runtime.rateLimit.goLiveLarge = allowed`.
+
+En mode `memory`, le healthcheck doit rester dégradé et `goLiveLarge = blocked`.
+
+## Test 429 attendu
+
+Sur staging/production, une route publique sensible doit être appelée jusqu'au dépassement du preset attendu et retourner `429` avec headers `Retry-After` et `X-RateLimit-*`.
+
+## Verdict
+
+GO-LIVE LARGE INTERDIT tant que `redis` ou `upstash` n'est pas vérifié sur staging/production.

--- a/docs/go-live/_evidence/lot1quater-sensitive-fields-coverage.md
+++ b/docs/go-live/_evidence/lot1quater-sensitive-fields-coverage.md
@@ -1,0 +1,33 @@
+# Lot 1-quater — Couverture champs sensibles
+
+## Test global
+
+Fichier : `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`.
+
+## Couverture
+
+| Route | Couvert globalement | Test dédié | Raison si non couvert |
+| --- | --- | --- | --- |
+| `/api/bilan-gratuit` | Oui | Oui | - |
+| `/api/admin/invoices` | Oui | Oui | - |
+| `/api/bilans/generate` | Oui | Oui | - |
+| `/api/npc/submissions/[submissionId]/documents` | Oui | Oui | - |
+| `/api/payments/clictopay/init` | Oui | Oui | - |
+| `/api/payments/clictopay/webhook` | Oui | Oui | - |
+| `/api/student/activate` | Oui | Oui | - |
+| `/api/lamis/teacher-report` | Oui | Oui | - |
+| `/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate` | Oui | Oui | - |
+| `/api/parent/children` | Oui | Oui | - |
+| `/api/stages/[stageSlug]/reservations/[reservationId]/confirm` | Oui | Oui | - |
+| `/api/coach/trajectory` | Oui | Oui | - |
+| `/api/assessments/submit` | Non | Partiel | Route publique sensible complexe ; couverte par validation/rate limit, no-leak global à ajouter après décision token/session |
+| `/api/stages/[stageSlug]/inscrire` | Non | Oui partiel | Route publique avec emails/notifications ; test no-leak global à ajouter sans déclencher side effects mail/telegram |
+| Routes admin P1 restantes | Non | Partiel | Hors priorité Lot 1-quater |
+
+## Champs interdits
+
+`password`, `activationToken`, `activationUrl`, `tokenHash`, `totpSecret`, `totpBackupCodes`, `localPath`, `filePath`, `pdfPath`, `originalFilePath`, `contextJson`, `llmJson`, `validatedJson`, `latexSource`, `stack`, `errorDetails`, `metadata`, `bankReference`, `rawWebhook`, `rawPayload`.
+
+## Décision
+
+La couverture globale s'élargit de 9 à 12 routes mockables. Elle reste insuffisante pour go-live large mais progresse sur les routes Lot 1-quater traitées.

--- a/docs/go-live/_evidence/lot1quater-stages.md
+++ b/docs/go-live/_evidence/lot1quater-stages.md
@@ -1,0 +1,17 @@
+# Lot 1-quater — Stages
+
+## Routes traitées
+
+| Route | Avant | Après | Preuve |
+| --- | --- | --- | --- |
+| `/api/stages/[stageSlug]/inscrire` | P1 | P1 | Param `stageSlug` Zod, body Zod et rate limit déjà présents ; reste public sensible |
+| `/api/stages/[stageSlug]/reservations/[reservationId]/confirm` | P1 | P2 | Params Zod avant DB, staff-only conservé, test invalid params |
+
+## Tests
+
+- `__tests__/api/stages/confirm.test.ts`
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+
+## Réserves
+
+L'inscription stage publique reste P1 car elle collecte des données mineur/famille. Elle doit rester sous rate limit distribué prouvé avant campagne large.

--- a/docs/go-live/_evidence/lot1quinquies-admin-routes.md
+++ b/docs/go-live/_evidence/lot1quinquies-admin-routes.md
@@ -1,0 +1,18 @@
+# Lot 1-quinquies — Routes admin P1
+
+## Synthèse
+
+Les six routes admin P1 identifiées après Lot 1-quater sont passées P2 par correction de code et tests. Aucune baisse ne vient d'une modification du script d'audit.
+
+| Route | Correction | Tests |
+| --- | --- | --- |
+| `/api/admin/config` | Zod strict PATCH, rejet champs inattendus avant transaction | `__tests__/api/admin.config.route.test.ts` |
+| `/api/admin/config/rollback` | Zod strict rollback, rejet `force` implicite | `__tests__/api/admin.config.route.test.ts` |
+| `/api/admin/directeur/stats` | `requireRole(UserRole.ADMIN)`, query vide stricte, rate limit avant DB | `__tests__/api/admin.directeur.stats.route.test.ts` |
+| `/api/admin/recompute-ssn` | `requireRole(UserRole.ADMIN)`, body strict, rate limit avant calcul | `__tests__/api/admin.recompute-ssn.route.test.ts` |
+| `/api/admin/subscriptions` | query/body stricts, pagination bornée, projections explicites | `__tests__/api/admin.subscriptions.route.test.ts` |
+| `/api/admin/test-email` | ADMIN-only, body strict, pas d'adresse email dans message succès | `__tests__/api/admin.test-email.route.test.ts` |
+
+## Risques résiduels
+
+Ces routes restent P2 statiques car elles manipulent de la configuration, des stats ou données admin. Elles ne sont pas autorisées hors rôle admin et doivent rester couvertes par monitoring/logs sobres.

--- a/docs/go-live/_evidence/lot1quinquies-clictopay-webhook.md
+++ b/docs/go-live/_evidence/lot1quinquies-clictopay-webhook.md
@@ -1,0 +1,29 @@
+# Lot 1-quinquies — ClicToPay webhook
+
+## Route
+
+`/api/payments/clictopay/webhook`
+
+## Statut
+
+P1 maintenu. La route est plus strictement désactivée, mais ne peut pas devenir P2/OK tant que l'intégration complète ClicToPay n'est pas livrée.
+
+## Contrat actuel
+
+- Webhook sans signature : `401 CLICTOPAY_SIGNATURE_REQUIRED`.
+- Signature invalide avec secret configuré : `401 CLICTOPAY_SIGNATURE_INVALID`.
+- Signature valide avec secret configuré : `501 CLICTOPAY_NOT_CONFIGURED`.
+- Signature présente sans secret runtime : `501 CLICTOPAY_NOT_CONFIGURED`.
+- Aucune mutation Prisma.
+- Aucune activation `payment`, `invoice`, `entitlement` ou crédit.
+- Réponse sans `rawWebhook`, `rawPayload`, `metadata`, `bankReference`, `stack`.
+
+## Tests
+
+- `__tests__/api/payments.clictopay.webhook.route.test.ts`
+- `__tests__/api/payments.clictopay.webhook.security.test.ts`
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+
+## Décision
+
+ClicToPay webhook reste non actif et non ambigu. Passage en OK interdit sans signature, idempotence, contrôle montant/devise/productCode, réconciliation facture/paiement/entitlement et tests bout-en-bout.

--- a/docs/go-live/_evidence/lot1quinquies-command-log.md
+++ b/docs/go-live/_evidence/lot1quinquies-command-log.md
@@ -1,0 +1,78 @@
+# Lot 1-quinquies — Journal de commandes
+
+Date locale initiale : 2026-07-03 06:48:44 CET.
+
+## Baseline
+
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Node : `v20.20.0`
+- npm : `10.8.2`
+- Répertoire : `/home/alaeddine/Bureau/nexus-project_v0`
+- État Git initial : worktree déjà chargé par les lots 0-bis, 1, 1-bis, 1-ter et 1-quater ; nombreux fichiers modifiés/non suivis hérités. Aucun fichier `.env` listé comme modifié.
+- Périmètre P1 initial extrait de `docs/go-live/api-security-matrix.full.md` : `P0=0`, `P1=12`, `P2=137`, `OK=27`, total 176 routes.
+
+## Commandes baseline exécutées
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `pwd` | OK | `/home/alaeddine/Bureau/nexus-project_v0` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node -v` | OK | `v20.20.0` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm -v` | OK | `10.8.2` |
+| `git rev-parse --abbrev-ref HEAD` | OK | `feat/lot4-accessors-runtime` |
+| `git rev-parse --short HEAD` | OK | `db8545a19` |
+| `git status --short --untracked-files=all` | OK | Worktree dirty hérité ; aucun `.env` listé comme modifié |
+
+## Commandes ciblées
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `npm run test:unit -- __tests__/api/payments.clictopay.webhook.security.test.ts __tests__/api/admin.config.route.test.ts __tests__/api/admin.directeur.stats.route.test.ts __tests__/api/admin.recompute-ssn.route.test.ts __tests__/api/admin.subscriptions.route.test.ts __tests__/api/admin.test-email.route.test.ts --runInBand` | ÉCHEC puis OK | RED initial : 10 échecs attendus ; après corrections : 46 tests passés |
+| `npm run test:unit -- __tests__/api/security/no-sensitive-fields-in-api-responses.test.ts __tests__/api/assessments-submit.test.ts __tests__/api/student.activate.route.test.ts __tests__/api/stages.inscrire.security.test.ts __tests__/api/payments.clictopay.webhook.route.test.ts __tests__/api/payments.clictopay.webhook.security.test.ts __tests__/api/admin.config.route.test.ts __tests__/api/admin.directeur.stats.route.test.ts __tests__/api/admin.recompute-ssn.route.test.ts __tests__/api/admin.subscriptions.route.test.ts __tests__/api/admin.test-email.route.test.ts --runInBand` | OK | 11 suites passées, 96 tests passés |
+| `npm run test:unit -- __tests__/api/admin.directeur.stats.route.test.ts __tests__/api/admin.recompute-ssn.route.test.ts __tests__/api/security/no-sensitive-fields-in-api-responses.test.ts --runInBand` | OK | 3 suites passées, 37 tests passés |
+| `npm run typecheck` | OK | `tsc --noEmit` OK après correction du typage `admin/test-email` |
+| `node scripts/security/audit-api-guards.mjs` | OK | `docs/security/API_GUARD_INVENTORY.md` régénéré, 176 routes |
+| `node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=6`, `P2=143`, `OK=27` |
+| `curl -sS -i --max-time 10 https://nexusreussite.academy/api/internal/health` | PARTIEL | Production répond `401 Unauthorized` sans secret ; mode Redis/Upstash non prouvé |
+| `npx tsx -e "import { getRateLimitProductionGate } from './lib/rate-limit/index.ts'; console.log(JSON.stringify(getRateLimitProductionGate()))"` | OK | Local : `memory`, décision `blocked` |
+| `node -e "const { getRateLimitProductionGate } = require('./dist-does-not-exist')"` | ÉCHEC | Commande exploratoire erronée, module inexistant ; aucun effet produit |
+
+## Commandes finales
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run typecheck` | OK | `tsc --noEmit` terminé sans erreur |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run lint` | OK | ESLint terminé avec avertissements sous le seuil configuré |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand` | OK | 517 suites passées, 1 ignorée ; 6449 tests passés, 4 ignorés |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run build` | OK | Build Next.js réussi ; 143 pages statiques générées |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/security/audit-api-guards.mjs` | OK | `docs/security/API_GUARD_INVENTORY.md` régénéré, 176 routes |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=6`, `P2=143`, `OK=27`, 176 routes |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run audit:site-map` | OK | Cartes d'architecture régénérées ; 290 routes, 412 edges, 0 link findings, 13 public orphan entries |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:no-hardcoded` | OK | `0 hardcoded values outside canonical sources` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:docs-archive` | OK | Aucun rapport historique à la racine de `docs/` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:bundle-weight` | OK | Toutes les routes suivies restent dans la baseline + 5 kB |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | OK | 24 tests Playwright passés |
+
+## Commandes échouées
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `npm run test:unit -- --runInBand` | ÉCHEC puis OK | Premier passage final : 4 échecs dans `__tests__/api/assessments-rbac.test.ts` dus à des attentes obsolètes après durcissement `requireRole`; test corrigé puis suite complète verte |
+| `node -e "const { getRateLimitProductionGate } = require('./dist-does-not-exist')"` | ÉCHEC | Commande exploratoire erronée, module inexistant ; aucun effet produit |
+
+## Résultat final matrice
+
+- `P0=0`
+- `P1=6`
+- `P2=143`
+- `OK=27`
+- Total : 176 routes
+
+## Limites initiales
+
+- Aucun secret lu.
+- Aucun `.env` modifié.
+- Aucun déploiement.
+- Aucune migration destructive.
+- Accès production limité à une requête HTTP non authentifiée sur `/api/internal/health`, sans secret ; résultat `401`, runtime distribué non prouvé.
+- Le build charge les fichiers d'environnement Next.js disponibles sans afficher leurs valeurs ; aucune valeur secrète n'a été lue ni copiée.

--- a/docs/go-live/_evidence/lot1quinquies-p1-before-after.md
+++ b/docs/go-live/_evidence/lot1quinquies-p1-before-after.md
@@ -1,0 +1,50 @@
+# Lot 1-quinquies — P1 avant/après
+
+Date locale : 2026-07-03.
+
+## Synthèse
+
+| Priorité | Avant | Après |
+| --- | ---: | ---: |
+| P0 | 0 | 0 |
+| P1 | 12 | 6 |
+| P2 | 137 | 143 |
+| OK | 27 | 27 |
+| Total | 176 | 176 |
+
+Commande de preuve :
+
+```bash
+node scripts/security/audit-api-guards.mjs
+node scripts/go-live/generate-api-security-matrix.mjs
+```
+
+Résultat observé après corrections :
+
+```text
+Wrote docs/security/API_GUARD_INVENTORY.md (176 routes)
+Wrote docs/go-live/api-security-matrix.full.md (176 routes)
+P0: 0, P1: 6, P2: 143, OK: 27
+```
+
+## Routes P1 fermées
+
+| Route | Avant | Après | Type de preuve |
+| --- | --- | --- | --- |
+| `/api/admin/config` | P1 | P2 | Zod strict PATCH + test champs inattendus |
+| `/api/admin/config/rollback` | P1 | P2 | Zod strict + test champs inattendus |
+| `/api/admin/directeur/stats` | P1 | P2 | `requireRole(UserRole.ADMIN)`, query stricte, rate limit + tests |
+| `/api/admin/recompute-ssn` | P1 | P2 | `requireRole(UserRole.ADMIN)`, body strict, rate limit + tests |
+| `/api/admin/subscriptions` | P1 | P2 | query/body stricts, pagination bornée, select explicite + tests |
+| `/api/admin/test-email` | P1 | P2 | ADMIN-only, body strict, réponse sans email destinataire + tests |
+
+## Routes P1 restantes
+
+| Route | Justification |
+| --- | --- |
+| `/api/payments/clictopay/webhook` | Ne peut pas devenir OK tant que l'intégration ClicToPay est désactivée/incomplète |
+| `/api/assessments/submit` | Route publique sensible ; fermeture complète nécessite décision token/session/auth |
+| `/api/bilan-gratuit` | Dette produit/RGPD : création de comptes inactifs malgré réponse API durcie |
+| `/api/lamis/teacher-report` | Route pédagogique publique à arbitrer avant bêta élargie |
+| `/api/stages/[stageSlug]/inscrire` | Route publique de conversion ; reste sensible malgré Zod/rate limit/no-leak |
+| `/api/student/activate` | Route publique par token ; reste sensible par nature jusqu'à audit activation complet |

--- a/docs/go-live/_evidence/lot1quinquies-public-sensitive-routes.md
+++ b/docs/go-live/_evidence/lot1quinquies-public-sensitive-routes.md
@@ -1,0 +1,66 @@
+# Lot 1-quinquies — Routes publiques sensibles
+
+## Synthèse
+
+Les routes publiques sensibles sont durcies, mais six P1 restent assumés parce que leur surface publique est une décision produit/sécurité non arbitré ou un flux token sensible.
+
+## Route : `/api/assessments/submit`
+
+- Statut avant : P1
+- Statut après : P1
+- Pourquoi P1 reste : route publique qui crée une ressource pédagogique mineur ; token/session/auth à arbitrer.
+- Zod : oui, schéma top-level, `studentData` et `metadata` stricts.
+- Rate limit : oui, `guardRateLimitAsync`.
+- Réponse minimale : succès limité à `assessmentId`, `redirectUrl`, `message`.
+- No-leak : couvert par test global.
+- Tests : `__tests__/api/assessments-submit.test.ts`, `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`.
+- Décision : à traiter dans un lot produit/pédagogique avant bêta élargie.
+
+## Route : `/api/bilan-gratuit`
+
+- Statut avant : P1
+- Statut après : P1
+- Pourquoi P1 reste : sortie durcie mais création de comptes inactifs ; dette produit/RGPD.
+- Zod : oui.
+- Rate limit : oui.
+- Honeypot / anti-abus : oui.
+- Réponse minimale : oui, pas d'IDs/tokens/email-existence.
+- No-leak : couvert.
+- Tests : `__tests__/api/bilan-gratuit.security.test.ts`, `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`.
+- Décision : Lot 3 doit arbitrer `lead_only` vs `account_activation`.
+
+## Route : `/api/lamis/teacher-report`
+
+- Statut avant : P1
+- Statut après : P1
+- Pourquoi P1 reste : rapport pédagogique public à arbitrer.
+- Zod : oui.
+- Rate limit : oui.
+- Réponse minimale : oui.
+- No-leak : couvert.
+- Tests : `__tests__/api/lamis.teacher-report.route.test.ts`, `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`.
+- Décision : auth/token ou décision publique explicite avant bêta élargie.
+
+## Route : `/api/stages/[stageSlug]/inscrire`
+
+- Statut avant : P1
+- Statut après : P1
+- Pourquoi P1 reste : inscription stage publique volontaire.
+- Zod : oui pour params/body.
+- Rate limit : oui.
+- Réponse minimale : doublon sans `reservationId`, succès sans ID interne.
+- No-leak : couvert.
+- Tests : `__tests__/api/stages.inscrire.security.test.ts`, `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`.
+- Décision : acceptable pour campagne contrôlée si monitoring/rate limiting runtime prouvé ; reste P1 avant bêta élargie.
+
+## Route : `/api/student/activate`
+
+- Statut avant : P1
+- Statut après : P1
+- Pourquoi P1 reste : activation publique par token.
+- Zod : oui, body strict.
+- Rate limit : oui, GET et POST.
+- Réponse minimale : validation/erreurs sans password/token brut.
+- No-leak : couvert.
+- Tests : `__tests__/api/student.activate.route.test.ts`, `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`.
+- Décision : conserver public par token, mais auditer expiration/token hashing en Lot RGPD/identity.

--- a/docs/go-live/_evidence/lot1quinquies-rate-limit-runtime-proof.md
+++ b/docs/go-live/_evidence/lot1quinquies-rate-limit-runtime-proof.md
@@ -1,0 +1,70 @@
+# Lot 1-quinquies — Preuve runtime Redis/Upstash
+
+## État local
+
+Commande :
+
+```bash
+npx tsx -e "import { getRateLimitProductionGate } from './lib/rate-limit/index.ts'; console.log(JSON.stringify(getRateLimitProductionGate()))"
+```
+
+Résultat :
+
+```json
+{"ok":false,"mode":"memory","decision":"blocked","reason":"Memory rate limiting is process-local and blocks go-live large."}
+```
+
+Le mode local est `memory`, donc non acceptable pour go-live large.
+
+## État staging
+
+À vérifier. Aucun environnement staging accessible sans secret n'a été identifié pendant ce lot.
+
+## État production
+
+Commande sûre sans secret :
+
+```bash
+curl -sS -i --max-time 10 https://nexusreussite.academy/api/internal/health
+```
+
+Résultat résumé :
+
+```text
+HTTP/2 401
+{"error":"Unauthorized","message":"You must be signed in to access this resource"}
+```
+
+L'endpoint interne est bien protégé, mais le mode `redis` ou `upstash` production n'est pas vérifiable depuis ce poste sans credential.
+
+## Healthcheck attendu
+
+Pour lever le blocage, un opérateur authentifié doit observer :
+
+```json
+{
+  "runtime": {
+    "rateLimit": {
+      "mode": "redis ou upstash",
+      "distributed": true,
+      "goLiveLarge": "allowed"
+    }
+  }
+}
+```
+
+## Test 429 attendu
+
+Sur staging/production, exécuter un test de dépassement contrôlé sur une route publique sensible non destructive et vérifier :
+
+- réponse `429` ;
+- headers `Retry-After`, `X-RateLimit-*` ;
+- comportement partagé entre instances si l'application est multi-process/multi-instance.
+
+## Résultat
+
+Redis/Upstash runtime non prouvé.
+
+## Décision go-live large
+
+INTERDIT.

--- a/docs/go-live/_evidence/lot1quinquies-sensitive-fields-coverage.md
+++ b/docs/go-live/_evidence/lot1quinquies-sensitive-fields-coverage.md
@@ -1,0 +1,22 @@
+# Lot 1-quinquies — Couverture champs sensibles
+
+Test global : `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`.
+
+Le test couvre désormais 20 réponses mockables, dont les 12 P1 de départ ou leurs réponses d'erreur/validation.
+
+| Route | Couvert globalement | Test dédié | Raison si non couvert |
+| --- | --- | --- | --- |
+| `/api/payments/clictopay/webhook` | Oui | Oui | N/A |
+| `/api/assessments/submit` | Oui | Oui | N/A |
+| `/api/bilan-gratuit` | Oui | Oui | N/A |
+| `/api/lamis/teacher-report` | Oui | Oui | N/A |
+| `/api/stages/[stageSlug]/inscrire` | Oui | Oui | N/A |
+| `/api/student/activate` | Oui | Oui | N/A |
+| `/api/admin/config` | Oui | Oui | N/A |
+| `/api/admin/config/rollback` | Oui | Oui | N/A |
+| `/api/admin/directeur/stats` | Oui | Oui | N/A |
+| `/api/admin/recompute-ssn` | Oui | Oui | N/A |
+| `/api/admin/subscriptions` | Oui | Oui | N/A |
+| `/api/admin/test-email` | Oui | Oui | N/A |
+
+Champs interdits vérifiés : `password`, `activationToken`, `activationUrl`, `tokenHash`, `totpSecret`, `totpBackupCodes`, `localPath`, `filePath`, `pdfPath`, `originalFilePath`, `contextJson`, `llmJson`, `validatedJson`, `latexSource`, `stack`, `errorDetails`, `metadata`, `bankReference`, `rawWebhook`, `rawPayload`.

--- a/docs/go-live/_evidence/lot1ter-bilans-assessments.md
+++ b/docs/go-live/_evidence/lot1ter-bilans-assessments.md
@@ -1,0 +1,25 @@
+# Lot 1-ter — Bilans et assessments
+
+## Bilans traités
+
+| Route | Après | Preuve |
+| --- | --- | --- |
+| `/api/bilans` | P2 | Query/body Zod, tests invalid filters, correction `isPublished` absent |
+| `/api/bilans/[id]` | P2 | Param/body Zod, tests unsafe ID et update fields |
+| `/api/bilans/[id]/export` | P2 | Param/query/body Zod, tests audience/format |
+| `/api/bilans/generate` | P2 | Body/query Zod, tests refus avant DB |
+
+## Assessments
+
+`/api/assessments/submit` reste P1. La route est publique sensible avec données pédagogiques mineur. Elle est hors fermeture complète Lot 1-ter car le choix token signé/session/auth doit être arbitré sans casser le tunnel pédagogique.
+
+## Tests
+
+- `__tests__/api/bilans.id.route.test.ts`
+- `__tests__/api/bilans.idor.test.ts`
+- `__tests__/api/bilans/generate.test.ts`
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+
+## Risque résiduel
+
+Les modèles `Diagnostic / Assessment / StageBilan / Bilan` restent à canonicaliser pour éviter les divergences fonctionnelles, même si les routes `Bilan` durcies ne sont plus P1 statiques.

--- a/docs/go-live/_evidence/lot1ter-coach-reports.md
+++ b/docs/go-live/_evidence/lot1ter-coach-reports.md
@@ -1,0 +1,31 @@
+# Lot 1-ter — Coach reports
+
+## Routes traitées
+
+| Route | Après | Preuve |
+| --- | --- | --- |
+| `/api/coach/students/[studentId]/generated-reports/[reportId]/generate` | P2 | Réexport de regenerate couvert par test params |
+| `/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate` | P2 | Params Zod, no-leak test |
+| `/api/coach/students/[studentId]/eaf-preparation-report/validate` | P2 | Param Zod, test avant assignment |
+| `/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale` | P2 | Param/body Zod, tests GET/PATCH |
+| `/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate` | P2 | Param Zod, test avant assignment |
+
+## Tests
+
+- `__tests__/api/coach.generated-reports.route.test.ts`
+- `__tests__/api/coach.eaf-preparation-report.validate.test.ts`
+- `__tests__/api/coach.eaf-stage-regenerate.security.test.ts`
+- `__tests__/api/coach.bilan-diagnostic-maths-terminale.security.test.ts`
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+
+## P1 coach restants
+
+- `/api/coach/students/[studentId]/notes`
+- `/api/coach/students/[studentId]/survival-mode`
+- `/api/coach/trajectory`
+- `/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent`
+- `/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student`
+
+## Décision
+
+Les routes coach reports traitées sont acceptables pour bêta contrôlée. Les P1 coach restants doivent être traités avant bêta élargie.

--- a/docs/go-live/_evidence/lot1ter-command-log.md
+++ b/docs/go-live/_evidence/lot1ter-command-log.md
@@ -1,0 +1,65 @@
+# Lot 1-ter — Journal de commandes
+
+Date locale : 2026-07-02 22:42:22 CET.
+
+## État initial
+
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Runtime Node : `v20.20.0`
+- npm : `10.8.2`
+- État Git : worktree déjà modifié par Lots 0-bis, 1 et 1-bis ; aucun fichier `.env` listé comme modifié.
+
+## Fichiers hérités des lots précédents
+
+Le `git status --short --untracked-files=all` initial montre notamment :
+
+- routes documents/factures/activation/Lamis/stages/automatismes modifiées par Lot 1 ;
+- `app/layout.tsx`, `components/marketing/PaymentMethodsNote.tsx`, tests Playwright publics modifiés par Lot 0-bis ;
+- `docs/go-live/**`, `docs/security/API_GUARD_INVENTORY.md`, `scripts/go-live/generate-api-security-matrix.mjs` issus des lots de baseline ;
+- tests Lot 1-bis ajoutés : `audit-api-guards.classification`, `bilan-gratuit.security`, `no-sensitive-fields-in-api-responses`, `admin.documents`.
+
+## Commandes baseline
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node -v` | OK | `v20.20.0` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm -v` | OK | `10.8.2` |
+| `git rev-parse --abbrev-ref HEAD` | OK | `feat/lot4-accessors-runtime` |
+| `git rev-parse --short HEAD` | OK | `db8545a19` |
+| `git status --short --untracked-files=all` | OK | worktree sale hérité ; aucun `.env` modifié |
+
+## Commandes ciblées
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `npm run test:unit -- --runInBand __tests__/api/admin.invoices.route.test.ts __tests__/api/payments.clictopay.init.route.test.ts __tests__/api/npc.documents.route.test.ts __tests__/api/npc.submissions.security.test.ts __tests__/api/npc.generate.test.ts __tests__/api/npc.uploads.route.test.ts __tests__/api/bilans.id.route.test.ts __tests__/api/bilans.idor.test.ts __tests__/api/bilans/generate.test.ts __tests__/api/coach.generated-reports.route.test.ts __tests__/api/coach.eaf-preparation-report.validate.test.ts __tests__/api/coach.eaf-stage-regenerate.security.test.ts __tests__/api/coach.bilan-diagnostic-maths-terminale.security.test.ts __tests__/api/security/no-sensitive-fields-in-api-responses.test.ts` | OK | 14 suites passées, 94 tests passés |
+| `npm run test:unit -- --runInBand __tests__/api/bilans/crud.test.ts __tests__/api/sessions.cancel.route.test.ts` | OK après correction | 2 suites passées, 14 tests passés ; correction du fixture CUID `sessions/cancel` et du message sobre `Données invalides` pour `POST /api/bilans` |
+| `node scripts/security/audit-api-guards.mjs` | OK | `docs/security/API_GUARD_INVENTORY.md` régénéré, 176 routes |
+| `node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=37`, `P2=112`, `OK=27` |
+| `npm run typecheck` | PARTIEL puis OK | Échec initial sur types `app/api/bilans/route.ts`, corrigé ; relances OK avant commandes finales |
+
+## Commandes finales
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run typecheck` | OK | `tsc --noEmit` OK |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run lint` | OK | Next lint OK avec warnings existants sous `--max-warnings 300` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand` | OK après correction | Premier run : 2 suites échouées (`bilans/crud`, `sessions.cancel`) ; correction appliquée ; relance complète : 512 suites passées, 1 ignorée, 6411 tests passés, 4 ignorés |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run build` | OK | Build Next OK, 143 pages générées, assets standalone copiés |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/security/audit-api-guards.mjs` | OK | `docs/security/API_GUARD_INVENTORY.md` régénéré, 176 routes |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=37`, `P2=112`, `OK=27` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run audit:site-map` | OK | 290 routes, 412 edges, 0 link finding, 13 public orphan entries |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:no-hardcoded` | OK | 0 hardcoded values outside canonical sources |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:docs-archive` | OK | no historical audit/report files at docs root |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:bundle-weight` | OK | all routes within baseline + 5 kB |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | OK | 24 tests passés |
+
+## Limites
+
+- Aucune valeur secrète lue ou affichée.
+- Aucun fichier `.env` modifié.
+- Aucune migration lancée.
+- ClicToPay reste non actif ; le webhook doit rester P1/501 tant que l’intégration complète n’existe pas.
+- Rate limiting distribué production non vérifié localement : `À vérifier en production`.
+- `/api/bilan-gratuit` reste une dette produit/RGPD tant que la création de comptes inactifs n’est pas arbitrée.

--- a/docs/go-live/_evidence/lot1ter-npc-documents.md
+++ b/docs/go-live/_evidence/lot1ter-npc-documents.md
@@ -1,0 +1,30 @@
+# Lot 1-ter — NPC documents et fichiers
+
+## Routes traitées
+
+| Route | Après | Preuve |
+| --- | --- | --- |
+| `/api/npc/submissions` | P2 | Body/query Zod, tests sécurité |
+| `/api/npc/submissions/[submissionId]/documents` | P2 | Param Zod, refus traversal avant DB |
+| `/api/npc/submissions/[submissionId]/documents/[documentId]` | P2 | Params/body Zod, documentId unsafe refusé |
+| `/api/npc/submissions/[submissionId]/generate` | P2 | Param Zod, refus avant DB |
+| `/api/npc/uploads` | P2 | Metadata Zod, tests invalid metadata/MIME |
+
+## Contrôles appliqués
+
+- Identifiants route bornés par regex avant DB.
+- Metadata upload strictement validée.
+- Champs inattendus refusés sur les mutations traitées.
+- Tests ciblés vérifient absence de DB/fichier avant paramètres valides.
+
+## Tests
+
+- `__tests__/api/npc.documents.route.test.ts`
+- `__tests__/api/npc.submissions.security.test.ts`
+- `__tests__/api/npc.generate.test.ts`
+- `__tests__/api/npc.uploads.route.test.ts`
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+
+## Réserves
+
+Le mode runtime NPC/worker, le stockage réel et la preuve production de non-exposition de chemins restent à vérifier hors mocks.

--- a/docs/go-live/_evidence/lot1ter-p1-before-after.md
+++ b/docs/go-live/_evidence/lot1ter-p1-before-after.md
@@ -1,0 +1,51 @@
+# Lot 1-ter — P1 avant / après
+
+Date locale : 2026-07-02.
+
+## Synthèse
+
+| Priorité | Avant Lot 1-ter | Après Lot 1-ter | Delta |
+| --- | ---: | ---: | ---: |
+| P0 | 0 | 0 | 0 |
+| P1 | 54 | 37 | -17 |
+| P2 | 95 | 112 | +17 |
+| OK | 27 | 27 | 0 |
+| Total | 176 | 176 | 0 |
+
+Sources :
+
+- Avant : état confirmé Lot 1-bis dans `docs/go-live/12_LOT1BIS_SECURITY_VERIFICATION.md`.
+- Après : `node scripts/security/audit-api-guards.mjs` puis `node scripts/go-live/generate-api-security-matrix.mjs`.
+
+## P1 fermés
+
+| Route | Avant | Après | Preuve |
+| --- | --- | --- | --- |
+| `/api/admin/invoices` | P1 | P2 | Zod GET/POST, pagination bornée, projection explicite, tests admin invoices |
+| `/api/payments/clictopay/init` | P1 | P2 | Zod, rôles explicites, `501` conservé, tests ClicToPay init |
+| `/api/sessions/cancel` | P1 | P2 | Body Zod strict |
+| `/api/bilans` | P1 | P2 | Query/body Zod, tests bilans IDOR |
+| `/api/bilans/[id]` | P1 | P2 | Param/body Zod, tests ownership |
+| `/api/bilans/[id]/export` | P1 | P2 | Param/query/body Zod, tests audience/export |
+| `/api/bilans/generate` | P1 | P2 | Body/query Zod, test refus avant DB |
+| `/api/npc/submissions` | P1 | P2 | Body/query Zod, tests refus unsafe |
+| `/api/npc/submissions/[submissionId]/documents` | P1 | P2 | Params Zod, tests traversal |
+| `/api/npc/submissions/[submissionId]/documents/[documentId]` | P1 | P2 | Params/body Zod, tests documentId unsafe |
+| `/api/npc/submissions/[submissionId]/generate` | P1 | P2 | Params Zod, tests refus avant DB |
+| `/api/npc/uploads` | P1 | P2 | Metadata Zod, tests MIME/metadata |
+| `/api/coach/students/[studentId]/generated-reports/[reportId]/generate` | P1 | P2 | Réexport regenerate, params testés |
+| `/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate` | P1 | P2 | Params Zod, tests no-leak |
+| `/api/coach/students/[studentId]/eaf-preparation-report/validate` | P1 | P2 | Params Zod, test avant assignment |
+| `/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale` | P1 | P2 | Params/body Zod, tests GET/PATCH |
+| `/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate` | P1 | P2 | Params Zod, test avant assignment |
+
+## P1 restants structurants
+
+- `/api/payments/clictopay/webhook` reste P1/501 par décision de sécurité.
+- `/api/assessments/submit`, `/api/bilan-gratuit`, `/api/stages/[stageSlug]/inscrire`, `/api/student/activate` restent publics sensibles.
+- `/api/assistante/quotes/pdf` reste P1 document.
+- Routes assistante/parent/student/coach restantes requièrent durcissement rate limit, Zod ou qualification rôle/ownership.
+
+## Décision
+
+Le delta est réel et provient de corrections de code/tests, pas d'une modification du script d'audit. La bêta élargie reste interdite avec 37 P1.

--- a/docs/go-live/_evidence/lot1ter-payments-invoices.md
+++ b/docs/go-live/_evidence/lot1ter-payments-invoices.md
@@ -1,0 +1,25 @@
+# Lot 1-ter — Paiements et factures
+
+## Paiements
+
+| Route | Statut après Lot 1-ter | Décision | Preuve |
+| --- | --- | --- | --- |
+| `/api/payments/clictopay/init` | P2 | Désactivée par `501`, durcie | Zod strict, rôle `PARENT/ADMIN/ASSISTANTE`, test invalid payload et rôle `ELEVE` |
+| `/api/payments/clictopay/webhook` | P1 | Désactivée par `501`, non fermée | Webhook non activé tant que signature/idempotence/montant/devise/entitlements ne sont pas complets |
+| `/api/payments/validate` | P2 hérité | Non modifiée dans Lot 1-ter | À traiter en lot paiement/entitlements pour idempotence métier complète |
+
+## Factures
+
+| Route | Statut après Lot 1-ter | Preuve |
+| --- | --- | --- |
+| `/api/admin/invoices` | P2 | Staff-only, query/body Zod, limite `50`, projection `select`, tests validation |
+| `/api/admin/invoices/[id]` | P2 hérité | Tests Lot 1/1-bis |
+| `/api/admin/invoices/[id]/send` | P2 hérité | Tests Lot 1/1-bis |
+| `/api/invoices/[id]/pdf` | P2 hérité | Tests ownership PDF |
+| `/api/invoices/[id]/receipt/pdf` | P2 hérité | Tests ownership receipt |
+
+## Réserves
+
+- ClicToPay ne doit pas être affiché comme actif.
+- Le webhook doit rester P1 tant qu'aucune signature/idempotence complète n'est implémentée.
+- Le lot paiement/entitlements doit vérifier `InvoiceItem.productCode`, montant/devise, beneficiary et absence de double activation.

--- a/docs/go-live/_evidence/lot1ter-sensitive-fields-coverage.md
+++ b/docs/go-live/_evidence/lot1ter-sensitive-fields-coverage.md
@@ -1,0 +1,34 @@
+# Lot 1-ter — Couverture champs sensibles
+
+## Test global
+
+Fichier : `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`.
+
+## Champs interdits vérifiés
+
+`password`, `activationToken`, `activationUrl`, `tokenHash`, `totpSecret`, `totpBackupCodes`, `localPath`, `filePath`, `pdfPath`, `originalFilePath`, `contextJson`, `llmJson`, `validatedJson`, `latexSource`, `stack`, `errorDetails`, `metadata`, `bankReference`, `rawWebhook`, `rawPayload`.
+
+## Routes couvertes
+
+| Route | Couverture |
+| --- | --- |
+| `/api/bilan-gratuit` | Réponse succès minimale |
+| `/api/student/activate` | Validation token/password minimale |
+| `/api/payments/clictopay/init` | `501` minimal |
+| `/api/payments/clictopay/webhook` | `501` minimal |
+| `/api/admin/invoices` | Validation payload minimale |
+| `/api/bilans/generate` | Validation `bilanId` minimale |
+| `/api/npc/submissions/[submissionId]/documents` | Validation param minimale |
+| `/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate` | Validation params minimale |
+| `/api/lamis/teacher-report` | Validation payload minimale |
+
+## Non couvert ou partiel
+
+- PDF facture/reçu : couvert par tests dédiés hérités, pas par ce test global.
+- Exports bilans complets : partiellement couverts par tests bilans, pas par ce test global.
+- Routes assistante/parent/student P1 restantes : non couvertes par le test global.
+- Logs runtime : non couverts dynamiquement en production.
+
+## Décision
+
+La couverture no-leak s'est élargie, mais elle reste insuffisante pour go-live large. Elle est acceptable pour réduire le risque sur les routes Lot 1-ter traitées.

--- a/docs/go-live/_evidence/lot2-assessments-submit-decision.md
+++ b/docs/go-live/_evidence/lot2-assessments-submit-decision.md
@@ -1,0 +1,39 @@
+# Lot 2 — Décision `/api/assessments/submit`
+
+## Décision
+
+Option A retenue : token signé court avant bêta élargie.
+
+## État actuel
+
+- Route publique.
+- Zod strict.
+- Rate limit async.
+- Payload pédagogique mineur.
+- Crée un `Assessment`.
+- Réponse avec `assessmentId` et `redirectUrl`, nécessaires au parcours actuel `/assessments/[id]/processing`.
+
+## Décision produit
+
+Le flux public actuel est toléré uniquement pour un parcours contrôlé et volume limité. Avant bêta élargie, la route doit exiger un token signé court :
+
+- token généré après lead qualifié ou session authentifiée ;
+- TTL court ;
+- scope `subject`, `grade`, éventuelle session/campagne ;
+- pas de token brut stocké ;
+- pas de réutilisation hors scope.
+
+## Mitigations actuelles
+
+- Pas de `contextJson`, `llmJson`, `validatedJson`, `latexSource`, `metadata` brute en réponse.
+- Champs inattendus rejetés.
+- No-leak succès/erreur couvert.
+
+## Tests
+
+- `__tests__/api/assessments-submit.test.ts`
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+
+## Verdict
+
+P1 maintenu par décision. Bêta élargie interdite tant que le token signé court n'est pas implémenté.

--- a/docs/go-live/_evidence/lot2-bilan-gratuit-product-rgpd.md
+++ b/docs/go-live/_evidence/lot2-bilan-gratuit-product-rgpd.md
@@ -1,0 +1,45 @@
+# Lot 2 — `/api/bilan-gratuit` produit/RGPD
+
+## Décision
+
+Option `lead_only` implémentée.
+
+## Avant
+
+La route publique créait :
+
+- `User` parent inactif ;
+- `ParentProfile` ;
+- `User` élève inactif ;
+- `Student` ;
+- token d'activation hashé ;
+- email d'activation avec token brut dans l'URL.
+
+## Après
+
+La route crée uniquement un `ContactLead` CRM via `captureContactLead`.
+
+- Aucune création de `User`.
+- Aucune création de `ParentProfile`.
+- Aucune création de `Student`.
+- Aucun token d'activation généré.
+- Aucun email d'activation envoyé.
+- Réponse neutre sans `leadId`, `parentId`, `studentId`, token ou email-existence.
+- `studentBirthDate` n'est pas persisté dans les notes CRM.
+
+## Données conservées
+
+- Parent : nom, email, téléphone.
+- Intérêt : bilan gratuit et niveau.
+- Notes minimisées : prénom/nom élève, niveau, établissement si fourni, matières, objectifs/difficultés tronqués, modalité/disponibilités.
+
+## Tests
+
+- `__tests__/api/bilan-gratuit.product-rgpd.test.ts`
+- `__tests__/api/bilan-gratuit.security.test.ts`
+- `__tests__/api/bilan-gratuit.test.ts`
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+
+## Verdict
+
+Ambiguïté produit/RGPD fermée pour le formulaire public. La route reste publique sensible et dépend du rate limiting runtime avant campagne large.

--- a/docs/go-live/_evidence/lot2-clictopay-payment-decision.md
+++ b/docs/go-live/_evidence/lot2-clictopay-payment-decision.md
@@ -1,0 +1,29 @@
+# Lot 2 — Décision ClicToPay
+
+## Décision
+
+ClicToPay reste désactivé.
+
+## Contrat webhook
+
+- Sans signature : `401 CLICTOPAY_SIGNATURE_REQUIRED`.
+- Signature invalide : `401 CLICTOPAY_SIGNATURE_INVALID`.
+- Signature valide : `501 CLICTOPAY_NOT_CONFIGURED`.
+- Aucune mutation Prisma.
+- Aucune activation payment/invoice/entitlement/credit.
+- Aucun succès ambigu.
+
+## UI publique
+
+`PaymentMethodsNote` n'affiche pas le paiement carte sans `NEXT_PUBLIC_ENABLE_CLICTOPAY_PUBLIC=true`.
+
+## Tests
+
+- `__tests__/api/payments.clictopay.webhook.disabled.test.ts`
+- `__tests__/api/payments.clictopay.webhook.security.test.ts`
+- `__tests__/api/payments.clictopay.webhook.route.test.ts`
+- `__tests__/ui/payment-methods.clictopay-disabled.test.tsx`
+
+## Verdict
+
+Route volontairement P1 paiement. Passage P2/OK interdit tant que signature, idempotence, montant/devise/productCode, facture, paiement et entitlement ne sont pas complets.

--- a/docs/go-live/_evidence/lot2-lamis-teacher-report-decision.md
+++ b/docs/go-live/_evidence/lot2-lamis-teacher-report-decision.md
@@ -1,0 +1,26 @@
+# Lot 2 — Décision `/api/lamis/teacher-report`
+
+## Décision
+
+Public anonyme assumé.
+
+## Justification
+
+La route calcule un rapport pédagogique à partir d'essais envoyés par le client, sans email, nom, compte, document, facture ou écriture DB. Elle reste publique pour supporter la page Lamis et l'usage pédagogique immédiat.
+
+## Mitigations
+
+- Zod strict.
+- Rate limit async.
+- Maximum 300 tentatives.
+- Pas de stockage serveur.
+- Pas de réponse avec champs interdits.
+
+## Tests
+
+- `__tests__/api/lamis.teacher-report.route.test.ts`
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+
+## Verdict
+
+Décision produit claire. La route peut rester publique, mais reste suivie en P1 statique par prudence jusqu'à preuve runtime Redis/Upstash.

--- a/docs/go-live/_evidence/lot2-public-product-rgpd-command-log.md
+++ b/docs/go-live/_evidence/lot2-public-product-rgpd-command-log.md
@@ -1,0 +1,69 @@
+# Lot 2 — Journal de commandes
+
+Date locale initiale : 2026-07-03 07:41:49 CET.
+
+## Baseline
+
+- Répertoire : `/home/alaeddine/Bureau/nexus-project_v0`
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Node : `v20.20.0`
+- npm : `10.8.2`
+- État Git initial : worktree déjà chargé par les lots précédents ; aucun fichier `.env` listé comme modifié.
+- P1 initiaux extraits de `docs/go-live/api-security-matrix.full.md` : 6 routes.
+
+## P1 initiaux
+
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+## Commandes baseline exécutées
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `node -v` sous Node 20 | OK | `v20.20.0` |
+| `npm -v` sous Node 20 | OK | `10.8.2` |
+| `git rev-parse --abbrev-ref HEAD` | OK | `feat/lot4-accessors-runtime` |
+| `git rev-parse --short HEAD` | OK | `db8545a19` |
+| `git status --short --untracked-files=all` | OK | Worktree dirty hérité ; aucun `.env` modifié |
+| `rg -n "^\\| P1 \\|" docs/go-live/api-security-matrix.full.md` | OK | 6 P1 confirmés |
+
+## Commandes ciblées
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| Tests Lot 2 initiaux | ÉCHEC puis OK | RED : `bilan-gratuit` créait encore des comptes ; stage consent non accepté par API. Après correction : 5 suites, 12 tests passés |
+| Tests routes impactées | OK | 16 suites, 99 tests passés |
+| `npx tsx -e "import { getRateLimitProductionGate } ..."` | OK | Local `memory`, décision `blocked` |
+| `curl -sS -i --max-time 10 https://nexusreussite.academy/api/internal/health` | PARTIEL | Production répond `401 Unauthorized`; Redis/Upstash non prouvé |
+
+## Commandes finales
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run typecheck` | ÉCHEC puis OK | Premier échec TypeScript sur le type UI des consentements stage (`boolean` vs `true`) ; corrigé par `Omit<...>` dans `StageInscriptionForm`. Relance OK |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run lint` | OK | `next lint --max-warnings 300` OK, warnings existants |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand` | OK | 522 suites passées, 1 ignorée ; 6466 tests passés, 4 ignorés |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run build` | OK | Next build OK ; 143 pages statiques générées ; assets standalone copiés |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/security/audit-api-guards.mjs` | OK | `docs/security/API_GUARD_INVENTORY.md` régénéré, 176 routes |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=6`, `P2=143`, `OK=27` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run audit:site-map` | OK | Routes 290 ; edges 412 ; link findings 0 ; public orphan entries 13 |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:no-hardcoded` | OK | 0 valeur hardcodée hors sources canoniques |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:docs-archive` | OK | Aucun audit/report historique au root docs |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:bundle-weight` | OK | Toutes les routes suivies dans baseline + 5 kB |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | OK | 24 tests passés |
+
+Commande non retenue comme gate mais exécutée par erreur de saisie : `source /home/alaeddine/.nvm/nvm use 20.20.0 >/dev/null && npm run check:bundle-weight` a échoué car le chemin `nvm` était invalide. La commande correcte a été relancée et est OK.
+
+## Limites
+
+- Aucun secret lu.
+- Aucun `.env` modifié.
+- Aucun déploiement.
+- Aucune migration destructive.
+- Healthcheck production authentifié non accessible sans credential ; mode Redis/Upstash production non prouvé.
+- Le smoke Playwright public affiche un warning webserver préexistant : table locale `public.business_configs` absente lors du refresh passif. Les tests publics passent néanmoins.

--- a/docs/go-live/_evidence/lot2-rate-limit-runtime-decision.md
+++ b/docs/go-live/_evidence/lot2-rate-limit-runtime-decision.md
@@ -1,0 +1,64 @@
+# Lot 2 — Décision rate limiting runtime
+
+## État local
+
+Commande :
+
+```bash
+npx tsx -e "import { getRateLimitProductionGate } from './lib/rate-limit/index.ts'; console.log(JSON.stringify(getRateLimitProductionGate()))"
+```
+
+Résultat :
+
+```json
+{"ok":false,"mode":"memory","decision":"blocked","reason":"Memory rate limiting is process-local and blocks go-live large."}
+```
+
+## État staging
+
+NON PROUVÉ. Aucun environnement staging accessible sans secret n'a été identifié.
+
+## État production
+
+Commande sûre sans secret :
+
+```bash
+curl -sS -i --max-time 10 https://nexusreussite.academy/api/internal/health
+```
+
+Résultat résumé :
+
+```text
+HTTP/2 401
+{"error":"Unauthorized","message":"You must be signed in to access this resource"}
+```
+
+L'endpoint est protégé, mais le mode runtime `redis` ou `upstash` n'est pas prouvé.
+
+## Healthcheck attendu
+
+Un opérateur authentifié doit vérifier sans exposer de secret :
+
+```json
+{
+  "runtime": {
+    "rateLimit": {
+      "mode": "redis ou upstash",
+      "distributed": true,
+      "goLiveLarge": "allowed"
+    }
+  }
+}
+```
+
+## Test 429 attendu
+
+Exécuter sur staging/production une saturation contrôlée d'une route publique non destructive et vérifier `429`, `Retry-After`, headers `X-RateLimit-*` et comportement partagé entre instances.
+
+## Résultat
+
+Redis/Upstash runtime NON PROUVÉ.
+
+## Décision
+
+GO-LIVE LARGE INTERDIT.

--- a/docs/go-live/_evidence/lot2-sensitive-fields-success-error-coverage.md
+++ b/docs/go-live/_evidence/lot2-sensitive-fields-success-error-coverage.md
@@ -1,0 +1,14 @@
+# Lot 2 — Couverture no-leak succès / erreur
+
+Test global : `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`.
+
+| Route | Success covered | Error covered | Dedicated test | Limite |
+|---|---:|---:|---|---|
+| `/api/payments/clictopay/webhook` | Oui, succès désactivé `501` | Oui | `payments.clictopay.webhook.*` | Pas de succès paiement actif tant que ClicToPay off |
+| `/api/assessments/submit` | Oui | Oui | `assessments-submit` | Token signé court non implémenté |
+| `/api/bilan-gratuit` | Oui | Oui | `bilan-gratuit.product-rgpd` | Route publique dépend du rate limit runtime |
+| `/api/lamis/teacher-report` | Oui | Oui | `lamis.teacher-report` | Public anonyme assumé |
+| `/api/stages/[stageSlug]/inscrire` | Oui | Oui | `stages.inscrire.product-rgpd` | Campagne large bloquée par Redis/Upstash non prouvé |
+| `/api/student/activate` | Oui | Oui | `student.activate.lifecycle-security` | Route publique par token |
+
+Champs interdits vérifiés : `password`, `activationToken`, `activationUrl`, `tokenHash`, `totpSecret`, `totpBackupCodes`, `localPath`, `filePath`, `pdfPath`, `originalFilePath`, `contextJson`, `llmJson`, `validatedJson`, `latexSource`, `stack`, `errorDetails`, `metadata`, `bankReference`, `rawWebhook`, `rawPayload`.

--- a/docs/go-live/_evidence/lot2-stages-inscrire-product-rgpd.md
+++ b/docs/go-live/_evidence/lot2-stages-inscrire-product-rgpd.md
@@ -1,0 +1,36 @@
+# Lot 2 — Décision stage inscription
+
+## Route
+
+`/api/stages/[stageSlug]/inscrire`
+
+## Décision
+
+Route publique assumée, avec consentement explicite API.
+
+## Changements Lot 2
+
+- `stageTermsAccepted: true` requis.
+- `dataProcessingAccepted: true` requis.
+- Le formulaire public transmet les deux consentements.
+- Les notes internes enregistrent uniquement les consentements oui/non, sans payload brut.
+
+## Contrat
+
+- Pas de création de compte.
+- Pas de token d'activation.
+- Pas d'ID interne en réponse.
+- Déduplication email/stage sans exposer `reservationId`.
+- Rate limit async.
+- Zod strict.
+
+## Tests
+
+- `__tests__/api/stages.inscrire.product-rgpd.test.ts`
+- `__tests__/api/stages.inscrire.security.test.ts`
+- `__tests__/api/stages/inscriptions.test.ts`
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+
+## Verdict
+
+Décision produit/RGPD claire. Route encore P1 tant que Redis/Upstash runtime n'est pas prouvé pour campagne large.

--- a/docs/go-live/_evidence/lot2-student-activate-token-lifecycle.md
+++ b/docs/go-live/_evidence/lot2-student-activate-token-lifecycle.md
@@ -1,0 +1,28 @@
+# Lot 2 — Student activation token lifecycle
+
+## Route
+
+`/api/student/activate`
+
+## Décision
+
+Route publique par token assumée.
+
+## Preuves code
+
+- Le token brut est hashé SHA-256 avant lookup.
+- Les recherches imposent expiration future.
+- Les comptes déjà activés sont exclus.
+- Après activation, `activationToken` et `activationExpiry` sont remis à `null`.
+- GET et POST sont rate-limited.
+- Réponses sobres.
+
+## Tests
+
+- `__tests__/api/student.activate.lifecycle-security.test.ts`
+- `__tests__/api/student.activate.route.test.ts`
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+
+## Verdict
+
+Cycle token défendable pour bêta contrôlée. La route reste P1 par nature publique et doit être surveillée en production.

--- a/docs/go-live/_evidence/lot3-assessments-public-token.md
+++ b/docs/go-live/_evidence/lot3-assessments-public-token.md
@@ -1,0 +1,39 @@
+# Lot 3 — Assessment public token
+
+## Décision
+
+`POST /api/assessments/submit` exige désormais un token signé court pour les soumissions publiques.
+
+## Implémentation
+
+- Helper : `lib/assessments/public-token.ts`
+- Route d'émission contrôlée staff-only : `app/api/assessments/public-token/route.ts`
+- Page publique : `app/bilan-gratuit/assessment/page.tsx`
+- Client assessment : `app/bilan-gratuit/assessment/AssessmentClient.tsx`
+- Runner : `components/assessments/AssessmentRunner.tsx`
+- Route protégée : `app/api/assessments/submit/route.ts`
+
+## Contrat sécurité
+
+- Signature HMAC.
+- TTL court par défaut : 15 minutes.
+- Scope : `usage=assessment_submit`, `subject`, `grade`, `source`, `campaignId` optionnel.
+- Aucun token brut stocké.
+- Pas de fallback insecure en production : un secret runtime est obligatoire.
+- Le token est envoyé par header `x-assessment-public-token` ou `Authorization: Bearer`.
+- Token absent, expiré, mal signé ou mal formé : `401`.
+- Scope, subject ou grade mismatch : `403`.
+
+## Tests
+
+- `__tests__/lib/assessments/public-token.test.ts`
+- `__tests__/api/assessments.public-token.route.test.ts`
+- `__tests__/api/assessments.submit.token-security.test.ts`
+- `__tests__/api/assessments-submit.test.ts`
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+
+Résultat ciblé : inclus dans le pack Lot 3, `14` suites passées, `99` tests passés.
+
+## Réserve
+
+La route `/api/assessments/submit` reste P1 dans la matrice car elle reste une surface publique sensible manipulant des données pédagogiques mineur. Le risque d'accès public ouvert est réduit par token court, mais la décision produit finale token/session/auth reste à confirmer avant bêta élargie.

--- a/docs/go-live/_evidence/lot3-bilan-gratuit-rgpd-register.md
+++ b/docs/go-live/_evidence/lot3-bilan-gratuit-rgpd-register.md
@@ -1,0 +1,49 @@
+# Lot 3 — Registre RGPD `/api/bilan-gratuit` lead_only
+
+## Décision
+
+Le tunnel public `/api/bilan-gratuit` reste en `lead_only`.
+
+## Finalité
+
+Permettre à un parent de demander un rappel ou un bilan pédagogique gratuit pour son enfant.
+
+## Base légale
+
+Consentement parent et demande précontractuelle.
+
+## Données traitées
+
+- Parent : prénom, nom, email, téléphone.
+- Élève : prénom, nom optionnel, niveau, établissement optionnel.
+- Besoin pédagogique : matières, niveau actuel, objectifs, difficultés, modalité, disponibilités.
+- Consentements : conditions et newsletter optionnelle.
+
+## Données retirées ou refusées
+
+- `studentBirthDate` n'est plus accepté dans le schéma public.
+- Aucun `User`, `ParentProfile`, `Student`, token d'activation ou email d'activation n'est créé.
+- Aucune réponse publique ne renvoie `leadId`, `parentId`, `studentId`, token ou email-existence.
+
+## Minimisation
+
+Les notes CRM sont tronquées et limitées aux éléments nécessaires au rappel. La date de naissance est rejetée au lieu d'être ignorée silencieusement.
+
+## Destinataires internes
+
+Équipe admissions/pédagogie Nexus Réussite.
+
+## Rétention
+
+Voir `docs/go-live/_evidence/lot3-contact-lead-retention-policy.md`.
+
+## Tests
+
+- `__tests__/api/bilan-gratuit.rgpd-minimization.test.ts`
+- `__tests__/api/bilan-gratuit.product-rgpd.test.ts`
+- `__tests__/api/bilan-gratuit.security.test.ts`
+- `__tests__/api/bilan-gratuit.test.ts`
+
+## Risque résiduel
+
+Le formulaire reste public et manipule des données de mineurs. La bêta élargie exige la preuve Redis/Upstash et une validation humaine de la politique de confidentialité.

--- a/docs/go-live/_evidence/lot3-business-configs-db-drift.md
+++ b/docs/go-live/_evidence/lot3-business-configs-db-drift.md
@@ -1,0 +1,30 @@
+# Lot 3 — `business_configs` DB drift
+
+## Constat
+
+Le smoke Playwright public passait mais le webserver local signalait régulièrement une table `public.business_configs` absente pendant un refresh passif.
+
+## Analyse code
+
+- Modèle Prisma : `BusinessConfig` avec `@@map("business_configs")`.
+- Accès runtime : `lib/config/snapshot.ts`.
+- Routes d'administration : `app/api/admin/config/*`.
+
+## Décision
+
+La table est un store d'overrides runtime. Quand elle est absente en local ou sur environnement non migré, le code doit utiliser les valeurs statiques et classer explicitement le fallback.
+
+## Correction
+
+- `lib/config/snapshot.ts` détecte l'erreur Prisma `P2021` sur `business_configs`.
+- Le fallback devient `static_fallback` sans `console.error` récurrent.
+- `app/api/internal/health/route.ts` expose `runtime.businessConfig`.
+
+## Tests
+
+- `__tests__/lib/business-config.fallback.test.ts`
+- `__tests__/api/internal.business-config.health.test.ts`
+
+## Décision migration
+
+Aucune migration n'a été lancée. Si la table est requise en production, une migration non destructive doit être validée humainement et appliquée via le process de release.

--- a/docs/go-live/_evidence/lot3-clictopay-disabled-contract.md
+++ b/docs/go-live/_evidence/lot3-clictopay-disabled-contract.md
@@ -1,0 +1,25 @@
+# Lot 3 — ClicToPay disabled contract
+
+## Décision
+
+ClicToPay reste désactivé. La carte bancaire ne doit pas être présentée comme active.
+
+## Contrat API
+
+- `init` reste `501 CLICTOPAY_NOT_CONFIGURED`.
+- `webhook` exige une signature.
+- Signature absente ou invalide : `401`.
+- Signature valide : `501 CLICTOPAY_NOT_CONFIGURED`.
+- Aucune mutation Prisma ne doit créer ou activer paiement, facture, entitlement ou crédit.
+- Aucun `rawWebhook`, `rawPayload`, `metadata` brute ou stack ne sort en réponse.
+
+## Tests
+
+- `__tests__/api/payments.clictopay.disabled-contract.test.ts`
+- `__tests__/api/payments.clictopay.webhook.disabled.test.ts`
+- `__tests__/api/payments.clictopay.webhook.security.test.ts`
+- `__tests__/ui/payment-methods.clictopay-disabled.test.tsx`
+
+## Plan complet futur
+
+Pour activer ClicToPay, il faudra implémenter et tester signature, idempotence, montant, devise, `productCode`, réconciliation facture, activation entitlement, replay protection, audit log et E2E paiement.

--- a/docs/go-live/_evidence/lot3-contact-lead-retention-policy.md
+++ b/docs/go-live/_evidence/lot3-contact-lead-retention-policy.md
@@ -1,0 +1,32 @@
+# Lot 3 — ContactLead retention policy
+
+## Décision
+
+Les leads publics mineur-related sont conservés avec une durée bornée et une procédure d'effacement.
+
+## Politique
+
+- Durée de conservation proposée : `365` jours.
+- SLA d'effacement demande parent : `30` jours maximum.
+- Base légale : consentement parent et demande précontractuelle.
+- Action production requise : planifier un job de purge/anonymisation avant go-live large.
+
+## Code
+
+- `lib/crm/contact-leads.ts`
+- Exports ajoutés :
+  - `CONTACT_LEAD_RETENTION_DAYS`
+  - `CONTACT_LEAD_ERASURE_SLA_DAYS`
+  - `buildContactLeadRetentionDecision()`
+
+## Dédoublonnage
+
+`captureContactLead` recherche un lead `NEW` existant pour le même email et la même source, puis met à jour cette ligne au lieu de créer systématiquement un doublon.
+
+## Tests
+
+- `__tests__/lib/crm/contact-leads.retention.test.ts`
+
+## Réserve
+
+Le job de purge réel n'est pas implémenté dans ce lot pour éviter une migration ou tâche runtime non validée. Il reste requis avant go-live large.

--- a/docs/go-live/_evidence/lot3-no-leak-success-error-runtime-coverage.md
+++ b/docs/go-live/_evidence/lot3-no-leak-success-error-runtime-coverage.md
@@ -1,0 +1,25 @@
+# Lot 3 — No-leak succès/erreurs runtime coverage
+
+## Synthèse
+
+Le test no-leak couvre les chemins succès et erreurs principaux des routes sensibles mockables, avec ajout du succès assessment sous token court.
+
+| Route | Success covered | Error covered | Mocked | Limite |
+|---|---:|---:|---:|---|
+| `/api/assessments/submit` | Oui | Oui | Oui | Succès mock Prisma/scoring ; route exige maintenant token court |
+| `/api/bilan-gratuit` | Oui | Oui | Oui | Lead CRM mocké, pas de DB réelle |
+| `/api/stages/[stageSlug]/inscrire` | Oui | Oui | Oui | Prisma stage/reservation mocké |
+| `/api/student/activate` | Oui | Oui | Oui | Service activation mocké |
+| `/api/payments/clictopay/init` | Oui, disabled `501` | Oui | Oui | Paiement carte non actif |
+| `/api/payments/clictopay/webhook` | Oui, disabled `501` | Oui | Oui | Aucun succès paiement actif |
+| `/api/lamis/teacher-report` | Oui | Oui | Oui | Route publique anonyme/minimisée |
+
+## Champs interdits couverts
+
+`password`, `activationToken`, `activationUrl`, `tokenHash`, `totpSecret`, `totpBackupCodes`, `localPath`, `pdfPath`, `filePath`, `originalFilePath`, `contextJson`, `llmJson`, `validatedJson`, `latexSource`, `stack`, `errorDetails`, `metadata`, `bankReference`, `rawWebhook`, `rawPayload`.
+
+## Tests
+
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+
+Résultat ciblé Lot 3 : inclus dans `14` suites passées, `99` tests passés.

--- a/docs/go-live/_evidence/lot3-redis-upstash-runtime-proof.md
+++ b/docs/go-live/_evidence/lot3-redis-upstash-runtime-proof.md
@@ -1,0 +1,39 @@
+# Lot 3 — Redis/Upstash runtime proof
+
+Date : 2026-07-03 12:27 CET.
+
+## État local
+
+- Commande : `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npx tsx -e "import { getRateLimitProductionGate, getRateLimitRuntimeMode } from './lib/rate-limit/index.ts'; console.log(JSON.stringify({mode:getRateLimitRuntimeMode(), gate:getRateLimitProductionGate()}));"`
+- Résultat : `mode=memory`, `gate.ok=false`, `gate.decision=blocked`.
+- Interprétation : le poste local ne prouve pas Redis/Upstash.
+
+## État staging
+
+À vérifier. Aucun environnement staging authentifié n'est disponible dans cette session sans secret.
+
+## État production
+
+- Commande sûre exécutée sans afficher de secret : `curl -sS -o /tmp/nexus-internal-health-lot3.txt -w "%{http_code}\n" https://nexusreussite.academy/api/internal/health`
+- Résultat HTTP : `401`.
+- Interprétation : le healthcheck interne est protégé ; aucun token/cookie n'a été fourni ni affiché. Le mode Redis/Upstash production reste non prouvé.
+
+## Healthcheck authentifié
+
+Attendu : réponse JSON authentifiée avec :
+
+- `runtime.rateLimit.mode = redis` ou `upstash`
+- `runtime.rateLimit.distributed = true`
+- `runtime.rateLimit.goLiveLarge = allowed`
+
+## Test 429 réel
+
+Non exécuté sur production : le code Lot 3 n'est pas déployé et aucun environnement staging authentifié n'est disponible. Un test 429 production sans fenêtre dédiée risquerait aussi de polluer les quotas publics depuis l'IP de vérification.
+
+## Résultat
+
+Redis/Upstash n'est pas prouvé en staging/production.
+
+## Décision go-live large
+
+INTERDIT.

--- a/docs/go-live/_evidence/lot3-runtime-rgpd-assessment-command-log.md
+++ b/docs/go-live/_evidence/lot3-runtime-rgpd-assessment-command-log.md
@@ -1,0 +1,119 @@
+# Lot 3 — Journal runtime / RGPD / assessment token
+
+Date locale initiale : 2026-07-03 12:12:25 CET.
+
+## Baseline
+
+- Répertoire : `/home/alaeddine/Bureau/nexus-project_v0`
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Node : `v20.20.0`
+- npm : `10.8.2`
+- État Git initial : worktree déjà chargé par les lots précédents ; beaucoup de fichiers modifiés/non suivis hérités des lots 0 à 2.
+- Aucun fichier `.env` ne doit être lu, affiché ou modifié.
+- Migrations destructives interdites ; aucune commande Prisma de migration/push ne doit être lancée.
+
+## P1 initiaux confirmés
+
+Extrait de `docs/go-live/api-security-matrix.full.md` :
+
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+Compteurs initiaux : `P0=0`, `P1=6`, `P2=143`, `OK=27`, total `176`.
+
+## Commandes baseline exécutées
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node -v` | OK | `v20.20.0` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm -v` | OK | `10.8.2` |
+| `git rev-parse --abbrev-ref HEAD` | OK | `feat/lot4-accessors-runtime` |
+| `git rev-parse --short HEAD` | OK | `db8545a19` |
+| `git status --short --untracked-files=all` | OK | Worktree dirty hérité ; aucun `.env` ne doit être touché |
+| `rg -n "^\\| P1 \\|" docs/go-live/api-security-matrix.full.md` | OK | 6 P1 confirmés |
+
+## Commandes ciblées
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `npm run test:unit -- --runInBand ...lot3 targeted tests...` | ÉCHEC attendu TDD | Premier passage rouge : helper/route token absents, `studentBirthDate` encore accepté, `business_configs` non classé, healthcheck sans statut config |
+| `npm run typecheck` | ÉCHEC puis OK | Premier passage : typage `searchParams`, mutation `NODE_ENV` en test, narrowing token ; second passage OK |
+| `node scripts/security/audit-api-guards.mjs` | OK | `docs/security/API_GUARD_INVENTORY.md` régénéré, `177` routes |
+| `npx tsx -e "...getRateLimitProductionGate..."` | OK | Local : `mode=memory`, `decision=blocked` |
+| `curl -sS -o /tmp/nexus-internal-health-lot3.txt -w "%{http_code}\n" https://nexusreussite.academy/api/internal/health` | PARTIEL | Production sans secret : `401`, Redis/Upstash non prouvé |
+| `node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=6`, `P2=144`, `OK=27`, total `177` |
+| `npm run test:unit -- --runInBand ...lot3 targeted tests...` | OK | `14` suites passées, `99` tests passés |
+
+## Commandes finales
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run typecheck` | OK | TypeScript OK après correction du typage `searchParams` de `/bilan-gratuit/assessment` et des tests token |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run lint` | OK | Lint terminé avec avertissements existants sous le seuil bloquant |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand` | ÉCHEC puis OK | Premier full run : 1 échec legacy mock `contactLead.findFirst` manquant ; fallback déduplication ajouté. Rerun final : `530` suites passées, `6489` tests passés, `1` suite skipped, `4` tests skipped |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run build` | OK | Next build OK, `142` pages statiques générées, assets standalone copiés |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/security/audit-api-guards.mjs` | OK | `docs/security/API_GUARD_INVENTORY.md` régénéré, `177` routes |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/go-live/generate-api-security-matrix.mjs` | OK | `docs/go-live/api-security-matrix.full.md` régénéré : `P0=0`, `P1=6`, `P2=144`, `OK=27` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run audit:site-map` | OK | Site map régénérée : `291` routes, `412` edges, `0` link findings, `13` public orphan entries |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:no-hardcoded` | OK | `0` hardcoded values outside canonical sources |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:docs-archive` | OK | Aucun fichier historique audit/report au root docs |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:bundle-weight` | OK | Toutes les routes sous baseline + `5 kB` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | OK | `24` tests Playwright Chromium passés |
+
+## Vérifications finales complémentaires
+
+- P1 finaux : `/api/payments/clictopay/webhook`, `/api/assessments/submit`, `/api/bilan-gratuit`, `/api/lamis/teacher-report`, `/api/stages/[stageSlug]/inscrire`, `/api/student/activate`.
+- `git diff --name-only | rg '(^|/)\\.env($|\\.)' || true` : OK, aucun fichier `.env` modifié.
+- `git status --short --untracked-files=all` : worktree toujours chargé par les lots précédents et Lot 3 ; aucun nettoyage destructif effectué.
+- Aucune migration Prisma, aucun `db push`, aucun déploiement.
+
+## Fichiers créés pendant Lot 3
+
+- `lib/assessments/public-token.ts`
+- `app/api/assessments/public-token/route.ts`
+- `app/bilan-gratuit/assessment/AssessmentClient.tsx`
+- `__tests__/lib/assessments/public-token.test.ts`
+- `__tests__/api/assessments.public-token.route.test.ts`
+- `__tests__/api/assessments.submit.token-security.test.ts`
+- `__tests__/api/bilan-gratuit.rgpd-minimization.test.ts`
+- `__tests__/lib/crm/contact-leads.retention.test.ts`
+- `__tests__/api/payments.clictopay.disabled-contract.test.ts`
+- `__tests__/lib/business-config.fallback.test.ts`
+- `__tests__/api/internal.business-config.health.test.ts`
+- `docs/go-live/17_LOT3_RUNTIME_RGPD_ASSESSMENT_TOKEN.md`
+- `docs/go-live/_evidence/lot3-redis-upstash-runtime-proof.md`
+- `docs/go-live/_evidence/lot3-assessments-public-token.md`
+- `docs/go-live/_evidence/lot3-bilan-gratuit-rgpd-register.md`
+- `docs/go-live/_evidence/lot3-contact-lead-retention-policy.md`
+- `docs/go-live/_evidence/lot3-clictopay-disabled-contract.md`
+- `docs/go-live/_evidence/lot3-business-configs-db-drift.md`
+- `docs/go-live/_evidence/lot3-no-leak-success-error-runtime-coverage.md`
+
+## Fichiers modifiés pendant Lot 3
+
+- `app/api/assessments/submit/route.ts`
+- `app/api/internal/health/route.ts`
+- `app/bilan-gratuit/assessment/page.tsx`
+- `components/assessments/AssessmentRunner.tsx`
+- `lib/config/snapshot.ts`
+- `lib/crm/contact-leads.ts`
+- `lib/validations.ts`
+- `docs/security/API_GUARD_INVENTORY.md`
+- `docs/go-live/api-security-matrix.full.md`
+- `docs/go-live/05_API_SECURITY_MATRIX.md`
+- `docs/go-live/02_P0_P1_BACKLOG.md`
+- `docs/go-live/04_TEST_MATRIX.md`
+- `docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md`
+- Tests existants assessment/bilan/no-leak alignés avec le nouveau contrat token/minimisation.
+
+## Limites initiales
+
+- Redis/Upstash staging/production non prouvé au démarrage.
+- `/api/internal/health` production nécessite une authentification ; aucun token/cookie ne sera affiché.
+- ClicToPay doit rester désactivé.
+- `business_configs` absent en DB locale doit être compris ou classé, sans migration destructive.

--- a/docs/go-live/_evidence/lot4-assessment-token-binding.md
+++ b/docs/go-live/_evidence/lot4-assessment-token-binding.md
@@ -1,0 +1,42 @@
+# Lot 4 — Assessment token binding
+
+## Problème confirmé
+
+Avant Lot 4, `/bilan-gratuit/assessment` pouvait générer un token `assessment_submit` depuis des `searchParams` publics. Ce token était court et signé, mais ne prouvait ni lead qualifié, ni session, ni invitation.
+
+## Décision
+
+Option B retenue : session/cookie de flux signé.
+
+## Contrat implémenté
+
+- `/api/bilan-gratuit` crée/met à jour le lead CRM puis pose un cookie HttpOnly `nexus_assessment_flow`.
+- Le cookie contient un token signé court `assessment_flow`.
+- Le payload inclut `subject`, `grade`, `source=bilan-gratuit`, `leadEmailHash`, `issuedAt`, `expiresAt`, `nonce`.
+- Aucun email brut dans le token de flux.
+- `/bilan-gratuit/assessment` ne génère plus de token depuis l'URL.
+- `/bilan-gratuit/assessment?...` redirige vers `/bilan-gratuit/assessment` avant rendu pour éviter la sérialisation RSC de PII en query.
+- Sans cookie valide, la page affiche un refus sobre.
+- Avec cookie valide, la page émet un token `assessment_submit` lié au `leadEmailHash`.
+- Le submit vérifie le token et l'email assessment pseudonyme.
+
+## Tests
+
+- `__tests__/api/assessments.public-token.binding.test.ts`
+- `__tests__/api/assessments.submit.token-binding.test.ts`
+- `__tests__/app/bilan-gratuit.assessment-page-token.test.tsx`
+- `__tests__/api/bilan-gratuit.product-rgpd.test.ts`
+- `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts`
+- `e2e/pages-public-bilan-assessment-token.spec.ts`
+
+## Résultat ciblé
+
+Pack unitaire ciblé : `11` suites passées, `53` tests passés.
+
+## Résultat E2E
+
+`npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium` : OK, `1` test passé après rebuild final.
+
+## Limite
+
+Le chemin complet lead submission -> cookie -> assessment n'est pas exécuté en E2E contre une DB réelle dans ce lot pour éviter une dépendance staging/production. Il est couvert par tests API/server-component mockés et par E2E du refus direct sans contexte.

--- a/docs/go-live/_evidence/lot4-business-config-production-gate.md
+++ b/docs/go-live/_evidence/lot4-business-config-production-gate.md
@@ -1,0 +1,31 @@
+# Lot 4 — BusinessConfig production gate
+
+## Problème
+
+Le fallback `business_configs` ne doit pas masquer une production non migrée.
+
+## Décision
+
+- local/test : fallback statique autorisé et explicite.
+- production : table absente = dégradé sauf opt-in explicite `BUSINESS_CONFIG_STATIC_FALLBACK_ALLOWED=true`.
+
+## Modes
+
+- `database` : table disponible.
+- `static_fallback_allowed` : table absente mais fallback autorisé.
+- `static_fallback_unexpected` : table absente en production sans opt-in, `ok=false`.
+- `static_fallback_error` : erreur non liée à table manquante.
+
+## Healthcheck
+
+`/api/internal/health` expose `runtime.businessConfig` et `checks.businessConfig`.
+
+## Tests
+
+- `__tests__/lib/business-config.production-gate.test.ts`
+- `__tests__/api/internal.business-config.health.test.ts`
+- `__tests__/lib/business-config.fallback.test.ts`
+
+## Migration
+
+Aucune migration automatique. Si la table est requise en production, appliquer une migration non destructive via le processus de release validé humainement.

--- a/docs/go-live/_evidence/lot4-clictopay-disabled-runbook.md
+++ b/docs/go-live/_evidence/lot4-clictopay-disabled-runbook.md
@@ -1,0 +1,23 @@
+# Lot 4 — ClicToPay disabled runbook
+
+## Décision
+
+ClicToPay reste désactivé durablement tant que l'intégration complète n'est pas livrée.
+
+## Contrat public/backend
+
+- UI publique : ne pas annoncer carte bancaire active.
+- `/api/payments/clictopay/init` : `501 CLICTOPAY_NOT_CONFIGURED` par défaut.
+- Si `NEXT_PUBLIC_ENABLE_CLICTOPAY_PUBLIC=true` alors que le backend est désactivé : `503 CLICTOPAY_PUBLIC_FLAG_INCONSISTENT`.
+- `/api/payments/clictopay/webhook` : signature absente/invalide refusée, signature valide `501`.
+- Aucune mutation paiement/facture/entitlement/crédit.
+
+## Tests
+
+- `__tests__/api/payments.clictopay.disabled-contract.test.ts`
+- `__tests__/ui/payment-methods.clictopay-disabled.test.tsx`
+- `__tests__/api/payments.clictopay.feature-flag-consistency.test.ts`
+
+## Activation future
+
+Impossible sans signature obligatoire, idempotence, contrôle montant/devise/productCode, réconciliation facture, activation entitlement, replay protection, audit log et E2E paiement.

--- a/docs/go-live/_evidence/lot4-contact-lead-retention-job.md
+++ b/docs/go-live/_evidence/lot4-contact-lead-retention-job.md
@@ -1,0 +1,32 @@
+# Lot 4 — ContactLead retention job
+
+## Script
+
+`scripts/maintenance/contact-leads-retention.ts`
+
+## Contrat
+
+- Dry-run par défaut.
+- Application uniquement avec `--apply`.
+- Anonymise les leads non convertis au-delà de `CONTACT_LEAD_RETENTION_DAYS`.
+- Supporte les demandes d'effacement parentales via `--email-hash` ou `--email-hashes-file`.
+- Ne renvoie/logue pas d'email ou téléphone en clair.
+- Ne modifie pas les leads `ENROLLED`.
+- N'anonymise pas les leads `QUALIFIED` par rétention automatique ; seulement sur demande d'effacement.
+
+## Données anonymisées
+
+- `name = Lead anonymisé`
+- `email = erased-<id>@deleted.nexus.local`
+- `phone/profile/interest/urgency/notes = null`
+- `source = retention-anonymized`
+- `status = LOST`
+
+## Tests
+
+- `__tests__/scripts/contact-leads-retention.test.ts`
+- `__tests__/lib/crm/contact-leads.retention.test.ts`
+
+## Décision opérationnelle
+
+Le mécanisme est exécutable et testé. L'exécution `--apply` en production requiert validation humaine et fenêtre de maintenance.

--- a/docs/go-live/_evidence/lot4-no-leak-e2e-runtime-coverage.md
+++ b/docs/go-live/_evidence/lot4-no-leak-e2e-runtime-coverage.md
@@ -1,0 +1,34 @@
+# Lot 4 — No-leak et E2E runtime coverage
+
+## No-leak unitaire
+
+`__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts` couvre désormais le chemin succès `assessments/submit` avec token lead-bound et email assessment pseudonyme.
+
+Champs interdits couverts : `password`, `activationToken`, `activationUrl`, `tokenHash`, `totpSecret`, `totpBackupCodes`, `localPath`, `pdfPath`, `filePath`, `originalFilePath`, `contextJson`, `llmJson`, `validatedJson`, `latexSource`, `stack`, `errorDetails`, `metadata`, `bankReference`, `rawWebhook`, `rawPayload`.
+
+## E2E assessment
+
+Nouveau test : `e2e/pages-public-bilan-assessment-token.spec.ts`.
+
+Objectif :
+
+- accès direct `/bilan-gratuit/assessment?subject=...&grade=...&email=...` refusé sans cookie de flux ;
+- aucun token dans l'URL ;
+- aucun token dans le HTML initial ;
+- email de query non réaffiché.
+
+## Résultat actuel
+
+Résultat final après rebuild standalone :
+
+- `npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium` : OK, `1` test passé.
+- Accès direct avec query params publics refusé.
+- URL canonique nettoyée.
+- Aucun token assessment dans URL/HTML.
+- L'email fourni en query n'apparaît plus dans le HTML initial.
+
+Incident traité pendant Lot 4 : un lancement après rebuild a montré que Next.js sérialisait la query dans le HTML RSC même si la page ne l'utilisait pas. Correction appliquée : redirection serveur immédiate vers `/bilan-gratuit/assessment` si des query params sont présents.
+
+## Limite
+
+Le chemin E2E complet lead submission -> cookie -> assessment n'est pas exécuté contre DB réelle dans ce lot pour éviter dépendance runtime DB/staging. Il est couvert en tests API/server-component mockés.

--- a/docs/go-live/_evidence/lot4-redis-upstash-runtime-proof.md
+++ b/docs/go-live/_evidence/lot4-redis-upstash-runtime-proof.md
@@ -1,0 +1,41 @@
+# Lot 4 — Redis/Upstash runtime proof
+
+## Local
+
+Commande sûre exécutée :
+
+`npx tsx -e "...getRateLimitProductionGate..."`
+
+Résultat : `mode=memory`, `gate.ok=false`, `decision=blocked`.
+
+## Staging
+
+À vérifier. Aucun environnement staging authentifié accessible sans secret dans cette session.
+
+## Production
+
+`NEXUS_HEALTH_AUTH` absent de l'environnement local de vérification.
+
+Commande sans secret :
+
+`curl -sS -o /tmp/nexus-internal-health-lot4.txt -w "%{http_code}\n" https://nexusreussite.academy/api/internal/health`
+
+Résultat : `401`.
+
+## Healthcheck authentifié attendu
+
+- `runtime.rateLimit.mode = redis` ou `upstash`
+- `runtime.rateLimit.distributed = true`
+- `runtime.rateLimit.goLiveLarge = allowed`
+
+## Test 429 réel
+
+Non exécuté : aucun staging/auth disponible et le code Lot 4 n'est pas déployé. Ne pas polluer les quotas production sans fenêtre dédiée.
+
+## Résultat
+
+Redis/Upstash NON PROUVÉ.
+
+## Décision
+
+BÊTA ÉLARGIE INTERDITE. GO-LIVE LARGE INTERDIT.

--- a/docs/go-live/_evidence/lot4-token-runtime-payment-command-log.md
+++ b/docs/go-live/_evidence/lot4-token-runtime-payment-command-log.md
@@ -1,0 +1,86 @@
+# Lot 4 — Journal token binding / runtime / rétention / paiement
+
+Date locale initiale : 2026-07-03 13:05 CET.
+
+## Baseline
+
+- Répertoire : `/home/alaeddine/Bureau/nexus-project_v0`
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Node : `v20.20.0`
+- npm : `10.8.2`
+- État Git initial : worktree déjà très chargé par les lots précédents ; fichiers modifiés et non suivis hérités des Lots 0 à 3.
+- Aucun fichier `.env` ne doit être lu, affiché ou modifié.
+- Aucune migration destructive, aucun `prisma migrate dev`, aucun `prisma migrate reset`, aucun `prisma db push`.
+- Aucun déploiement.
+
+## P1 initiaux confirmés
+
+Extrait de `docs/go-live/api-security-matrix.full.md` :
+
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+Compteurs initiaux : `P0=0`, `P1=6`, `P2=144`, `OK=27`, total `177`.
+
+## Commandes baseline exécutées
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node -v` | OK | `v20.20.0` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm -v` | OK | `10.8.2` |
+| `git rev-parse --abbrev-ref HEAD` | OK | `feat/lot4-accessors-runtime` |
+| `git rev-parse --short HEAD` | OK | `db8545a19` |
+| `git status --short --untracked-files=all` | OK | Worktree dirty hérité ; aucun `.env` ne doit être touché |
+| `rg -n "^\\| P1 \\|" docs/go-live/api-security-matrix.full.md` | OK | 6 P1 confirmés |
+
+## Commandes ciblées
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `npm run test:unit -- --runInBand __tests__/api/assessments.public-token.binding.test.ts __tests__/api/assessments.submit.token-binding.test.ts __tests__/app/bilan-gratuit.assessment-page-token.test.tsx __tests__/scripts/contact-leads-retention.test.ts __tests__/lib/business-config.production-gate.test.ts __tests__/api/payments.clictopay.feature-flag-consistency.test.ts` | ÉCHEC attendu TDD | Premier passage rouge : helpers de binding absents, page assessment génère encore depuis query params, script purge absent, BusinessConfig fallback non discriminé, flag ClicToPay public retourne encore `501` |
+| `npm run test:unit -- --runInBand __tests__/api/assessments.public-token.binding.test.ts __tests__/api/assessments.submit.token-binding.test.ts __tests__/app/bilan-gratuit.assessment-page-token.test.tsx __tests__/api/bilan-gratuit.product-rgpd.test.ts __tests__/scripts/contact-leads-retention.test.ts __tests__/lib/business-config.production-gate.test.ts __tests__/api/payments.clictopay.feature-flag-consistency.test.ts` | OK | `7` suites passées, `21` tests passés |
+| `npm run test:unit -- --runInBand __tests__/api/assessments.public-token.binding.test.ts __tests__/api/assessments.submit.token-binding.test.ts __tests__/app/bilan-gratuit.assessment-page-token.test.tsx __tests__/api/bilan-gratuit.product-rgpd.test.ts __tests__/scripts/contact-leads-retention.test.ts __tests__/lib/business-config.production-gate.test.ts __tests__/api/payments.clictopay.feature-flag-consistency.test.ts __tests__/api/security/no-sensitive-fields-in-api-responses.test.ts __tests__/api/internal.business-config.health.test.ts __tests__/lib/business-config.fallback.test.ts __tests__/api/payments.clictopay.disabled-contract.test.ts` | OK | `11` suites passées, `53` tests passés |
+| `npm run typecheck` | ÉCHEC puis OK | Premier passage : typage enum `Grade`, union discriminée BusinessConfig, type de raison token ; second passage OK |
+| `npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium` | ÉCHEC ciblé avant rebuild | Playwright servait `.next/standalone` issu du build précédent ; snapshot montrait encore l'ancien flux. À relancer après `npm run build` |
+| `npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium` | ÉCHEC ciblé après rebuild | La page refusait bien l'accès, mais l'email fourni en query apparaissait dans le HTML RSC via sérialisation de l'URL Next.js. Correction : redirection canonique vers `/bilan-gratuit/assessment` dès présence de query params |
+| `npx tsx -e "...getRateLimitProductionGate..."` | OK | Local : `mode=memory`, `gate.ok=false`, `decision=blocked` |
+| `if [ -n "${NEXUS_HEALTH_AUTH:-}" ]; then echo 'NEXUS_HEALTH_AUTH_PRESENT'; else echo 'NEXUS_HEALTH_AUTH_ABSENT'; fi` | OK | `NEXUS_HEALTH_AUTH_ABSENT` |
+| `curl -sS -o /tmp/nexus-internal-health-lot4.txt -w "%{http_code}\n" https://nexusreussite.academy/api/internal/health` | PARTIEL | Production sans secret : `401`, Redis/Upstash non prouvé |
+
+## Commandes finales
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run typecheck` | OK | `tsc --noEmit` vert |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run lint` | OK | Warnings existants, pas d'échec |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand` | OK | `536` suites passées, `1` skipped ; `6504` tests passés, `4` skipped |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run build` | OK | Build Next standalone vert, `build-output.log` mis à jour |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/security/audit-api-guards.mjs` | OK | `docs/security/API_GUARD_INVENTORY.md` régénéré, `177` routes |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=6`, `P2=144`, `OK=27`, total `177` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run audit:site-map` | OK | `291` routes, `413` edges, `0` link findings, `13` public orphan entries |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:no-hardcoded` | OK | `0` hardcoded values outside canonical sources |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:docs-archive` | OK | No historical audit/report files at docs root |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:bundle-weight` | OK | Toutes les routes dans baseline + `5 kB`; `/bilan-gratuit/assessment` reconnue dynamique `ƒ`, `420 kB` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | OK | `24` tests passés |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium` | OK | `1` test passé |
+
+## Vérifications finales de sûreté
+
+- Aucun fichier `.env` modifié.
+- Aucune migration destructive lancée.
+- Aucun `prisma migrate dev`, `prisma migrate reset` ou `prisma db push`.
+- Aucun secret lu ou affiché.
+- Aucun déploiement.
+
+## Limites initiales
+
+- Redis/Upstash staging/production non prouvé au démarrage.
+- `/api/internal/health` production nécessite une authentification ; aucun token/cookie ne sera affiché.
+- ClicToPay doit rester désactivé.
+- Le token assessment Lot 3 est court et signé, mais la page `/bilan-gratuit/assessment` doit être contre-auditée car elle ne doit pas générer un token valide depuis de simples query params publics.
+- La politique ContactLead existe, mais le mécanisme opérationnel de purge/anonymisation n'existe pas encore.

--- a/docs/go-live/_evidence/lot5-business-config-runtime-decision.md
+++ b/docs/go-live/_evidence/lot5-business-config-runtime-decision.md
@@ -1,0 +1,41 @@
+# Lot 5 — BusinessConfig runtime decision
+
+## Objectif
+
+Éviter qu'un fallback statique masque une production non migrée.
+
+## Tests exécutés
+
+Commande :
+
+```bash
+npm run test:unit -- --runInBand \
+__tests__/lib/business-config.production-gate.test.ts \
+__tests__/api/internal.business-config.health.test.ts \
+__tests__/lib/business-config.fallback.test.ts
+```
+
+Résultat : OK, `3` suites, `6` tests.
+
+## Décision
+
+- local/test : `static_fallback_allowed` acceptable ;
+- production : `static_fallback_unexpected`, `ok=false`, sauf opt-in explicite `BUSINESS_CONFIG_STATIC_FALLBACK_ALLOWED=true` ;
+- aucune migration automatique ;
+- si la table est requise en production, migration non destructive à valider humainement.
+
+## Healthcheck production
+
+Non vérifié authentifié : `NEXUS_HEALTH_AUTH_ABSENT`.
+
+Procédure attendue :
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer ${NEXUS_HEALTH_AUTH}" \
+  https://nexusreussite.academy/api/internal/health \
+  | jq '{businessConfig: .runtime.businessConfig, check: .checks.businessConfig}'
+```
+
+Ne jamais afficher la valeur du token.
+

--- a/docs/go-live/_evidence/lot5-clictopay-final-disabled-decision.md
+++ b/docs/go-live/_evidence/lot5-clictopay-final-disabled-decision.md
@@ -1,0 +1,36 @@
+# Lot 5 — ClicToPay final disabled decision
+
+## Décision
+
+- `CLICTOPAY_STATUS = DISABLED`
+- `CARD_PAYMENT_PUBLIC = NO`
+- `MANUAL_PAYMENT_ONLY = YES`
+- `GO_LIVE_CARD_PAYMENT = NO`
+
+## Preuves
+
+Tests exécutés :
+
+```bash
+npm run test:unit -- --runInBand \
+__tests__/api/payments.clictopay.disabled-contract.test.ts \
+__tests__/api/payments.clictopay.feature-flag-consistency.test.ts \
+__tests__/ui/payment-methods.clictopay-disabled.test.tsx
+```
+
+Résultat : OK, `3` suites, `5` tests.
+
+## Contrat confirmé
+
+- UI publique : carte bancaire non annoncée comme active.
+- `/api/payments/clictopay/init` par défaut : `501 CLICTOPAY_NOT_CONFIGURED`.
+- Flag public actif + backend disabled : `503 CLICTOPAY_PUBLIC_FLAG_INCONSISTENT`.
+- Webhook : signature requise/invalide refusée ; signature valide reste `501`.
+- Aucune mutation `payment`, `invoice`, `entitlement`, `creditTransaction`.
+
+## Décision go-live
+
+Paiement manuel uniquement.
+
+Paiement carte interdit tant que signature, idempotence, montant, devise, productCode, réconciliation facture, activation entitlement, replay protection, audit log et E2E paiement ne sont pas livrés.
+

--- a/docs/go-live/_evidence/lot5-contact-lead-retention-dry-run.md
+++ b/docs/go-live/_evidence/lot5-contact-lead-retention-dry-run.md
@@ -1,0 +1,41 @@
+# Lot 5 — ContactLead retention dry-run
+
+## Objectif
+
+Prouver que la purge/anonymisation ContactLead est exécutable en dry-run et ne sort pas de PII.
+
+## Dry-run local DB
+
+Commande :
+
+`npx tsx scripts/maintenance/contact-leads-retention.ts`
+
+Résultat : ÉCHEC non destructif.
+
+Cause : DB locale configurée indisponible, impossible de joindre `postgres:5432`.
+
+Impact : aucun `--apply`, aucune écriture, aucune PII affichée.
+
+## Preuve par test fixture
+
+Commande :
+
+`npm run test:unit -- --runInBand __tests__/scripts/contact-leads-retention.test.ts`
+
+Résultat : OK, `1` suite, `3` tests.
+
+Couverture :
+
+- dry-run par défaut ;
+- pas d'email/téléphone en clair dans le résultat ;
+- effacement parental par hash email ;
+- `--apply` explicite requis avant anonymisation.
+
+## Décision
+
+Mécanisme opérationnel présent et testé.
+
+Dry-run réel contre DB locale/staging : À EXÉCUTER quand une DB non production est disponible.
+
+`--apply` production : INTERDIT sans validation humaine explicite.
+

--- a/docs/go-live/_evidence/lot5-p1-go-no-go-register.md
+++ b/docs/go-live/_evidence/lot5-p1-go-no-go-register.md
@@ -1,0 +1,19 @@
+# Lot 5 — Registre go/no-go des 6 P1
+
+| Route | Décision | Bêta contrôlée | Bêta élargie | Go-live large | Condition de levée |
+|---|---|---:|---:|---:|---|
+| `/api/payments/clictopay/webhook` | Reste `501`; ClicToPay désactivé contractuellement | Oui, si paiement manuel uniquement | Non | Non | Intégration complète webhook signée, idempotente, réconciliée et testée E2E |
+| `/api/assessments/submit` | Token lead-bound en place ; reste P1 par données pédagogiques mineur et runtime Redis non prouvé | Oui, volume contrôlé | Non | Non | Redis/Upstash prouvé + test 429 réel + décision humaine sur surface publique |
+| `/api/bilan-gratuit` | `lead_only`, no-leak, cookie flow ; reste formulaire public mineur | Oui, volume contrôlé | Non | Non | Redis/Upstash prouvé + dry-run ContactLead réel + monitoring leads |
+| `/api/lamis/teacher-report` | Public pédagogique minimisé ; reste P1 par nature publique | Oui, volume contrôlé | Non | Non | Redis/Upstash prouvé + arbitrage token/session si usage nominatif |
+| `/api/stages/[stageSlug]/inscrire` | Inscription publique assumée ; consentement et anti-abus | Oui, volume contrôlé | Non | Non | Redis/Upstash prouvé + test 429 réel + supervision admissions |
+| `/api/student/activate` | Public par token ; lifecycle durci, reste sensible | Oui, avec monitoring | Non | Non | Redis/Upstash prouvé + alerting activation/token abuse |
+
+## Décision transversale
+
+Tant que Redis/Upstash n'est pas prouvé et qu'un `429` réel n'est pas validé sur staging/production, aucune route publique sensible ne peut être validée pour bêta élargie.
+
+Tant que ClicToPay reste `501`, le paiement carte est interdit.
+
+Tant que `ContactLead --apply` n'est pas validé humainement et qu'un dry-run DB réel n'est pas exécuté, le go-live large reste interdit.
+

--- a/docs/go-live/_evidence/lot5-public-e2e-critical-paths.md
+++ b/docs/go-live/_evidence/lot5-public-e2e-critical-paths.md
@@ -1,0 +1,46 @@
+# Lot 5 — Public E2E critical paths
+
+## Objectif
+
+Vérifier les parcours publics critiques après build frais.
+
+## Tests à exécuter en gates finales
+
+```bash
+npm run build
+npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium
+npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium
+```
+
+## Critères
+
+- `/`, `/offres`, `/bilan-gratuit` : pas de 500, CTA critiques et contenu attendu visibles.
+- `/bilan-gratuit/assessment?...email=...` : redirection vers URL canonique.
+- Email query absent du HTML.
+- Token assessment absent de l'URL.
+- Token assessment absent du HTML.
+- Message de refus sobre sans cookie.
+
+## Résultat
+
+Build frais : OK.
+
+Premier lancement Playwright sur port par défaut : ÉCHEC environnement, port `3002` déjà occupé par un autre projet local (`Qantara_IA` en `next dev`). Aucun test Nexus exécuté sur cette tentative.
+
+Relance sur port isolé :
+
+```bash
+PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium
+```
+
+Résultat : OK, `24` tests passés.
+
+```bash
+PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium
+```
+
+Résultat : OK, `1` test passé.
+
+## Décision
+
+Parcours publics critiques validés localement après build frais, sur port isolé `3012`.

--- a/docs/go-live/_evidence/lot5-rate-limit-429-proof.md
+++ b/docs/go-live/_evidence/lot5-rate-limit-429-proof.md
@@ -1,0 +1,61 @@
+# Lot 5 — Rate limit 429 proof
+
+## Objectif
+
+Vérifier qu'un dépassement réel de limite retourne `429` sans frapper une route métier.
+
+## Route de probe ajoutée
+
+Route : `/api/internal/rate-limit-probe`
+
+Contrat :
+
+- accès protégé par `enforcePolicy('admin.dashboard')` ;
+- preset rate limit `auth` ;
+- réponse minimale sans secret ;
+- route non destructive ;
+- utilisable pour une fenêtre de test staging/production.
+
+## Test local exécuté
+
+Commande :
+
+`npm run test:unit -- --runInBand __tests__/api/internal.rate-limit-probe.test.ts`
+
+Résultat : OK.
+
+Preuves :
+
+- non authentifié/policy refusée -> `401` ;
+- sous limite -> `200` avec metadata runtime sûre ;
+- dépassement même clé -> `429` avec `Retry-After`.
+
+## Test 429 staging/production
+
+Exécuté : NON.
+
+Raison : aucun staging authentifié ni fenêtre dédiée disponible ; ne pas saturer une route production.
+
+## Procédure manuelle staging
+
+À exécuter sur staging ou fenêtre production dédiée, avec credential non affiché :
+
+```bash
+for i in 1 2 3 4 5 6; do
+  curl -sS -o /tmp/nexus-rl-probe-${i}.json \
+    -w "%{http_code} retry_after=%{header_json}\n" \
+    -H "Authorization: Bearer ${NEXUS_HEALTH_AUTH}" \
+    https://nexusreussite.academy/api/internal/rate-limit-probe
+done
+```
+
+Adapter l'authentification si l'environnement utilise un cookie admin plutôt qu'un bearer token. Ne jamais afficher le token/cookie.
+
+## Décision
+
+Preuve locale : OK.
+
+Preuve staging/production : NON PROUVÉE.
+
+Bêta élargie et go-live large restent interdits tant qu'un `429` réel n'est pas validé sur staging/production avec Redis/Upstash.
+

--- a/docs/go-live/_evidence/lot5-redis-upstash-authenticated-healthcheck.md
+++ b/docs/go-live/_evidence/lot5-redis-upstash-authenticated-healthcheck.md
@@ -1,0 +1,57 @@
+# Lot 5 — Redis/Upstash authenticated healthcheck
+
+## Objectif
+
+Prouver le mode runtime Redis/Upstash sur staging/production, ou maintenir un blocage formel.
+
+## Vérification locale sans secret
+
+Commande :
+
+`if [ -n "${NEXUS_HEALTH_AUTH:-}" ]; then echo "NEXUS_HEALTH_AUTH_PRESENT"; else echo "NEXUS_HEALTH_AUTH_ABSENT"; fi`
+
+Résultat : `NEXUS_HEALTH_AUTH_ABSENT`.
+
+## Production sans secret
+
+Commande non authentifiée :
+
+`curl -sS -o /tmp/nexus-internal-health-lot5.txt -w "%{http_code}\n" https://nexusreussite.academy/api/internal/health`
+
+Résultat : `401`.
+
+## État local
+
+Commande Node locale :
+
+`npx tsx -e "...getRateLimitProductionGate..."`
+
+Résultat : `mode=memory`, `decision=blocked`.
+
+## Critères non prouvés
+
+- `runtime.rateLimit.mode = redis` ou `upstash` : NON PROUVÉ.
+- `runtime.rateLimit.distributed = true` : NON PROUVÉ.
+- `runtime.rateLimit.goLiveLarge = allowed` : NON PROUVÉ.
+- `checks.redis.ok = true` : NON PROUVÉ.
+
+## Procédure manuelle sûre
+
+À exécuter uniquement avec un token/cookie admin/monitoring non affiché :
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer ${NEXUS_HEALTH_AUTH}" \
+  https://nexusreussite.academy/api/internal/health \
+  | jq '{runtime: .runtime.rateLimit, businessConfig: .runtime.businessConfig, checks: {redis: .checks.redis, businessConfig: .checks.businessConfig}}'
+```
+
+Ne jamais copier la valeur de `NEXUS_HEALTH_AUTH`.
+
+## Décision
+
+Redis/Upstash runtime NON PROUVÉ.
+
+- BÊTA ÉLARGIE : INTERDITE.
+- GO-LIVE LARGE : INTERDIT.
+

--- a/docs/go-live/_evidence/lot5-runtime-exploitation-command-log.md
+++ b/docs/go-live/_evidence/lot5-runtime-exploitation-command-log.md
@@ -1,0 +1,89 @@
+# Lot 5 — Journal runtime exploitation / go-no-go
+
+Date locale initiale : 2026-07-03 13:54:53 CET.
+
+## Baseline
+
+- Répertoire : `/home/alaeddine/Bureau/nexus-project_v0`
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Node : `v20.20.0`
+- npm : `10.8.2`
+- État Git initial : worktree déjà très chargé par les lots précédents ; modifications héritées des Lots 0 à 4.
+- Fichiers `.env` modifiés : aucun détecté par `git diff --name-only | rg '(^|/)\\.env($|\\.)' || true`.
+- Aucune migration destructive, aucun `prisma migrate dev`, aucun `prisma migrate reset`, aucun `prisma db push`.
+- Aucun déploiement.
+- Aucun secret lu ou affiché.
+
+## P1 initiaux confirmés
+
+Compteurs initiaux Lot 5 : `P0=0`, `P1=6`, `P2=144`, `OK=27`, total `177`.
+
+Routes P1 :
+
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+## Commandes baseline exécutées
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node -v` | OK | `v20.20.0` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm -v` | OK | `10.8.2` |
+| `git rev-parse --abbrev-ref HEAD` | OK | `feat/lot4-accessors-runtime` |
+| `git rev-parse --short HEAD` | OK | `db8545a19` |
+| `git status --short --untracked-files=all` | OK | Worktree dirty hérité |
+| `git diff --name-only | rg '(^|/)\\.env($|\\.)' || true` | OK | Aucun fichier `.env` modifié |
+| `rg -n "^\\| P1 \\|" docs/go-live/api-security-matrix.full.md` | OK | 6 P1 confirmés |
+
+## Commandes ciblées
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `npm run test:unit -- --runInBand __tests__/api/internal.rate-limit-probe.test.ts` | ÉCHEC attendu TDD puis OK | Rouge initial : route absente ; après implémentation : `1` suite, `3` tests OK, dont 429 local |
+| `if [ -n "${NEXUS_HEALTH_AUTH:-}" ]; then echo "NEXUS_HEALTH_AUTH_PRESENT"; else echo "NEXUS_HEALTH_AUTH_ABSENT"; fi` | OK | `NEXUS_HEALTH_AUTH_ABSENT` |
+| `curl -sS -o /tmp/nexus-internal-health-lot5.txt -w "%{http_code}\\n" https://nexusreussite.academy/api/internal/health` | PARTIEL | Production sans secret : `401` |
+| `npx tsx -e "...getRateLimitProductionGate..."` | OK | Local : `mode=memory`, `decision=blocked` |
+| `npx tsx scripts/maintenance/contact-leads-retention.ts` | ÉCHEC | DB locale configurée indisponible : impossible de joindre `postgres:5432`; aucun `--apply`, aucune mutation |
+| `npm run test:unit -- --runInBand __tests__/scripts/contact-leads-retention.test.ts` | OK | `1` suite, `3` tests OK ; dry-run/PII/apply couverts par fixtures |
+| `npm run test:unit -- --runInBand __tests__/api/payments.clictopay.disabled-contract.test.ts __tests__/api/payments.clictopay.feature-flag-consistency.test.ts __tests__/ui/payment-methods.clictopay-disabled.test.tsx` | OK | `3` suites, `5` tests OK |
+| `npm run test:unit -- --runInBand __tests__/lib/business-config.production-gate.test.ts __tests__/api/internal.business-config.health.test.ts __tests__/lib/business-config.fallback.test.ts` | OK | `3` suites, `6` tests OK |
+| `node scripts/security/audit-api-guards.mjs && node scripts/go-live/generate-api-security-matrix.mjs` | OK | Après ajout probe : `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178` |
+
+## Commandes finales
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run typecheck` | OK | `tsc --noEmit` vert |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run lint` | OK | Warnings existants, pas d'échec |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand` | OK | `537` suites passées, `1` skipped ; `6507` tests passés, `4` skipped |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run build` | OK | Build Next standalone vert, `build-output.log` mis à jour |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/security/audit-api-guards.mjs` | OK | `docs/security/API_GUARD_INVENTORY.md` régénéré, `178` routes |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=6`, `P2=144`, `OK=28`, total `178` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run audit:site-map` | OK | `292` routes, `413` edges, `0` link findings, `13` public orphan entries |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:no-hardcoded` | OK | `0` hardcoded values outside canonical sources |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:docs-archive` | OK | No historical audit/report files at docs root |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:bundle-weight` | OK | Toutes les routes dans baseline + `5 kB` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | ÉCHEC environnement | Le port `3002` était déjà utilisé par un autre projet local (`Qantara_IA` en `next dev`) ; aucun test Nexus exécuté |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | OK | `24` tests passés sur port isolé `3012` |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium` | OK | `1` test passé sur port isolé `3012` |
+
+## Vérifications finales de sûreté
+
+- Aucun fichier `.env` modifié.
+- Aucune migration destructive lancée.
+- Aucun `prisma migrate dev`, `prisma migrate reset` ou `prisma db push`.
+- Aucun secret lu ou affiché.
+- Aucun déploiement.
+
+## Limites
+
+- Redis/Upstash staging/production non prouvé : pas de credential healthcheck disponible localement.
+- Test 429 réel staging/production non exécuté : pas d'environnement staging authentifié ni fenêtre dédiée.
+- Dry-run ContactLead réel local non exécuté : DB locale configurée indisponible.
+- ClicToPay reste volontairement désactivé.
+- Les 6 P1 restent visibles ; aucune requalification P1 vers P2/OK.

--- a/docs/go-live/_evidence/lot6-contact-lead-retention-db-dry-run.md
+++ b/docs/go-live/_evidence/lot6-contact-lead-retention-db-dry-run.md
@@ -1,0 +1,44 @@
+# Lot 6 — ContactLead retention DB dry-run
+
+## Objectif
+
+Valider le script de purge/anonymisation ContactLead en dry-run contre une DB non production, sans PII et sans mutation.
+
+## Préconditions vérifiées
+
+```bash
+if [ -n "${DATABASE_URL:-}" ]; then echo "DATABASE_URL_PRESENT"; else echo "DATABASE_URL_ABSENT"; fi
+if [ "${NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB:-}" = "true" ]; then echo "CONTACT_LEAD_DRY_RUN_ALLOWED"; else echo "CONTACT_LEAD_DRY_RUN_NOT_ALLOWED"; fi
+```
+
+Résultats :
+
+- `DATABASE_URL_ABSENT`
+- `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED`
+
+## Dry-run DB
+
+NON EXÉCUTÉ.
+
+Cause : aucune DB non production disponible dans l'environnement local et aucune autorisation explicite.
+
+Commande attendue quand la DB non production est confirmée :
+
+```bash
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npx tsx scripts/maintenance/contact-leads-retention.ts
+```
+
+## Preuve par fixture existante
+
+Lot 5 a validé `__tests__/scripts/contact-leads-retention.test.ts` :
+
+- dry-run par défaut ;
+- pas d'email/téléphone en clair ;
+- demande d'effacement parentale par hash ;
+- `--apply` explicite requis.
+
+## Décision
+
+- `CONTACT_LEAD_DB_DRY_RUN = NOT_PROVEN`
+- `--apply` production interdit sans validation humaine explicite.
+- Go-live large interdit tant qu'un dry-run DB non production n'est pas exécuté.

--- a/docs/go-live/_evidence/lot6-final-go-no-go-register.md
+++ b/docs/go-live/_evidence/lot6-final-go-no-go-register.md
@@ -1,0 +1,26 @@
+# Lot 6 — Final go/no-go register
+
+| Domaine | Statut | Preuve | Décision |
+| --- | --- | --- | --- |
+| Redis/Upstash | NON PROUVÉ | `NEXUS_HEALTH_AUTH_ABSENT`; healthcheck sans auth `401` | `BETA_ELARGIE_BLOCKED`, `GO_LIVE_LARGE_BLOCKED` |
+| 429 runtime | NON PROUVÉ | `AUTH_ABSENT`, `RL_PROBE_NOT_ALLOWED`; test local unitaire seulement | `BETA_ELARGIE_BLOCKED`, `GO_LIVE_LARGE_BLOCKED` |
+| ContactLead dry-run DB | NON PROUVÉ | `DATABASE_URL_ABSENT`, `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED`; fixture OK seulement | `GO_LIVE_LARGE_BLOCKED` |
+| ClicToPay | DISABLED | Contrat Lot 5 : init/webhook désactivés, carte non disponible | Paiement manuel uniquement |
+| BusinessConfig | OK local / NON PROUVÉ runtime | Tests locaux et build OK ; healthcheck authentifié indisponible | Production à vérifier avant élargissement |
+| Public E2E | OK local | `24 passed` public + `1 passed` assessment sur port `3012` | Condition bêta contrôlée satisfaite localement |
+| P1 register | OK | 6 P1 maintenus dans matrice | Aucun maquillage P1 |
+| Worktree RC | OK avec réserve | Audit Lot 6 créé ; rapport racine non suivi à exclure | Revue humaine avant commit |
+
+## Décision finale Lot 6
+
+- `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`
+- `BETA_ELARGIE_BLOCKED`
+- `GO_LIVE_LARGE_BLOCKED`
+
+## Conditions de levée
+
+1. Fournir `NEXUS_HEALTH_AUTH` sans l'afficher.
+2. Exécuter le healthcheck authentifié et obtenir `mode=redis|upstash`, `distributed=true`, `goLiveLarge=allowed`, `checks.redis.ok=true`.
+3. Autoriser une fenêtre de test 429 staging/production avec `NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE=true`.
+4. Fournir une DB non production et autoriser `NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB=true`.
+5. Rejouer les gates finales Node 20 et Playwright critiques.

--- a/docs/go-live/_evidence/lot6-rate-limit-429-runtime-proof.md
+++ b/docs/go-live/_evidence/lot6-rate-limit-429-runtime-proof.md
@@ -1,0 +1,46 @@
+# Lot 6 — Rate limit 429 runtime proof
+
+## Objectif
+
+Obtenir une preuve 429 réelle sur staging/production via `/api/internal/rate-limit-probe`, sans test bruyant ni destructif.
+
+## Préconditions vérifiées
+
+```bash
+if [ -n "${NEXUS_HEALTH_AUTH:-}" ]; then echo "AUTH_PRESENT"; else echo "AUTH_ABSENT"; fi
+if [ "${NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE:-}" = "true" ]; then echo "RL_PROBE_ALLOWED"; else echo "RL_PROBE_NOT_ALLOWED"; fi
+```
+
+Résultats :
+
+- `AUTH_ABSENT`
+- `RL_PROBE_NOT_ALLOWED`
+
+## Test runtime
+
+NON EXÉCUTÉ.
+
+Cause : pas de credential healthcheck et pas d'autorisation explicite `NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE=true`.
+
+Commande autorisée uniquement avec credential et fenêtre confirmée :
+
+```bash
+for i in 1 2 3 4 5 6; do
+  curl -sS \
+    -o "/tmp/nexus-rl-probe-${i}.json" \
+    -w "attempt=${i} status=%{http_code}\n" \
+    -H "Authorization: Bearer ${NEXUS_HEALTH_AUTH}" \
+    https://nexusreussite.academy/api/internal/rate-limit-probe
+done
+```
+
+## Preuve locale disponible
+
+- Route `app/api/internal/rate-limit-probe/route.ts` protégée par policy admin.
+- Test unitaire `__tests__/api/internal.rate-limit-probe.test.ts` couvre `401`, `200` sous limite et `429` après dépassement local.
+
+## Décision
+
+- `RUNTIME_429_PROOF = NOT_EXECUTED`
+- Bêta élargie interdite.
+- Go-live large interdit.

--- a/docs/go-live/_evidence/lot6-redis-upstash-authenticated-proof.md
+++ b/docs/go-live/_evidence/lot6-redis-upstash-authenticated-proof.md
@@ -1,0 +1,66 @@
+# Lot 6 — Redis/Upstash authenticated proof
+
+## Objectif
+
+Prouver que le runtime réel utilise Redis ou Upstash pour le rate limiting distribué.
+
+## Commande de présence credential
+
+```bash
+if [ -n "${NEXUS_HEALTH_AUTH:-}" ]; then echo "NEXUS_HEALTH_AUTH_PRESENT"; else echo "NEXUS_HEALTH_AUTH_ABSENT"; fi
+```
+
+Résultat : `NEXUS_HEALTH_AUTH_ABSENT`.
+
+## Healthcheck authentifié
+
+NON EXÉCUTÉ.
+
+Cause : aucun credential `NEXUS_HEALTH_AUTH` disponible dans l'environnement local. La valeur d'un éventuel token ne doit jamais être affichée ni écrite dans un fichier.
+
+Commande attendue quand le credential est disponible :
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer ${NEXUS_HEALTH_AUTH}" \
+  https://nexusreussite.academy/api/internal/health \
+  | jq '{
+      rateLimit: .runtime.rateLimit,
+      businessConfig: .runtime.businessConfig,
+      redisCheck: .checks.redis,
+      businessConfigCheck: .checks.businessConfig
+    }'
+```
+
+## Contrôle sans auth
+
+Commande :
+
+```bash
+curl -sS -o /tmp/nexus-health-unauth-lot6.json -w "%{http_code}\n" https://nexusreussite.academy/api/internal/health
+```
+
+Résultat : `401`.
+
+Interprétation : l'endpoint est protégé, mais cela ne prouve pas Redis/Upstash.
+
+## Critères attendus
+
+```json
+{
+  "rateLimit": {
+    "mode": "redis ou upstash",
+    "distributed": true,
+    "goLiveLarge": "allowed"
+  },
+  "redisCheck": {
+    "ok": true
+  }
+}
+```
+
+## Décision
+
+- `REDIS_UPSTASH_PROOF = NOT_PROVEN`
+- `BETA_ELARGIE = NO`
+- `GO_LIVE_LARGE = NO`

--- a/docs/go-live/_evidence/lot6-release-candidate-worktree-audit.md
+++ b/docs/go-live/_evidence/lot6-release-candidate-worktree-audit.md
@@ -1,0 +1,40 @@
+# Lot 6 — Release candidate worktree audit
+
+## Synthèse
+
+- `git status --porcelain --untracked-files=all` : `261` entrées.
+- `git diff --name-only` : `130` fichiers suivis modifiés.
+- `git ls-files --others --exclude-standard` : `131` fichiers non suivis.
+- `git diff --stat` : `130 files changed, 3269 insertions(+), 1258 deletions(-)`.
+- Diff `.env` : aucun.
+- Artefacts à exclure détectés : `rapport_audit_2_07_2026.md` non suivi.
+- Après création des artefacts Lot 6 : `268` entrées `git status --short --untracked-files=all`.
+
+## Classification release candidate
+
+| Fichier / groupe | Type | Inclure release candidate | Raison |
+| --- | --- | ---: | --- |
+| `app/api/**` modifiés Lots 1-5 | Code API sécurité | Oui | Corrections ownership, projections, rate limit, P1/P2 |
+| `app/api/internal/rate-limit-probe/route.ts` | Code runtime | Oui | Sonde 429 protégée nécessaire aux preuves staging |
+| `app/api/internal/health/route.ts` | Code runtime | Oui | Expose rateLimit/businessConfig sans secret |
+| `lib/rate-limit/index.ts` | Code runtime | Oui | Gate memory vs redis/upstash |
+| `lib/config/snapshot.ts` | Code runtime | Oui | BusinessConfig production gate |
+| `lib/assessments/public-token.ts` | Code sécurité | Oui | Token assessment signé et binding lead |
+| `app/bilan-gratuit/assessment/**` | Front public critique | Oui | Empêche token libre par query params |
+| `scripts/maintenance/contact-leads-retention.ts` | Script maintenance | Oui | Purge/anonymisation dry-run ContactLead |
+| `scripts/go-live/generate-api-security-matrix.mjs` | Script pilotage | Oui | Génère matrice API exploitable |
+| `scripts/security/audit-api-guards.mjs` | Script audit | Oui avec revue | Modifié par lots précédents ; tests classification associés |
+| `__tests__/**` ajoutés/modifiés | Tests | Oui | Gates de sécurité, no-leak, runtime, paiement |
+| `e2e/pages-public-bilan-assessment-token.spec.ts` | Test Playwright | Oui | Preuve E2E assessment sans token URL/HTML |
+| `docs/go-live/**` | Documentation release | Oui | Preuves et décisions go/no-go |
+| `docs/go-live/20_LOT6_STAGING_RELEASE_CANDIDATE_GO_NO_GO.md` et `_evidence/lot6-*` | Documentation release Lot 6 | Oui | Preuves runtime absentes, worktree audit, go/no-go final |
+| `docs/security/API_GUARD_INVENTORY.md` | Inventaire généré | Oui | Source de vérité statique actuelle |
+| `docs/audits/audit-nexus-reussite.md` | Documentation audit | À vérifier | Non demandé dans Lot 6 ; inclure seulement si relié aux preuves précédentes |
+| `rapport_audit_2_07_2026.md` | Rapport racine non suivi | Non | Ne doit pas être modifié/inclus sans décision explicite |
+| `.env*` | Secrets/env | Non | Jamais inclure |
+| `test-results/`, `playwright-report/`, `.next/`, `node_modules/` | Artefacts générés | Non | Jamais inclure |
+| `build-output.log` | Artefact build | À vérifier | Inclure seulement si nécessaire au `check:bundle-weight`, sinon exclure |
+
+## Décision
+
+Préparer une release candidate sans commit automatique. La sélection doit être revue humainement avant commit, en excluant explicitement le rapport racine non suivi et tout artefact généré non nécessaire.

--- a/docs/go-live/_evidence/lot6-staging-release-candidate-command-log.md
+++ b/docs/go-live/_evidence/lot6-staging-release-candidate-command-log.md
@@ -1,0 +1,94 @@
+# Lot 6 — Command log staging/release candidate
+
+## Baseline
+
+- Date locale : 2026-07-03 14:14:02 CET
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Node : `v20.20.0`
+- npm : `10.8.2`
+- État initial : worktree chargé, `261` entrées `git status --porcelain`, `130` fichiers suivis modifiés, `131` fichiers non suivis.
+- Diff `.env` : aucun.
+- Rapport racine `rapport_audit_2_07_2026.md` : non suivi, à exclure de la release candidate sauf décision humaine explicite.
+
+## P1 initiaux
+
+| Route | Statut Lot 6 |
+| --- | --- |
+| `/api/payments/clictopay/webhook` | P1 maintenu |
+| `/api/assessments/submit` | P1 maintenu |
+| `/api/bilan-gratuit` | P1 maintenu |
+| `/api/lamis/teacher-report` | P1 maintenu |
+| `/api/stages/[stageSlug]/inscrire` | P1 maintenu |
+| `/api/student/activate` | P1 maintenu |
+
+## Commandes baseline exécutées
+
+| Commande | Résultat | Statut |
+| --- | --- | --- |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node -v` | `v20.20.0` | OK |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm -v` | `10.8.2` | OK |
+| `git rev-parse --abbrev-ref HEAD` | `feat/lot4-accessors-runtime` | OK |
+| `git rev-parse --short HEAD` | `db8545a19` | OK |
+| `git status --short --untracked-files=all` | worktree chargé, détails dans audit worktree | OK |
+| `git diff --name-only \| rg '(^\|/)\\.env($\|\\.)' \|\| true` | aucune sortie | OK |
+| `rg -n "^\\| P1 \\|" docs/go-live/api-security-matrix.full.md` | 6 P1 confirmés | OK |
+
+## Commandes avec secrets absents
+
+| Commande | Résultat | Décision |
+| --- | --- | --- |
+| `if [ -n "${NEXUS_HEALTH_AUTH:-}" ]; then echo "NEXUS_HEALTH_AUTH_PRESENT"; else echo "NEXUS_HEALTH_AUTH_ABSENT"; fi` | `NEXUS_HEALTH_AUTH_ABSENT` | Healthcheck authentifié non exécuté |
+| `if [ -n "${NEXUS_HEALTH_AUTH:-}" ]; then echo "AUTH_PRESENT"; else echo "AUTH_ABSENT"; fi` | `AUTH_ABSENT` | Probe 429 runtime non exécutée |
+| `if [ "${NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE:-}" = "true" ]; then echo "RL_PROBE_ALLOWED"; else echo "RL_PROBE_NOT_ALLOWED"; fi` | `RL_PROBE_NOT_ALLOWED` | Probe 429 production/staging non autorisée |
+| `if [ -n "${DATABASE_URL:-}" ]; then echo "DATABASE_URL_PRESENT"; else echo "DATABASE_URL_ABSENT"; fi` | `DATABASE_URL_ABSENT` | Dry-run DB ContactLead non exécuté |
+| `if [ "${NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB:-}" = "true" ]; then echo "CONTACT_LEAD_DRY_RUN_ALLOWED"; else echo "CONTACT_LEAD_DRY_RUN_NOT_ALLOWED"; fi` | `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED` | Dry-run DB ContactLead non autorisé |
+
+## Commandes runtime sûres
+
+| Commande | Résultat | Statut |
+| --- | --- | --- |
+| `curl -sS -o /tmp/nexus-health-unauth-lot6.json -w "%{http_code}\\n" https://nexusreussite.academy/api/internal/health` | `401` | OK : endpoint protégé, pas de preuve Redis/Upstash |
+
+## Commandes release candidate
+
+| Commande | Résultat | Statut |
+| --- | --- | --- |
+| `git diff --name-only` | `130` fichiers suivis modifiés | OK |
+| `git diff --stat` | `130 files changed, 3269 insertions(+), 1258 deletions(-)` | OK |
+| `git diff --name-only \| rg 'rapport_audit_2_07_2026.md\|build-output.log\|test-results\|playwright-report\|\\.next\|node_modules' \|\| true` | aucune sortie | OK |
+| `git ls-files --others --exclude-standard \| rg '(^\|/)\\.env($\|\\.)\|rapport_audit_2_07_2026.md\|build-output.log\|test-results\|playwright-report\|\\.next\|node_modules' \|\| true` | `rapport_audit_2_07_2026.md` | OK : à exclure |
+
+## Gates finales
+
+| Commande | Résultat | Statut |
+| --- | --- | --- |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run typecheck` | `tsc --noEmit`, code `0` | OK |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run lint` | code `0`, warnings ESLint sous `--max-warnings 300` | OK |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand` | `537` suites passées, `1` skipped, `6507` tests passés, `4` skipped | OK |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run build` | build Next.js code `0`, `142` pages générées, assets standalone copiés | OK |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/security/audit-api-guards.mjs` | `Wrote docs/security/API_GUARD_INVENTORY.md (178 routes)` | OK |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node scripts/go-live/generate-api-security-matrix.mjs` | `P0: 0, P1: 6, P2: 144, OK: 28` | OK |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run audit:site-map` | `Routes: 292; edges: 413; link findings: 0; public orphan entries: 13` | OK |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:no-hardcoded` | `OK: 0 hardcoded values outside canonical sources` | OK |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:docs-archive` | `OK: no historical audit/report files at docs/ root` | OK |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run check:bundle-weight` | toutes routes dans baseline + `5 kB` | OK |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | `24 passed` | OK |
+| `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium` | `1 passed` | OK |
+
+## Commandes non exécutées
+
+| Commande | Statut | Raison |
+| --- | --- | --- |
+| Healthcheck authentifié production avec `NEXUS_HEALTH_AUTH` | NON EXÉCUTÉ | `NEXUS_HEALTH_AUTH_ABSENT` |
+| Test 429 runtime production/staging via `/api/internal/rate-limit-probe` | NON EXÉCUTÉ | `AUTH_ABSENT`, `RL_PROBE_NOT_ALLOWED` |
+| ContactLead dry-run DB non production | NON EXÉCUTÉ | `DATABASE_URL_ABSENT`, `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED` |
+
+## Limites
+
+- Aucun secret lu ou affiché.
+- Aucun `.env` modifié.
+- Aucun déploiement.
+- Aucune migration.
+- Aucun test 429 production exécuté.
+- Aucun dry-run ContactLead DB exécuté faute de `DATABASE_URL` et d'autorisation explicite.

--- a/docs/go-live/_evidence/lot7-final-decision-register.md
+++ b/docs/go-live/_evidence/lot7-final-decision-register.md
@@ -1,0 +1,27 @@
+# Lot 7 — Registre final decisionnel
+
+| Condition | Statut | Preuve | Decision |
+|---|---|---|---|
+| P0 | `0` | `docs/go-live/api-security-matrix.full.md` | `OK` |
+| P1 | `6` | Matrice : ClicToPay webhook, assessment submit, bilan gratuit, Lamis, stage inscrire, student activate | `BETA_CONTROLEE_ALLOWED_WITH_RESERVES` uniquement |
+| Redis/Upstash | `NON PROUVÉ` | `NEXUS_HEALTH_AUTH_ABSENT`, healthcheck public `401` | `BETA_ELARGIE_BLOCKED`, `GO_LIVE_LARGE_BLOCKED` |
+| 429 runtime | `NON PROUVÉ` | `RL_PROBE_NOT_ALLOWED` | `BETA_ELARGIE_BLOCKED`, `GO_LIVE_LARGE_BLOCKED` |
+| ContactLead dry-run DB | `NON PROUVÉ` | `DATABASE_URL_ABSENT`, dry-run DB non autorise | `GO_LIVE_LARGE_BLOCKED` |
+| ClicToPay | `DISABLED` | Docs Lot 5/Lot 6 + routes `501/P1` | Paiement manuel uniquement |
+| BusinessConfig | `DÉGRADÉ SI FALLBACK PROD NON OPT-IN` | Gate Lot 4/Lot 5/Lot 6 | Controle runtime requis |
+| Security scripts audit | `ACCEPTED` | `lot7-security-scripts-audit.md`, tests scripts verts | Inclure avec tests de regression |
+| Worktree RC | `NOT_READY` | `276` entrees git finales, manifest et plan de commit créés | Revue humaine avant commit/PR |
+| Gates finales | `OK` | Typecheck, lint, unit, build, audit API, matrice, site-map, checks, Playwright publics verts | RC techniquement testée localement |
+
+## Decision globale
+
+- Bêta controlee : `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`
+- Bêta elargie : `BETA_ELARGIE_BLOCKED`
+- Go-live large : `GO_LIVE_LARGE_BLOCKED`
+
+Condition de levee minimale pour beta elargie :
+
+1. Healthcheck Redis/Upstash authentifie prouve.
+2. Test 429 runtime reel execute sur staging ou fenetre autorisee.
+3. Dry-run ContactLead DB non production execute sans PII.
+4. Acceptation humaine explicite des 6 P1 publics/paiement.

--- a/docs/go-live/_evidence/lot7-release-candidate-audit-command-log.md
+++ b/docs/go-live/_evidence/lot7-release-candidate-audit-command-log.md
@@ -1,0 +1,116 @@
+# Lot 7 — Journal commandes release candidate
+
+## Baseline
+
+- Date locale : 2026-07-03 14:33:55 CET
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Node : `v20.20.0`
+- npm : `10.8.2`
+- Etat Git initial : `269` entrees `git status --short --untracked-files=all`
+- Fichiers suivis modifies : `130`
+- Fichiers non suivis : `139`
+- Diff `.env` : aucun chemin detecte par `git diff --name-only | rg '(^|/)\\.env($|\\.)' || true`
+
+## P1 initiaux
+
+Commande :
+
+```bash
+rg -n "^\\| P1 \\|" docs/go-live/api-security-matrix.full.md
+```
+
+Resultat :
+
+- `/api/payments/clictopay/webhook`
+- `/api/assessments/submit`
+- `/api/bilan-gratuit`
+- `/api/lamis/teacher-report`
+- `/api/stages/[stageSlug]/inscrire`
+- `/api/student/activate`
+
+## Presence variables runtime
+
+Commande executee sans afficher de valeur :
+
+```bash
+if [ -n "${NEXUS_HEALTH_AUTH:-}" ]; then echo "NEXUS_HEALTH_AUTH_PRESENT"; else echo "NEXUS_HEALTH_AUTH_ABSENT"; fi
+if [ "${NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE:-}" = "true" ]; then echo "RL_PROBE_ALLOWED"; else echo "RL_PROBE_NOT_ALLOWED"; fi
+if [ -n "${DATABASE_URL:-}" ]; then echo "DATABASE_URL_PRESENT"; else echo "DATABASE_URL_ABSENT"; fi
+if [ "${NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB:-}" = "true" ]; then echo "CONTACT_LEAD_DRY_RUN_ALLOWED"; else echo "CONTACT_LEAD_DRY_RUN_NOT_ALLOWED"; fi
+```
+
+Resultat :
+
+- `NEXUS_HEALTH_AUTH_ABSENT`
+- `RL_PROBE_NOT_ALLOWED`
+- `DATABASE_URL_ABSENT`
+- `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED`
+
+## Healthcheck public sans auth
+
+Commande :
+
+```bash
+curl -sS -o /tmp/nexus-health-lot7.json -w "%{http_code}\\n" https://nexusreussite.academy/api/internal/health
+```
+
+Resultat : `401`
+
+Statut : attendu pour une route interne protegee. Ne prouve pas Redis/Upstash.
+
+## Audit scripts
+
+Commandes :
+
+```bash
+git diff -- scripts/security/audit-api-guards.mjs
+git diff -- scripts/go-live/generate-api-security-matrix.mjs
+git diff -- scripts/check-bundle-weight.sh
+```
+
+Resultat resume :
+
+- `scripts/security/audit-api-guards.mjs` modifie depuis les lots precedents : detection reexports, rate limit, ownership helpers, routes staff-only, routes publiques fixes, routes `410/501`.
+- `scripts/go-live/generate-api-security-matrix.mjs` est non suivi : generateur de matrice depuis `docs/security/API_GUARD_INVENTORY.md`.
+- `scripts/check-bundle-weight.sh` modifie : detection des routes statiques ou dynamiques dans le build output.
+
+Test cible execute :
+
+```bash
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand __tests__/scripts/audit-api-guards.classification.test.ts __tests__/scripts/security-audit-scripts-regression.test.ts
+```
+
+Resultat : `2` suites passees, `10` tests passes.
+
+## Gates finales
+
+| Commande | Statut | Résultat |
+|---|---|---|
+| `npm run typecheck` | OK | `tsc --noEmit` sans erreur |
+| `npm run lint` | OK | Warnings existants sous `--max-warnings 300` |
+| `npm run test:unit -- --runInBand` | OK | `538` suites passées, `1` skipped ; `6510` tests passés, `4` skipped |
+| `npm run build` | OK | Build Next `15.5.12`, `142/142` pages statiques générées, assets standalone copiés |
+| `node scripts/security/audit-api-guards.mjs` | OK | `178` routes écrites dans `docs/security/API_GUARD_INVENTORY.md` |
+| `node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=6`, `P2=144`, `OK=28` |
+| `npm run audit:site-map` | OK | `292` routes, `413` edges, `0` link finding, `13` orphan entries |
+| `npm run check:no-hardcoded` | OK | `0` hardcoded value hors sources canoniques |
+| `npm run check:docs-archive` | OK | Aucun audit historique à la racine `docs/` |
+| `npm run check:bundle-weight` | OK | Toutes les routes dans baseline + `5 kB` |
+| Playwright public `homepage/offres/bilan-gratuit` | OK | `24 passed` |
+| Playwright assessment token | OK | `1 passed` |
+
+## Worktree final apres gates
+
+- Entrées `git status --short --untracked-files=all` : `276`
+- Fichiers suivis modifies : `130`
+- Fichiers non suivis : `146`
+- Diff `.env` : aucun chemin detecte.
+
+## Limites
+
+- Redis/Upstash staging/production : non prouve, faute de `NEXUS_HEALTH_AUTH`.
+- Test 429 runtime reel : non execute, faute de credential et de flag `NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE=true`.
+- ContactLead dry-run DB : non execute, faute de `DATABASE_URL` et de flag `NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB=true`.
+- Aucun secret lu ou affiche.
+- Aucun `.env` modifie.

--- a/docs/go-live/_evidence/lot7-release-candidate-commit-plan.md
+++ b/docs/go-live/_evidence/lot7-release-candidate-commit-plan.md
@@ -1,0 +1,89 @@
+# Lot 7 — Plan de commits release candidate
+
+Ce plan ne cree aucun commit. Il propose une decomposition lisible pour revue humaine.
+
+## 1. `security-api-p1-closure`
+
+Inclure :
+
+- Routes API sensibles durcies : `app/api/documents/**`, `app/api/invoices/**`, `app/api/bilans/**`, `app/api/npc/**`, `app/api/parent/**`, `app/api/student/**`, `app/api/coach/**`, `app/api/stages/**`, `app/api/admin/**`, `app/api/assistante/**`.
+- Helpers de projection/ownership associes : `lib/invoice/**`, `lib/stages/**`, `lib/validations.ts`.
+- Tests IDOR et no-leak associes dans `__tests__/api/**`.
+
+Risque : commit volumineux ; verifier que les tests IDOR restent lisibles.
+
+## 2. `public-funnel-rgpd-assessment-token`
+
+Inclure :
+
+- `app/api/bilan-gratuit/route.ts`
+- `app/api/bilan-gratuit/dismiss/route.ts`
+- `app/bilan-gratuit/assessment/page.tsx`
+- `app/bilan-gratuit/assessment/AssessmentClient.tsx`
+- `app/api/assessments/public-token/route.ts`
+- `app/api/assessments/submit/route.ts`
+- `app/api/assessments/submit/types.ts`
+- `components/assessments/AssessmentRunner.tsx`
+- `lib/assessments/public-token.ts`
+- `lib/crm/contact-leads.ts`
+- tests assessment/bilan associes.
+
+Risque : flux public critique ; conserver les tests Playwright assessment.
+
+## 3. `runtime-rate-limit-business-config`
+
+Inclure :
+
+- `app/api/internal/health/route.ts`
+- `app/api/internal/rate-limit-probe/route.ts`
+- `lib/rate-limit/index.ts`
+- `lib/config/snapshot.ts`
+- tests `internal.health`, `internal.rate-limit-probe`, `business-config`.
+
+Risque : ne pas confondre preuves locales avec preuves staging/production.
+
+## 4. `payments-clictopay-disabled`
+
+Inclure :
+
+- `app/api/payments/clictopay/init/route.ts`
+- `app/api/payments/clictopay/webhook/route.ts`
+- `components/marketing/PaymentMethodsNote.tsx`
+- tests ClicToPay disabled/feature-flag.
+
+Risque : garder `CLICTOPAY_STATUS=DISABLED`, aucune activation paiement carte.
+
+## 5. `maintenance-contactlead-retention`
+
+Inclure :
+
+- `scripts/maintenance/contact-leads-retention.ts`
+- tests retention ContactLead.
+- docs runbook retention.
+
+Risque : ne jamais executer `--apply` sans validation humaine.
+
+## 6. `tests-security-e2e`
+
+Inclure :
+
+- nouveaux tests `__tests__/api/**`, `__tests__/lib/**`, `__tests__/scripts/**`, `__tests__/ui/**`.
+- `e2e/pages-public-bilan-assessment-token.spec.ts`
+- modifications Playwright publiques et `playwright.config.ts`.
+
+Risque : verifier la stabilite sous Node 20 avant commit.
+
+## 7. `docs-go-live-evidence`
+
+Inclure :
+
+- `docs/go-live/**`
+- `docs/security/API_GUARD_INVENTORY.md`
+- `docs/audits/audit-nexus-reussite.md` seulement si revue humaine confirme son utilite.
+
+Exclure :
+
+- `rapport_audit_2_07_2026.md` sauf decision humaine explicite.
+- `.env*`
+- `.next/`, `node_modules/`, `test-results/`, `playwright-report/`
+- tout artefact local non necessaire a la release candidate.

--- a/docs/go-live/_evidence/lot7-release-candidate-file-manifest.md
+++ b/docs/go-live/_evidence/lot7-release-candidate-file-manifest.md
@@ -1,0 +1,302 @@
+# Lot 7 — Manifest release candidate
+
+Source : `git status --porcelain=v1 -uall` après gates finales Lot 7. Ce manifeste classe chaque entrée modifiée ou non suivie sans supprimer de fichier.
+
+| Fichier | État Git | Groupe | Inclure RC | Justification | Risque |
+|---|---|---|---:|---|---|
+| `__tests__/api/admin.config.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/admin.directeur.stats.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/admin.documents.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/admin.invoices.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/admin.recompute-ssn.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/admin.subscriptions.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/admin.test-email.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/assessments-rbac.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/assessments-submit.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/assistant.credit-requests.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/assistant.students.credits.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/assistant.subscription-requests.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/assistant.subscriptions.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/assistante.quotes.pdf.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/bilan-gratuit.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/bilans.id.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/bilans.idor.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/bilans/crud.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/bilans/generate.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/coach.eaf-preparation-report.validate.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/coach.generated-reports.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/documents-access.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/documents.id.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/invoices.pdf.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/invoices.receipt.pdf.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/npc.documents.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/npc.files.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/npc.generate.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/npc.uploads.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/parent.children.activation.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/parent.children.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/parent.subscription-requests.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/parent.subscriptions.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/payments.clictopay.init.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/payments.clictopay.webhook.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/programme.maths-1ere-stmg.stage-progress.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/public-rate-limit.coverage.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/sessions.cancel.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/sessions.video.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/stages.inscrire.security.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/stages/confirm.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/stages/inscriptions.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/student.activate.route.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/components/offer-detail-dialog.test.tsx` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/components/offres-page.test.tsx` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/lib/bilan-gratuit-form.test.tsx` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/lib/validations.test.ts` | `M` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `app/api/admin/config/rollback/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/admin/config/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/admin/directeur/stats/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/admin/documents/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/admin/invoices/route.ts` | `M` | API security | Oui | Facturation/projections/ownership | Revue humaine standard |
+| `app/api/admin/recompute-ssn/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/admin/subscriptions/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/admin/test-email/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/assessments/submit/route.ts` | `M` | Public funnel | Oui | Flux lead_only et token assessment | Flux conversion/RGPD critique |
+| `app/api/assessments/submit/types.ts` | `M` | Public funnel | Oui | Flux lead_only et token assessment | Flux conversion/RGPD critique |
+| `app/api/assistante/credit-requests/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/assistante/quotes/pdf/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/assistante/students/credits/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/assistante/subscription-requests/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/assistante/subscriptions/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/bilan-gratuit/dismiss/route.ts` | `M` | Public funnel | Oui | Flux lead_only et token assessment | Flux conversion/RGPD critique |
+| `app/api/bilan-gratuit/route.ts` | `M` | Public funnel | Oui | Flux lead_only et token assessment | Flux conversion/RGPD critique |
+| `app/api/bilans/[id]/export/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/bilans/[id]/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/bilans/generate/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/bilans/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/coach/students/[studentId]/documents/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/coach/students/[studentId]/eaf-preparation-report/validate/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/coach/students/[studentId]/notes/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/coach/students/[studentId]/survival-mode/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/coach/trajectory/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/documents/[id]/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/eleve/bilan-diagnostic-maths-terminale/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/internal/health/route.ts` | `M` | Rate limit runtime | Oui | Health/runtime gates | Preuve runtime encore absente |
+| `app/api/invoices/[id]/pdf/route.ts` | `M` | API security | Oui | Facturation/projections/ownership | Revue humaine standard |
+| `app/api/invoices/[id]/receipt/pdf/route.ts` | `M` | API security | Oui | Facturation/projections/ownership | Revue humaine standard |
+| `app/api/lamis/teacher-report/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/npc/submissions/[submissionId]/documents/[documentId]/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/npc/submissions/[submissionId]/documents/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/npc/submissions/[submissionId]/generate/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/npc/submissions/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/npc/uploads/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/parent/children/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/parent/subscription-requests/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/parent/subscriptions/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/payments/clictopay/init/route.ts` | `M` | ClicToPay disabled | Oui | Contrat paiement carte désactivé | Ne pas réactiver paiement carte |
+| `app/api/payments/clictopay/webhook/route.ts` | `M` | ClicToPay disabled | Oui | Contrat paiement carte désactivé | Ne pas réactiver paiement carte |
+| `app/api/programme/maths-1ere-stmg/stage-progress/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/sessions/cancel/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/sessions/video/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/stages/[stageSlug]/inscrire/route.ts` | `M` | API security | Oui | Stages publics/staff | Revue humaine standard |
+| `app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts` | `M` | API security | Oui | Stages publics/staff | Revue humaine standard |
+| `app/api/stages/[stageSlug]/route.ts` | `M` | API security | Oui | Stages publics/staff | Revue humaine standard |
+| `app/api/student/activate/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/student/automatismes/attempts/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/student/automatismes/check-answer/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/student/automatismes/series/[id]/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/student/documents/[id]/download/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/student/nexus-index/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/student/survival/phrases/[phraseId]/copied/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/student/survival/progress/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/student/survival/qcm/attempt/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/student/survival/reflexes/[reflexId]/attempt/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/api/student/trajectory/route.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `app/bilan-gratuit/assessment/page.tsx` | `M` | Public funnel | Oui | Flux lead_only et token assessment | Flux conversion/RGPD critique |
+| `app/layout.tsx` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `components/assessments/AssessmentRunner.tsx` | `M` | Public funnel | Oui | Flux lead_only et token assessment | Flux conversion/RGPD critique |
+| `components/marketing/PaymentMethodsNote.tsx` | `M` | ClicToPay disabled | Oui | Contrat paiement carte désactivé | Ne pas réactiver paiement carte |
+| `components/stages/StageInscriptionForm.tsx` | `M` | API security | Oui | Stages publics/staff | Revue humaine standard |
+| `docs/security/API_GUARD_INVENTORY.md` | `M` | Docs go-live | Oui | Inventaire/matrice sécurité | Revue humaine standard |
+| `e2e/pages-public-bilan-gratuit.spec.ts` | `M` | Tests E2E | Oui | Smoke public et assessment | Revue humaine standard |
+| `e2e/pages-public-homepage.spec.ts` | `M` | Tests E2E | Oui | Smoke public et assessment | Revue humaine standard |
+| `e2e/pages-public-offres.spec.ts` | `M` | Tests E2E | Oui | Smoke public et assessment | Revue humaine standard |
+| `lib/config/snapshot.ts` | `M` | Rate limit runtime | Oui | Health/runtime gates | Preuve runtime encore absente |
+| `lib/crm/contact-leads.ts` | `M` | Public funnel | Oui | Flux lead_only et token assessment | Flux conversion/RGPD critique |
+| `lib/invoice/index.ts` | `M` | API security | Oui | Facturation/projections/ownership | Revue humaine standard |
+| `lib/invoice/not-found.ts` | `M` | API security | Oui | Facturation/projections/ownership | Revue humaine standard |
+| `lib/rate-limit/index.ts` | `M` | Rate limit runtime | Oui | Health/runtime gates | Preuve runtime encore absente |
+| `lib/stages/inscription-schema.ts` | `M` | API security | Oui | Stages publics/staff | Revue humaine standard |
+| `lib/validations.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `playwright.config.ts` | `M` | API security | Oui | Code produit testé dans les lots sécurité | Revue humaine standard |
+| `scripts/check-bundle-weight.sh` | `M` | Scripts audit | Oui | Correction nécessaire pour routes dynamiques Next | Risque de classification, mitigé par tests |
+| `scripts/security/audit-api-guards.mjs` | `M` | Scripts audit | Oui | Script audité et couvert par regression | Risque de classification, mitigé par tests |
+| `__tests__/api/assessments.public-token.binding.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/assessments.public-token.route.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/assessments.submit.token-binding.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/assessments.submit.token-security.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/bilan-gratuit.product-rgpd.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/bilan-gratuit.rgpd-minimization.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/bilan-gratuit.security.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/coach.bilan-diagnostic-maths-terminale.security.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/coach.eaf-stage-regenerate.security.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/coach.trajectory.security.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/eleve.bilan-diagnostic-maths-terminale.security.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/internal.business-config.health.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/internal.health.rate-limit.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/internal.rate-limit-probe.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/lamis.teacher-report.route.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/npc.submissions.security.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/payments.clictopay.disabled-contract.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/payments.clictopay.feature-flag-consistency.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/payments.clictopay.webhook.disabled.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/payments.clictopay.webhook.security.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/stages.inscrire.product-rgpd.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/api/student.activate.lifecycle-security.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/app/bilan-gratuit.assessment-page-token.test.tsx` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/lib/assessments/public-token.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/lib/business-config.fallback.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/lib/business-config.production-gate.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/lib/crm/contact-leads.retention.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/lib/invoice/access-scope.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/lib/rate-limit.production-gate.test.ts` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `__tests__/scripts/audit-api-guards.classification.test.ts` | `??` | Scripts audit | Oui | Tests de non-régression scripts | Risque de classification, mitigé par tests |
+| `__tests__/scripts/contact-leads-retention.test.ts` | `??` | Scripts audit | Oui | Tests de non-régression scripts | Risque de classification, mitigé par tests |
+| `__tests__/scripts/security-audit-scripts-regression.test.ts` | `??` | Scripts audit | Oui | Tests de non-régression scripts | Risque de classification, mitigé par tests |
+| `__tests__/ui/payment-methods.clictopay-disabled.test.tsx` | `??` | Tests unitaires | Oui | Couverture sécurité/régression | Revue humaine standard |
+| `app/api/assessments/public-token/route.ts` | `??` | Public funnel | Oui | Flux lead_only et token assessment | Flux conversion/RGPD critique |
+| `app/api/internal/rate-limit-probe/route.ts` | `??` | Rate limit runtime | Oui | Health/runtime gates | Preuve runtime encore absente |
+| `app/bilan-gratuit/assessment/AssessmentClient.tsx` | `??` | Public funnel | Oui | Flux lead_only et token assessment | Flux conversion/RGPD critique |
+| `docs/audits/audit-nexus-reussite.md` | `??` | À exclure | Non | Document audit secondaire à valider humainement avant inclusion | Exclure de la RC ou valider humainement |
+| `docs/go-live/00_EXECUTIVE_STATE.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/01_ACTION_PLAN.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/02_P0_P1_BACKLOG.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/03_RELEASE_GATES.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/04_TEST_MATRIX.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/05_API_SECURITY_MATRIX.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/06_BUSINESS_LOGIC_DECISIONS.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/07_ENV_INFRA_CHECKLIST.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/08_MARKETING_CONTENT_CHECKLIST.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/10_LOT0_ACCEPTANCE.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/11_LOT1_SECURITY_CLOSURE.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/12_LOT1BIS_SECURITY_VERIFICATION.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/13_LOT1TER_P1_SECURITY_CLOSURE.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/14_LOT1QUATER_PUBLIC_ROLE_SECURITY_CLOSURE.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/15_LOT1QUINQUIES_FINAL_P1_SECURITY_CLOSURE.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/16_LOT2_PUBLIC_PRODUCT_RGPD_PAYMENT_DECISIONS.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/17_LOT3_RUNTIME_RGPD_ASSESSMENT_TOKEN.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/18_LOT4_RUNTIME_PAYMENT_RETENTION_TOKEN_BINDING.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/19_LOT5_RUNTIME_EXPLOITATION_GO_NO_GO.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/20_LOT6_STAGING_RELEASE_CANDIDATE_GO_NO_GO.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/21_LOT7_RELEASE_CANDIDATE_SECURITY_AUDIT.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `docs/go-live/_evidence/entitlement-pricing-delta.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/hardcoded-pricing-triage.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot0-command-log.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1-api-route-triage.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1-command-log.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1-idor-tests.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1-rate-limit-runtime.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1bis-audit-script-review.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1bis-command-log.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1bis-p0-reclassification-audit.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1bis-p1-closure.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1bis-rate-limit-production-gate.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quater-assistante.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quater-coach.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quater-command-log.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quater-p1-before-after.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quater-parent-student.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quater-public-routes.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quater-rate-limit-runtime-proof.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quater-sensitive-fields-coverage.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quater-stages.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quinquies-admin-routes.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quinquies-clictopay-webhook.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quinquies-command-log.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quinquies-p1-before-after.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quinquies-public-sensitive-routes.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quinquies-rate-limit-runtime-proof.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quinquies-sensitive-fields-coverage.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1ter-bilans-assessments.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1ter-coach-reports.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1ter-command-log.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1ter-npc-documents.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1ter-p1-before-after.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1ter-payments-invoices.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1ter-sensitive-fields-coverage.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot2-assessments-submit-decision.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot2-bilan-gratuit-product-rgpd.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot2-clictopay-payment-decision.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot2-lamis-teacher-report-decision.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot2-public-product-rgpd-command-log.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot2-rate-limit-runtime-decision.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot2-sensitive-fields-success-error-coverage.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot2-stages-inscrire-product-rgpd.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot2-student-activate-token-lifecycle.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot3-assessments-public-token.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot3-bilan-gratuit-rgpd-register.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot3-business-configs-db-drift.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot3-clictopay-disabled-contract.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot3-contact-lead-retention-policy.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot3-no-leak-success-error-runtime-coverage.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot3-redis-upstash-runtime-proof.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot3-runtime-rgpd-assessment-command-log.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot4-assessment-token-binding.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot4-business-config-production-gate.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot4-clictopay-disabled-runbook.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot4-contact-lead-retention-job.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot4-no-leak-e2e-runtime-coverage.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot4-redis-upstash-runtime-proof.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot4-token-runtime-payment-command-log.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot5-business-config-runtime-decision.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot5-clictopay-final-disabled-decision.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot5-contact-lead-retention-dry-run.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot5-p1-go-no-go-register.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot5-public-e2e-critical-paths.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot5-rate-limit-429-proof.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot5-redis-upstash-authenticated-healthcheck.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot5-runtime-exploitation-command-log.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot6-contact-lead-retention-db-dry-run.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot6-final-go-no-go-register.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot6-rate-limit-429-runtime-proof.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot6-redis-upstash-authenticated-proof.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot6-release-candidate-worktree-audit.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot6-staging-release-candidate-command-log.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot7-final-decision-register.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot7-release-candidate-audit-command-log.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot7-release-candidate-commit-plan.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot7-release-candidate-file-manifest.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot7-runtime-human-assisted-proof.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot7-security-scripts-audit.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/_evidence/playwright-public-smoke-triage.md` | `??` | Docs evidence | Oui | Preuve go-live utilisée par la RC | Volume documentaire élevé |
+| `docs/go-live/api-security-matrix.full.md` | `??` | Docs go-live | Oui | Documentation go-live structurante | Revue humaine standard |
+| `e2e/pages-public-bilan-assessment-token.spec.ts` | `??` | Tests E2E | Oui | Smoke public et assessment | Revue humaine standard |
+| `lib/assessments/public-token.ts` | `??` | Public funnel | Oui | Flux lead_only et token assessment | Flux conversion/RGPD critique |
+| `rapport_audit_2_07_2026.md` | `??` | À exclure | Non | Rapport racine non suivi explicitement exclu | Exclure de la RC ou valider humainement |
+| `scripts/go-live/generate-api-security-matrix.mjs` | `??` | Scripts audit | Oui | Script audité et couvert par regression | Risque de classification, mitigé par tests |
+| `scripts/maintenance/contact-leads-retention.ts` | `??` | Scripts maintenance | Oui | Retention ContactLead dry-run | Revue humaine standard |
+
+## Synthèse
+- À exclure : 2
+- API security : 64
+- ClicToPay disabled : 3
+- Docs evidence : 80
+- Docs go-live : 24
+- Public funnel : 10
+- Rate limit runtime : 4
+- Scripts audit : 6
+- Scripts maintenance : 1
+- Tests E2E : 4
+- Tests unitaires : 78
+
+## Exclusions explicites
+
+- `.env*` : jamais inclus.
+- `rapport_audit_2_07_2026.md` : non suivi, exclu sauf décision humaine explicite.
+- `test-results/`, `playwright-report/`, `.next/`, `node_modules/` : jamais inclus.
+- `docs/audits/audit-nexus-reussite.md` : exclu par défaut, à valider humainement si nécessaire.

--- a/docs/go-live/_evidence/lot7-runtime-human-assisted-proof.md
+++ b/docs/go-live/_evidence/lot7-runtime-human-assisted-proof.md
@@ -1,0 +1,55 @@
+# Lot 7 — Preuves runtime assistees humainement
+
+## Variables verifiees sans afficher de valeur
+
+| Variable / flag | Resultat | Impact |
+|---|---|---|
+| `NEXUS_HEALTH_AUTH` | `ABSENT` | Healthcheck authentifie non executable |
+| `NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE` | `NOT_ALLOWED` | Test 429 production/staging non autorise |
+| `DATABASE_URL` | `ABSENT` | Dry-run DB ContactLead non executable |
+| `NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB` | `NOT_ALLOWED` | Dry-run DB ContactLead non autorise |
+
+## Healthcheck public sans authentification
+
+- URL : `https://nexusreussite.academy/api/internal/health`
+- Statut observe : `401`
+- Interpretation : protection attendue de la route interne ; ne prouve pas Redis/Upstash.
+
+## Redis/Upstash
+
+Statut : `NON PROUVÉ`
+
+Preuve manquante :
+
+- `runtime.rateLimit.mode = redis` ou `upstash`
+- `runtime.rateLimit.distributed = true`
+- `runtime.rateLimit.goLiveLarge = allowed`
+- `checks.redis.ok = true`
+
+Decision : `BETA_ELARGIE_BLOCKED` et `GO_LIVE_LARGE_BLOCKED`.
+
+## 429 runtime
+
+Statut : `NON EXÉCUTÉ`
+
+Cause :
+
+- `NEXUS_HEALTH_AUTH_ABSENT`
+- `RL_PROBE_NOT_ALLOWED`
+
+Decision : test 429 reel a executer uniquement avec credential et fenetre autorisee.
+
+## ContactLead dry-run DB
+
+Statut : `NON EXÉCUTÉ`
+
+Cause :
+
+- `DATABASE_URL_ABSENT`
+- `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED`
+
+Decision : dry-run DB non production requis avant beta elargie/go-live large.
+
+## Secrets
+
+Aucune valeur de secret, token, cookie, DSN ou `.env` n'a ete lue ou ecrite dans les documents.

--- a/docs/go-live/_evidence/lot7-security-scripts-audit.md
+++ b/docs/go-live/_evidence/lot7-security-scripts-audit.md
@@ -1,0 +1,82 @@
+# Lot 7 — Audit des scripts de securite
+
+## Verdict
+
+`SECURITY_AUDIT_SCRIPTS_ACCEPTED`
+
+Acceptation avec reserves : les scripts sont acceptes comme outils de triage statique, pas comme preuve unique de securite applicative. Les 6 P1 restent visibles et ne sont pas requalifies.
+
+## Scripts audites
+
+| Script | Statut | Decision |
+|---|---|---|
+| `scripts/security/audit-api-guards.mjs` | Modifie | Accepte avec tests de classification et regression |
+| `scripts/go-live/generate-api-security-matrix.mjs` | Non suivi / nouveau | Accepte comme generateur documentaire depuis l'inventaire |
+| `scripts/check-bundle-weight.sh` | Modifie | Accepte, correction de detection des routes dynamiques dans le build |
+
+## `scripts/security/audit-api-guards.mjs`
+
+Constats :
+
+- Le script suit les reexports via `sourceFor`, ce qui reduit les faux positifs pour les routes qui exportent un handler partage.
+- Les routes webhook `501` restent `P1`, pas `OK`.
+- Les routes publiques sensibles avec Zod et rate limit restent `P1` si mutation, pas `OK`.
+- Les routes publiques fixes/documentaires peuvent etre `P2`, mais pas `OK`.
+- Les routes staff-only ne sont sorties de `P0` que si auth et role guard sont detectes.
+- Les helpers ownership reconnus sont des signaux statiques ; ils ne remplacent pas les tests IDOR.
+
+Risques :
+
+- La detection ownership reste heuristique.
+- Une route avec un helper mal utilise peut etre surclassee statiquement.
+- L'inventaire ne prouve pas la couverture runtime, ni Redis/Upstash, ni les decisions produit/RGPD.
+
+Mitigations :
+
+- Test existant `__tests__/scripts/audit-api-guards.classification.test.ts`.
+- Test ajoute Lot 7 `__tests__/scripts/security-audit-scripts-regression.test.ts`.
+- Les 6 P1 actuels sont verrouilles en regression.
+
+## `scripts/go-live/generate-api-security-matrix.mjs`
+
+Constats :
+
+- Le script lit `docs/security/API_GUARD_INVENTORY.md`.
+- Il ne reclassifie pas independamment une route vers `OK`.
+- Les compteurs de la matrice dependent des statuts de l'inventaire genere.
+- Les sections P1 conservent les 6 routes publiques/paiement.
+
+Risque :
+
+- Si l'inventaire source est faux, la matrice reproduit l'erreur.
+
+Mitigation :
+
+- Test Lot 7 : verification que les 6 P1 restent P1 dans l'inventaire et la matrice.
+- Gate finale : regeneration de l'inventaire et de la matrice apres tests.
+
+## `scripts/check-bundle-weight.sh`
+
+Constats :
+
+- Le diff remplace la recherche stricte `○ route` par une recherche de ligne contenant ` route `.
+- Objectif : ne pas echouer si Next marque une page protegee par cookie comme dynamique `ƒ`.
+- La route reste exigee : si elle disparait du build output, le script echoue encore.
+
+Verdict : accepte.
+
+## Tests executes
+
+```bash
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand __tests__/scripts/audit-api-guards.classification.test.ts __tests__/scripts/security-audit-scripts-regression.test.ts
+```
+
+Resultat : `2` suites passees, `10` tests passes.
+
+## Decision
+
+Les scripts ne maquillaient pas les 6 P1 au moment de l'audit Lot 7. Ils restent acceptables pour release candidate avec les reserves suivantes :
+
+- ne pas utiliser l'inventaire comme preuve unique ;
+- conserver les tests de regression script ;
+- garder les P1 visibles jusqu'a preuve runtime et decision humaine.

--- a/docs/go-live/_evidence/lot8-final-release-candidate-register.md
+++ b/docs/go-live/_evidence/lot8-final-release-candidate-register.md
@@ -1,0 +1,22 @@
+# Lot 8 — Registre final release candidate
+
+| Domaine | Statut | Preuve | Décision |
+|---|---|---|---|
+| P0 | 0 | matrice | OK |
+| P1 | 6 | matrice | bêta contrôlée seulement |
+| Scripts audit | ACCEPTED | tests scripts | garder P1 visibles |
+| Manifest RC | CLEAN | `lot8-release-candidate-file-manifest-clean.md` | RC_READY_FOR_HUMAN_REVIEW |
+| Commit plan | READY | `lot8-release-candidate-commit-plan-clean.md` | RC_READY_FOR_HUMAN_REVIEW |
+| Runtime Redis | NOT_PROVEN | variables absentes ou non exécutées | BETA_ELARGIE_BLOCKED |
+| 429 runtime | NOT_PROVEN | variables absentes ou non exécutées | BETA_ELARGIE_BLOCKED |
+| ContactLead DB dry-run | NOT_PROVEN | variables absentes ou non exécutées | GO_LIVE_LARGE_BLOCKED |
+| ClicToPay | DISABLED | routes/docs | manual payment |
+| Worktree | READY_FOR_HUMAN_COMMIT | `283` entrées classées, `281` Include RC, `1` Exclude, `1` Needs human review | commit manuel seulement |
+| Gates finales | OK | Typecheck, lint, unit, build, audits, checks, Playwright public et assessment | RC_READY_FOR_HUMAN_REVIEW |
+
+## Décision finale Lot 8
+
+- `RC_READY_FOR_HUMAN_REVIEW`
+- `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`
+- `BETA_ELARGIE_BLOCKED`
+- `GO_LIVE_LARGE_BLOCKED`

--- a/docs/go-live/_evidence/lot8-release-candidate-clean-manifest-command-log.md
+++ b/docs/go-live/_evidence/lot8-release-candidate-clean-manifest-command-log.md
@@ -1,0 +1,95 @@
+# Lot 8 — Journal release candidate cleanup
+
+## Baseline
+
+- Date locale : 2026-07-03 15:51:19 CET
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Node : `v20.20.0`
+- npm : `10.8.2`
+- Diff `.env` : aucun chemin détecté.
+
+## Commandes baseline exécutées
+
+```bash
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node -v
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm -v
+git rev-parse --abbrev-ref HEAD
+git rev-parse --short HEAD
+git status --short --untracked-files=all
+git diff --name-only
+git diff --stat
+git ls-files --others --exclude-standard
+git diff --name-only | rg '(^|/)\\.env($|\\.)' || true
+```
+
+## État initial observé
+
+- Fichiers suivis modifiés : `130`
+- Diff stat : `130 files changed, 3269 insertions(+), 1258 deletions(-)`
+- Fichiers non suivis initiaux : `146`
+- P1 visibles : `6`
+
+## État après création des artefacts Lot 8
+
+- Entrées `git status --short --untracked-files=all` : `283`
+- Fichiers suivis modifiés : `130`
+- Fichiers non suivis : `153`
+- Manifeste propre : `docs/go-live/_evidence/lot8-release-candidate-file-manifest-clean.md`
+- Plan de commits propre : `docs/go-live/_evidence/lot8-release-candidate-commit-plan-clean.md`
+- Include RC : `281`
+- Exclude : `1`
+- Needs human review : `1`
+
+## Runtime assisté
+
+```bash
+if [ -n "${NEXUS_HEALTH_AUTH:-}" ]; then echo "NEXUS_HEALTH_AUTH_PRESENT"; else echo "NEXUS_HEALTH_AUTH_ABSENT"; fi
+if [ "${NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE:-}" = "true" ]; then echo "RL_PROBE_ALLOWED"; else echo "RL_PROBE_NOT_ALLOWED"; fi
+if [ -n "${DATABASE_URL:-}" ]; then echo "DATABASE_URL_PRESENT"; else echo "DATABASE_URL_ABSENT"; fi
+if [ "${NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB:-}" = "true" ]; then echo "CONTACT_LEAD_DRY_RUN_ALLOWED"; else echo "CONTACT_LEAD_DRY_RUN_NOT_ALLOWED"; fi
+```
+
+Résultat :
+
+- `NEXUS_HEALTH_AUTH_ABSENT`
+- `RL_PROBE_NOT_ALLOWED`
+- `DATABASE_URL_ABSENT`
+- `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED`
+
+Statut : preuves runtime non exécutées et blocage maintenu.
+
+## Gates finales
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `npm run typecheck` | OK | `tsc --noEmit` sans erreur |
+| `npm run lint` | OK | Commande terminée avec code `0`; warnings existants dans le seuil configuré |
+| `npm run test:unit -- --runInBand` | OK | `538` suites passées sur `539`, `1` skipped ; `6516` tests passés sur `6520`, `4` skipped |
+| `npm run build` | OK | Build Next.js terminé ; `142` pages statiques générées ; assets standalone copiés |
+| `node scripts/security/audit-api-guards.mjs` | OK | `178` routes écrites dans `docs/security/API_GUARD_INVENTORY.md` |
+| `node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=6`, `P2=144`, `OK=28` |
+| `npm run audit:site-map` | OK | `292` routes, `413` edges, `0` link finding, `13` orphan entries |
+| `npm run check:no-hardcoded` | OK | `0` hardcoded values outside canonical sources |
+| `npm run check:docs-archive` | OK | Aucun audit/report historique à la racine `docs/` |
+| `npm run check:bundle-weight` | OK | Toutes les routes dans baseline + `5 kB` |
+| `PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | OK | `24` tests passés |
+| `PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium` | OK | `1` test passé |
+
+## Vérifications post-gates
+
+- Matrice API : `P0=0`, `P1=6`, `P2=144`, `OK=28`.
+- P1 visibles : `/api/payments/clictopay/webhook`, `/api/assessments/submit`, `/api/bilan-gratuit`, `/api/lamis/teacher-report`, `/api/stages/[stageSlug]/inscrire`, `/api/student/activate`.
+- Diff `.env` : aucune sortie.
+- Worktree : `283` entrées classées par le manifeste Lot 8.
+- Tests classés comme artefacts générés : aucun cas détecté.
+
+## Limites
+
+- Aucun secret lu.
+- Aucun `.env` modifié.
+- Aucun commit.
+- Aucune PR.
+- Aucune preuve Redis/Upstash staging/production.
+- Aucun test `429` runtime staging/production.
+- Aucun dry-run DB ContactLead non production.

--- a/docs/go-live/_evidence/lot8-release-candidate-commit-plan-clean.md
+++ b/docs/go-live/_evidence/lot8-release-candidate-commit-plan-clean.md
@@ -1,0 +1,354 @@
+# Lot 8 — Plan de commits release candidate propre
+
+Aucun commit n’est exécuté. Chaque fichier `Include RC = Oui` du manifeste Lot 8 apparaît dans exactement un commit proposé. Les fichiers `Exclude` et `Needs human review` ne sont pas inclus.
+
+## 1. chore(go-live): update security inventory and matrices
+
+Tests à relancer : `node scripts/security/audit-api-guards.mjs`, `node scripts/go-live/generate-api-security-matrix.mjs`, `npm run check:bundle-weight`
+
+| Fichier |
+|---|
+| `docs/go-live/api-security-matrix.full.md` |
+| `docs/security/API_GUARD_INVENTORY.md` |
+| `scripts/check-bundle-weight.sh` |
+| `scripts/go-live/generate-api-security-matrix.mjs` |
+| `scripts/security/audit-api-guards.mjs` |
+
+## 2. fix(api-security): close admin and role guard gaps
+
+Tests à relancer : `npm run test:unit -- --runInBand __tests__/api/admin.config.route.test.ts __tests__/api/admin.documents.route.test.ts __tests__/api/bilans.id.route.test.ts`
+
+| Fichier |
+|---|
+| `app/api/admin/config/rollback/route.ts` |
+| `app/api/admin/config/route.ts` |
+| `app/api/admin/directeur/stats/route.ts` |
+| `app/api/admin/documents/route.ts` |
+| `app/api/admin/invoices/route.ts` |
+| `app/api/admin/recompute-ssn/route.ts` |
+| `app/api/admin/subscriptions/route.ts` |
+| `app/api/admin/test-email/route.ts` |
+| `app/api/assistante/credit-requests/route.ts` |
+| `app/api/assistante/quotes/pdf/route.ts` |
+| `app/api/assistante/students/credits/route.ts` |
+| `app/api/assistante/subscription-requests/route.ts` |
+| `app/api/assistante/subscriptions/route.ts` |
+| `app/api/bilans/[id]/export/route.ts` |
+| `app/api/bilans/[id]/route.ts` |
+| `app/api/bilans/generate/route.ts` |
+| `app/api/bilans/route.ts` |
+| `app/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate/route.ts` |
+| `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent/route.ts` |
+| `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student/route.ts` |
+| `app/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale/route.ts` |
+| `app/api/coach/students/[studentId]/documents/route.ts` |
+| `app/api/coach/students/[studentId]/eaf-preparation-report/validate/route.ts` |
+| `app/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate/route.ts` |
+| `app/api/coach/students/[studentId]/notes/route.ts` |
+| `app/api/coach/students/[studentId]/survival-mode/route.ts` |
+| `app/api/coach/trajectory/route.ts` |
+| `app/api/documents/[id]/route.ts` |
+| `app/api/eleve/bilan-diagnostic-maths-terminale/route.ts` |
+| `app/api/invoices/[id]/pdf/route.ts` |
+| `app/api/invoices/[id]/receipt/pdf/route.ts` |
+| `app/api/lamis/teacher-report/route.ts` |
+| `app/api/npc/submissions/[submissionId]/documents/[documentId]/route.ts` |
+| `app/api/npc/submissions/[submissionId]/documents/route.ts` |
+| `app/api/npc/submissions/[submissionId]/generate/route.ts` |
+| `app/api/npc/submissions/route.ts` |
+| `app/api/npc/uploads/route.ts` |
+| `app/api/parent/children/route.ts` |
+| `app/api/parent/subscription-requests/route.ts` |
+| `app/api/parent/subscriptions/route.ts` |
+| `app/api/programme/maths-1ere-stmg/stage-progress/route.ts` |
+| `app/api/sessions/cancel/route.ts` |
+| `app/api/sessions/video/route.ts` |
+| `app/api/stages/[stageSlug]/inscrire/route.ts` |
+| `app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts` |
+| `app/api/stages/[stageSlug]/route.ts` |
+| `app/api/student/activate/route.ts` |
+| `app/api/student/automatismes/attempts/route.ts` |
+| `app/api/student/automatismes/check-answer/route.ts` |
+| `app/api/student/automatismes/series/[id]/route.ts` |
+| `app/api/student/documents/[id]/download/route.ts` |
+| `app/api/student/nexus-index/route.ts` |
+| `app/api/student/survival/phrases/[phraseId]/copied/route.ts` |
+| `app/api/student/survival/progress/route.ts` |
+| `app/api/student/survival/qcm/attempt/route.ts` |
+| `app/api/student/survival/reflexes/[reflexId]/attempt/route.ts` |
+| `app/api/student/trajectory/route.ts` |
+| `lib/invoice/index.ts` |
+| `lib/invoice/not-found.ts` |
+| `lib/stages/inscription-schema.ts` |
+| `lib/validations.ts` |
+
+## 3. fix(public-funnel): lead-only bilan and assessment token binding
+
+Tests à relancer : `npm run test:unit -- --runInBand __tests__/api/bilan-gratuit.product-rgpd.test.ts __tests__/api/assessments.submit.token-binding.test.ts __tests__/app/bilan-gratuit.assessment-page-token.test.tsx`
+
+| Fichier |
+|---|
+| `app/api/assessments/public-token/route.ts` |
+| `app/api/assessments/submit/route.ts` |
+| `app/api/assessments/submit/types.ts` |
+| `app/api/bilan-gratuit/dismiss/route.ts` |
+| `app/api/bilan-gratuit/route.ts` |
+| `app/bilan-gratuit/assessment/AssessmentClient.tsx` |
+| `app/bilan-gratuit/assessment/page.tsx` |
+| `app/layout.tsx` |
+| `components/assessments/AssessmentRunner.tsx` |
+| `components/stages/StageInscriptionForm.tsx` |
+| `lib/assessments/public-token.ts` |
+| `lib/crm/contact-leads.ts` |
+
+## 4. fix(runtime): rate-limit probe and business-config gate
+
+Tests à relancer : `npm run test:unit -- --runInBand __tests__/api/internal.rate-limit-probe.test.ts __tests__/api/internal.business-config.health.test.ts __tests__/lib/rate-limit.production-gate.test.ts`
+
+| Fichier |
+|---|
+| `app/api/internal/health/route.ts` |
+| `app/api/internal/rate-limit-probe/route.ts` |
+| `lib/config/snapshot.ts` |
+| `lib/rate-limit/index.ts` |
+
+## 5. fix(payments): keep clictopay disabled and fail closed
+
+Tests à relancer : `npm run test:unit -- --runInBand __tests__/api/payments.clictopay.disabled-contract.test.ts __tests__/api/payments.clictopay.feature-flag-consistency.test.ts __tests__/ui/payment-methods.clictopay-disabled.test.tsx`
+
+| Fichier |
+|---|
+| `app/api/payments/clictopay/init/route.ts` |
+| `app/api/payments/clictopay/webhook/route.ts` |
+| `components/marketing/PaymentMethodsNote.tsx` |
+
+## 6. chore(maintenance): add contact-lead retention dry-run
+
+Tests à relancer : `npm run test:unit -- --runInBand __tests__/scripts/contact-leads-retention.test.ts __tests__/lib/crm/contact-leads.retention.test.ts`
+
+| Fichier |
+|---|
+| `scripts/maintenance/contact-leads-retention.ts` |
+
+## 7. test(security): add no-leak, idor, token and audit regressions
+
+Tests à relancer : `npm run test:unit -- --runInBand`
+
+| Fichier |
+|---|
+| `__tests__/api/admin.config.route.test.ts` |
+| `__tests__/api/admin.directeur.stats.route.test.ts` |
+| `__tests__/api/admin.documents.route.test.ts` |
+| `__tests__/api/admin.invoices.route.test.ts` |
+| `__tests__/api/admin.recompute-ssn.route.test.ts` |
+| `__tests__/api/admin.subscriptions.route.test.ts` |
+| `__tests__/api/admin.test-email.route.test.ts` |
+| `__tests__/api/assessments-rbac.test.ts` |
+| `__tests__/api/assessments-submit.test.ts` |
+| `__tests__/api/assessments.public-token.binding.test.ts` |
+| `__tests__/api/assessments.public-token.route.test.ts` |
+| `__tests__/api/assessments.submit.token-binding.test.ts` |
+| `__tests__/api/assessments.submit.token-security.test.ts` |
+| `__tests__/api/assistant.credit-requests.route.test.ts` |
+| `__tests__/api/assistant.students.credits.route.test.ts` |
+| `__tests__/api/assistant.subscription-requests.route.test.ts` |
+| `__tests__/api/assistant.subscriptions.route.test.ts` |
+| `__tests__/api/assistante.quotes.pdf.route.test.ts` |
+| `__tests__/api/bilan-gratuit.product-rgpd.test.ts` |
+| `__tests__/api/bilan-gratuit.rgpd-minimization.test.ts` |
+| `__tests__/api/bilan-gratuit.security.test.ts` |
+| `__tests__/api/bilan-gratuit.test.ts` |
+| `__tests__/api/bilans.id.route.test.ts` |
+| `__tests__/api/bilans.idor.test.ts` |
+| `__tests__/api/bilans/crud.test.ts` |
+| `__tests__/api/bilans/generate.test.ts` |
+| `__tests__/api/coach.bilan-diagnostic-maths-terminale.security.test.ts` |
+| `__tests__/api/coach.eaf-preparation-report.validate.test.ts` |
+| `__tests__/api/coach.eaf-stage-regenerate.security.test.ts` |
+| `__tests__/api/coach.generated-reports.route.test.ts` |
+| `__tests__/api/coach.trajectory.security.test.ts` |
+| `__tests__/api/documents-access.test.ts` |
+| `__tests__/api/documents.id.route.test.ts` |
+| `__tests__/api/eleve.bilan-diagnostic-maths-terminale.security.test.ts` |
+| `__tests__/api/internal.business-config.health.test.ts` |
+| `__tests__/api/internal.health.rate-limit.test.ts` |
+| `__tests__/api/internal.rate-limit-probe.test.ts` |
+| `__tests__/api/invoices.pdf.route.test.ts` |
+| `__tests__/api/invoices.receipt.pdf.route.test.ts` |
+| `__tests__/api/lamis.teacher-report.route.test.ts` |
+| `__tests__/api/npc.documents.route.test.ts` |
+| `__tests__/api/npc.files.route.test.ts` |
+| `__tests__/api/npc.generate.test.ts` |
+| `__tests__/api/npc.submissions.security.test.ts` |
+| `__tests__/api/npc.uploads.route.test.ts` |
+| `__tests__/api/parent.children.activation.route.test.ts` |
+| `__tests__/api/parent.children.route.test.ts` |
+| `__tests__/api/parent.subscription-requests.route.test.ts` |
+| `__tests__/api/parent.subscriptions.route.test.ts` |
+| `__tests__/api/payments.clictopay.disabled-contract.test.ts` |
+| `__tests__/api/payments.clictopay.feature-flag-consistency.test.ts` |
+| `__tests__/api/payments.clictopay.init.route.test.ts` |
+| `__tests__/api/payments.clictopay.webhook.disabled.test.ts` |
+| `__tests__/api/payments.clictopay.webhook.route.test.ts` |
+| `__tests__/api/payments.clictopay.webhook.security.test.ts` |
+| `__tests__/api/programme.maths-1ere-stmg.stage-progress.test.ts` |
+| `__tests__/api/public-rate-limit.coverage.test.ts` |
+| `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts` |
+| `__tests__/api/sessions.cancel.route.test.ts` |
+| `__tests__/api/sessions.video.route.test.ts` |
+| `__tests__/api/stages.inscrire.product-rgpd.test.ts` |
+| `__tests__/api/stages.inscrire.security.test.ts` |
+| `__tests__/api/stages/confirm.test.ts` |
+| `__tests__/api/stages/inscriptions.test.ts` |
+| `__tests__/api/student.activate.lifecycle-security.test.ts` |
+| `__tests__/api/student.activate.route.test.ts` |
+| `__tests__/app/bilan-gratuit.assessment-page-token.test.tsx` |
+| `__tests__/components/offer-detail-dialog.test.tsx` |
+| `__tests__/components/offres-page.test.tsx` |
+| `__tests__/lib/assessments/public-token.test.ts` |
+| `__tests__/lib/bilan-gratuit-form.test.tsx` |
+| `__tests__/lib/business-config.fallback.test.ts` |
+| `__tests__/lib/business-config.production-gate.test.ts` |
+| `__tests__/lib/crm/contact-leads.retention.test.ts` |
+| `__tests__/lib/invoice/access-scope.test.ts` |
+| `__tests__/lib/rate-limit.production-gate.test.ts` |
+| `__tests__/lib/validations.test.ts` |
+| `__tests__/scripts/audit-api-guards.classification.test.ts` |
+| `__tests__/scripts/contact-leads-retention.test.ts` |
+| `__tests__/scripts/security-audit-scripts-regression.test.ts` |
+| `__tests__/ui/payment-methods.clictopay-disabled.test.tsx` |
+
+## 8. test(e2e): protect public assessment route
+
+Tests à relancer : `PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium`
+
+| Fichier |
+|---|
+| `e2e/pages-public-bilan-assessment-token.spec.ts` |
+| `e2e/pages-public-bilan-gratuit.spec.ts` |
+| `e2e/pages-public-homepage.spec.ts` |
+| `e2e/pages-public-offres.spec.ts` |
+| `playwright.config.ts` |
+
+## 9. docs(go-live): add evidence and go-no-go registers
+
+Tests à relancer : `npm run check:docs-archive` + relecture docs go-live
+
+| Fichier |
+|---|
+| `docs/go-live/00_EXECUTIVE_STATE.md` |
+| `docs/go-live/01_ACTION_PLAN.md` |
+| `docs/go-live/02_P0_P1_BACKLOG.md` |
+| `docs/go-live/03_RELEASE_GATES.md` |
+| `docs/go-live/04_TEST_MATRIX.md` |
+| `docs/go-live/05_API_SECURITY_MATRIX.md` |
+| `docs/go-live/06_BUSINESS_LOGIC_DECISIONS.md` |
+| `docs/go-live/07_ENV_INFRA_CHECKLIST.md` |
+| `docs/go-live/08_MARKETING_CONTENT_CHECKLIST.md` |
+| `docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md` |
+| `docs/go-live/10_LOT0_ACCEPTANCE.md` |
+| `docs/go-live/11_LOT1_SECURITY_CLOSURE.md` |
+| `docs/go-live/12_LOT1BIS_SECURITY_VERIFICATION.md` |
+| `docs/go-live/13_LOT1TER_P1_SECURITY_CLOSURE.md` |
+| `docs/go-live/14_LOT1QUATER_PUBLIC_ROLE_SECURITY_CLOSURE.md` |
+| `docs/go-live/15_LOT1QUINQUIES_FINAL_P1_SECURITY_CLOSURE.md` |
+| `docs/go-live/16_LOT2_PUBLIC_PRODUCT_RGPD_PAYMENT_DECISIONS.md` |
+| `docs/go-live/17_LOT3_RUNTIME_RGPD_ASSESSMENT_TOKEN.md` |
+| `docs/go-live/18_LOT4_RUNTIME_PAYMENT_RETENTION_TOKEN_BINDING.md` |
+| `docs/go-live/19_LOT5_RUNTIME_EXPLOITATION_GO_NO_GO.md` |
+| `docs/go-live/20_LOT6_STAGING_RELEASE_CANDIDATE_GO_NO_GO.md` |
+| `docs/go-live/21_LOT7_RELEASE_CANDIDATE_SECURITY_AUDIT.md` |
+| `docs/go-live/22_LOT8_RELEASE_CANDIDATE_CLEANUP.md` |
+| `docs/go-live/_evidence/entitlement-pricing-delta.md` |
+| `docs/go-live/_evidence/hardcoded-pricing-triage.md` |
+| `docs/go-live/_evidence/lot0-command-log.md` |
+| `docs/go-live/_evidence/lot1-api-route-triage.md` |
+| `docs/go-live/_evidence/lot1-command-log.md` |
+| `docs/go-live/_evidence/lot1-idor-tests.md` |
+| `docs/go-live/_evidence/lot1-rate-limit-runtime.md` |
+| `docs/go-live/_evidence/lot1bis-audit-script-review.md` |
+| `docs/go-live/_evidence/lot1bis-command-log.md` |
+| `docs/go-live/_evidence/lot1bis-p0-reclassification-audit.md` |
+| `docs/go-live/_evidence/lot1bis-p1-closure.md` |
+| `docs/go-live/_evidence/lot1bis-rate-limit-production-gate.md` |
+| `docs/go-live/_evidence/lot1quater-assistante.md` |
+| `docs/go-live/_evidence/lot1quater-coach.md` |
+| `docs/go-live/_evidence/lot1quater-command-log.md` |
+| `docs/go-live/_evidence/lot1quater-p1-before-after.md` |
+| `docs/go-live/_evidence/lot1quater-parent-student.md` |
+| `docs/go-live/_evidence/lot1quater-public-routes.md` |
+| `docs/go-live/_evidence/lot1quater-rate-limit-runtime-proof.md` |
+| `docs/go-live/_evidence/lot1quater-sensitive-fields-coverage.md` |
+| `docs/go-live/_evidence/lot1quater-stages.md` |
+| `docs/go-live/_evidence/lot1quinquies-admin-routes.md` |
+| `docs/go-live/_evidence/lot1quinquies-clictopay-webhook.md` |
+| `docs/go-live/_evidence/lot1quinquies-command-log.md` |
+| `docs/go-live/_evidence/lot1quinquies-p1-before-after.md` |
+| `docs/go-live/_evidence/lot1quinquies-public-sensitive-routes.md` |
+| `docs/go-live/_evidence/lot1quinquies-rate-limit-runtime-proof.md` |
+| `docs/go-live/_evidence/lot1quinquies-sensitive-fields-coverage.md` |
+| `docs/go-live/_evidence/lot1ter-bilans-assessments.md` |
+| `docs/go-live/_evidence/lot1ter-coach-reports.md` |
+| `docs/go-live/_evidence/lot1ter-command-log.md` |
+| `docs/go-live/_evidence/lot1ter-npc-documents.md` |
+| `docs/go-live/_evidence/lot1ter-p1-before-after.md` |
+| `docs/go-live/_evidence/lot1ter-payments-invoices.md` |
+| `docs/go-live/_evidence/lot1ter-sensitive-fields-coverage.md` |
+| `docs/go-live/_evidence/lot2-assessments-submit-decision.md` |
+| `docs/go-live/_evidence/lot2-bilan-gratuit-product-rgpd.md` |
+| `docs/go-live/_evidence/lot2-clictopay-payment-decision.md` |
+| `docs/go-live/_evidence/lot2-lamis-teacher-report-decision.md` |
+| `docs/go-live/_evidence/lot2-public-product-rgpd-command-log.md` |
+| `docs/go-live/_evidence/lot2-rate-limit-runtime-decision.md` |
+| `docs/go-live/_evidence/lot2-sensitive-fields-success-error-coverage.md` |
+| `docs/go-live/_evidence/lot2-stages-inscrire-product-rgpd.md` |
+| `docs/go-live/_evidence/lot2-student-activate-token-lifecycle.md` |
+| `docs/go-live/_evidence/lot3-assessments-public-token.md` |
+| `docs/go-live/_evidence/lot3-bilan-gratuit-rgpd-register.md` |
+| `docs/go-live/_evidence/lot3-business-configs-db-drift.md` |
+| `docs/go-live/_evidence/lot3-clictopay-disabled-contract.md` |
+| `docs/go-live/_evidence/lot3-contact-lead-retention-policy.md` |
+| `docs/go-live/_evidence/lot3-no-leak-success-error-runtime-coverage.md` |
+| `docs/go-live/_evidence/lot3-redis-upstash-runtime-proof.md` |
+| `docs/go-live/_evidence/lot3-runtime-rgpd-assessment-command-log.md` |
+| `docs/go-live/_evidence/lot4-assessment-token-binding.md` |
+| `docs/go-live/_evidence/lot4-business-config-production-gate.md` |
+| `docs/go-live/_evidence/lot4-clictopay-disabled-runbook.md` |
+| `docs/go-live/_evidence/lot4-contact-lead-retention-job.md` |
+| `docs/go-live/_evidence/lot4-no-leak-e2e-runtime-coverage.md` |
+| `docs/go-live/_evidence/lot4-redis-upstash-runtime-proof.md` |
+| `docs/go-live/_evidence/lot4-token-runtime-payment-command-log.md` |
+| `docs/go-live/_evidence/lot5-business-config-runtime-decision.md` |
+| `docs/go-live/_evidence/lot5-clictopay-final-disabled-decision.md` |
+| `docs/go-live/_evidence/lot5-contact-lead-retention-dry-run.md` |
+| `docs/go-live/_evidence/lot5-p1-go-no-go-register.md` |
+| `docs/go-live/_evidence/lot5-public-e2e-critical-paths.md` |
+| `docs/go-live/_evidence/lot5-rate-limit-429-proof.md` |
+| `docs/go-live/_evidence/lot5-redis-upstash-authenticated-healthcheck.md` |
+| `docs/go-live/_evidence/lot5-runtime-exploitation-command-log.md` |
+| `docs/go-live/_evidence/lot6-contact-lead-retention-db-dry-run.md` |
+| `docs/go-live/_evidence/lot6-final-go-no-go-register.md` |
+| `docs/go-live/_evidence/lot6-rate-limit-429-runtime-proof.md` |
+| `docs/go-live/_evidence/lot6-redis-upstash-authenticated-proof.md` |
+| `docs/go-live/_evidence/lot6-release-candidate-worktree-audit.md` |
+| `docs/go-live/_evidence/lot6-staging-release-candidate-command-log.md` |
+| `docs/go-live/_evidence/lot7-final-decision-register.md` |
+| `docs/go-live/_evidence/lot7-release-candidate-audit-command-log.md` |
+| `docs/go-live/_evidence/lot7-release-candidate-commit-plan.md` |
+| `docs/go-live/_evidence/lot7-release-candidate-file-manifest.md` |
+| `docs/go-live/_evidence/lot7-runtime-human-assisted-proof.md` |
+| `docs/go-live/_evidence/lot7-security-scripts-audit.md` |
+| `docs/go-live/_evidence/lot8-final-release-candidate-register.md` |
+| `docs/go-live/_evidence/lot8-release-candidate-clean-manifest-command-log.md` |
+| `docs/go-live/_evidence/lot8-release-candidate-commit-plan-clean.md` |
+| `docs/go-live/_evidence/lot8-release-candidate-file-manifest-clean.md` |
+| `docs/go-live/_evidence/lot8-runtime-proof-status.md` |
+| `docs/go-live/_evidence/lot8-security-scripts-regression-audit.md` |
+| `docs/go-live/_evidence/playwright-public-smoke-triage.md` |
+
+## Fichiers exclus ou en revue humaine
+
+| Fichier | Groupe | Raison |
+|---|---|---|
+| `docs/audits/audit-nexus-reussite.md` | Needs human review | Audit secondaire non demandé dans la RC |
+| `rapport_audit_2_07_2026.md` | Exclude | Rapport racine non suivi explicitement exclu |

--- a/docs/go-live/_evidence/lot8-release-candidate-file-manifest-clean.md
+++ b/docs/go-live/_evidence/lot8-release-candidate-file-manifest-clean.md
@@ -1,0 +1,305 @@
+# Lot 8 — Manifest release candidate propre
+
+Source : `git status --porcelain=v1 -uall` pendant le Lot 8. Aucun fichier n’est supprimé par ce manifeste.
+
+| Fichier | État Git | Groupe | Inclure RC | Commit proposé | Justification | Risque |
+|---|---|---|---:|---|---|---|
+| `__tests__/api/admin.config.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/admin.directeur.stats.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/admin.documents.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/admin.invoices.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/admin.recompute-ssn.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/admin.subscriptions.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/admin.test-email.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/assessments-rbac.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/assessments-submit.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/assistant.credit-requests.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/assistant.students.credits.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/assistant.subscription-requests.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/assistant.subscriptions.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/assistante.quotes.pdf.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/bilan-gratuit.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/bilans.id.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/bilans.idor.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/bilans/crud.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/bilans/generate.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/coach.eaf-preparation-report.validate.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/coach.generated-reports.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/documents-access.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/documents.id.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/invoices.pdf.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/invoices.receipt.pdf.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/npc.documents.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/npc.files.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/npc.generate.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/npc.uploads.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/parent.children.activation.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/parent.children.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/parent.subscription-requests.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/parent.subscriptions.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/payments.clictopay.init.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/payments.clictopay.webhook.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/programme.maths-1ere-stmg.stage-progress.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/public-rate-limit.coverage.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/sessions.cancel.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/sessions.video.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/stages.inscrire.security.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/stages/confirm.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/stages/inscriptions.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/student.activate.route.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/components/offer-detail-dialog.test.tsx` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/components/offres-page.test.tsx` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/lib/bilan-gratuit-form.test.tsx` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/lib/validations.test.ts` | `M` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `app/api/admin/config/rollback/route.ts` | `M` | API admin | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement routes admin | Revue sécurité admin |
+| `app/api/admin/config/route.ts` | `M` | API admin | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement routes admin | Revue sécurité admin |
+| `app/api/admin/directeur/stats/route.ts` | `M` | API admin | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement routes admin | Revue sécurité admin |
+| `app/api/admin/documents/route.ts` | `M` | API admin | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement routes admin | Revue sécurité admin |
+| `app/api/admin/invoices/route.ts` | `M` | API admin | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement routes admin | Revue sécurité admin |
+| `app/api/admin/recompute-ssn/route.ts` | `M` | API admin | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement routes admin | Revue sécurité admin |
+| `app/api/admin/subscriptions/route.ts` | `M` | API admin | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement routes admin | Revue sécurité admin |
+| `app/api/admin/test-email/route.ts` | `M` | API admin | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement routes admin | Revue sécurité admin |
+| `app/api/assessments/submit/route.ts` | `M` | Assessment token | Oui | `fix(public-funnel): lead-only bilan and assessment token binding` | Token assessment lié au flux lead/cookie | Flux public critique |
+| `app/api/assessments/submit/types.ts` | `M` | Assessment token | Oui | `fix(public-funnel): lead-only bilan and assessment token binding` | Token assessment lié au flux lead/cookie | Flux public critique |
+| `app/api/assistante/credit-requests/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/assistante/quotes/pdf/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/assistante/students/credits/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/assistante/subscription-requests/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/assistante/subscriptions/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/bilan-gratuit/dismiss/route.ts` | `M` | API public funnel | Oui | `fix(public-funnel): lead-only bilan and assessment token binding` | Bilan gratuit lead-only | Flux RGPD mineurs |
+| `app/api/bilan-gratuit/route.ts` | `M` | API public funnel | Oui | `fix(public-funnel): lead-only bilan and assessment token binding` | Bilan gratuit lead-only | Flux RGPD mineurs |
+| `app/api/bilans/[id]/export/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/bilans/[id]/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/bilans/generate/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/bilans/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/coach/students/[studentId]/documents/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/coach/students/[studentId]/eaf-preparation-report/validate/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/coach/students/[studentId]/notes/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/coach/students/[studentId]/survival-mode/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/coach/trajectory/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/documents/[id]/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/eleve/bilan-diagnostic-maths-terminale/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/internal/health/route.ts` | `M` | Rate limit | Oui | `fix(runtime): rate-limit probe and business-config gate` | Probe/health/rate limit runtime | Preuve runtime externe encore absente |
+| `app/api/invoices/[id]/pdf/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/invoices/[id]/receipt/pdf/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/lamis/teacher-report/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/npc/submissions/[submissionId]/documents/[documentId]/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/npc/submissions/[submissionId]/documents/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/npc/submissions/[submissionId]/generate/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/npc/submissions/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/npc/uploads/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/parent/children/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/parent/subscription-requests/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/parent/subscriptions/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/payments/clictopay/init/route.ts` | `M` | API payments | Oui | `fix(payments): keep clictopay disabled and fail closed` | ClicToPay désactivé/fail-closed | Ne pas réactiver paiement carte |
+| `app/api/payments/clictopay/webhook/route.ts` | `M` | API payments | Oui | `fix(payments): keep clictopay disabled and fail closed` | ClicToPay désactivé/fail-closed | Ne pas réactiver paiement carte |
+| `app/api/programme/maths-1ere-stmg/stage-progress/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/sessions/cancel/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/sessions/video/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/stages/[stageSlug]/inscrire/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/stages/[stageSlug]/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/student/activate/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/student/automatismes/attempts/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/student/automatismes/check-answer/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/student/automatismes/series/[id]/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/student/documents/[id]/download/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/student/nexus-index/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/student/survival/phrases/[phraseId]/copied/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/student/survival/progress/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/student/survival/qcm/attempt/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/student/survival/reflexes/[reflexId]/attempt/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/api/student/trajectory/route.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Durcissement API et ownership | Revue sécurité API |
+| `app/bilan-gratuit/assessment/page.tsx` | `M` | Assessment token | Oui | `fix(public-funnel): lead-only bilan and assessment token binding` | Token assessment lié au flux lead/cookie | Flux public critique |
+| `app/layout.tsx` | `M` | Front public | Oui | `fix(public-funnel): lead-only bilan and assessment token binding` | Front public critique ou configuration E2E | Revue UX/QA |
+| `components/assessments/AssessmentRunner.tsx` | `M` | Assessment token | Oui | `fix(public-funnel): lead-only bilan and assessment token binding` | Token assessment lié au flux lead/cookie | Flux public critique |
+| `components/marketing/PaymentMethodsNote.tsx` | `M` | API payments | Oui | `fix(payments): keep clictopay disabled and fail closed` | ClicToPay désactivé/fail-closed | Ne pas réactiver paiement carte |
+| `components/stages/StageInscriptionForm.tsx` | `M` | Front public | Oui | `fix(public-funnel): lead-only bilan and assessment token binding` | Front public critique ou configuration E2E | Revue UX/QA |
+| `docs/security/API_GUARD_INVENTORY.md` | `M` | Generated inventories | Oui | `chore(go-live): update security inventory and matrices` | Inventaire/matrice générés par gates | À régénérer avant commit |
+| `e2e/pages-public-bilan-gratuit.spec.ts` | `M` | Tests E2E | Oui | `test(e2e): protect public assessment route` | Smoke public ou assessment | Revue Playwright standard |
+| `e2e/pages-public-homepage.spec.ts` | `M` | Tests E2E | Oui | `test(e2e): protect public assessment route` | Smoke public ou assessment | Revue Playwright standard |
+| `e2e/pages-public-offres.spec.ts` | `M` | Tests E2E | Oui | `test(e2e): protect public assessment route` | Smoke public ou assessment | Revue Playwright standard |
+| `lib/config/snapshot.ts` | `M` | BusinessConfig | Oui | `fix(runtime): rate-limit probe and business-config gate` | Gate BusinessConfig production | Preuve runtime externe encore absente |
+| `lib/crm/contact-leads.ts` | `M` | RGPD/ContactLead | Oui | `fix(public-funnel): lead-only bilan and assessment token binding` | Lead-only et minimisation ContactLead | Flux RGPD mineurs |
+| `lib/invoice/index.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Helpers sécurité/facturation/stages | Revue sécurité API |
+| `lib/invoice/not-found.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Helpers sécurité/facturation/stages | Revue sécurité API |
+| `lib/rate-limit/index.ts` | `M` | Rate limit | Oui | `fix(runtime): rate-limit probe and business-config gate` | Probe/health/rate limit runtime | Preuve runtime externe encore absente |
+| `lib/stages/inscription-schema.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Helpers sécurité/facturation/stages | Revue sécurité API |
+| `lib/validations.ts` | `M` | API security | Oui | `fix(api-security): close admin and role guard gaps` | Helpers sécurité/facturation/stages | Revue sécurité API |
+| `playwright.config.ts` | `M` | Front public | Oui | `test(e2e): protect public assessment route` | Front public critique ou configuration E2E | Revue UX/QA |
+| `scripts/check-bundle-weight.sh` | `M` | Scripts audit | Oui | `chore(go-live): update security inventory and matrices` | Gate bundle corrigée pour routes dynamiques | Risque faible, couvert par check bundle |
+| `scripts/security/audit-api-guards.mjs` | `M` | Scripts audit | Oui | `chore(go-live): update security inventory and matrices` | Script audit sécurité couvert par régression | Risque classification, mitigé par tests |
+| `__tests__/api/assessments.public-token.binding.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/assessments.public-token.route.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/assessments.submit.token-binding.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/assessments.submit.token-security.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/bilan-gratuit.product-rgpd.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/bilan-gratuit.rgpd-minimization.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/bilan-gratuit.security.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/coach.bilan-diagnostic-maths-terminale.security.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/coach.eaf-stage-regenerate.security.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/coach.trajectory.security.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/eleve.bilan-diagnostic-maths-terminale.security.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/internal.business-config.health.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/internal.health.rate-limit.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/internal.rate-limit-probe.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/lamis.teacher-report.route.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/npc.submissions.security.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/payments.clictopay.disabled-contract.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/payments.clictopay.feature-flag-consistency.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/payments.clictopay.webhook.disabled.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/payments.clictopay.webhook.security.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/security/no-sensitive-fields-in-api-responses.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/stages.inscrire.product-rgpd.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/api/student.activate.lifecycle-security.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/app/bilan-gratuit.assessment-page-token.test.tsx` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/lib/assessments/public-token.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/lib/business-config.fallback.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/lib/business-config.production-gate.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/lib/crm/contact-leads.retention.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/lib/invoice/access-scope.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/lib/rate-limit.production-gate.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/scripts/audit-api-guards.classification.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/scripts/contact-leads-retention.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/scripts/security-audit-scripts-regression.test.ts` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `__tests__/ui/payment-methods.clictopay-disabled.test.tsx` | `??` | Tests unitaires | Oui | `test(security): add no-leak, idor, token and audit regressions` | Test unitaire/régression lié aux lots sécurité | Revue test standard |
+| `app/api/assessments/public-token/route.ts` | `??` | Assessment token | Oui | `fix(public-funnel): lead-only bilan and assessment token binding` | Token assessment lié au flux lead/cookie | Flux public critique |
+| `app/api/internal/rate-limit-probe/route.ts` | `??` | Rate limit | Oui | `fix(runtime): rate-limit probe and business-config gate` | Probe/health/rate limit runtime | Preuve runtime externe encore absente |
+| `app/bilan-gratuit/assessment/AssessmentClient.tsx` | `??` | Assessment token | Oui | `fix(public-funnel): lead-only bilan and assessment token binding` | Token assessment lié au flux lead/cookie | Flux public critique |
+| `docs/audits/audit-nexus-reussite.md` | `??` | Needs human review | Non | N/A | Audit secondaire non demandé dans la RC | Revue humaine avant inclusion |
+| `docs/go-live/00_EXECUTIVE_STATE.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/01_ACTION_PLAN.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/02_P0_P1_BACKLOG.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/03_RELEASE_GATES.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/04_TEST_MATRIX.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/05_API_SECURITY_MATRIX.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/06_BUSINESS_LOGIC_DECISIONS.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/07_ENV_INFRA_CHECKLIST.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/08_MARKETING_CONTENT_CHECKLIST.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/09_CODEX_NEXT_LOT_PROMPTS.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/10_LOT0_ACCEPTANCE.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/11_LOT1_SECURITY_CLOSURE.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/12_LOT1BIS_SECURITY_VERIFICATION.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/13_LOT1TER_P1_SECURITY_CLOSURE.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/14_LOT1QUATER_PUBLIC_ROLE_SECURITY_CLOSURE.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/15_LOT1QUINQUIES_FINAL_P1_SECURITY_CLOSURE.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/16_LOT2_PUBLIC_PRODUCT_RGPD_PAYMENT_DECISIONS.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/17_LOT3_RUNTIME_RGPD_ASSESSMENT_TOKEN.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/18_LOT4_RUNTIME_PAYMENT_RETENTION_TOKEN_BINDING.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/19_LOT5_RUNTIME_EXPLOITATION_GO_NO_GO.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/20_LOT6_STAGING_RELEASE_CANDIDATE_GO_NO_GO.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/21_LOT7_RELEASE_CANDIDATE_SECURITY_AUDIT.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/22_LOT8_RELEASE_CANDIDATE_CLEANUP.md` | `??` | Docs go-live | Oui | `docs(go-live): add evidence and go-no-go registers` | Documentation go-live structurante | Revue documentaire |
+| `docs/go-live/_evidence/entitlement-pricing-delta.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/hardcoded-pricing-triage.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot0-command-log.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1-api-route-triage.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1-command-log.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1-idor-tests.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1-rate-limit-runtime.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1bis-audit-script-review.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1bis-command-log.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1bis-p0-reclassification-audit.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1bis-p1-closure.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1bis-rate-limit-production-gate.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quater-assistante.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quater-coach.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quater-command-log.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quater-p1-before-after.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quater-parent-student.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quater-public-routes.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quater-rate-limit-runtime-proof.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quater-sensitive-fields-coverage.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quater-stages.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quinquies-admin-routes.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quinquies-clictopay-webhook.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quinquies-command-log.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quinquies-p1-before-after.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quinquies-public-sensitive-routes.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quinquies-rate-limit-runtime-proof.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1quinquies-sensitive-fields-coverage.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1ter-bilans-assessments.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1ter-coach-reports.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1ter-command-log.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1ter-npc-documents.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1ter-p1-before-after.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1ter-payments-invoices.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot1ter-sensitive-fields-coverage.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot2-assessments-submit-decision.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot2-bilan-gratuit-product-rgpd.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot2-clictopay-payment-decision.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot2-lamis-teacher-report-decision.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot2-public-product-rgpd-command-log.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot2-rate-limit-runtime-decision.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot2-sensitive-fields-success-error-coverage.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot2-stages-inscrire-product-rgpd.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot2-student-activate-token-lifecycle.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot3-assessments-public-token.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot3-bilan-gratuit-rgpd-register.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot3-business-configs-db-drift.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot3-clictopay-disabled-contract.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot3-contact-lead-retention-policy.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot3-no-leak-success-error-runtime-coverage.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot3-redis-upstash-runtime-proof.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot3-runtime-rgpd-assessment-command-log.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot4-assessment-token-binding.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot4-business-config-production-gate.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot4-clictopay-disabled-runbook.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot4-contact-lead-retention-job.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot4-no-leak-e2e-runtime-coverage.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot4-redis-upstash-runtime-proof.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot4-token-runtime-payment-command-log.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot5-business-config-runtime-decision.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot5-clictopay-final-disabled-decision.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot5-contact-lead-retention-dry-run.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot5-p1-go-no-go-register.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot5-public-e2e-critical-paths.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot5-rate-limit-429-proof.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot5-redis-upstash-authenticated-healthcheck.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot5-runtime-exploitation-command-log.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot6-contact-lead-retention-db-dry-run.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot6-final-go-no-go-register.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot6-rate-limit-429-runtime-proof.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot6-redis-upstash-authenticated-proof.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot6-release-candidate-worktree-audit.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot6-staging-release-candidate-command-log.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot7-final-decision-register.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot7-release-candidate-audit-command-log.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot7-release-candidate-commit-plan.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot7-release-candidate-file-manifest.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot7-runtime-human-assisted-proof.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot7-security-scripts-audit.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot8-final-release-candidate-register.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot8-release-candidate-clean-manifest-command-log.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot8-release-candidate-commit-plan-clean.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot8-release-candidate-file-manifest-clean.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot8-runtime-proof-status.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/lot8-security-scripts-regression-audit.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/_evidence/playwright-public-smoke-triage.md` | `??` | Docs evidence | Oui | `docs(go-live): add evidence and go-no-go registers` | Preuve go-live/release candidate | Volume documentaire élevé |
+| `docs/go-live/api-security-matrix.full.md` | `??` | Generated inventories | Oui | `chore(go-live): update security inventory and matrices` | Inventaire/matrice générés par gates | À régénérer avant commit |
+| `e2e/pages-public-bilan-assessment-token.spec.ts` | `??` | Tests E2E | Oui | `test(e2e): protect public assessment route` | Smoke public ou assessment | Revue Playwright standard |
+| `lib/assessments/public-token.ts` | `??` | Assessment token | Oui | `fix(public-funnel): lead-only bilan and assessment token binding` | Token assessment lié au flux lead/cookie | Flux public critique |
+| `rapport_audit_2_07_2026.md` | `??` | Exclude | Non | N/A | Rapport racine non suivi explicitement exclu | Ne pas inclure sans décision humaine |
+| `scripts/go-live/generate-api-security-matrix.mjs` | `??` | Scripts go-live | Oui | `chore(go-live): update security inventory and matrices` | Génération matrice go-live | Risque documentaire, mitigé par tests |
+| `scripts/maintenance/contact-leads-retention.ts` | `??` | Scripts maintenance | Oui | `chore(maintenance): add contact-lead retention dry-run` | Script maintenance dry-run | Ne jamais lancer --apply sans validation |
+
+## Synthèse
+- total fichiers suivis modifiés : 130
+- total fichiers non suivis : 153
+- total Include RC : 281
+- total Exclude : 1
+- total Needs human review : 1
+- fichiers .env détectés : 0
+- fichiers racine suspects : `playwright.config.ts`, `rapport_audit_2_07_2026.md`
+
+## Contrôles Lot 8
+
+- Tous les chemins `__tests__/**` sont classés `Tests unitaires`.
+- Tous les chemins `e2e/**` sont classés `Tests E2E`.
+- `rapport_audit_2_07_2026.md` est classé `Exclude`.
+- `docs/audits/audit-nexus-reussite.md` est classé `Needs human review`.

--- a/docs/go-live/_evidence/lot8-runtime-proof-status.md
+++ b/docs/go-live/_evidence/lot8-runtime-proof-status.md
@@ -1,0 +1,22 @@
+# Lot 8 — Statut preuves runtime
+
+## Variables vérifiées sans afficher de valeur
+
+| Variable / flag | Résultat | Commande exécutée |
+|---|---|---|
+| `NEXUS_HEALTH_AUTH` | `NEXUS_HEALTH_AUTH_ABSENT` | présence uniquement, valeur non affichée |
+| `NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE` | `RL_PROBE_NOT_ALLOWED` | comparaison à `true`, valeur non affichée |
+| `DATABASE_URL` | `DATABASE_URL_ABSENT` | présence uniquement, valeur non affichée |
+| `NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB` | `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED` | comparaison à `true`, valeur non affichée |
+
+## Exécution runtime
+
+- Healthcheck authentifié Redis/Upstash : non exécuté.
+- Test `429` staging/production : non exécuté.
+- Dry-run DB ContactLead : non exécuté.
+
+Cause : variables/autorisation absentes.
+
+## Décision
+
+Redis/Upstash, le `429` runtime réel et le dry-run DB ContactLead restent non prouvés tant que les variables/autorisation ne sont pas présentes.

--- a/docs/go-live/_evidence/lot8-security-scripts-regression-audit.md
+++ b/docs/go-live/_evidence/lot8-security-scripts-regression-audit.md
@@ -1,0 +1,32 @@
+# Lot 8 — Audit regression scripts securite
+
+## Verdict
+
+`ACCEPTED`
+
+## Tests renforcés
+
+Fichier : `__tests__/scripts/security-audit-scripts-regression.test.ts`
+
+Cas couverts :
+
+- route publique avec mutation + Zod + rate limit reste `P1` ;
+- webhook disabled `501` reste `P1` ;
+- route staff-looking sans rôle explicite ne devient pas `OK` ;
+- route PII authentifiée sans ownership ne devient pas `OK` ;
+- route dynamique `[id]` sensible sans ownership reste au-dessus de `OK` ;
+- `/api/internal/rate-limit-probe` reste `OK` uniquement comme route interne non-PII ;
+- les 6 P1 actuels restent `P1` ;
+- le total route files correspond à l’inventaire.
+
+## Commande ciblée
+
+```bash
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand __tests__/scripts/audit-api-guards.classification.test.ts __tests__/scripts/security-audit-scripts-regression.test.ts
+```
+
+Résultat : `2` suites passées, `16` tests passés.
+
+## Décision
+
+Les scripts d’audit restent acceptés comme triage statique, avec réserve : ils ne remplacent ni les tests IDOR, ni la preuve runtime Redis/Upstash, ni la décision humaine sur les P1.

--- a/docs/go-live/_evidence/lot9-final-release-candidate-register.md
+++ b/docs/go-live/_evidence/lot9-final-release-candidate-register.md
@@ -1,0 +1,21 @@
+# Lot 9 — Registre final release candidate
+
+| Domaine | Statut | Preuve | Décision |
+|---|---|---|---|
+| P0 | 0 | matrice | OK |
+| P1 | 6 | matrice | bêta contrôlée seulement |
+| Manifest consistency | PASSED | `__tests__/scripts/release-candidate-manifest-consistency.test.ts` | RC_READY_FOR_HUMAN_REVIEW |
+| Commit plan consistency | PASSED | `__tests__/scripts/release-candidate-manifest-consistency.test.ts` | RC_READY_FOR_HUMAN_REVIEW |
+| Runtime Redis | NOT_PROVEN | variables absentes | BETA_ELARGIE_BLOCKED |
+| 429 runtime | NOT_PROVEN | probe non autorisée | BETA_ELARGIE_BLOCKED |
+| ContactLead DB dry-run | NOT_PROVEN | DB/autorisation absentes | GO_LIVE_LARGE_BLOCKED |
+| ClicToPay | DISABLED | décisions Lots 5-8 | manual payment |
+| RC | READY_FOR_HUMAN_REVIEW | manifeste/plan cohérents, gates ciblées OK | commit humain seulement |
+| Gates finales | OK | Typecheck, lint, unit, build, audits, checks, Playwright public et assessment | RC_READY_FOR_HUMAN_REVIEW |
+
+## Décision finale Lot 9
+
+- `RC_READY_FOR_HUMAN_REVIEW`
+- `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`
+- `BETA_ELARGIE_BLOCKED`
+- `GO_LIVE_LARGE_BLOCKED`

--- a/docs/go-live/_evidence/lot9-human-review-checklist.md
+++ b/docs/go-live/_evidence/lot9-human-review-checklist.md
@@ -1,0 +1,75 @@
+# Lot 9 — Checklist revue humaine RC
+
+## À vérifier avant commit
+
+- [ ] Les 6 P1 sont encore visibles.
+- [ ] Aucun `.env` n'est inclus.
+- [ ] `rapport_audit_2_07_2026.md` est exclu.
+- [ ] `docs/audits/audit-nexus-reussite.md` est décidé explicitement.
+- [ ] Les scripts d'audit sont acceptés avec les tests de régression.
+- [ ] Aucun artefact `.next`, `node_modules`, `test-results`, `playwright-report` n'est inclus.
+- [ ] ClicToPay reste disabled.
+- [ ] Le paiement carte n'est pas annoncé publiquement.
+- [ ] Le flux assessment public ne révèle pas de token ou email en query/HTML.
+- [ ] ContactLead retention reste en dry-run par défaut.
+- [ ] Aucun `--apply` production n'est prévu.
+- [ ] Les commits proposés sont validés dans l'ordre.
+
+## Commit 1 — chore(go-live): update security inventory and matrices
+
+- [ ] Fichiers relus
+- [ ] Tests relancés
+- [ ] Risques acceptés
+
+## Commit 2 — fix(api-security): close admin and role guard gaps
+
+- [ ] Fichiers relus
+- [ ] Tests relancés
+- [ ] Risques acceptés
+
+## Commit 3 — fix(public-funnel): lead-only bilan and assessment token binding
+
+- [ ] Fichiers relus
+- [ ] Tests relancés
+- [ ] Risques acceptés
+
+## Commit 4 — fix(runtime): rate-limit probe and business-config gate
+
+- [ ] Fichiers relus
+- [ ] Tests relancés
+- [ ] Risques acceptés
+
+## Commit 5 — fix(payments): keep clictopay disabled and fail closed
+
+- [ ] Fichiers relus
+- [ ] Tests relancés
+- [ ] Risques acceptés
+
+## Commit 6 — chore(maintenance): add contact-lead retention dry-run
+
+- [ ] Fichiers relus
+- [ ] Tests relancés
+- [ ] Risques acceptés
+
+## Commit 7 — test(security): add no-leak, idor, token and audit regressions
+
+- [ ] Fichiers relus
+- [ ] Tests relancés
+- [ ] Risques acceptés
+
+## Commit 8 — test(e2e): protect public assessment route
+
+- [ ] Fichiers relus
+- [ ] Tests relancés
+- [ ] Risques acceptés
+
+## Commit 9 — docs(go-live): add evidence and go-no-go registers
+
+- [ ] Fichiers relus
+- [ ] Tests relancés
+- [ ] Risques acceptés
+
+## Artefacts Lot 9 à décider
+
+- [ ] Inclure `__tests__/scripts/release-candidate-manifest-consistency.test.ts` dans le commit tests si la validation mécanique devient une gate RC permanente.
+- [ ] Inclure les preuves Lot 9 dans le commit docs go-live si la revue humaine s'appuie dessus.

--- a/docs/go-live/_evidence/lot9-rc-manifest-consistency-proof.md
+++ b/docs/go-live/_evidence/lot9-rc-manifest-consistency-proof.md
@@ -1,0 +1,56 @@
+# Lot 9 — RC manifest consistency proof
+
+## Résultat
+
+`PASSED`
+
+## Fichiers Include RC
+
+`281`
+
+## Fichiers Exclude
+
+`1`
+
+## Fichiers Needs human review
+
+`1`
+
+## Fichiers non couverts par un commit
+
+Aucun.
+
+## Fichiers couverts plusieurs fois
+
+Aucun.
+
+## Fichiers Exclude inclus par erreur
+
+Aucun.
+
+## Needs human review inclus
+
+Aucun.
+
+## Règles verrouillées par test
+
+- `__tests__/**` doit être `Tests unitaires`.
+- `e2e/**` doit être `Tests E2E`.
+- `scripts/security/**` doit être `Scripts audit`.
+- `scripts/go-live/**` doit être `Scripts go-live`.
+- `scripts/maintenance/**` doit être `Scripts maintenance`.
+- `rapport_audit_2_07_2026.md` doit rester `Exclude`.
+- Aucun `.env*`, `.next/**`, `node_modules/**`, `test-results/**`, `playwright-report/**` ne doit être `Include RC`.
+- Les 6 P1 doivent rester visibles dans `docs/go-live/api-security-matrix.full.md`.
+
+## Test exécuté
+
+```bash
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand __tests__/scripts/security-audit-scripts-regression.test.ts __tests__/scripts/release-candidate-manifest-consistency.test.ts
+```
+
+Résultat : `2` suites passées, `14` tests passés.
+
+## Décision
+
+`RC_READY_FOR_HUMAN_REVIEW`

--- a/docs/go-live/_evidence/lot9-rc-manifest-validation-command-log.md
+++ b/docs/go-live/_evidence/lot9-rc-manifest-validation-command-log.md
@@ -1,0 +1,132 @@
+# Lot 9 — Journal validation manifeste RC
+
+## Baseline
+
+- Date locale : 2026-07-03 16:12:02 CET
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Node : `v20.20.0`
+- npm : `10.8.2`
+- Diff `.env` : aucune sortie.
+
+## Commandes baseline exécutées
+
+```bash
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && node -v
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm -v
+git rev-parse --abbrev-ref HEAD
+git rev-parse --short HEAD
+git status --short --untracked-files=all
+git diff --name-only
+git diff --stat
+git ls-files --others --exclude-standard
+git diff --name-only | rg '(^|/)\\.env($|\\.)' || true
+```
+
+## État initial observé
+
+- Fichiers suivis modifiés : `130`
+- Fichiers non suivis avant artefacts Lot 9 : `153`
+- Entrées `git status --short --untracked-files=all` après ajout du test Lot 9 : `284`
+- Entrées `git status --short --untracked-files=all` après création des preuves Lot 9 : `290`
+- Diff stat suivi : `130 files changed, 3269 insertions(+), 1258 deletions(-)`
+- P1 visibles : `6`
+
+## Test ciblé Lot 9
+
+Commande :
+
+```bash
+source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run test:unit -- --runInBand __tests__/scripts/security-audit-scripts-regression.test.ts __tests__/scripts/release-candidate-manifest-consistency.test.ts
+```
+
+Résultat : `OK`, `2` suites passées, `14` tests passés.
+
+Note TDD : un premier run RED a échoué car le parseur initial comptait la table finale d'exclusion du plan de commits comme appartenant au dernier commit, et parce que la liste attendue P1 était volontairement incomplète. Le test a ensuite été corrigé pour ne collecter que les sections de commits numérotées et verrouiller les 6 P1.
+
+## Runtime assisté
+
+```bash
+if [ -n "${NEXUS_HEALTH_AUTH:-}" ]; then echo "NEXUS_HEALTH_AUTH_PRESENT"; else echo "NEXUS_HEALTH_AUTH_ABSENT"; fi
+if [ "${NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE:-}" = "true" ]; then echo "RL_PROBE_ALLOWED"; else echo "RL_PROBE_NOT_ALLOWED"; fi
+if [ -n "${DATABASE_URL:-}" ]; then echo "DATABASE_URL_PRESENT"; else echo "DATABASE_URL_ABSENT"; fi
+if [ "${NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB:-}" = "true" ]; then echo "CONTACT_LEAD_DRY_RUN_ALLOWED"; else echo "CONTACT_LEAD_DRY_RUN_NOT_ALLOWED"; fi
+```
+
+Résultat :
+
+- `NEXUS_HEALTH_AUTH_ABSENT`
+- `RL_PROBE_NOT_ALLOWED`
+- `DATABASE_URL_ABSENT`
+- `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED`
+
+## Limites
+
+- Aucun secret lu.
+- Aucun `.env` modifié.
+- Aucun commit.
+- Aucune PR.
+- Aucune preuve Redis/Upstash staging/production.
+- Aucun test `429` runtime staging/production.
+- Aucun dry-run DB ContactLead non production.
+
+## Gates finales
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `npm run typecheck` | OK | `tsc --noEmit` sans erreur |
+| `npm run lint` | OK | Commande terminée avec code `0`; warnings existants dans le seuil configuré |
+| `npm run test:unit -- --runInBand` | OK | `539` suites passées sur `540`, `1` skipped ; `6521` tests passés sur `6525`, `4` skipped |
+| `npm run build` | OK | Build Next.js terminé ; `142` pages statiques générées ; assets standalone copiés |
+| `node scripts/security/audit-api-guards.mjs` | OK | `178` routes écrites dans `docs/security/API_GUARD_INVENTORY.md` |
+| `node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=6`, `P2=144`, `OK=28` |
+| `npm run audit:site-map` | OK | `292` routes, `413` edges, `0` link finding, `13` orphan entries |
+| `npm run check:no-hardcoded` | OK | `0` hardcoded values outside canonical sources |
+| `npm run check:docs-archive` | OK | Aucun audit/report historique à la racine `docs/` |
+| `npm run check:bundle-weight` | OK | Toutes les routes dans baseline + `5 kB` |
+| `PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | OK | `24` tests passés |
+| `PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium` | OK | `1` test passé |
+
+## Vérifications post-gates
+
+- Matrice API : `P0=0`, `P1=6`, `P2=144`, `OK=28`.
+- P1 visibles : `/api/payments/clictopay/webhook`, `/api/assessments/submit`, `/api/bilan-gratuit`, `/api/lamis/teacher-report`, `/api/stages/[stageSlug]/inscrire`, `/api/student/activate`.
+- Diff `.env` : aucune sortie.
+- Aucun commit.
+- Aucune PR.
+
+## Revalidation demandée
+
+- Date locale : 2026-07-03 16:28:39 CET
+- Node : `v20.20.0`
+- npm : `10.8.2`
+- Branche : `feat/lot4-accessors-runtime`
+- Commit court : `db8545a19`
+- Entrées `git status --short --untracked-files=all` : `290`
+- Diff `.env` : aucune sortie.
+
+Résultats revalidés :
+
+| Commande | Statut | Résultat |
+| --- | --- | --- |
+| `npm run test:unit -- --runInBand __tests__/scripts/security-audit-scripts-regression.test.ts __tests__/scripts/release-candidate-manifest-consistency.test.ts` | OK | `2` suites passées, `14` tests passés |
+| `npm run typecheck` | OK | `tsc --noEmit` sans erreur |
+| `npm run lint` | OK | Commande terminée avec code `0`; warnings existants dans le seuil configuré |
+| `npm run test:unit -- --runInBand` | OK | `539` suites passées sur `540`, `1` skipped ; `6521` tests passés sur `6525`, `4` skipped |
+| `npm run build` | OK | Build Next.js terminé ; `142` pages statiques générées ; assets standalone copiés |
+| `node scripts/security/audit-api-guards.mjs` | OK | `178` routes écrites dans `docs/security/API_GUARD_INVENTORY.md` |
+| `node scripts/go-live/generate-api-security-matrix.mjs` | OK | `P0=0`, `P1=6`, `P2=144`, `OK=28` |
+| `npm run audit:site-map` | OK | `292` routes, `413` edges, `0` link finding, `13` orphan entries |
+| `npm run check:no-hardcoded` | OK | `0` hardcoded values outside canonical sources |
+| `npm run check:docs-archive` | OK | Aucun audit/report historique à la racine `docs/` |
+| `npm run check:bundle-weight` | OK | Toutes les routes dans baseline + `5 kB` |
+| `PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | OK | `24` tests passés |
+| `PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3012 npx playwright test e2e/pages-public-bilan-assessment-token.spec.ts --project=chromium` | OK | `1` test passé |
+
+Commande échouée puis corrigée :
+
+```bash
+source /home/alaeddine/.nvm/nvm use 20.20.0 >/dev/null && npm run lint
+```
+
+Résultat : `ÉCHEC` par faute de frappe locale (`/home/alaeddine/.nvm/nvm` au lieu de `nvm.sh`). La commande correcte a été relancée immédiatement et a terminé `OK`.

--- a/docs/go-live/_evidence/lot9-runtime-proof-status.md
+++ b/docs/go-live/_evidence/lot9-runtime-proof-status.md
@@ -1,0 +1,22 @@
+# Lot 9 — Statut preuves runtime
+
+## Variables vérifiées sans afficher de valeur
+
+| Variable / flag | Résultat | Commande exécutée |
+|---|---|---|
+| `NEXUS_HEALTH_AUTH` | `NEXUS_HEALTH_AUTH_ABSENT` | présence uniquement, valeur non affichée |
+| `NEXUS_ALLOW_RATE_LIMIT_PROD_PROBE` | `RL_PROBE_NOT_ALLOWED` | comparaison à `true`, valeur non affichée |
+| `DATABASE_URL` | `DATABASE_URL_ABSENT` | présence uniquement, valeur non affichée |
+| `NEXUS_ALLOW_CONTACT_LEAD_DRY_RUN_DB` | `CONTACT_LEAD_DRY_RUN_NOT_ALLOWED` | comparaison à `true`, valeur non affichée |
+
+## Exécution runtime
+
+- Healthcheck authentifié Redis/Upstash : non exécuté.
+- Test `429` staging/production : non exécuté.
+- Dry-run DB ContactLead : non exécuté.
+
+Cause : variables/autorisation absentes.
+
+## Décision
+
+Redis/Upstash, le `429` runtime réel et le dry-run DB ContactLead restent non prouvés. Bêta élargie et go-live large restent bloqués.

--- a/docs/go-live/_evidence/playwright-public-smoke-triage.md
+++ b/docs/go-live/_evidence/playwright-public-smoke-triage.md
@@ -1,0 +1,75 @@
+# Triage smoke Playwright public Lot 0-bis
+
+Date locale : 2026-07-02 18:20 CET  
+Branche : `feat/lot4-accessors-runtime`  
+Commit court : `db8545a19`
+
+## Commandes et résultats
+
+| Statut | Objectif | Commande exacte | Résultat observé |
+| --- | --- | --- | --- |
+| ÉCHEC | Reproduire l'état Lot 0 | `npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | 18 passés, 4 échoués. |
+| OK | Vérifier l'hydratation réelle | Script Playwright local sur `http://127.0.0.1:3002/bilan-gratuit` | 404 sur de nombreux chunks `_next/static`, aucune erreur formulaire après clic. |
+| OK | Aligner le build avec CI/Docker | `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npm run build` | Build Next OK, 143 pages générées. |
+| OK | Rejouer le smoke sur build propre Node 20 | `source /home/alaeddine/.nvm/nvm.sh && nvm use 20.20.0 >/dev/null && npx playwright test e2e/pages-public-homepage.spec.ts e2e/pages-public-offres.spec.ts e2e/pages-public-bilan-gratuit.spec.ts --project=chromium` | 24 passés, 0 échoué. |
+
+Note : le serveur Playwright a loggé un warning Prisma `P2021` sur `business_configs` absent dans la base e2e locale. Le warning n'a pas fait échouer le smoke public, mais reste à traiter avec la baseline DB e2e.
+
+## Échec Playwright public — validation vide bilan gratuit
+
+- Spec : `e2e/pages-public-bilan-gratuit.spec.ts`
+- Page : `/bilan-gratuit`
+- Attendu : `Prénom requis`, `Email invalide`, `Classe requise`.
+- Observé : aucun message affiché sur le serveur déjà présent en port `3002`.
+- Cause probable : serveur standalone ancien réutilisé par Playwright ; HTML servi mais chunks `_next/static` 404, donc client React non hydraté.
+- Test obsolète ? Non.
+- Régression UX ? Non prouvée sur build propre ; régression de harness test.
+- Correction retenue : `playwright.config.ts` ne réutilise plus un serveur existant par défaut et dérive `PORT`/`NEXTAUTH_URL` du `baseURL`.
+- Fichiers modifiés : `playwright.config.ts`.
+- Test de validation : smoke ciblé Node 20 vert, 24/24.
+
+## Échec Playwright public — email invalide bilan gratuit
+
+- Spec : `e2e/pages-public-bilan-gratuit.spec.ts`
+- Page : `/bilan-gratuit`
+- Attendu : `Email invalide`.
+- Observé : aucun message affiché sur serveur stale.
+- Cause probable : même défaut d'hydratation causé par chunks 404.
+- Test obsolète ? Non.
+- Régression UX ? Non sur build propre.
+- Correction retenue : revalidation sur serveur Playwright propre ; test conservé.
+- Fichiers modifiés : `playwright.config.ts`.
+- Test de validation : smoke ciblé Node 20 vert, 24/24.
+
+## Échec Playwright public — disparition erreur email
+
+- Spec : `e2e/pages-public-bilan-gratuit.spec.ts`
+- Page : `/bilan-gratuit`
+- Attendu : `Email invalide` visible après soumission vide puis disparition après saisie valide.
+- Observé : erreur jamais affichée sur serveur stale.
+- Cause probable : même défaut d'hydratation causé par chunks 404.
+- Test obsolète ? Non.
+- Régression UX ? Non sur build propre.
+- Correction retenue : revalidation sur serveur Playwright propre ; test conservé.
+- Fichiers modifiés : `playwright.config.ts`.
+- Test de validation : smoke ciblé Node 20 vert, 24/24.
+
+## Échec Playwright public — compteur WhatsApp homepage
+
+- Spec : `e2e/pages-public-homepage.spec.ts`
+- Page : `/`
+- Attendu Lot 0 : exactement 2 liens WhatsApp au chargement, puis 4 dans le DOM après scroll.
+- Observé Lot 0 : 3 liens au chargement sur serveur stale ; build propre : 2 liens possibles au chargement, liens flottants rendus selon scroll/viewport.
+- Cause probable : test trop couplé à un nombre exact de liens alors que l'UX officielle comporte hero/footer/contact direct et liens flottants conditionnels.
+- Test obsolète ? Oui pour le comptage exact.
+- Régression UX ? Non : les liens visibles ont un `href` WhatsApp canonique et un nom accessible.
+- Correction retenue : remplacer le comptage exact par un contrôle snapshot DOM : au moins 2 liens au chargement, `href` `wa.me/21699192829`, nom accessible, liens visibles desktop et mobile après scroll.
+- Fichiers modifiés : `e2e/pages-public-homepage.spec.ts`.
+- Test de validation : smoke ciblé Node 20 vert, 24/24.
+
+## Décisions QA associées
+
+- Les tests `/bilan-gratuit` restent des tests produit valides.
+- Le test WhatsApp a été requalifié comme obsolète dans sa forme exacte, pas comme régression UX.
+- Le smoke public ciblé doit être lancé sur un serveur Playwright propre, sauf opt-in explicite `PLAYWRIGHT_REUSE_EXISTING_SERVER=true`.
+- Le smoke vérifie maintenant aussi que GA n'est pas chargé dans le HTML initial sans opt-in explicite et que ClicToPay n'est pas exposé publiquement tant que l'intégration publique n'est pas activée.

--- a/docs/go-live/api-security-matrix.full.md
+++ b/docs/go-live/api-security-matrix.full.md
@@ -1,0 +1,216 @@
+# Annexe matrice API sécurité complète
+
+Source : `docs/security/API_GUARD_INVENTORY.md`.
+Généré le : 2026-07-06T20:47:11.266Z.
+
+Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Zod détecté` et `Ownership requis` sont des indices de pilotage. `À vérifier` signifie qu’aucune preuve suffisante n’a été établie dans ce lot.
+
+## Synthèse
+
+| Priorité | Nombre |
+| --- | ---: |
+| P0 | 0 |
+| P1 | 6 |
+| P2 | 144 |
+| OK | 28 |
+| Total | 178 |
+
+## Top 20 à corriger en priorité (P1)
+
+| Priorité | Route | Domaine | Risque dominant | Action Lot suivant |
+| --- | --- | --- | --- | --- |
+| P1 | `/api/payments/clictopay/webhook` | Paiement | Facture/paiement | Durcir avant bêta élargie |
+| P1 | `/api/assessments/submit` | Bilans/assessments | Données pédagogiques mineur | Durcir avant bêta élargie |
+| P1 | `/api/bilan-gratuit` | Bilans/assessments | Données pédagogiques mineur | Durcir avant bêta élargie |
+| P1 | `/api/lamis/teacher-report` | Bilans/assessments | Données pédagogiques mineur | Durcir avant bêta élargie |
+| P1 | `/api/stages/[stageSlug]/inscrire` | Stages | Réservation/session | Durcir avant bêta élargie |
+| P1 | `/api/student/activate` | Élève | PII/utilisateur | Durcir avant bêta élargie |
+
+## Matrice route par route
+
+| Priorité | Route | Méthodes | Domaine | Public/Auth | Rôle requis | Ownership requis | Auth guard détecté | Role guard détecté | Zod détecté | Rate limit détecté | Données sensibles | Action Lot suivant |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| P2 | `/api/admin/activities` | GET | Admin | Auth | Admin/staff | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/analytics` | GET | Admin | Auth | Admin/staff | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/config/history` | GET | Admin | Auth | Admin/staff | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/config/rollback` | POST | Admin | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/config` | GET, PATCH | Admin | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/dashboard` | GET | Admin | Auth | Admin/staff | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/directeur/stats` | GET | Admin | Auth | Admin/staff | Oui | Oui | Oui | Oui | Oui | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/documents` | POST | Documents | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | Document/fichier, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/invoices/[id]` | PATCH | Facturation | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | Facture/paiement, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/invoices/[id]/send` | POST | Facturation | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | Facture/paiement, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/invoices` | POST, GET | Facturation | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | Facture/paiement, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/recompute-ssn` | POST | Admin | Auth | Admin/staff | Oui | Oui | Oui | Oui | Oui | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/stages/[stageId]/coaches` | GET, POST, DELETE | Stages | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/admin/stages/[stageId]` | GET, PATCH, DELETE | Stages | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/admin/stages/[stageId]/sessions/[sessionId]` | PATCH, DELETE | Stages | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/admin/stages/[stageId]/sessions` | GET, POST | Stages | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/admin/stages` | GET, POST | Stages | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/admin/subscriptions` | GET, PUT | Admin | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/test-email` | POST, GET | Admin | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/users` | GET, POST, PATCH, DELETE | Admin | Auth | Admin/staff | Oui | Oui | Oui | Oui | Oui | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/users/search` | GET | Admin | Auth | Admin/staff | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| OK | `/api/analytics/event` | POST | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| P2 | `/api/aria/chat` | POST | ARIA/RAG | Auth | Élève/abonné à vérifier | Oui | Oui | Oui | Oui | Non | Conversation IA | Suivi qualité P2 |
+| P2 | `/api/aria/conversations` | GET | ARIA/RAG | Auth | Élève/abonné à vérifier | Oui | Oui | Oui | Non | Non | Conversation IA | Suivi qualité P2 |
+| P2 | `/api/aria/feedback` | POST | ARIA/RAG | Auth | Élève/abonné à vérifier | Oui | Oui | Oui | Oui | Non | Conversation IA | Suivi qualité P2 |
+| P2 | `/api/assessments/[id]/export` | GET | Bilans/assessments | Auth | À vérifier | Oui | Oui | Non | Non | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/assessments/[id]/result` | GET | Bilans/assessments | Auth | À vérifier | Oui | Oui | Non | Non | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/assessments/[id]/status` | GET | Bilans/assessments | Auth | À vérifier | Oui | Oui | Non | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/assessments/predict` | POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/assessments/public-token` | POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Oui | Données pédagogiques mineur | Suivi qualité P2 |
+| P1 | `/api/assessments/submit` | POST | Bilans/assessments | Public | N/A | N/A | Non | Non | Oui | Oui | Données pédagogiques mineur | Durcir avant bêta élargie |
+| P2 | `/api/assessments/test` | GET | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/assistante/activate-student` | POST | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/assignments/[id]` | GET, PATCH | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/assignments` | GET, POST | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/coaches/manage/[id]` | PUT, DELETE | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/coaches/manage` | GET, POST | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/coaches` | GET | Assistante | Auth | Assistante | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/credit-requests` | GET, POST | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/dashboard` | GET | Assistante | Auth | Assistante | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/planning` | GET | Assistante | Auth | Assistante | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/quotes/pdf` | POST | Documents | Auth | Assistante | Oui | Oui | Oui | Oui | Oui | Document/fichier, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/sessions` | POST | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/assistante/stages` | GET | Stages | Auth | Assistante | Oui | Oui | Oui | Non | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/assistante/students/[studentId]/documents` | GET, POST | Documents | Auth | Assistante | Oui | Oui | Oui | Oui | Non | Document/fichier, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/students/[studentId]` | GET | Assistante | Auth | Assistante | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/students/credits` | GET, POST | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/students` | GET, POST | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/subscription-requests` | GET, PATCH | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/subscriptions` | GET, POST | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| OK | `/api/auth/[...nextauth]` | - | Auth | Public/À vérifier | N/A | Oui | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/auth/resend-activation` | POST | Auth | Public/À vérifier | N/A | N/A | Non | Non | Oui | Oui | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/auth/reset-password` | POST | Auth | Public/À vérifier | N/A | N/A | Non | Non | Oui | Oui | À vérifier | Maintenir tests de non-régression |
+| P2 | `/api/bilan-gratuit/dismiss` | POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P1 | `/api/bilan-gratuit` | POST | Bilans/assessments | Public | N/A | N/A | Non | Non | Oui | Oui | Données pédagogiques mineur | Durcir avant bêta élargie |
+| P2 | `/api/bilan-gratuit/status` | GET | Bilans/assessments | Auth | À vérifier | Oui | Oui | Non | Non | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/bilan-pallier2-maths/retry` | POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/bilan-pallier2-maths` | POST, GET | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Oui | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/bilans/[id]/export` | GET, POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/bilans/[id]` | GET, PUT, DELETE | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/bilans/generate` | POST, GET | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/bilans` | GET, POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/coach/dashboard` | GET | Coach | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate` | POST | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/coach/eaf-stage-printemps/students/[studentId]/report` | GET, POST, PATCH | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/coach/eaf-stage-printemps/students` | GET | Stages | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent` | POST | Stages | Auth | Coach | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student` | POST | Stages | Auth | Coach | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/coach/maths-premiere-stage-printemps/students/[studentId]/report` | GET, POST, PATCH | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/coach/maths-premiere-stage-printemps/students` | GET | Stages | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/coach/nsi-pratique-2026/students/[studentId]/progress` | GET | Coach | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/nsi-pratique-2026/students` | GET | Coach | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/sessions/[sessionId]/report` | POST, GET | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/coach/stages` | GET | Stages | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale` | GET, PATCH | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/documents` | GET, POST | Documents | Auth | Coach | Oui | Oui | Oui | Oui | Non | Document/fichier, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/dossier` | GET | Coach | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/eaf-preparation-report` | GET, PUT | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/eaf-preparation-report/validate` | POST | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/generated-reports/[reportId]/download` | GET | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Non | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/generated-reports/[reportId]/generate` | POST | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate` | POST | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/generated-reports` | GET, POST | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/notes` | GET, POST | Coach | Auth | Coach | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]` | GET | Coach | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/survival-mode` | POST | Coach | Auth | Coach | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/eam-summary` | GET | Coach | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students` | GET | Coach | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/trajectory` | POST | Coach | Auth | Coach | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coaches/availability` | POST, GET, DELETE | Coach | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coaches/available` | GET | Coach | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| OK | `/api/contact` | POST | Leads/messages | Public | N/A | N/A | Non | Non | Non | Oui | Lead/contact | Maintenir tests de non-régression |
+| OK | `/api/diagnostics/definitions` | GET | Bilans/assessments | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | Données pédagogiques mineur | Maintenir tests de non-régression |
+| P2 | `/api/documents/[id]` | GET | Documents | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Document/fichier | Suivi qualité P2 |
+| OK | `/api/eam/progress` | GET, POST | Autre | Auth | À vérifier | À vérifier | Oui | Non | Oui | Non | À vérifier | Maintenir tests de non-régression |
+| P2 | `/api/eleve/bilan-diagnostic-maths-terminale` | GET, POST | Bilans/assessments | Auth | Élève | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| OK | `/api/eleve/nsi-pratique-2026/progress` | GET, PUT | Élève | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur | Maintenir tests de non-régression |
+| P2 | `/api/eleve/questionnaire-eaf-stage-printemps` | GET, POST | Stages | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/eleve/questionnaire-maths-premiere-stage-printemps` | GET, POST | Stages | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/eleve/stages` | GET | Stages | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| OK | `/api/health` | GET | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/internal/health` | GET | Autre | Auth | Rôle détecté, à qualifier | À vérifier | Oui | Oui | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/internal/rate-limit-probe` | GET | Autre | Auth | Rôle détecté, à qualifier | À vérifier | Oui | Oui | Non | Oui | À vérifier | Maintenir tests de non-régression |
+| P2 | `/api/invoices/[id]/pdf` | GET | Facturation | Auth | À vérifier | Oui | Oui | Non | Non | Non | Facture/paiement, Document/fichier | Suivi qualité P2 |
+| P2 | `/api/invoices/[id]/receipt/pdf` | GET | Facturation | Auth | À vérifier | Oui | Oui | Non | Oui | Non | Facture/paiement, Document/fichier | Suivi qualité P2 |
+| OK | `/api/lamis/attempt` | POST | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/lamis/exercises` | - | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/lamis/export` | POST | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/lamis/progress` | POST | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| P1 | `/api/lamis/teacher-report` | POST, GET | Bilans/assessments | Public/À vérifier | N/A | N/A | Non | Non | Oui | Oui | Données pédagogiques mineur | Durcir avant bêta élargie |
+| OK | `/api/me/next-step` | GET | Autre | Auth | À vérifier | À vérifier | Oui | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/messages/conversations` | GET | Autre | Auth | À vérifier | Oui | Oui | Non | Non | Non | Conversation IA | Maintenir tests de non-régression |
+| OK | `/api/messages/send` | POST | Autre | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Conversation IA | Maintenir tests de non-régression |
+| OK | `/api/newsletter` | POST | Leads/messages | Public | N/A | N/A | Non | Non | Non | Oui | Lead/contact | Maintenir tests de non-régression |
+| OK | `/api/notifications` | GET, PATCH | Autre | Auth | À vérifier | À vérifier | Oui | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/notify/email` | POST | Leads/messages | Public | N/A | N/A | Non | Non | Oui | Oui | Lead/contact | Maintenir tests de non-régression |
+| P2 | `/api/npc/files/[...path]` | GET | Documents | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | Document/fichier | Suivi qualité P2 |
+| P2 | `/api/npc/submissions/[submissionId]/documents/[documentId]` | PATCH, DELETE | Documents | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Document/fichier, Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/npc/submissions/[submissionId]/documents` | GET, POST | Documents | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Document/fichier, Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/npc/submissions/[submissionId]/generate` | POST | NPC | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/npc/submissions` | POST, GET | NPC | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/npc/uploads` | POST | NPC | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Document/fichier | Suivi qualité P2 |
+| P2 | `/api/parent/bilans/[id]/pdf` | GET | Documents | Auth | Parent | Oui | Oui | Oui | Non | Non | Document/fichier, Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/parent/children` | GET, POST | Parent | Auth | Parent | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/parent/credit-request` | POST | Parent | Auth | Parent | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/parent/dashboard` | GET | Parent | Auth | Parent | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/parent/stages` | GET | Stages | Auth | Parent | Oui | Oui | Oui | Non | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/parent/subscription-requests` | POST, GET | Parent | Auth | Parent | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/parent/subscriptions` | GET, POST | Parent | Auth | Parent | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/payments/bank-transfer/confirm` | POST | Paiement | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Facture/paiement | Suivi qualité P2 |
+| P2 | `/api/payments/check-pending` | GET | Paiement | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | Facture/paiement | Suivi qualité P2 |
+| P2 | `/api/payments/clictopay/init` | POST | Paiement | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Facture/paiement | Suivi qualité P2 |
+| P1 | `/api/payments/clictopay/webhook` | POST | Paiement | Public webhook | N/A | N/A | Non | Non | Non | Non | Facture/paiement | Durcir avant bêta élargie |
+| P2 | `/api/payments/pending` | GET | Paiement | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | Facture/paiement | Suivi qualité P2 |
+| P2 | `/api/payments/validate` | POST | Paiement | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Facture/paiement | Suivi qualité P2 |
+| OK | `/api/programme/maths-1ere/progress` | POST, GET | Autre | Auth | À vérifier | À vérifier | Oui | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/programme/maths-1ere/rag` | POST | ARIA/RAG | Auth | À vérifier | À vérifier | Oui | Non | Oui | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/programme/maths-1ere-stmg/progress` | POST, GET | Autre | Auth | À vérifier | À vérifier | Oui | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/programme/maths-1ere-stmg/rag` | POST | ARIA/RAG | Auth | À vérifier | À vérifier | Oui | Non | Oui | Non | À vérifier | Maintenir tests de non-régression |
+| P2 | `/api/programme/maths-1ere-stmg/stage-progress` | GET, POST | Stages | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Réservation/session | Suivi qualité P2 |
+| OK | `/api/programme/maths-terminale/progress` | POST, GET | Autre | Auth | À vérifier | À vérifier | Oui | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| P2 | `/api/public-documents/corrige-dnb-maths-2026` | GET | Documents | Public | N/A | N/A | Non | Non | Non | Non | Document/fichier | Suivi qualité P2 |
+| OK | `/api/reservation` | POST, GET, PATCH | Autre | Auth | À vérifier | Oui | Oui | Non | Oui | Oui | Réservation/session | Maintenir tests de non-régression |
+| OK | `/api/reservation/verify` | POST | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | Réservation/session | Maintenir tests de non-régression |
+| P2 | `/api/sessions/book` | POST | Autre | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Oui | Réservation/session | Suivi qualité P2 |
+| P2 | `/api/sessions/cancel` | POST | Autre | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Oui | Réservation/session | Suivi qualité P2 |
+| P2 | `/api/sessions/video` | POST | Autre | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Oui | Réservation/session | Suivi qualité P2 |
+| P2 | `/api/stages/[stageSlug]/bilans` | GET, POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, Réservation/session | Suivi qualité P2 |
+| P1 | `/api/stages/[stageSlug]/inscrire` | POST | Stages | Public | N/A | Oui | Non | Non | Oui | Oui | Réservation/session | Durcir avant bêta élargie |
+| P2 | `/api/stages/[stageSlug]/reservations/[reservationId]/confirm` | POST | Stages | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Réservation/session | Suivi qualité P2 |
+| P2 | `/api/stages/[stageSlug]/reservations` | GET | Stages | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | Réservation/session | Suivi qualité P2 |
+| P2 | `/api/stages/[stageSlug]` | GET | Stages | Public/À vérifier | N/A | Oui | Non | Non | Oui | Non | Réservation/session | Suivi qualité P2 |
+| P2 | `/api/stages` | GET | Stages | Public/À vérifier | N/A | N/A | Non | Non | Oui | Non | Réservation/session | Suivi qualité P2 |
+| P1 | `/api/student/activate` | GET, POST | Élève | Public | N/A | N/A | Non | Non | Oui | Oui | PII/utilisateur | Durcir avant bêta élargie |
+| P2 | `/api/student/automatismes/attempts/[id]` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/automatismes/attempts` | POST, GET | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/automatismes/check-answer` | POST | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/automatismes/series/[id]` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/automatismes/series` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/bilans/[publicShareId]` | GET | Bilans/assessments | Auth | Élève | Oui | Oui | Oui | Non | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/credits` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Non | Oui | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/dashboard` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/documents/[id]/download` | GET | Documents | Auth | Élève | Oui | Oui | Oui | Non | Non | Document/fichier, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/documents` | GET | Documents | Auth | Élève | Oui | Oui | Oui | Non | Non | Document/fichier, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/nexus-index` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/resources/official/[slug]` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/resources` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/sessions` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Non | Oui | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/student/stages` | GET | Stages | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/student/survival/phrases/[phraseId]/copied` | POST | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/survival/progress` | GET, POST | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/survival/qcm/attempt` | POST | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/survival/reflexes/[reflexId]/attempt` | POST | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/survival/ritual` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/trajectory` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/students/[studentId]/badges` | GET | Élève | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/subscriptions/aria-addon` | POST | ARIA/RAG | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | Conversation IA | Suivi qualité P2 |
+| P2 | `/api/subscriptions/change` | POST | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Suivi qualité P2 |
+
+## Limites
+
+- Les guards détectés proviennent de motifs statiques ; ils ne prouvent pas l’absence d’IDOR.
+- Le rate limiting est détecté par motifs de code locaux ; une protection middleware, reverse proxy ou provider externe reste `À vérifier` sans preuve runtime.
+- Les routes `OK` ne sont pas déclarées go-live ready ; elles sont seulement moins prioritaires dans l’inventaire statique.

--- a/docs/go-live/api-security-matrix.full.md
+++ b/docs/go-live/api-security-matrix.full.md
@@ -1,7 +1,7 @@
 # Annexe matrice API sécurité complète
 
 Source : `docs/security/API_GUARD_INVENTORY.md`.
-Généré le : 2026-07-06T21:06:13.911Z.
+Généré le : 2026-07-06T21:29:09.336Z.
 
 Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Zod détecté` et `Ownership requis` sont des indices de pilotage. `À vérifier` signifie qu’aucune preuve suffisante n’a été établie dans ce lot.
 

--- a/docs/go-live/api-security-matrix.full.md
+++ b/docs/go-live/api-security-matrix.full.md
@@ -1,7 +1,7 @@
 # Annexe matrice API sécurité complète
 
 Source : `docs/security/API_GUARD_INVENTORY.md`.
-Généré le : 2026-07-06T20:47:11.266Z.
+Généré le : 2026-07-06T21:06:13.911Z.
 
 Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Zod détecté` et `Ownership requis` sont des indices de pilotage. `À vérifier` signifie qu’aucune preuve suffisante n’a été établie dans ce lot.
 

--- a/docs/security/API_GUARD_INVENTORY.md
+++ b/docs/security/API_GUARD_INVENTORY.md
@@ -1,6 +1,6 @@
 # Inventaire initial des guards API
 
-Généré le : 2026-07-06T20:47:06.898Z
+Généré le : 2026-07-06T21:06:06.597Z
 
 Lecture statique uniquement. La colonne `Ownership explicit` signale des indices de filtrage propriétaire dans le fichier; elle ne remplace pas un audit manuel IDOR.
 

--- a/docs/security/API_GUARD_INVENTORY.md
+++ b/docs/security/API_GUARD_INVENTORY.md
@@ -1,6 +1,6 @@
 # Inventaire initial des guards API
 
-Généré le : 2026-07-06T21:06:06.597Z
+Généré le : 2026-07-06T21:28:57.989Z
 
 Lecture statique uniquement. La colonne `Ownership explicit` signale des indices de filtrage propriétaire dans le fichier; elle ne remplace pas un audit manuel IDOR.
 

--- a/docs/security/API_GUARD_INVENTORY.md
+++ b/docs/security/API_GUARD_INVENTORY.md
@@ -1,31 +1,31 @@
 # Inventaire initial des guards API
 
-Généré le : 2026-05-29T19:21:45.562Z
+Généré le : 2026-07-06T20:47:06.898Z
 
 Lecture statique uniquement. La colonne `Ownership explicit` signale des indices de filtrage propriétaire dans le fichier; elle ne remplace pas un audit manuel IDOR.
 
 ## Synthèse
 
-- P0 : 42
-- P1 : 38
-- P2 : 62
-- OK : 22
-- Total routes : 164
+- P0 : 0
+- P1 : 6
+- P2 : 144
+- OK : 28
+- Total routes : 178
 
 ## 10 routes à auditer en priorité
 
 | Route | Methods | Risk | Notes |
 |---|---|---|---|
-| `app/api/admin/invoices/[id]/route.ts` | PATCH | P0 | staff/admin; finance; audit manuel prioritaire; guard manuel |
-| `app/api/admin/invoices/[id]/send/route.ts` | POST | P0 | staff/admin; finance; audit manuel prioritaire; guard manuel |
-| `app/api/admin/stages/[stageId]/coaches/route.ts` | GET, POST, DELETE | P0 | staff/admin; audit manuel prioritaire |
-| `app/api/admin/stages/[stageId]/route.ts` | GET, PATCH, DELETE | P0 | staff/admin; audit manuel prioritaire |
-| `app/api/admin/stages/[stageId]/sessions/[sessionId]/route.ts` | PATCH, DELETE | P0 | staff/admin; audit manuel prioritaire |
-| `app/api/admin/stages/[stageId]/sessions/route.ts` | GET, POST | P0 | staff/admin; audit manuel prioritaire |
-| `app/api/assessments/submit/route.ts` | POST | P0 | pédagogique sensible; audit manuel prioritaire |
-| `app/api/assistante/assignments/[id]/route.ts` | GET, PATCH | P0 | assistante; audit manuel prioritaire |
-| `app/api/assistante/coaches/manage/[id]/route.ts` | PUT, DELETE | P0 | assistante; audit manuel prioritaire; guard manuel |
-| `app/api/assistante/students/[studentId]/documents/route.ts` | GET, POST | P0 | assistante; documents/PII; audit manuel prioritaire |
+| `app/api/assessments/submit/route.ts` | POST | P1 | pédagogique sensible |
+| `app/api/bilan-gratuit/route.ts` | POST | P1 | pédagogique sensible |
+| `app/api/lamis/teacher-report/route.ts` | POST, GET | P1 | pédagogique sensible |
+| `app/api/payments/clictopay/webhook/route.ts` | POST | P1 | finance |
+| `app/api/stages/[stageSlug]/inscrire/route.ts` | POST | P1 | - |
+| `app/api/student/activate/route.ts` | GET, POST | P1 | - |
+| `app/api/admin/activities/route.ts` | GET | P2 | staff/admin |
+| `app/api/admin/analytics/route.ts` | GET | P2 | staff/admin |
+| `app/api/admin/config/history/route.ts` | GET | P2 | staff/admin |
+| `app/api/admin/config/rollback/route.ts` | POST | P2 | staff/admin |
 
 ## Inventaire complet
 
@@ -33,20 +33,23 @@ Lecture statique uniquement. La colonne `Ownership explicit` signale des indices
 |---|---|---|---|---|---|---|---|---|---|
 | `app/api/admin/activities/route.ts` | GET | no | yes | yes | no | no | no | P2 | staff/admin |
 | `app/api/admin/analytics/route.ts` | GET | no | yes | yes | no | no | no | P2 | staff/admin |
+| `app/api/admin/config/history/route.ts` | GET | no | yes | yes | no | no | no | P2 | staff/admin |
+| `app/api/admin/config/rollback/route.ts` | POST | no | yes | yes | no | yes | no | P2 | staff/admin |
+| `app/api/admin/config/route.ts` | GET, PATCH | no | yes | yes | no | yes | no | P2 | staff/admin |
 | `app/api/admin/dashboard/route.ts` | GET | no | yes | yes | no | no | no | P2 | staff/admin |
-| `app/api/admin/directeur/stats/route.ts` | GET | no | yes | no | no | no | no | P1 | staff/admin; guard manuel |
-| `app/api/admin/documents/route.ts` | POST | no | yes | yes | no | no | yes | P1 | staff/admin; documents/PII |
-| `app/api/admin/invoices/[id]/route.ts` | PATCH | yes | yes | no | no | yes | no | P0 | staff/admin; finance; audit manuel prioritaire; guard manuel |
-| `app/api/admin/invoices/[id]/send/route.ts` | POST | yes | yes | yes | no | yes | no | P0 | staff/admin; finance; audit manuel prioritaire; guard manuel |
-| `app/api/admin/invoices/route.ts` | POST, GET | no | yes | no | no | yes | no | P1 | staff/admin; finance; guard manuel |
-| `app/api/admin/recompute-ssn/route.ts` | POST | no | yes | no | no | no | no | P1 | staff/admin; guard manuel |
-| `app/api/admin/stages/[stageId]/coaches/route.ts` | GET, POST, DELETE | yes | yes | yes | no | yes | no | P0 | staff/admin; audit manuel prioritaire |
-| `app/api/admin/stages/[stageId]/route.ts` | GET, PATCH, DELETE | yes | yes | yes | no | yes | no | P0 | staff/admin; audit manuel prioritaire |
-| `app/api/admin/stages/[stageId]/sessions/[sessionId]/route.ts` | PATCH, DELETE | yes | yes | yes | no | yes | no | P0 | staff/admin; audit manuel prioritaire |
-| `app/api/admin/stages/[stageId]/sessions/route.ts` | GET, POST | yes | yes | yes | no | yes | no | P0 | staff/admin; audit manuel prioritaire |
+| `app/api/admin/directeur/stats/route.ts` | GET | no | yes | yes | no | yes | no | P2 | staff/admin |
+| `app/api/admin/documents/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | staff/admin; documents/PII |
+| `app/api/admin/invoices/[id]/route.ts` | PATCH | yes | yes | yes | no | yes | no | P2 | staff/admin; finance; guard manuel |
+| `app/api/admin/invoices/[id]/send/route.ts` | POST | yes | yes | yes | no | yes | no | P2 | staff/admin; finance; guard manuel |
+| `app/api/admin/invoices/route.ts` | POST, GET | no | yes | yes | no | yes | no | P2 | staff/admin; finance; guard manuel |
+| `app/api/admin/recompute-ssn/route.ts` | POST | no | yes | yes | no | yes | no | P2 | staff/admin |
+| `app/api/admin/stages/[stageId]/coaches/route.ts` | GET, POST, DELETE | yes | yes | yes | no | yes | yes | P2 | staff/admin |
+| `app/api/admin/stages/[stageId]/route.ts` | GET, PATCH, DELETE | yes | yes | yes | no | yes | no | P2 | staff/admin |
+| `app/api/admin/stages/[stageId]/sessions/[sessionId]/route.ts` | PATCH, DELETE | yes | yes | yes | no | yes | yes | P2 | staff/admin |
+| `app/api/admin/stages/[stageId]/sessions/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | staff/admin |
 | `app/api/admin/stages/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | staff/admin |
-| `app/api/admin/subscriptions/route.ts` | GET, PUT | no | yes | yes | no | no | no | P1 | staff/admin |
-| `app/api/admin/test-email/route.ts` | POST, GET | no | yes | yes | no | no | no | P1 | staff/admin; guard manuel |
+| `app/api/admin/subscriptions/route.ts` | GET, PUT | no | yes | yes | no | yes | no | P2 | staff/admin |
+| `app/api/admin/test-email/route.ts` | POST, GET | no | yes | yes | no | yes | no | P2 | staff/admin; guard manuel |
 | `app/api/admin/users/route.ts` | GET, POST, PATCH, DELETE | no | yes | yes | no | yes | no | P2 | staff/admin |
 | `app/api/admin/users/search/route.ts` | GET | no | yes | yes | no | no | no | P2 | staff/admin |
 | `app/api/analytics/event/route.ts` | POST | no | no | no | no | no | no | OK | - |
@@ -57,144 +60,155 @@ Lecture statique uniquement. La colonne `Ownership explicit` signale des indices
 | `app/api/assessments/[id]/result/route.ts` | GET | yes | yes | no | no | no | yes | P2 | pédagogique sensible; guard manuel |
 | `app/api/assessments/[id]/status/route.ts` | GET | yes | yes | no | no | yes | yes | P2 | pédagogique sensible; guard manuel |
 | `app/api/assessments/predict/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | pédagogique sensible; guard manuel |
-| `app/api/assessments/submit/route.ts` | POST | no | no | no | no | yes | no | P0 | pédagogique sensible; audit manuel prioritaire |
+| `app/api/assessments/public-token/route.ts` | POST | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
+| `app/api/assessments/submit/route.ts` | POST | no | no | no | no | yes | no | P1 | pédagogique sensible |
 | `app/api/assessments/test/route.ts` | GET | no | yes | yes | no | no | no | P2 | pédagogique sensible; guard manuel |
 | `app/api/assistante/activate-student/route.ts` | POST | no | yes | yes | no | yes | no | P2 | assistante; guard manuel |
-| `app/api/assistante/assignments/[id]/route.ts` | GET, PATCH | yes | yes | yes | no | yes | no | P0 | assistante; audit manuel prioritaire |
+| `app/api/assistante/assignments/[id]/route.ts` | GET, PATCH | yes | yes | yes | no | yes | no | P2 | assistante |
 | `app/api/assistante/assignments/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | assistante |
-| `app/api/assistante/coaches/manage/[id]/route.ts` | PUT, DELETE | yes | yes | yes | no | yes | no | P0 | assistante; audit manuel prioritaire; guard manuel |
+| `app/api/assistante/coaches/manage/[id]/route.ts` | PUT, DELETE | yes | yes | yes | no | yes | no | P2 | assistante; guard manuel |
 | `app/api/assistante/coaches/manage/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | assistante; guard manuel |
 | `app/api/assistante/coaches/route.ts` | GET | no | yes | yes | no | no | no | P2 | assistante |
-| `app/api/assistante/credit-requests/route.ts` | GET, POST | no | yes | yes | no | no | no | P1 | assistante; guard manuel |
+| `app/api/assistante/credit-requests/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | assistante; guard manuel |
 | `app/api/assistante/dashboard/route.ts` | GET | no | yes | yes | no | no | no | P2 | assistante; guard manuel |
 | `app/api/assistante/planning/route.ts` | GET | no | yes | yes | no | no | no | P2 | assistante |
+| `app/api/assistante/quotes/pdf/route.ts` | POST | no | yes | yes | no | yes | no | P2 | assistante |
 | `app/api/assistante/sessions/route.ts` | POST | no | yes | yes | no | yes | no | P2 | assistante |
 | `app/api/assistante/stages/route.ts` | GET | no | yes | yes | no | no | no | P2 | assistante |
-| `app/api/assistante/students/[studentId]/documents/route.ts` | GET, POST | yes | yes | yes | no | yes | no | P0 | assistante; documents/PII; audit manuel prioritaire |
-| `app/api/assistante/students/[studentId]/route.ts` | GET | yes | yes | yes | no | no | no | P0 | assistante; audit manuel prioritaire |
-| `app/api/assistante/students/credits/route.ts` | GET, POST | no | yes | yes | no | no | no | P1 | assistante; guard manuel |
+| `app/api/assistante/students/[studentId]/documents/route.ts` | GET, POST | yes | yes | yes | no | yes | no | P2 | assistante; documents/PII |
+| `app/api/assistante/students/[studentId]/route.ts` | GET | yes | yes | yes | no | no | no | P2 | assistante |
+| `app/api/assistante/students/credits/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | assistante; guard manuel |
 | `app/api/assistante/students/route.ts` | GET, POST | no | yes | yes | no | yes | yes | P2 | assistante |
-| `app/api/assistante/subscription-requests/route.ts` | GET, PATCH | no | yes | yes | no | no | no | P1 | assistante; guard manuel |
-| `app/api/assistante/subscriptions/route.ts` | GET, POST | no | yes | yes | no | no | no | P1 | assistante; guard manuel |
+| `app/api/assistante/subscription-requests/route.ts` | GET, PATCH | no | yes | yes | no | yes | no | P2 | assistante; guard manuel |
+| `app/api/assistante/subscriptions/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | assistante; guard manuel |
 | `app/api/auth/[...nextauth]/route.ts` | - | yes | no | no | no | no | no | OK | - |
 | `app/api/auth/resend-activation/route.ts` | POST | no | no | no | no | yes | no | OK | - |
 | `app/api/auth/reset-password/route.ts` | POST | no | no | no | no | yes | yes | OK | - |
-| `app/api/bilan-gratuit/dismiss/route.ts` | POST | no | yes | yes | no | no | yes | P1 | pédagogique sensible; guard manuel |
-| `app/api/bilan-gratuit/route.ts` | POST | no | no | yes | no | yes | no | P0 | pédagogique sensible; audit manuel prioritaire |
+| `app/api/bilan-gratuit/dismiss/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | pédagogique sensible; guard manuel |
+| `app/api/bilan-gratuit/route.ts` | POST | no | no | no | no | yes | no | P1 | pédagogique sensible |
 | `app/api/bilan-gratuit/status/route.ts` | GET | no | yes | no | no | no | yes | P2 | pédagogique sensible; guard manuel |
 | `app/api/bilan-pallier2-maths/retry/route.ts` | POST | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
 | `app/api/bilan-pallier2-maths/route.ts` | POST, GET | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
-| `app/api/bilans/[id]/export/route.ts` | GET, POST | yes | yes | yes | no | no | yes | P1 | pédagogique sensible |
-| `app/api/bilans/[id]/route.ts` | GET, PUT, DELETE | yes | yes | yes | no | no | yes | P1 | pédagogique sensible |
-| `app/api/bilans/generate/route.ts` | POST, GET | no | yes | yes | no | no | no | P1 | pédagogique sensible |
-| `app/api/bilans/route.ts` | GET, POST | no | yes | yes | no | no | no | P1 | pédagogique sensible |
+| `app/api/bilans/[id]/export/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | pédagogique sensible |
+| `app/api/bilans/[id]/route.ts` | GET, PUT, DELETE | yes | yes | yes | no | yes | yes | P2 | pédagogique sensible |
+| `app/api/bilans/generate/route.ts` | POST, GET | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
+| `app/api/bilans/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
 | `app/api/coach/dashboard/route.ts` | GET | no | yes | yes | no | no | no | P2 | coach; guard manuel |
-| `app/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate/route.ts` | POST | yes | yes | yes | no | no | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
-| `app/api/coach/eaf-stage-printemps/students/[studentId]/report/route.ts` | GET, POST, PATCH | yes | yes | yes | no | yes | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
+| `app/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
+| `app/api/coach/eaf-stage-printemps/students/[studentId]/report/route.ts` | GET, POST, PATCH | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
 | `app/api/coach/eaf-stage-printemps/students/route.ts` | GET | no | yes | yes | no | no | no | P2 | coach |
-| `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent/route.ts` | POST | yes | yes | yes | no | no | no | P0 | coach; audit manuel prioritaire |
-| `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student/route.ts` | POST | yes | yes | yes | no | no | no | P0 | coach; audit manuel prioritaire |
-| `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/report/route.ts` | GET, POST, PATCH | yes | yes | yes | no | yes | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
+| `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | coach |
+| `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | coach |
+| `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/report/route.ts` | GET, POST, PATCH | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
 | `app/api/coach/maths-premiere-stage-printemps/students/route.ts` | GET | no | yes | yes | no | no | no | P2 | coach |
-| `app/api/coach/nsi-pratique-2026/students/[studentId]/progress/route.ts` | GET | yes | yes | yes | no | no | no | P0 | coach; audit manuel prioritaire |
+| `app/api/coach/nsi-pratique-2026/students/[studentId]/progress/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | coach |
 | `app/api/coach/nsi-pratique-2026/students/route.ts` | GET | no | yes | yes | no | no | no | P2 | coach |
-| `app/api/coach/sessions/[sessionId]/report/route.ts` | POST, GET | yes | yes | yes | no | yes | no | P0 | coach; pédagogique sensible; audit manuel prioritaire; guard manuel |
+| `app/api/coach/sessions/[sessionId]/report/route.ts` | POST, GET | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible; guard manuel |
 | `app/api/coach/stages/route.ts` | GET | no | yes | yes | no | no | no | P2 | coach |
-| `app/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale/route.ts` | GET, PATCH | yes | yes | yes | no | no | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
-| `app/api/coach/students/[studentId]/documents/route.ts` | GET, POST | yes | yes | yes | no | yes | no | P0 | coach; documents/PII; audit manuel prioritaire |
+| `app/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale/route.ts` | GET, PATCH | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
+| `app/api/coach/students/[studentId]/documents/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | coach; documents/PII |
 | `app/api/coach/students/[studentId]/dossier/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | coach; guard manuel |
-| `app/api/coach/students/[studentId]/eaf-preparation-report/route.ts` | GET, PUT | yes | yes | yes | no | yes | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
-| `app/api/coach/students/[studentId]/eaf-preparation-report/validate/route.ts` | POST | yes | yes | yes | no | no | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
-| `app/api/coach/students/[studentId]/generated-reports/[reportId]/download/route.ts` | GET | yes | yes | yes | no | no | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
-| `app/api/coach/students/[studentId]/generated-reports/[reportId]/generate/route.ts` | - | yes | no | no | no | no | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
-| `app/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate/route.ts` | POST | yes | yes | yes | no | no | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
-| `app/api/coach/students/[studentId]/generated-reports/route.ts` | GET, POST | yes | yes | yes | no | yes | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
-| `app/api/coach/students/[studentId]/notes/route.ts` | GET, POST | yes | yes | yes | no | no | yes | P1 | coach; guard manuel |
+| `app/api/coach/students/[studentId]/eaf-preparation-report/route.ts` | GET, PUT | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
+| `app/api/coach/students/[studentId]/eaf-preparation-report/validate/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
+| `app/api/coach/students/[studentId]/generated-reports/[reportId]/download/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | coach; pédagogique sensible |
+| `app/api/coach/students/[studentId]/generated-reports/[reportId]/generate/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
+| `app/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
+| `app/api/coach/students/[studentId]/generated-reports/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
+| `app/api/coach/students/[studentId]/notes/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | coach; guard manuel |
 | `app/api/coach/students/[studentId]/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | coach |
-| `app/api/coach/students/[studentId]/survival-mode/route.ts` | POST | yes | yes | yes | no | no | yes | P1 | coach; guard manuel |
+| `app/api/coach/students/[studentId]/survival-mode/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | coach; guard manuel |
 | `app/api/coach/students/eam-summary/route.ts` | GET | no | yes | yes | no | no | yes | P2 | coach; guard manuel |
 | `app/api/coach/students/route.ts` | GET | no | yes | yes | no | no | no | P2 | coach |
-| `app/api/coach/trajectory/route.ts` | POST | no | yes | yes | no | no | no | P1 | coach; guard manuel |
+| `app/api/coach/trajectory/route.ts` | POST | no | yes | yes | no | yes | no | P2 | coach; guard manuel |
 | `app/api/coaches/availability/route.ts` | POST, GET, DELETE | no | yes | yes | no | yes | yes | P2 | guard manuel |
 | `app/api/coaches/available/route.ts` | GET | no | yes | yes | no | no | no | P2 | guard manuel |
 | `app/api/contact/route.ts` | POST | no | no | no | no | no | no | OK | - |
 | `app/api/diagnostics/definitions/route.ts` | GET | no | no | no | no | no | no | OK | - |
-| `app/api/documents/[id]/route.ts` | GET | yes | yes | yes | no | no | no | P0 | documents/PII; audit manuel prioritaire; guard manuel |
+| `app/api/documents/[id]/route.ts` | GET | yes | yes | yes | no | yes | yes | P2 | documents/PII; guard manuel |
 | `app/api/eam/progress/route.ts` | GET, POST | no | yes | no | no | yes | no | OK | guard manuel |
-| `app/api/eleve/bilan-diagnostic-maths-terminale/route.ts` | GET, POST | no | yes | yes | no | no | yes | P1 | pédagogique sensible |
+| `app/api/eleve/bilan-diagnostic-maths-terminale/route.ts` | GET, POST | no | yes | yes | no | yes | yes | P2 | pédagogique sensible |
 | `app/api/eleve/nsi-pratique-2026/progress/route.ts` | GET, PUT | no | yes | yes | no | no | yes | OK | - |
 | `app/api/eleve/questionnaire-eaf-stage-printemps/route.ts` | GET, POST | no | yes | yes | no | yes | yes | P2 | - |
 | `app/api/eleve/questionnaire-maths-premiere-stage-printemps/route.ts` | GET, POST | no | yes | yes | no | yes | yes | P2 | - |
 | `app/api/eleve/stages/route.ts` | GET | no | yes | yes | no | no | yes | P2 | - |
 | `app/api/health/route.ts` | GET | no | no | no | no | no | no | OK | - |
-| `app/api/invoices/[id]/pdf/route.ts` | GET | yes | yes | no | no | no | no | P0 | finance; audit manuel prioritaire; guard manuel |
-| `app/api/invoices/[id]/receipt/pdf/route.ts` | GET | yes | yes | no | no | yes | no | P0 | finance; audit manuel prioritaire; guard manuel |
+| `app/api/internal/health/route.ts` | GET | no | yes | yes | no | no | no | OK | - |
+| `app/api/internal/rate-limit-probe/route.ts` | GET | no | yes | yes | no | no | no | OK | - |
+| `app/api/invoices/[id]/pdf/route.ts` | GET | yes | yes | no | no | no | yes | P2 | finance; guard manuel |
+| `app/api/invoices/[id]/receipt/pdf/route.ts` | GET | yes | yes | no | no | yes | yes | P2 | finance; guard manuel |
+| `app/api/lamis/attempt/route.ts` | POST | no | no | no | no | no | no | OK | - |
+| `app/api/lamis/exercises/route.ts` | - | no | no | no | no | no | no | OK | - |
+| `app/api/lamis/export/route.ts` | POST | no | no | no | no | no | no | OK | - |
+| `app/api/lamis/progress/route.ts` | POST | no | no | no | no | no | no | OK | - |
+| `app/api/lamis/teacher-report/route.ts` | POST, GET | no | no | no | no | yes | no | P1 | pédagogique sensible |
 | `app/api/me/next-step/route.ts` | GET | no | yes | no | no | no | no | OK | guard manuel |
 | `app/api/messages/conversations/route.ts` | GET | no | yes | no | no | no | no | OK | guard manuel |
 | `app/api/messages/send/route.ts` | POST | no | yes | yes | no | yes | no | OK | guard manuel |
+| `app/api/newsletter/route.ts` | POST | no | no | no | no | no | no | OK | - |
 | `app/api/notifications/route.ts` | GET, PATCH | no | yes | no | no | no | yes | OK | guard manuel |
 | `app/api/notify/email/route.ts` | POST | no | no | no | no | yes | no | OK | - |
-| `app/api/npc/files/[...path]/route.ts` | GET | yes | yes | no | no | no | no | P0 | audit manuel prioritaire; guard manuel |
-| `app/api/npc/submissions/[submissionId]/documents/[documentId]/route.ts` | PATCH, DELETE | yes | yes | yes | no | no | yes | P1 | documents/PII; pédagogique sensible; guard manuel |
-| `app/api/npc/submissions/[submissionId]/documents/route.ts` | GET, POST | yes | yes | yes | no | no | yes | P1 | documents/PII; pédagogique sensible; guard manuel |
-| `app/api/npc/submissions/[submissionId]/generate/route.ts` | POST | yes | yes | yes | no | no | yes | P1 | pédagogique sensible; guard manuel |
-| `app/api/npc/submissions/route.ts` | POST, GET | no | yes | yes | no | no | yes | P1 | pédagogique sensible; guard manuel |
-| `app/api/npc/uploads/route.ts` | POST | no | yes | yes | no | no | yes | P1 | guard manuel |
-| `app/api/parent/bilans/[id]/pdf/route.ts` | GET | yes | yes | yes | no | no | no | P0 | pédagogique sensible; audit manuel prioritaire |
-| `app/api/parent/children/route.ts` | GET, POST | no | yes | yes | no | no | yes | P1 | guard manuel |
+| `app/api/npc/files/[...path]/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | guard manuel |
+| `app/api/npc/submissions/[submissionId]/documents/[documentId]/route.ts` | PATCH, DELETE | yes | yes | yes | no | yes | yes | P2 | documents/PII; pédagogique sensible; guard manuel |
+| `app/api/npc/submissions/[submissionId]/documents/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | documents/PII; pédagogique sensible; guard manuel |
+| `app/api/npc/submissions/[submissionId]/generate/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | pédagogique sensible; guard manuel |
+| `app/api/npc/submissions/route.ts` | POST, GET | no | yes | yes | no | yes | yes | P2 | pédagogique sensible; guard manuel |
+| `app/api/npc/uploads/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | guard manuel |
+| `app/api/parent/bilans/[id]/pdf/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | pédagogique sensible |
+| `app/api/parent/children/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | guard manuel |
 | `app/api/parent/credit-request/route.ts` | POST | no | yes | yes | no | yes | no | P2 | guard manuel |
 | `app/api/parent/dashboard/route.ts` | GET | no | yes | yes | no | no | yes | P2 | guard manuel |
-| `app/api/parent/stages/route.ts` | GET | no | yes | yes | no | no | no | P2 | - |
-| `app/api/parent/subscription-requests/route.ts` | POST, GET | no | yes | yes | no | no | no | P1 | guard manuel |
-| `app/api/parent/subscriptions/route.ts` | GET, POST | no | yes | yes | no | no | no | P1 | guard manuel |
+| `app/api/parent/stages/route.ts` | GET | no | yes | yes | no | no | yes | P2 | - |
+| `app/api/parent/subscription-requests/route.ts` | POST, GET | no | yes | yes | no | yes | no | P2 | guard manuel |
+| `app/api/parent/subscriptions/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | guard manuel |
 | `app/api/payments/bank-transfer/confirm/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | finance; guard manuel |
 | `app/api/payments/check-pending/route.ts` | GET | no | yes | yes | no | no | yes | P2 | finance; guard manuel |
-| `app/api/payments/clictopay/init/route.ts` | POST | no | yes | no | no | no | no | P1 | finance; guard manuel |
-| `app/api/payments/clictopay/webhook/route.ts` | POST | no | no | no | no | no | no | P0 | finance; audit manuel prioritaire |
+| `app/api/payments/clictopay/init/route.ts` | POST | no | yes | yes | no | yes | no | P2 | finance; guard manuel |
+| `app/api/payments/clictopay/webhook/route.ts` | POST | no | no | no | no | no | no | P1 | finance |
 | `app/api/payments/pending/route.ts` | GET | no | yes | yes | no | no | no | P2 | finance; guard manuel |
 | `app/api/payments/validate/route.ts` | POST | no | yes | yes | no | yes | no | P2 | finance; guard manuel |
 | `app/api/programme/maths-1ere/progress/route.ts` | POST, GET | no | yes | no | no | no | no | OK | guard manuel |
 | `app/api/programme/maths-1ere/rag/route.ts` | POST | no | yes | no | no | yes | no | OK | guard manuel |
 | `app/api/programme/maths-1ere-stmg/progress/route.ts` | POST, GET | no | yes | no | no | no | no | OK | guard manuel |
 | `app/api/programme/maths-1ere-stmg/rag/route.ts` | POST | no | yes | no | no | yes | no | OK | guard manuel |
+| `app/api/programme/maths-1ere-stmg/stage-progress/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | guard manuel |
 | `app/api/programme/maths-terminale/progress/route.ts` | POST, GET | no | yes | no | no | no | no | OK | guard manuel |
+| `app/api/public-documents/corrige-dnb-maths-2026/route.ts` | GET | no | no | no | no | no | no | P2 | - |
 | `app/api/reservation/route.ts` | POST, GET, PATCH | no | yes | no | no | yes | no | OK | guard manuel |
 | `app/api/reservation/verify/route.ts` | POST | no | no | no | no | no | no | OK | - |
 | `app/api/sessions/book/route.ts` | POST | no | yes | yes | yes | yes | no | P2 | - |
-| `app/api/sessions/cancel/route.ts` | POST | no | yes | yes | no | no | no | P1 | - |
-| `app/api/sessions/video/route.ts` | POST | no | yes | yes | no | no | yes | P1 | guard manuel |
-| `app/api/stages/[stageSlug]/bilans/route.ts` | GET, POST | yes | yes | yes | no | yes | no | P0 | pédagogique sensible; audit manuel prioritaire |
-| `app/api/stages/[stageSlug]/inscrire/route.ts` | POST | yes | no | no | no | yes | no | P0 | audit manuel prioritaire |
-| `app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts` | POST | yes | yes | yes | no | no | no | P0 | audit manuel prioritaire |
-| `app/api/stages/[stageSlug]/reservations/route.ts` | GET | yes | yes | yes | no | no | no | P0 | audit manuel prioritaire |
-| `app/api/stages/[stageSlug]/route.ts` | GET | yes | no | no | no | no | no | P0 | audit manuel prioritaire |
-| `app/api/stages/route.ts` | GET | no | no | no | no | yes | no | P0 | audit manuel prioritaire |
-| `app/api/stages/submit-diagnostic/route.ts` | POST | no | no | no | no | yes | no | P0 | audit manuel prioritaire |
-| `app/api/student/activate/route.ts` | GET, POST | no | no | no | no | yes | no | P0 | audit manuel prioritaire |
+| `app/api/sessions/cancel/route.ts` | POST | no | yes | yes | no | yes | no | P2 | - |
+| `app/api/sessions/video/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | guard manuel |
+| `app/api/stages/[stageSlug]/bilans/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | pédagogique sensible |
+| `app/api/stages/[stageSlug]/inscrire/route.ts` | POST | yes | no | no | no | yes | no | P1 | - |
+| `app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | - |
+| `app/api/stages/[stageSlug]/reservations/route.ts` | GET | yes | yes | yes | no | no | no | P2 | - |
+| `app/api/stages/[stageSlug]/route.ts` | GET | yes | no | no | no | yes | no | P2 | - |
+| `app/api/stages/route.ts` | GET | no | no | no | no | yes | no | P2 | - |
+| `app/api/student/activate/route.ts` | GET, POST | no | no | no | no | yes | no | P1 | - |
 | `app/api/student/automatismes/attempts/[id]/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | guard manuel |
-| `app/api/student/automatismes/attempts/route.ts` | POST, GET | no | yes | yes | no | no | yes | P1 | guard manuel |
-| `app/api/student/automatismes/check-answer/route.ts` | POST | no | yes | yes | no | no | no | P1 | guard manuel |
-| `app/api/student/automatismes/series/[id]/route.ts` | GET | yes | yes | yes | no | no | no | P0 | audit manuel prioritaire; guard manuel |
+| `app/api/student/automatismes/attempts/route.ts` | POST, GET | no | yes | yes | no | yes | yes | P2 | guard manuel |
+| `app/api/student/automatismes/check-answer/route.ts` | POST | no | yes | yes | no | yes | no | P2 | guard manuel |
+| `app/api/student/automatismes/series/[id]/route.ts` | GET | yes | yes | yes | no | yes | no | P2 | guard manuel |
 | `app/api/student/automatismes/series/route.ts` | GET | no | yes | yes | no | no | no | P2 | guard manuel |
 | `app/api/student/bilans/[publicShareId]/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | pédagogique sensible |
 | `app/api/student/credits/route.ts` | GET | no | yes | yes | no | no | no | P2 | - |
 | `app/api/student/dashboard/route.ts` | GET | no | yes | yes | no | no | no | P2 | - |
 | `app/api/student/documents/[id]/download/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | documents/PII |
 | `app/api/student/documents/route.ts` | GET | no | yes | yes | no | no | yes | P2 | documents/PII; guard manuel |
-| `app/api/student/nexus-index/route.ts` | GET | no | yes | no | no | no | no | P1 | guard manuel |
+| `app/api/student/nexus-index/route.ts` | GET | no | yes | yes | no | yes | no | P2 | guard manuel |
 | `app/api/student/resources/official/[slug]/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | - |
 | `app/api/student/resources/route.ts` | GET | no | yes | yes | no | no | no | P2 | guard manuel |
 | `app/api/student/sessions/route.ts` | GET | no | yes | yes | no | no | no | P2 | - |
 | `app/api/student/stages/route.ts` | GET | no | yes | yes | no | no | yes | P2 | - |
-| `app/api/student/survival/phrases/[phraseId]/copied/route.ts` | POST | yes | yes | yes | no | no | yes | P1 | guard manuel |
-| `app/api/student/survival/progress/route.ts` | GET, POST | no | yes | yes | no | no | yes | P1 | guard manuel |
-| `app/api/student/survival/qcm/attempt/route.ts` | POST | no | yes | yes | no | no | yes | P1 | guard manuel |
-| `app/api/student/survival/reflexes/[reflexId]/attempt/route.ts` | POST | yes | yes | yes | no | no | yes | P1 | guard manuel |
+| `app/api/student/survival/phrases/[phraseId]/copied/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | guard manuel |
+| `app/api/student/survival/progress/route.ts` | GET, POST | no | yes | yes | no | yes | yes | P2 | guard manuel |
+| `app/api/student/survival/qcm/attempt/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | guard manuel |
+| `app/api/student/survival/reflexes/[reflexId]/attempt/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | guard manuel |
 | `app/api/student/survival/ritual/route.ts` | GET | no | yes | yes | no | no | yes | P2 | guard manuel |
-| `app/api/student/trajectory/route.ts` | GET | no | yes | no | no | no | no | P1 | guard manuel |
+| `app/api/student/trajectory/route.ts` | GET | no | yes | yes | no | yes | no | P2 | guard manuel |
 | `app/api/students/[studentId]/badges/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | guard manuel |
-| `app/api/subscriptions/aria-addon/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | ARIA; guard manuel |
-| `app/api/subscriptions/change/route.ts` | POST | no | yes | yes | no | yes | yes | OK | guard manuel |
+| `app/api/subscriptions/aria-addon/route.ts` | POST | no | no | no | no | no | no | P2 | ARIA |
+| `app/api/subscriptions/change/route.ts` | POST | no | no | no | no | no | no | P2 | - |
 
 ## Prochaines étapes
 

--- a/e2e/pages-public-bilan-assessment-token.spec.ts
+++ b/e2e/pages-public-bilan-assessment-token.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('/bilan-gratuit/assessment — token binding', () => {
+  test('refuse l’accès direct par query params publics sans cookie de flux signé', async ({ page }) => {
+    const response = await page.goto(
+      '/bilan-gratuit/assessment?subject=MATHEMATIQUES&grade=terminale&email=attacker@example.test',
+    );
+
+    expect(response?.status()).toBe(200);
+    await expect(page.getByRole('heading', { name: /accès au diagnostic expiré/i })).toBeVisible();
+    await expect(page.locator('[data-testid="assessment-client"]')).toHaveCount(0);
+
+    expect(page.url()).not.toContain('assessmentPublicToken');
+    expect(page.url()).not.toContain('x-assessment-public-token');
+
+    const html = await page.content();
+    expect(html).not.toContain('x-assessment-public-token');
+    expect(html).not.toContain('assessmentPublicToken');
+    expect(html).not.toContain('attacker@example.test');
+  });
+});

--- a/e2e/pages-public-bilan-gratuit.spec.ts
+++ b/e2e/pages-public-bilan-gratuit.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { CGV_POLICY } from '@/lib/cgv-policy';
 
 test.describe('Bilan Gratuit — Formulaire stratégique', () => {
   test.beforeEach(async ({ page }) => {
@@ -58,7 +59,7 @@ test.describe('Bilan Gratuit — Formulaire stratégique', () => {
     await expect(page.locator('a[href*="wa.me"]').first()).toBeVisible();
   });
 
-  test('offre repérée et paiement carte sont présents dans le HTML initial', async ({ page }) => {
+  test('offre repérée visible sans exposition ClicToPay ni RIB public', async ({ page }) => {
     const response = await page.request.get('/bilan-gratuit?offer=term-spe-simple');
     expect(response.status()).toBe(200);
 
@@ -66,9 +67,19 @@ test.describe('Bilan Gratuit — Formulaire stratégique', () => {
     expect(html).not.toContain('BAILOUT_TO_CLIENT_SIDE_RENDERING');
     expect(html).toContain('Offre repérée');
     expect(html).toContain('Terminale Spécialité simple');
-    expect(html).toContain('ClicToPay');
-    expect(html).toContain('Banque Zitouna');
+    expect(html).toContain('Paiement confirmé après validation pédagogique');
+    expect(html).not.toContain(CGV_POLICY.payment.provider);
+    expect(html).not.toContain(CGV_POLICY.payment.bank);
     expect(html).not.toContain('25 079 000 0001569084 04');
     expect(html).not.toContain('TN59 25 079 000 0001569084 04');
+  });
+
+  test('analytics non essentiels absents du HTML initial sans opt-in explicite', async ({ page }) => {
+    const response = await page.request.get('/bilan-gratuit');
+    expect(response.status()).toBe(200);
+
+    const html = await response.text();
+    expect(html).not.toContain('googletagmanager.com/gtag/js');
+    expect(html).not.toContain('gtag-init');
   });
 });

--- a/e2e/pages-public-homepage.spec.ts
+++ b/e2e/pages-public-homepage.spec.ts
@@ -50,27 +50,47 @@ test.describe('Homepage (/) - Landing Nexus Reussite', () => {
     await expect(sections).toHaveCount(9);
   });
 
-  test('2 WA links at load, 3 visible after scroll (+ bubble), MobileStickyBar in DOM but hidden', async ({ page }) => {
-    // At load (desktop): hero WA + final CTA WA = 2 in DOM
-    // FloatingAdvisorBubble hidden (hero visible), MobileStickyBar returns null
+  test('liens WhatsApp visibles, accessibles et stables desktop/mobile', async ({ page }) => {
     const waLinks = page.locator('a[href*="wa.me"]');
-    await expect(waLinks).toHaveCount(2);
+    const initialLinks = await waLinks.evaluateAll((els) =>
+      els.map((element) => ({
+        href: element.getAttribute('href') || '',
+        accessibleName: (element.getAttribute('aria-label') || element.textContent || '').trim(),
+      }))
+    );
+    expect(initialLinks.length).toBeGreaterThanOrEqual(2);
+    for (const link of initialLinks) {
+      expect(link.href).toContain('wa.me/21699192829');
+      expect(link.accessibleName.length).toBeGreaterThan(0);
+    }
 
-    // Scroll past hero → bubble + MobileStickyBar render (4 DOM, 3 visible)
     await page.evaluate(() => window.scrollBy(0, 1200));
     await page.waitForTimeout(800);
 
-    // 4 in DOM: hero + CTA + bubble + MobileStickyBar(md:hidden)
-    await expect(waLinks).toHaveCount(4);
+    const afterScrollCount = await waLinks.count();
+    expect(afterScrollCount).toBeGreaterThanOrEqual(initialLinks.length);
 
-    // Only 3 visible (MobileStickyBar hidden at desktop)
     const visibleCount = await waLinks.evaluateAll((els) =>
       els.filter((el) => {
         const cs = getComputedStyle(el);
         return el instanceof HTMLElement && cs.display !== 'none' && el.offsetWidth > 0;
       }).length
     );
-    expect(visibleCount).toBe(3);
+    expect(visibleCount).toBeGreaterThanOrEqual(3);
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.evaluate(() => window.scrollBy(0, 1200));
+    await page.waitForTimeout(800);
+
+    const mobileVisibleCount = await page.locator('a[href*="wa.me"]').evaluateAll((els) =>
+      els.filter((el) => {
+        const cs = getComputedStyle(el);
+        return el instanceof HTMLElement && cs.display !== 'none' && el.offsetWidth > 0;
+      }).length
+    );
+    expect(mobileVisibleCount).toBeGreaterThanOrEqual(2);
   });
 
   test('tous les liens footer internes ne retournent pas 404', async ({ page }) => {

--- a/e2e/pages-public-offres.spec.ts
+++ b/e2e/pages-public-offres.spec.ts
@@ -37,15 +37,25 @@ test.describe('/offres — Page Tarifs', () => {
     await expect(page.getByText(/[ÉE]ch[ée]anciers\s+transparents/).first()).toBeVisible();
   });
 
-  test('paiement carte ClicToPay visible sans RIB public', async ({ page }) => {
+  test('paiement carte non exposé tant que ClicToPay public n’est pas activé', async ({ page }) => {
     await expect(page.getByTestId('payment-methods-note').first()).toBeVisible();
-    await expect(page.getByText(CGV_POLICY.payment.provider).first()).toBeVisible();
-    await expect(page.getByText(CGV_POLICY.payment.acceptedCards).first()).toBeVisible();
-    await expect(page.getByText(CGV_POLICY.payment.cardFee).first()).toBeVisible();
+    await expect(page.getByText(/Paiement confirmé après validation pédagogique/).first()).toBeVisible();
 
     const body = await page.textContent('body');
+    expect(body).not.toContain(CGV_POLICY.payment.provider);
+    expect(body).not.toContain(CGV_POLICY.payment.bank);
+    expect(body).not.toContain(CGV_POLICY.payment.acceptedCards);
     expect(body).not.toContain(LEGAL.billing.rib);
     expect(body).not.toContain(LEGAL.billing.iban);
+  });
+
+  test('analytics non essentiels absents du HTML initial sans opt-in explicite', async ({ page }) => {
+    const response = await page.request.get('/offres');
+    expect(response.status()).toBe(200);
+
+    const html = await response.text();
+    expect(html).not.toContain('googletagmanager.com/gtag/js');
+    expect(html).not.toContain('gtag-init');
   });
 
   test('page charge sans erreur 500', async ({ page }) => {

--- a/e2e/real/pages/04-bilan-gratuit.spec.ts
+++ b/e2e/real/pages/04-bilan-gratuit.spec.ts
@@ -55,7 +55,7 @@ test.describe('REAL — Bilan Gratuit (/bilan-gratuit)', () => {
     await expect(page.locator('#parentFirstName')).toBeVisible();
   });
 
-  test('Soumission complète — crée parent + élève en DB', async ({ page }) => {
+  test('Soumission complète — contrat public sécurisé et confirmation', async ({ page }) => {
     const uniqueEmail = `test.audit.${Date.now()}@e2e-test.com`;
 
     await page.locator('#parentFirstName').fill('TestAudit');
@@ -83,18 +83,20 @@ test.describe('REAL — Bilan Gratuit (/bilan-gratuit)', () => {
     const status = apiResponse.status();
     console.log(`API /api/bilan-gratuit → HTTP ${status}`);
 
-    if (status === 200) {
-      const body = await apiResponse.json();
-      console.log('API response:', JSON.stringify(body));
-      expect(body.success, 'API ne retourne pas success=true').toBe(true);
-      expect(body.parentId, 'API ne retourne pas parentId').toBeTruthy();
-      expect(body.studentId, 'API ne retourne pas studentId').toBeTruthy();
-      await page.waitForURL('**/bilan-gratuit/confirmation', { timeout: 10000 });
-    } else {
-      const body = await apiResponse.json().catch(() => ({}));
-      console.log(`API error response: ${JSON.stringify(body)}`);
-      expect(status, `API retourne ${status}: ${JSON.stringify(body)}`).toBeLessThan(500);
-    }
+    const body = await apiResponse.json();
+
+    expect(status, `API retourne ${status}: ${JSON.stringify(body)}`).toBe(200);
+    expect(body.success, 'API ne retourne pas success=true').toBe(true);
+    expect(body.message, 'API ne retourne pas de message de confirmation').toBeTruthy();
+    expect(body).not.toHaveProperty('parentId');
+    expect(body).not.toHaveProperty('studentId');
+    expect(body).not.toHaveProperty('token');
+    expect(body).not.toHaveProperty('assessmentToken');
+    expect(body).not.toHaveProperty('leadEmailHash');
+    expect(JSON.stringify(body)).not.toMatch(/parentId|studentId|token|assessmentToken|leadEmailHash/i);
+
+    await page.waitForURL('**/bilan-gratuit/confirmation', { timeout: 10000 });
+    await expect(page.getByRole('heading', { name: /votre demande de bilan a bien été enregistrée/i })).toBeVisible();
   });
 
   test('Confirmation page charge après soumission', async ({ page }) => {

--- a/lib/assessments/public-token.ts
+++ b/lib/assessments/public-token.ts
@@ -1,0 +1,292 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
+import { z } from 'zod';
+import { Subject } from '@/lib/assessments/core/types';
+
+export const ASSESSMENT_PUBLIC_TOKEN_TTL_SECONDS = 15 * 60;
+export const ASSESSMENT_FLOW_TOKEN_TTL_SECONDS = 30 * 60;
+export const ASSESSMENT_FLOW_COOKIE_NAME = 'nexus_assessment_flow';
+
+const emailHashSchema = z.string().regex(/^[a-f0-9]{64}$/);
+
+const assessmentPublicTokenPayloadSchema = z.object({
+  v: z.literal(1),
+  usage: z.literal('assessment_submit'),
+  subject: z.nativeEnum(Subject),
+  grade: z.enum(['PREMIERE', 'TERMINALE']),
+  source: z.string().trim().min(1).max(80).optional(),
+  campaignId: z.string().trim().min(1).max(80).optional(),
+  binding: z.enum(['staff', 'lead']),
+  leadEmailHash: emailHashSchema.optional(),
+  issuedAt: z.number().int().positive(),
+  expiresAt: z.number().int().positive(),
+  nonce: z.string().min(16).max(64),
+}).strict().superRefine((payload, ctx) => {
+  if (payload.binding === 'lead' && !payload.leadEmailHash) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['leadEmailHash'],
+      message: 'leadEmailHash is required for lead-bound assessment tokens',
+    });
+  }
+});
+
+const assessmentFlowTokenPayloadSchema = z.object({
+  v: z.literal(1),
+  usage: z.literal('assessment_flow'),
+  subject: z.nativeEnum(Subject),
+  grade: z.enum(['PREMIERE', 'TERMINALE']),
+  source: z.string().trim().min(1).max(80),
+  leadEmailHash: emailHashSchema,
+  issuedAt: z.number().int().positive(),
+  expiresAt: z.number().int().positive(),
+  nonce: z.string().min(16).max(64),
+}).strict();
+
+export type AssessmentPublicTokenPayload = z.infer<typeof assessmentPublicTokenPayloadSchema>;
+export type AssessmentFlowTokenPayload = z.infer<typeof assessmentFlowTokenPayloadSchema>;
+
+type AssessmentTokenFailureReason =
+  | 'missing'
+  | 'malformed'
+  | 'bad_signature'
+  | 'expired'
+  | 'scope_mismatch'
+  | 'secret_unavailable';
+
+export type AssessmentPublicTokenExpectation = {
+  usage: 'assessment_submit';
+  subject: Subject;
+  grade: 'PREMIERE' | 'TERMINALE';
+  source?: string;
+  campaignId?: string;
+  binding?: 'staff' | 'lead';
+  leadEmailHash?: string;
+  studentEmail?: string;
+};
+
+export type AssessmentPublicTokenVerification =
+  | { valid: true; payload: AssessmentPublicTokenPayload }
+  | {
+      valid: false;
+      reason: AssessmentTokenFailureReason;
+    };
+
+export type AssessmentFlowTokenVerification =
+  | { valid: true; payload: AssessmentFlowTokenPayload }
+  | {
+      valid: false;
+      reason: AssessmentTokenFailureReason;
+    };
+
+function toBase64Url(value: Buffer | string): string {
+  const buffer = Buffer.isBuffer(value) ? value : Buffer.from(value, 'utf8');
+  return buffer.toString('base64url');
+}
+
+function fromBase64Url(value: string): Buffer {
+  return Buffer.from(value, 'base64url');
+}
+
+function nowSeconds(now = Date.now()): number {
+  return Math.floor(now / 1000);
+}
+
+function getSecret(): string {
+  const secret =
+    process.env.ASSESSMENT_PUBLIC_TOKEN_SECRET ||
+    process.env.NEXTAUTH_SECRET ||
+    process.env.AUTH_SECRET;
+
+  if (secret) return secret;
+
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('ASSESSMENT_PUBLIC_TOKEN_SECRET_REQUIRED');
+  }
+
+  return 'test-assessment-public-token-secret';
+}
+
+function sign(payloadPart: string): string {
+  return createHmac('sha256', getSecret()).update(payloadPart).digest('base64url');
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export function hashAssessmentLeadEmail(email: string): string {
+  return createHmac('sha256', getSecret()).update(normalizeEmail(email)).digest('hex');
+}
+
+export function buildAssessmentAliasEmail(leadEmailHash: string): string {
+  const parsed = emailHashSchema.parse(leadEmailHash);
+  return `assessment+${parsed.slice(0, 24)}@nexusreussite.academy`;
+}
+
+export function createAssessmentPublicToken(
+  input: {
+    subject: Subject;
+    grade: 'PREMIERE' | 'TERMINALE';
+    source?: string;
+    campaignId?: string;
+    binding?: 'staff' | 'lead';
+    leadEmailHash?: string;
+  },
+  options: {
+    now?: number;
+    ttlSeconds?: number;
+  } = {},
+): string {
+  const issuedAt = nowSeconds(options.now);
+  const ttlSeconds = options.ttlSeconds ?? ASSESSMENT_PUBLIC_TOKEN_TTL_SECONDS;
+  const payload = assessmentPublicTokenPayloadSchema.parse({
+    v: 1,
+    usage: 'assessment_submit',
+    subject: input.subject,
+    grade: input.grade,
+    source: input.source,
+    campaignId: input.campaignId,
+    binding: input.binding ?? (input.leadEmailHash ? 'lead' : 'staff'),
+    leadEmailHash: input.leadEmailHash,
+    issuedAt,
+    expiresAt: issuedAt + ttlSeconds,
+    nonce: randomBytes(16).toString('base64url'),
+  });
+
+  const payloadPart = toBase64Url(JSON.stringify(payload));
+  return `v1.${payloadPart}.${sign(payloadPart)}`;
+}
+
+export function createAssessmentFlowToken(
+  input: {
+    subject: Subject;
+    grade: 'PREMIERE' | 'TERMINALE';
+    source: string;
+    leadEmailHash: string;
+  },
+  options: {
+    now?: number;
+    ttlSeconds?: number;
+  } = {},
+): string {
+  const issuedAt = nowSeconds(options.now);
+  const ttlSeconds = options.ttlSeconds ?? ASSESSMENT_FLOW_TOKEN_TTL_SECONDS;
+  const payload = assessmentFlowTokenPayloadSchema.parse({
+    v: 1,
+    usage: 'assessment_flow',
+    subject: input.subject,
+    grade: input.grade,
+    source: input.source,
+    leadEmailHash: input.leadEmailHash,
+    issuedAt,
+    expiresAt: issuedAt + ttlSeconds,
+    nonce: randomBytes(16).toString('base64url'),
+  });
+
+  const payloadPart = toBase64Url(JSON.stringify(payload));
+  return `v1.${payloadPart}.${sign(payloadPart)}`;
+}
+
+function verifySignatureAndParse<T>(
+  token: string | null | undefined,
+  schema: z.ZodType<T>,
+  options: { now?: number } = {},
+):
+  | { ok: true; payload: T }
+  | { ok: false; reason: AssessmentTokenFailureReason } {
+  if (!token) return { ok: false, reason: 'missing' };
+
+  const parts = token.split('.');
+  if (parts.length !== 3 || parts[0] !== 'v1') {
+    return { ok: false, reason: 'malformed' };
+  }
+
+  const [, payloadPart, signature] = parts;
+
+  let expectedSignature: string;
+  try {
+    expectedSignature = sign(payloadPart);
+  } catch {
+    return { ok: false, reason: 'secret_unavailable' };
+  }
+
+  try {
+    const signatureBuffer = Buffer.from(signature, 'base64url');
+    const expectedBuffer = Buffer.from(expectedSignature, 'base64url');
+    if (
+      signatureBuffer.length !== expectedBuffer.length ||
+      !timingSafeEqual(signatureBuffer, expectedBuffer)
+    ) {
+      return { ok: false, reason: 'bad_signature' };
+    }
+  } catch {
+    return { ok: false, reason: 'bad_signature' };
+  }
+
+  let payload: T & { expiresAt?: unknown };
+  try {
+    payload = schema.parse(JSON.parse(fromBase64Url(payloadPart).toString('utf8'))) as T & {
+      expiresAt?: unknown;
+    };
+  } catch {
+    return { ok: false, reason: 'malformed' };
+  }
+
+  if (typeof payload.expiresAt !== 'number' || payload.expiresAt <= nowSeconds(options.now)) {
+    return { ok: false, reason: 'expired' };
+  }
+
+  return { ok: true, payload: payload as T };
+}
+
+export function verifyAssessmentPublicToken(
+  token: string | null | undefined,
+  expected: AssessmentPublicTokenExpectation,
+  options: { now?: number } = {},
+): AssessmentPublicTokenVerification {
+  const verification = verifySignatureAndParse(
+    token,
+    assessmentPublicTokenPayloadSchema,
+    options,
+  );
+  if (!verification.ok) return { valid: false, reason: verification.reason };
+  const payload = verification.payload;
+
+  if (
+    payload.usage !== expected.usage ||
+    payload.subject !== expected.subject ||
+    payload.grade !== expected.grade ||
+    (expected.source !== undefined && payload.source !== expected.source) ||
+    (expected.campaignId !== undefined && payload.campaignId !== expected.campaignId) ||
+    (expected.binding !== undefined && payload.binding !== expected.binding) ||
+    (expected.leadEmailHash !== undefined && payload.leadEmailHash !== expected.leadEmailHash) ||
+    (expected.studentEmail !== undefined &&
+      payload.binding === 'lead' &&
+      payload.leadEmailHash !== undefined &&
+      normalizeEmail(expected.studentEmail) !== buildAssessmentAliasEmail(payload.leadEmailHash))
+  ) {
+    return { valid: false, reason: 'scope_mismatch' };
+  }
+
+  return { valid: true, payload };
+}
+
+export function verifyAssessmentFlowToken(
+  token: string | null | undefined,
+  expected: { source?: string } = {},
+  options: { now?: number } = {},
+): AssessmentFlowTokenVerification {
+  const verification = verifySignatureAndParse(
+    token,
+    assessmentFlowTokenPayloadSchema,
+    options,
+  );
+  if (!verification.ok) return { valid: false, reason: verification.reason };
+  const payload = verification.payload;
+
+  if (expected.source !== undefined && payload.source !== expected.source) {
+    return { valid: false, reason: 'scope_mismatch' };
+  }
+
+  return { valid: true, payload };
+}

--- a/lib/config/snapshot.ts
+++ b/lib/config/snapshot.ts
@@ -34,6 +34,25 @@ export interface ConfigEntry {
   updatedAt: Date;
 }
 
+export type ConfigSnapshotRuntimeStatus =
+  | { mode: 'not_loaded'; ok: true; lastError: null }
+  | { mode: 'database'; ok: true; lastError: null }
+  | {
+      mode: 'static_fallback_allowed';
+      ok: true;
+      lastError: { kind: 'missing_table'; table: 'business_configs' };
+    }
+  | {
+      mode: 'static_fallback_unexpected';
+      ok: false;
+      lastError: { kind: 'missing_table'; table: 'business_configs' };
+    }
+  | {
+      mode: 'static_fallback_error';
+      ok: false;
+      lastError: { kind: 'load_error'; name: string };
+    };
+
 // ── State ──
 
 const TTL_MS = 60_000;
@@ -43,6 +62,44 @@ let lastLoadedAt = 0;
 let hasLoadedOnce = false; // True after first successful full load (_doLoad)
 let passiveInflight: Promise<void> | null = null;
 let swapSequence = 0; // Monotonic: incremented on passive full-snapshot swap
+let runtimeStatus: ConfigSnapshotRuntimeStatus = {
+  mode: 'not_loaded',
+  ok: true,
+  lastError: null,
+};
+
+function isMissingBusinessConfigTableError(error: unknown): boolean {
+  const candidate = error as { code?: unknown; meta?: { table?: unknown }; message?: unknown };
+  const table = String(candidate.meta?.table ?? '');
+  const message = String(candidate.message ?? '');
+  return (
+    candidate.code === 'P2021' &&
+    (table.includes('business_configs') || message.includes('business_configs'))
+  );
+}
+
+function isStaticFallbackAllowed(): boolean {
+  return (
+    process.env.BUSINESS_CONFIG_STATIC_FALLBACK_ALLOWED === 'true' ||
+    process.env.NODE_ENV !== 'production'
+  );
+}
+
+function buildMissingTableRuntimeStatus(): ConfigSnapshotRuntimeStatus {
+  if (isStaticFallbackAllowed()) {
+    return {
+      mode: 'static_fallback_allowed',
+      ok: true,
+      lastError: { kind: 'missing_table', table: 'business_configs' },
+    };
+  }
+
+  return {
+    mode: 'static_fallback_unexpected',
+    ok: false,
+    lastError: { kind: 'missing_table', table: 'business_configs' },
+  };
+}
 
 // ── Internal: passive load ──
 
@@ -83,6 +140,11 @@ async function _doLoad(): Promise<void> {
   swapSequence++;
   hasLoadedOnce = true;
   lastLoadedAt = Date.now();
+  runtimeStatus = {
+    mode: 'database',
+    ok: true,
+    lastError: null,
+  };
 }
 
 // ── Public API: reads ──
@@ -110,6 +172,10 @@ export function getAllEntries(): ConfigEntry[] {
   return Array.from(snapshot.values());
 }
 
+export function getConfigSnapshotRuntimeStatus(): ConfigSnapshotRuntimeStatus {
+  return runtimeStatus;
+}
+
 // ── Lifecycle: passive path ──
 
 export async function loadConfigSnapshot(): Promise<void> {
@@ -119,7 +185,21 @@ export async function loadConfigSnapshot(): Promise<void> {
   }
 
   passiveInflight = _doLoad().catch((error) => {
-    console.error('[config/snapshot] Passive refresh failed:', error);
+    if (isMissingBusinessConfigTableError(error)) {
+      hasLoadedOnce = true;
+      lastLoadedAt = Date.now();
+      runtimeStatus = buildMissingTableRuntimeStatus();
+      return;
+    }
+
+    runtimeStatus = {
+      mode: 'static_fallback_error',
+      ok: false,
+      lastError: { kind: 'load_error', name: error instanceof Error ? error.name : 'Error' },
+    };
+    console.error('[config/snapshot] Passive refresh failed:', {
+      name: error instanceof Error ? error.name : 'Error',
+    });
   });
 
   try {
@@ -191,6 +271,11 @@ export function _resetForTest(): void {
   hasLoadedOnce = false;
   passiveInflight = null;
   swapSequence = 0;
+  runtimeStatus = {
+    mode: 'not_loaded',
+    ok: true,
+    lastError: null,
+  };
 }
 
 export function _setForTest(entries: ConfigEntry[]): void {
@@ -203,4 +288,10 @@ export function _setForTest(entries: ConfigEntry[]): void {
   }
   swapSequence++;
   lastLoadedAt = Date.now();
+  hasLoadedOnce = true;
+  runtimeStatus = {
+    mode: 'database',
+    ok: true,
+    lastError: null,
+  };
 }

--- a/lib/crm/contact-leads.ts
+++ b/lib/crm/contact-leads.ts
@@ -3,7 +3,6 @@ import { prisma } from '@/lib/prisma';
 import { sendMail } from '@/lib/email/mailer';
 import { contactLeadNotification } from '@/lib/email/templates';
 import { LEGAL } from '@/lib/legal';
-import { serializeError } from '@/lib/utils/serialize-error';
 
 const optionalText = z
   .preprocess(
@@ -40,6 +39,21 @@ export class ContactLeadValidationError extends Error {
 
 export type ContactLeadInput = z.input<typeof contactLeadPayloadSchema>;
 
+export const CONTACT_LEAD_RETENTION_DAYS = 365;
+export const CONTACT_LEAD_ERASURE_SLA_DAYS = 30;
+
+export function buildContactLeadRetentionDecision() {
+  return {
+    dataCategory: 'public_lead_minor_related',
+    legalBasis: 'parent_consent_and_precontractual_request',
+    retentionDays: CONTACT_LEAD_RETENTION_DAYS,
+    erasureSlaDays: CONTACT_LEAD_ERASURE_SLA_DAYS,
+    deletionProcedure:
+      'Supprimer ou anonymiser les lignes ContactLead à la demande parentale et purger les leads non convertis au-delà de la durée de conservation.',
+    productionAction: 'schedule_retention_job_before_go_live_large',
+  } as const;
+}
+
 function getLeadNotificationRecipient(): string {
   return (
     process.env.CRM_LEAD_NOTIFICATION_EMAIL ||
@@ -69,8 +83,7 @@ export async function captureContactLead(payload: unknown) {
     throw new ContactLeadValidationError('missing_required');
   }
 
-  const lead = await prisma.contactLead.create({
-    data: {
+  const leadData = {
       name: data.name,
       email: data.email,
       phone: data.phone,
@@ -80,8 +93,27 @@ export async function captureContactLead(payload: unknown) {
       source: data.source,
       status: 'NEW',
       notes: data.notes,
-    },
-  });
+  } as const;
+
+  const existingLead = typeof prisma.contactLead.findFirst === 'function'
+    ? await prisma.contactLead.findFirst({
+        where: {
+          email: data.email,
+          source: data.source,
+          status: 'NEW',
+        },
+        orderBy: { createdAt: 'desc' },
+      })
+    : null;
+
+  const lead = existingLead && typeof prisma.contactLead.update === 'function'
+    ? await prisma.contactLead.update({
+        where: { id: existingLead.id },
+        data: leadData,
+      })
+    : await prisma.contactLead.create({
+        data: leadData,
+      });
 
   const template = contactLeadNotification({
     id: lead.id,
@@ -104,7 +136,9 @@ export async function captureContactLead(payload: unknown) {
       replyTo: lead.email,
     });
   } catch (error) {
-    console.error('[contact] lead notification failed', serializeError(error));
+    console.error('[contact] lead notification failed', {
+      name: error instanceof Error ? error.name : 'Error',
+    });
   }
 
   return lead;

--- a/lib/invoice/index.ts
+++ b/lib/invoice/index.ts
@@ -25,7 +25,7 @@ export type {
 export { createInvoiceEvent, appendInvoiceEvent, assertMillimes, MillimesValidationError, PAYMENT_METHOD_LABELS } from './types';
 export type { InvoiceEventDetails } from './types';
 export { sanitizeEventDetails, MAX_EVENT_DETAILS_SIZE } from './types';
-export { notFoundResponse, buildInvoiceScopeWhere } from './not-found';
+export { notFoundResponse, buildInvoiceScopeWhere, buildInvoiceAccessWhere } from './not-found';
 export {
   validateTransition,
   canPerformStatusAction,

--- a/lib/invoice/not-found.ts
+++ b/lib/invoice/not-found.ts
@@ -9,6 +9,7 @@
  */
 
 import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
 
 /** Canonical 404 JSON body — frozen, never varies. */
 const NOT_FOUND_BODY = { error: 'NOT_FOUND' } as const;
@@ -48,4 +49,56 @@ export function buildInvoiceScopeWhere(
     return { id, customerEmail: email };
   }
   return null;
+}
+
+type InvoiceAccessUser = {
+  id: string;
+  role?: string | null;
+  email?: string | null;
+};
+
+/**
+ * Build a Prisma WHERE clause scoped to the authenticated user.
+ *
+ * Parent access is based on child beneficiary user ids when available, with a
+ * legacy customerEmail fallback for older invoices that predate beneficiaryUserId.
+ */
+export async function buildInvoiceAccessWhere(
+  id: string,
+  user: InvoiceAccessUser
+): Promise<Record<string, unknown> | null> {
+  if (user.role === 'ADMIN' || user.role === 'ASSISTANTE') {
+    return { id };
+  }
+
+  if (user.role !== 'PARENT') {
+    return null;
+  }
+
+  const parentProfile = await prisma.parentProfile.findUnique({
+    where: { userId: user.id },
+    select: {
+      children: {
+        select: { userId: true },
+      },
+    },
+  });
+
+  const childUserIds = parentProfile?.children
+    .map((child) => child.userId)
+    .filter((childUserId): childUserId is string => Boolean(childUserId)) ?? [];
+
+  const ownershipFilters: Record<string, unknown>[] = [];
+  if (childUserIds.length > 0) {
+    ownershipFilters.push({ beneficiaryUserId: { in: childUserIds } });
+  }
+  if (user.email) {
+    ownershipFilters.push({ customerEmail: user.email });
+  }
+
+  if (ownershipFilters.length === 0) {
+    return null;
+  }
+
+  return { id, OR: ownershipFilters };
 }

--- a/lib/rate-limit/index.ts
+++ b/lib/rate-limit/index.ts
@@ -70,6 +70,31 @@ export function getRateLimitRuntimeMode(): RateLimitRuntimeMode {
   return 'memory';
 }
 
+export function isDistributedRateLimitMode(
+  mode: RateLimitRuntimeMode = getRateLimitRuntimeMode(),
+): boolean {
+  return mode === 'redis' || mode === 'upstash';
+}
+
+export function getRateLimitProductionGate(
+  mode: RateLimitRuntimeMode = getRateLimitRuntimeMode(),
+): {
+  ok: boolean;
+  mode: RateLimitRuntimeMode;
+  decision: 'allowed' | 'blocked';
+  reason: string;
+} {
+  const ok = isDistributedRateLimitMode(mode);
+  return {
+    ok,
+    mode,
+    decision: ok ? 'allowed' : 'blocked',
+    reason: ok
+      ? 'Distributed rate limiting runtime is configured.'
+      : 'Memory rate limiting is process-local and blocks go-live large.',
+  };
+}
+
 function getDistributedStore(): RedisStore | UpstashStore | null {
   const mode = getRateLimitRuntimeMode();
 

--- a/lib/stages/inscription-schema.ts
+++ b/lib/stages/inscription-schema.ts
@@ -11,6 +11,8 @@ export const publicStageInscriptionSchema = z.object({
   parentEmail: z.union([z.string().trim().email(), z.literal('')]).optional(),
   parentPhone: z.string().trim().max(30).optional(),
   notes: z.string().trim().max(500).optional(),
+  stageTermsAccepted: z.literal(true),
+  dataProcessingAccepted: z.literal(true),
 }).strict();
 
 export type PublicStageInscriptionInput = z.infer<typeof publicStageInscriptionSchema>;

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -28,7 +28,6 @@ export const bilanGratuitSchema = z.object({
   studentLastName: z.string().min(2, 'Le nom doit contenir au moins 2 caractères').optional(),
   studentGrade: z.string().min(1, 'Veuillez sélectionner une classe'),
   studentSchool: z.string().optional(),
-  studentBirthDate: z.string().optional(),
 
   // Besoins et objectifs
   subjects: z.array(z.enum(Object.values(Subject) as [string, ...string[]])).min(1, 'Sélectionnez au moins une matière'),

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,6 +8,9 @@ const baseURL =
   process.env.PLAYWRIGHT_TEST_BASE_URL ??
   'http://127.0.0.1:3002';
 
+const webServerUrl = new URL(baseURL);
+const webServerPort = webServerUrl.port || (webServerUrl.protocol === 'https:' ? '443' : '80');
+
 const e2eDatabaseUrl =
   process.env.E2E_DATABASE_URL ??
   'postgresql://postgres:postgres@127.0.0.1:5435/nexus_e2e?schema=public';
@@ -47,14 +50,14 @@ export default defineConfig({
         webServer: {
           command: 'node .next/standalone/server.js',
           env: {
-            HOSTNAME: '127.0.0.1',
-            PORT: '3002',
-            NEXTAUTH_URL: 'http://127.0.0.1:3002',
+            HOSTNAME: webServerUrl.hostname,
+            PORT: webServerPort,
+            NEXTAUTH_URL: baseURL,
             DATABASE_URL: e2eDatabaseUrl,
             TEST_DATABASE_URL: e2eDatabaseUrl,
           },
           url: baseURL,
-          reuseExistingServer: true,
+          reuseExistingServer: process.env.PLAYWRIGHT_REUSE_EXISTING_SERVER === 'true',
           timeout: 120_000,
         },
       }),

--- a/scripts/check-bundle-weight.sh
+++ b/scripts/check-bundle-weight.sh
@@ -49,8 +49,9 @@ for route in "${!BASELINES[@]}"; do
   baseline="${BASELINES[$route]}"
   budget=$((baseline + TOLERANCE_KB))
 
-  # Match the route in build output — handles both ┌ and ├ prefixes
-  line=$(grep -E "○ ${route} " "$BUILD_LOG" | head -1 || true)
+  # Match the route in build output regardless of whether Next marks it as
+  # static (○) or dynamic (ƒ). Some protected marketing flows read cookies.
+  line=$(grep -F " ${route} " "$BUILD_LOG" | head -1 || true)
   if [ -z "$line" ]; then
     echo "✗  ${route}: not found in build output (protected route vanished from build)"
     FAILURES=$((FAILURES + 1))

--- a/scripts/go-live/generate-api-security-matrix.mjs
+++ b/scripts/go-live/generate-api-security-matrix.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = process.cwd();
+const inventoryPath = join(root, 'docs/security/API_GUARD_INVENTORY.md');
+const outPath = join(root, 'docs/go-live/api-security-matrix.full.md');
+
+const inventory = readFileSync(inventoryPath, 'utf8');
+
+const fullInventory = inventory.split('## Inventaire complet')[1] ?? '';
+
+const rows = fullInventory
+  .split('\n')
+  .filter((line) => line.startsWith('| `app/api/') && line.includes('/route.ts` |'))
+  .map((line) => {
+    const cells = line.split('|').slice(1, -1).map((cell) => cell.trim());
+    const routeFile = cells[0].replace(/`/g, '');
+    return {
+      routeFile,
+      route: `/${routeFile.replace(/^app\//, '').replace(/\/route\.ts$/, '')}`,
+      methods: cells[1],
+      dynamic: cells[2],
+      authGuard: cells[3],
+      roleGuard: cells[4],
+      featureGuard: cells[5],
+      zod: cells[6],
+      ownershipDetected: cells[7],
+      priority: cells[8],
+      notes: cells[9] || '-',
+    };
+  });
+
+const domainRules = [
+  [/invoice|facturation|billing/i, 'Facturation'],
+  [/payment|clictopay/i, 'Paiement'],
+  [/document|pdf|files/i, 'Documents'],
+  [/bilan|assessment|diagnostic|report/i, 'Bilans/assessments'],
+  [/aria|rag/i, 'ARIA/RAG'],
+  [/npc|submission|upload/i, 'NPC'],
+  [/stage/i, 'Stages'],
+  [/admin/i, 'Admin'],
+  [/assistante/i, 'Assistante'],
+  [/coach/i, 'Coach'],
+  [/parent/i, 'Parent'],
+  [/student|eleve/i, 'Élève'],
+  [/auth|activate|reset-password/i, 'Auth'],
+  [/contact|newsletter|notify/i, 'Leads/messages'],
+];
+
+const sensitiveRules = [
+  [/invoice|payment|billing|facturation/i, 'Facture/paiement'],
+  [/document|pdf|files|upload/i, 'Document/fichier'],
+  [/bilan|assessment|diagnostic|report|submission/i, 'Données pédagogiques mineur'],
+  [/aria|conversation|message/i, 'Conversation IA'],
+  [/student|eleve|parent|coach|assistante|admin|user/i, 'PII/utilisateur'],
+  [/stage|reservation|session/i, 'Réservation/session'],
+  [/contact|newsletter|notify/i, 'Lead/contact'],
+];
+
+const p0DomainOrder = [
+  'Documents',
+  'Facturation',
+  'Paiement',
+  'Bilans/assessments',
+  'NPC',
+  'Coach',
+  'Stages',
+  'Assistante',
+  'Auth',
+  'ARIA/RAG',
+  'Admin',
+  'Parent',
+  'Élève',
+  'Leads/messages',
+];
+
+function escapeCell(value) {
+  return String(value ?? '')
+    .replaceAll('|', '\\|')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function domainFor(route, notes) {
+  const haystack = `${route} ${notes}`;
+  return domainRules.find(([pattern]) => pattern.test(haystack))?.[1] ?? 'Autre';
+}
+
+function sensitiveFor(route, notes) {
+  const haystack = `${route} ${notes}`;
+  const labels = sensitiveRules
+    .filter(([pattern]) => pattern.test(haystack))
+    .map(([, label]) => label);
+  return labels.length ? [...new Set(labels)].join(', ') : 'À vérifier';
+}
+
+function publicAuthFor(row) {
+  if (row.authGuard === 'yes') return 'Auth';
+  if (/webhook/i.test(row.route)) return 'Public webhook';
+  if (/contact|newsletter|notify|bilan-gratuit$|stages\/\[stageSlug\]\/inscrire|assessments\/submit|public-documents|student\/activate/i.test(row.route)) {
+    return 'Public';
+  }
+  return 'Public/À vérifier';
+}
+
+function roleFor(row) {
+  const route = row.route;
+  if (row.roleGuard !== 'yes') return row.authGuard === 'yes' ? 'À vérifier' : 'N/A';
+  if (/\/admin\//.test(route)) return 'Admin/staff';
+  if (/\/assistante\//.test(route)) return 'Assistante';
+  if (/\/coach\//.test(route)) return 'Coach';
+  if (/\/parent\//.test(route)) return 'Parent';
+  if (/\/student\/|\/eleve\//.test(route)) return 'Élève';
+  if (/\/aria\//.test(route)) return 'Élève/abonné à vérifier';
+  return 'Rôle détecté, à qualifier';
+}
+
+function ownershipRequired(row, domain, sensitiveData) {
+  if (row.dynamic === 'yes') return 'Oui';
+  if (row.authGuard === 'yes' && /Document|Facture|paiement|Données pédagogiques|Conversation|PII|Réservation/.test(sensitiveData)) {
+    return 'Oui';
+  }
+  if (row.publicAuth.startsWith?.('Public')) return 'N/A';
+  if (['Admin', 'Leads/messages', 'Autre'].includes(domain)) return 'À vérifier';
+  return 'À vérifier';
+}
+
+function rateLimitDetected(routeFile) {
+  const full = join(root, routeFile);
+  if (!existsSync(full)) return 'À vérifier';
+  const source = readFileSync(full, 'utf8');
+  return (
+    /\bguardRateLimitAsync\s*\(/.test(source) ||
+    /\bguardRateLimit\s*\(/.test(source) ||
+    /\bcheckRateLimitAsync\s*\(/.test(source) ||
+    /\bcheckRateLimit\s*\(/.test(source) ||
+    /\brateLimitResponse\s*\(/.test(source) ||
+    /\bRateLimitPresets\.[A-Za-z0-9_]+\s*\(/.test(source) ||
+    /\bwithRateLimit\s*\(/.test(source) ||
+    /\bapplyRateLimit\s*\(/.test(source) ||
+    /\bpublicLeadRateLimit\s*\(/.test(source) ||
+    /\benforceRateLimit\s*\(/.test(source)
+  )
+    ? 'Oui'
+    : 'Non';
+}
+
+function actionFor(row, domain, rateLimit) {
+  if (row.priority === 'OK') return 'Maintenir tests de non-régression';
+  if (row.priority === 'P0') {
+    if (domain === 'Paiement') return 'Lot 1/4 : signature, idempotence, auth et non-exposition publique';
+    if (domain === 'Facturation') return 'Lot 1 : ownership facture/PDF + tests IDOR';
+    if (domain === 'Documents') return 'Lot 1 : ownership strict, path no-leak, tests IDOR';
+    if (domain === 'Bilans/assessments') return 'Lot 1 : auth/token signé + ownership résultats';
+    if (domain === 'NPC') return 'Lot 1 : traversal + ownership soumission/document';
+    if (domain === 'Stages') return 'Lot 1 : scope stage, role staff, anti-spam public';
+    if (domain === 'Coach') return 'Lot 1 : assignment actif obligatoire';
+    if (domain === 'Assistante') return 'Lot 1 : périmètre assistante + audit IDOR';
+    if (domain === 'Auth') return 'Lot 1 : token, expiration, rate limit';
+    if (rateLimit === 'Non' && publicAuthFor(row).startsWith('Public')) return 'Lot 1 : ajouter rate limit public';
+    return 'Lot 1 : audit manuel prioritaire + tests IDOR';
+  }
+  if (row.priority === 'P1') return 'Durcir avant bêta élargie';
+  return 'Suivi qualité P2';
+}
+
+const enriched = rows.map((row) => {
+  const domain = domainFor(row.route, row.notes);
+  const sensitiveData = sensitiveFor(row.route, row.notes);
+  const publicAuth = publicAuthFor(row);
+  const ownershipRequiredValue = ownershipRequired({ ...row, publicAuth }, domain, sensitiveData);
+  const rateLimit = rateLimitDetected(row.routeFile);
+  return {
+    ...row,
+    domain,
+    sensitiveData,
+    publicAuth,
+    roleRequired: roleFor(row),
+    ownershipRequired: ownershipRequiredValue,
+    rateLimit,
+    action: actionFor(row, domain, rateLimit),
+  };
+});
+
+const counts = ['P0', 'P1', 'P2', 'OK'].map((priority) => [
+  priority,
+  enriched.filter((row) => row.priority === priority).length,
+]);
+
+const topPriority = enriched.some((row) => row.priority === 'P0') ? 'P0' : 'P1';
+const top20 = enriched
+  .filter((row) => row.priority === topPriority)
+  .sort((a, b) => {
+    const domainDelta = p0DomainOrder.indexOf(a.domain) - p0DomainOrder.indexOf(b.domain);
+    if (domainDelta !== 0) return domainDelta;
+    return a.route.localeCompare(b.route);
+  })
+  .slice(0, 20);
+
+const lines = [];
+lines.push('# Annexe matrice API sécurité complète');
+lines.push('');
+lines.push(`Source : \`${inventoryPath.replace(`${root}/`, '')}\`.`);
+lines.push(`Généré le : ${new Date().toISOString()}.`);
+lines.push('');
+lines.push('Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Zod détecté` et `Ownership requis` sont des indices de pilotage. `À vérifier` signifie qu’aucune preuve suffisante n’a été établie dans ce lot.');
+lines.push('');
+lines.push('## Synthèse');
+lines.push('');
+lines.push('| Priorité | Nombre |');
+lines.push('| --- | ---: |');
+for (const [priority, count] of counts) lines.push(`| ${priority} | ${count} |`);
+lines.push(`| Total | ${enriched.length} |`);
+lines.push('');
+lines.push(`## Top 20 à corriger en priorité (${topPriority})`);
+lines.push('');
+lines.push('| Priorité | Route | Domaine | Risque dominant | Action Lot suivant |');
+lines.push('| --- | --- | --- | --- | --- |');
+for (const row of top20) {
+  lines.push(`| ${row.priority} | \`${row.route}\` | ${row.domain} | ${escapeCell(row.sensitiveData)} | ${escapeCell(row.action)} |`);
+}
+lines.push('');
+lines.push('## Matrice route par route');
+lines.push('');
+lines.push('| Priorité | Route | Méthodes | Domaine | Public/Auth | Rôle requis | Ownership requis | Auth guard détecté | Role guard détecté | Zod détecté | Rate limit détecté | Données sensibles | Action Lot suivant |');
+lines.push('| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |');
+for (const row of enriched) {
+  lines.push([
+    row.priority,
+    `\`${row.route}\``,
+    row.methods,
+    row.domain,
+    row.publicAuth,
+    row.roleRequired,
+    row.ownershipRequired,
+    row.authGuard === 'yes' ? 'Oui' : 'Non',
+    row.roleGuard === 'yes' ? 'Oui' : 'Non',
+    row.zod === 'yes' ? 'Oui' : 'Non',
+    row.rateLimit,
+    row.sensitiveData,
+    row.action,
+  ].map(escapeCell).join(' | ').replace(/^/, '| ').concat(' |'));
+}
+lines.push('');
+lines.push('## Limites');
+lines.push('');
+lines.push('- Les guards détectés proviennent de motifs statiques ; ils ne prouvent pas l’absence d’IDOR.');
+lines.push('- Le rate limiting est détecté par motifs de code locaux ; une protection middleware, reverse proxy ou provider externe reste `À vérifier` sans preuve runtime.');
+lines.push('- Les routes `OK` ne sont pas déclarées go-live ready ; elles sont seulement moins prioritaires dans l’inventaire statique.');
+
+writeFileSync(outPath, `${lines.join('\n')}\n`);
+console.log(`Wrote ${outPath.replace(`${root}/`, '')} (${enriched.length} routes)`);
+console.log(counts.map(([priority, count]) => `${priority}: ${count}`).join(', '));

--- a/scripts/maintenance/contact-leads-retention.ts
+++ b/scripts/maintenance/contact-leads-retention.ts
@@ -1,0 +1,201 @@
+import { createHash } from 'crypto';
+import { readFileSync } from 'fs';
+import { prisma } from '@/lib/prisma';
+import { CONTACT_LEAD_RETENTION_DAYS } from '@/lib/crm/contact-leads';
+
+type ContactLeadRetentionStatus = 'NEW' | 'CONTACTED' | 'QUALIFIED' | 'ENROLLED' | 'LOST';
+
+export type ContactLeadRetentionLead = {
+  id: string;
+  email: string;
+  status: ContactLeadRetentionStatus | string;
+  createdAt: Date;
+};
+
+export type ContactLeadRetentionPlanItem = {
+  id: string;
+  reason: 'retention_expired' | 'parent_erasure_request';
+  status: string;
+  ageDays: number;
+  emailHash: string;
+};
+
+export type ContactLeadRetentionPlan = {
+  now: string;
+  retentionDays: number;
+  scanned: number;
+  toAnonymize: ContactLeadRetentionPlanItem[];
+};
+
+const RETENTION_PURGE_STATUSES = new Set(['NEW', 'CONTACTED', 'LOST']);
+const ERASURE_ALLOWED_STATUSES = new Set(['NEW', 'CONTACTED', 'QUALIFIED', 'LOST']);
+
+function ageDays(createdAt: Date, now: Date): number {
+  return Math.floor((now.getTime() - createdAt.getTime()) / 86_400_000);
+}
+
+function sanitizeIdForAlias(id: string): string {
+  return id.toLowerCase().replace(/[^a-z0-9-]/g, '-').slice(0, 80) || 'lead';
+}
+
+export function hashContactLeadErasureEmail(email: string): string {
+  return createHash('sha256').update(email.trim().toLowerCase()).digest('hex');
+}
+
+export function buildContactLeadRetentionPlan({
+  leads,
+  now = new Date(),
+  retentionDays = CONTACT_LEAD_RETENTION_DAYS,
+  erasureEmailHashes = [],
+}: {
+  leads: ContactLeadRetentionLead[];
+  now?: Date;
+  retentionDays?: number;
+  erasureEmailHashes?: string[];
+}): ContactLeadRetentionPlan {
+  const erasureSet = new Set(erasureEmailHashes.map((hash) => hash.trim().toLowerCase()).filter(Boolean));
+  const toAnonymize: ContactLeadRetentionPlanItem[] = [];
+
+  for (const lead of leads) {
+    const leadAgeDays = ageDays(lead.createdAt, now);
+    const emailHash = hashContactLeadErasureEmail(lead.email);
+    const status = String(lead.status);
+
+    const retentionExpired =
+      leadAgeDays >= retentionDays && RETENTION_PURGE_STATUSES.has(status);
+    const erasureRequested =
+      erasureSet.has(emailHash) && ERASURE_ALLOWED_STATUSES.has(status);
+
+    if (!retentionExpired && !erasureRequested) continue;
+
+    toAnonymize.push({
+      id: lead.id,
+      reason: erasureRequested ? 'parent_erasure_request' : 'retention_expired',
+      status,
+      ageDays: leadAgeDays,
+      emailHash,
+    });
+  }
+
+  return {
+    now: now.toISOString(),
+    retentionDays,
+    scanned: leads.length,
+    toAnonymize,
+  };
+}
+
+function anonymizedLeadData(id: string) {
+  return {
+    name: 'Lead anonymisé',
+    email: `erased-${sanitizeIdForAlias(id)}@deleted.nexus.local`,
+    phone: null,
+    profile: null,
+    interest: null,
+    urgency: null,
+    source: 'retention-anonymized',
+    notes: null,
+    status: 'LOST' as const,
+  };
+}
+
+export async function runContactLeadRetention({
+  prismaClient = prisma,
+  now = new Date(),
+  retentionDays = CONTACT_LEAD_RETENTION_DAYS,
+  erasureEmailHashes = [],
+  apply = false,
+}: {
+  prismaClient?: typeof prisma;
+  now?: Date;
+  retentionDays?: number;
+  erasureEmailHashes?: string[];
+  apply?: boolean;
+}) {
+  const leads = await prismaClient.contactLead.findMany({
+    where: {
+      status: { not: 'ENROLLED' },
+    },
+    select: {
+      id: true,
+      email: true,
+      status: true,
+      createdAt: true,
+    },
+  }) as ContactLeadRetentionLead[];
+
+  const plan = buildContactLeadRetentionPlan({
+    leads,
+    now,
+    retentionDays,
+    erasureEmailHashes,
+  });
+
+  if (apply) {
+    for (const item of plan.toAnonymize) {
+      await prismaClient.contactLead.update({
+        where: { id: item.id },
+        data: anonymizedLeadData(item.id),
+      });
+    }
+  }
+
+  return {
+    dryRun: !apply,
+    scanned: plan.scanned,
+    planned: plan.toAnonymize.length,
+    applied: apply ? plan.toAnonymize.length : 0,
+    reasons: plan.toAnonymize.reduce<Record<string, number>>((acc, item) => {
+      acc[item.reason] = (acc[item.reason] ?? 0) + 1;
+      return acc;
+    }, {}),
+    retentionDays: plan.retentionDays,
+  };
+}
+
+function parseArgs(argv: string[]) {
+  const args = new Set(argv);
+  const erasureEmailHashes: string[] = [];
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === '--email-hash' && argv[index + 1]) {
+      erasureEmailHashes.push(argv[index + 1]);
+      index++;
+    }
+    if (arg === '--email-hashes-file' && argv[index + 1]) {
+      const content = readFileSync(argv[index + 1], 'utf8');
+      erasureEmailHashes.push(
+        ...content
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .filter(Boolean),
+      );
+      index++;
+    }
+  }
+
+  return {
+    apply: args.has('--apply'),
+    erasureEmailHashes,
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const result = await runContactLeadRetention(options);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+if (process.argv[1]?.endsWith('contact-leads-retention.ts')) {
+  main()
+    .catch((error) => {
+      console.error('[contact-leads-retention] failed', {
+        name: error instanceof Error ? error.name : 'Error',
+      });
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      await prisma.$disconnect?.();
+    });
+}

--- a/scripts/security/audit-api-guards.mjs
+++ b/scripts/security/audit-api-guards.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 
 const root = process.cwd();
 const apiRoot = join(root, 'app/api');
@@ -27,11 +27,59 @@ function methodsOf(source) {
   return matches.map((match) => match[1]).join(', ') || '-';
 }
 
+function hasRateLimitGuard(source) {
+  return hasAny(source, [
+    /\bguardRateLimitAsync\s*\(/,
+    /\bguardRateLimit\s*\(/,
+    /\bcheckRateLimitAsync\s*\(/,
+    /\bcheckRateLimit\s*\(/,
+    /\brateLimitResponse\s*\(/,
+    /\bRateLimitPresets\.[A-Za-z0-9_]+\s*\(/,
+    /\bwithRateLimit\s*\(/,
+    /\bapplyRateLimit\s*\(/,
+    /\bpublicLeadRateLimit\s*\(/,
+    /\benforceRateLimit\s*\(/,
+  ]);
+}
+
+function sourceFor(file) {
+  const source = readFileSync(file, 'utf8');
+  const reexportMatches = [...source.matchAll(/export\s*\{\s*([^}]+)\s*\}\s*from\s*['"]([^'"]+)['"]/g)];
+  if (reexportMatches.length === 0) return source;
+
+  const importedSources = reexportMatches
+    .map((match) => {
+      const target = resolve(dirname(file), match[2]);
+      const targetFile = target.endsWith('.ts') ? target : `${target}.ts`;
+      try {
+        return readFileSync(targetFile, 'utf8');
+      } catch {
+        return '';
+      }
+    })
+    .filter(Boolean);
+
+  return [source, ...importedSources].join('\n');
+}
+
 function riskFor(route, source, dynamic, authGuard, roleGuard, ownership, zod) {
   const sensitivePath = /documents|invoice|billing|payment|bilan|assessment|aria|session|stage|coach|assistante|admin|parent|student|npc|submission|report/i.test(route);
   const mutation = /\b(POST|PATCH|PUT|DELETE)\b/.test(methodsOf(source));
+  const staffOnlyRoute = (
+    /app\/api\/(admin|assistante)\//.test(route) ||
+    /requireAnyRole\s*\(\s*\[\s*['"]ADMIN['"]\s*,\s*['"]ASSISTANTE['"]/.test(source)
+  ) && authGuard && roleGuard;
+  const publicSensitiveWithControls = !authGuard && sensitivePath && zod && hasRateLimitGuard(source);
+  const fixedPublicDocument = /app\/api\/public-documents\//.test(route) && methodsOf(source) === 'GET' && /const\s+FILE_NAME\b/.test(source);
+  const disabledWebhook = /webhook/i.test(route) && /status:\s*501/.test(source) && /NOT_CONFIGURED|not configured|en cours de configuration/i.test(source);
+  const deprecatedRoute = /status:\s*410/.test(source);
+  const publicStageCatalog = /^app\/api\/stages(\/\[[^\]]+\])?\/route\.ts$/.test(route) && methodsOf(source) === 'GET';
+  const staticStudentContent = /app\/api\/student\/automatismes\/series\/\[id\]\/route\.ts/.test(route) && methodsOf(source) === 'GET';
 
-  if (dynamic && sensitivePath && authGuard && !ownership) return 'P0';
+  if (fixedPublicDocument || deprecatedRoute || publicStageCatalog || staticStudentContent) return 'P2';
+  if (disabledWebhook) return 'P1';
+  if (dynamic && sensitivePath && authGuard && !ownership && !staffOnlyRoute) return 'P0';
+  if (publicSensitiveWithControls) return mutation ? 'P1' : 'P2';
   if (sensitivePath && !authGuard) return 'P0';
   if (mutation && sensitivePath && !zod) return 'P1';
   if (sensitivePath && authGuard && !roleGuard && !ownership) return 'P1';
@@ -54,11 +102,26 @@ function notesFor(route, source, risk) {
 }
 
 const rows = walk(apiRoot).map((file) => {
-  const source = readFileSync(file, 'utf8');
+  const source = sourceFor(file);
   const route = relative(root, file);
   const dynamic = /\[[^\]]+\]/.test(route) ? 'yes' : 'no';
-  const authGuard = hasAny(source, [/\bauth\s*\(/, /\brequireAuth\b/, /\brequireRole\b/, /\brequireAnyRole\b/]) ? 'yes' : 'no';
-  const roleGuard = hasAny(source, [/\brequireRole\b/, /\brequireAnyRole\b/, /session\.user\.role/, /UserRole\./]) ? 'yes' : 'no';
+  const authGuard = hasAny(source, [
+    /\bauth\s*\(/,
+    /\brequireAuth\b/,
+    /\brequireRole\b/,
+    /\brequireAnyRole\b/,
+    /\benforcePolicy\b/,
+    /\bgetActor\b/,
+  ]) ? 'yes' : 'no';
+  const roleGuard = hasAny(source, [
+    /\brequireRole\b/,
+    /\brequireAnyRole\b/,
+    /\benforcePolicy\b/,
+    /\bcanPerformStatusAction\b/,
+    /\bcan\s*\(\s*role\s*,/,
+    /session\.user\.role/,
+    /UserRole\./,
+  ]) ? 'yes' : 'no';
   const featureGuard = hasAny(source, [/\brequireFeatureApi\b/, /\brequireFeature\b/]) ? 'yes' : 'no';
   const zod = hasAny(source, [/\bzod\b/, /\bz\./, /\.parse\s*\(/, /\.safeParse\s*\(/]) ? 'yes' : 'no';
   const ownership = hasAny(source, [
@@ -68,6 +131,32 @@ const rows = walk(apiRoot).map((file) => {
     /coachId\s*:\s*session\.user\.id/,
     /student\s*:\s*\{[^}]*userId\s*:\s*session\.user\.id/s,
     /where\s*:\s*\{[^}]*id\s*:[^}]*userId/s,
+    /\bbuildDocumentOwnershipWhere\b/,
+    /\bhasDocumentOwnership\b/,
+    /\bassertCoachCanAccessStudent\b/,
+    /\bisCoachAssignedToStudent\b/,
+    /\bcanReadSubmission\b/,
+    /\bcanManageSubmissionDocuments\b/,
+    /\bauthenticateAndAuthorize\b/,
+    /\bverifyStageAccess\b/,
+    /\bstageCoach\.findFirst\b/,
+    /stage\s*:\s*\{\s*slug\s*:\s*stageSlug\s*\}/,
+    /sessionBooking\.coachId\s*!==\s*coachUserId/,
+    /sessionBooking\.coachId\s*!==\s*session\.user\.id/,
+    /sessionBooking\.studentId\s*!==\s*session\.user\.id/,
+    /sessionBooking\.parentId\s*!==\s*session\.user\.id/,
+    /\bbuildInvoiceAccessWhere\b/,
+    /\bbuildInvoiceScopeWhere\b/,
+    /\bbuildAssessmentAccessWhere\b/,
+    /\bbuildBilanReadWhere\b/,
+    /\bbuildBilanWriteWhere\b/,
+    /studentId\s*:\s*\{\s*in\s*:\s*childIds\s*\}/,
+    /parentProfile\.findUnique\s*\([^]*userId\s*:\s*sessionOrError\.user\.id/s,
+    /\brequireParentOwnsStudent\b/,
+    /\brequireParentOwnsInvoice\b/,
+    /\brequireCoachAssignedToStudent\b/,
+    /\brequireStudentOwnsResource\b/,
+    /\benforceOwnership\b/,
     /ownership/i,
   ]) ? 'yes' : 'no';
   const methods = methodsOf(source);


### PR DESCRIPTION
## Objet

Cette PR regroupe la release candidate go-live issue des Lots 4 à 16.

Elle inclut :

- durcissement de la matrice sécurité API ;
- maintien explicite des 6 P1 visibles ;
- correction du flux public bilan/assessment avec binding lead-only ;
- garde runtime rate-limit / business config ;
- ClicToPay maintenu désactivé et fail-closed ;
- dry-run ContactLead retention ;
- tests de non-régression sécurité, token, IDOR, no-leak ;
- E2E de protection de la route assessment ;
- registres go-live, preuves de release, runbooks et décisions go/no-go.

## Statut sécurité

Matrice attendue :

- P0 = 0
- P1 = 6
- P2 = 144
- OK = 28
- Total = 178 routes

Les 6 P1 restent volontairement visibles :

- `/api/payments/clictopay/webhook`
- `/api/assessments/submit`
- `/api/bilan-gratuit`
- `/api/lamis/teacher-report`
- `/api/stages/[stageSlug]/inscrire`
- `/api/student/activate`

## Gates locales rapportées

Dernières gates locales Lot 15 / Lot 16 :

- `npm run typecheck` : PASS
- `npm run lint` : PASS
- `npm run test:unit -- --runInBand` : PASS
- `npm run build` : PASS
- `node scripts/security/audit-api-guards.mjs` : PASS
- `node scripts/go-live/generate-api-security-matrix.mjs` : PASS
- `npm run audit:site-map` : PASS
- `npm run check:no-hardcoded` : PASS
- `npm run check:docs-archive` : PASS
- `npm run check:bundle-weight` : PASS
- Playwright public : 24 passed
- Playwright assessment token : 1 passed

## Fichiers explicitement exclus de la RC

Ces fichiers restent hors commits standards :

- `docs/audits/audit-nexus-reussite.md`
- `rapport_audit_2_07_2026.md`

## Décisions go/no-go

- `BETA_CONTROLEE_ALLOWED_WITH_RESERVES`
- `BETA_ELARGIE_BLOCKED`
- `GO_LIVE_LARGE_BLOCKED`

## Réserves bloquantes hors bêta contrôlée

- Redis/Upstash runtime non prouvé ;
- test 429 runtime réel non exécuté ;
- ContactLead DB dry-run non exécuté ;
- ClicToPay maintenu désactivé ;
- 6 P1 encore ouverts.

## Règles de revue

Cette PR est créée en **draft**. Elle ne doit pas être mergée tant que :

- la revue GitHub n’est pas terminée ;
- les checks GitHub ne sont pas lus ;
- aucune régression CI n’est ouverte ;
- les fichiers exclus ne sont pas réintroduits ;
- les 6 P1 restent visibles ;
- aucun déploiement ni migration n’a été lancé depuis cette PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Go-live release candidate that hardens API security and validation, introduces a lead-only public assessment funnel with short‑lived tokens, and keeps card payments disabled by default. Adds runtime gates, internal probes, and release evidence for the go/no‑go process.

- **Security & Runtime**
  - Enforce role guards (`requireRole`/`requireAnyRole`) and strict `zod` validation across admin/staff and public routes; reject unexpected fields and unsafe IDs/params; add explicit `select` projections and hide sensitive fields.
  - Add public rate‑limit guards and an internal probe; classify distributed vs memory modes for go‑live gating; introduce business‑config snapshot fallback and production gate; expand health checks.
  - Extend coverage with IDOR, token binding, webhook signature, and “no sensitive fields” regressions; update security matrix (P0=0, P1=6, P2=144, OK=28; 178 routes). The 6 P1 remain visible: `/api/payments/clictopay/webhook`, `/api/assessments/submit`, `/api/bilan-gratuit`, `/api/lamis/teacher-report`, `/api/stages/[stageSlug]/inscrire`, `/api/student/activate`.

- **Public Funnel & Payments**
  - Lead-only public flow: minimize `/api/bilan-gratuit` data and align its response contract; add flow cookie and short‑lived assessment tokens; new `POST /api/assessments/public-token` for staff, with token binding on `/api/assessments/submit`.
  - Keep ClicToPay disabled and fail‑closed: require signed webhooks, no state mutation while disabled, parent‑only init, and hide provider in UI until `NEXT_PUBLIC_ENABLE_CLICTOPAY_PUBLIC` is set.
  - Add dry‑run ContactLead retention logic and include go‑live evidence (registers, matrices, runbooks, and consistency checks).

<sup>Written for commit 3336022e9b407c42fc891b6f86f95537e252ca77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

