### PR TITLE
fix(api-security): close admin and role guard gaps

### DIFF
--- a/__tests__/api/admin.config.route.test.ts
+++ b/__tests__/api/admin.config.route.test.ts
@@ -187,6 +187,17 @@ describe('PATCH /api/admin/config', () => {
     expect(res.status).toBe(400);
   });
 
+  it('rejects unexpected fields in config writes', async () => {
+    const res = await PATCH(makeRequest({
+      namespace: 'pricing.rules',
+      key: 'semi_individual_surcharge_pct',
+      value: 60,
+      rawPayload: { leak: true },
+    }));
+    expect(res.status).toBe(400);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
   it('rejects unknown namespace', async () => {
     const res = await PATCH(makeRequest({
       namespace: 'unknown.ns', key: 'foo', value: 1,
@@ -209,6 +220,25 @@ describe('PATCH /api/admin/config', () => {
       'SELECT pg_advisory_xact_lock($1)',
       expect.any(Number),
     );
+  });
+});
+
+describe('POST /api/admin/config/rollback', () => {
+  it('rejects unexpected fields in rollback payloads', async () => {
+    const { POST: ROLLBACK } = require('@/app/api/admin/config/rollback/route');
+    const rollbackReq = new NextRequest('http://localhost:3000/api/admin/config/rollback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        namespace: 'pricing.rules',
+        key: 'semi_individual_surcharge_pct',
+        force: true,
+      }),
+    });
+
+    const res = await ROLLBACK(rollbackReq);
+    expect(res.status).toBe(400);
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 });
 

--- a/__tests__/api/admin.directeur.stats.route.test.ts
+++ b/__tests__/api/admin.directeur.stats.route.test.ts
@@ -6,15 +6,22 @@
  * Source: app/api/admin/directeur/stats/route.ts
  */
 
-jest.mock('@/auth', () => ({
-  auth: jest.fn(),
+jest.mock('@/lib/guards', () => ({
+  requireRole: jest.fn(),
+  isErrorResponse: jest.fn((result) => result && typeof result === 'object' && 'status' in result),
+}));
+
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: jest.fn().mockResolvedValue(null),
 }));
 
 import { GET } from '@/app/api/admin/directeur/stats/route';
-import { auth } from '@/auth';
+import { requireRole } from '@/lib/guards';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
 import { NextRequest } from 'next/server';
 
-const mockAuth = auth as jest.Mock;
+const mockRequireRole = requireRole as jest.Mock;
+const mockGuardRateLimit = guardRateLimitAsync as jest.Mock;
 
 let prisma: any;
 
@@ -22,6 +29,10 @@ beforeEach(async () => {
   const mod = await import('@/lib/prisma');
   prisma = (mod as any).prisma;
   jest.clearAllMocks();
+  mockRequireRole.mockResolvedValue({
+    user: { id: 'admin-1', role: 'ADMIN', email: 'admin@test.com' },
+  });
+  mockGuardRateLimit.mockResolvedValue(null);
 });
 
 function makeRequest(): NextRequest {
@@ -29,33 +40,51 @@ function makeRequest(): NextRequest {
 }
 
 describe('GET /api/admin/directeur/stats', () => {
-  it('should return 403 when not authenticated', async () => {
-    mockAuth.mockResolvedValue(null as any);
+  it('should return 401 when not authenticated', async () => {
+    mockRequireRole.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+    );
 
     const res = await GET(makeRequest());
     const body = await res.json();
 
-    expect(res.status).toBe(403);
-    expect(body.success).toBe(false);
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('Unauthorized');
   });
 
   it('should return 403 for non-ADMIN role', async () => {
-    mockAuth.mockResolvedValue({
-      user: { id: 'user-1', role: 'ELEVE' },
-    } as any);
+    mockRequireRole.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Forbidden', message: 'Access denied. Required role: ADMIN' }), { status: 403 })
+    );
 
     const res = await GET(makeRequest());
     const body = await res.json();
 
     expect(res.status).toBe(403);
-    expect(body.error).toContain('ADMIN');
+    expect(body.message).toContain('ADMIN');
+  });
+
+  it('rejects unexpected query parameters', async () => {
+    const res = await GET(new NextRequest('http://localhost:3000/api/admin/directeur/stats?rawPayload=true'));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('Paramètres invalides');
+    expect(prisma.assessment.count).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 before DB work when rate limit is exceeded', async () => {
+    mockGuardRateLimit.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'rate limited' }), { status: 429 })
+    );
+
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(429);
+    expect(prisma.assessment.count).not.toHaveBeenCalled();
   });
 
   it('should return KPIs for ADMIN', async () => {
-    mockAuth.mockResolvedValue({
-      user: { id: 'admin-1', role: 'ADMIN' },
-    } as any);
-
     prisma.assessment.count
       .mockResolvedValueOnce(100) // totalAssessments
       .mockResolvedValueOnce(80); // completedAssessments
@@ -86,10 +115,6 @@ describe('GET /api/admin/directeur/stats', () => {
   });
 
   it('should handle SSN distribution correctly', async () => {
-    mockAuth.mockResolvedValue({
-      user: { id: 'admin-1', role: 'ADMIN' },
-    } as any);
-
     prisma.assessment.count.mockResolvedValue(0);
     prisma.student.count.mockResolvedValue(0);
     prisma.assessment.aggregate.mockResolvedValue({ _avg: { globalScore: null } });
@@ -118,10 +143,6 @@ describe('GET /api/admin/directeur/stats', () => {
   });
 
   it('should handle DB errors gracefully', async () => {
-    mockAuth.mockResolvedValue({
-      user: { id: 'admin-1', role: 'ADMIN' },
-    } as any);
-
     prisma.assessment.count.mockRejectedValue(new Error('DB error'));
 
     const res = await GET(makeRequest());

--- a/__tests__/api/admin.documents.route.test.ts
+++ b/__tests__/api/admin.documents.route.test.ts
@@ -1,138 +1,104 @@
-/**
- * Admin Documents API — Complete Test Suite
- *
- * Tests: POST /api/admin/documents
- *
- * Source: app/api/admin/documents/route.ts
- *
- * Note: FormData parsing via NextRequest hangs in Jest's jsdom environment.
- * We test RBAC enforcement directly and mock request.formData() for the rest.
- */
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/admin/documents/route';
+import { requireAnyRole, isErrorResponse } from '@/lib/guards';
+import { prisma } from '@/lib/prisma';
+import { writeFile, mkdir } from 'fs/promises';
 
 jest.mock('@/lib/guards', () => ({
   requireAnyRole: jest.fn(),
-  isErrorResponse: jest.fn(),
+  isErrorResponse: jest.fn((value: unknown) => value instanceof Response),
 }));
 
 jest.mock('fs/promises', () => ({
   mkdir: jest.fn().mockResolvedValue(undefined),
   writeFile: jest.fn().mockResolvedValue(undefined),
-  readFile: jest.fn(),
-  stat: jest.fn(),
 }));
 
 jest.mock('node:fs/promises', () => ({
   mkdir: jest.fn().mockResolvedValue(undefined),
   writeFile: jest.fn().mockResolvedValue(undefined),
-  readFile: jest.fn(),
-  stat: jest.fn(),
 }));
 
 jest.mock('@paralleldrive/cuid2', () => ({
-  createId: jest.fn().mockReturnValue('mock-cuid-123'),
+  createId: jest.fn().mockReturnValue('doc-secure-id'),
 }));
 
-import { POST } from '@/app/api/admin/documents/route';
-import { requireAnyRole, isErrorResponse } from '@/lib/guards';
-import { NextRequest, NextResponse } from 'next/server';
+function mockFile(name: string, type: string, content = '%PDF-1.4') {
+  return {
+    name,
+    type,
+    size: Buffer.byteLength(content),
+    arrayBuffer: jest.fn().mockResolvedValue(Buffer.from(content).buffer),
+  } as unknown as File;
+}
 
-const mockRequireAnyRole = requireAnyRole as jest.Mock;
-const mockIsErrorResponse = isErrorResponse as unknown as jest.Mock;
-
-let prisma: any;
-
-beforeEach(async () => {
-  const mod = await import('@/lib/prisma');
-  prisma = (mod as any).prisma;
-  jest.clearAllMocks();
-});
-
-/**
- * Build a NextRequest with a mocked formData() method to avoid jsdom timeout.
- */
-function makeRequest(formDataMap: Record<string, unknown>): NextRequest {
-  const req = new NextRequest('http://localhost:3000/api/admin/documents', { method: 'POST' });
-  (req as any).formData = jest.fn().mockResolvedValue({
-    get: (key: string) => formDataMap[key] ?? null,
-  });
-  return req;
+function uploadRequest(file: File, userId = 'user-1') {
+  const formData = {
+    get: jest.fn((key: string) => {
+      if (key === 'file') return file;
+      if (key === 'userId') return userId;
+      return null;
+    }),
+  };
+  return {
+    formData: jest.fn().mockResolvedValue(formData),
+  } as unknown as NextRequest;
 }
 
 describe('POST /api/admin/documents', () => {
-  it('should return 403 for unauthorized role', async () => {
-    const errorRes = NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-    mockRequireAnyRole.mockResolvedValue(errorRes as any);
-    mockIsErrorResponse.mockReturnValue(true);
-
-    const req = makeRequest({ userId: 'u1', file: new File(['x'], 'test.pdf') });
-    const res = await POST(req);
-    expect(res.status).toBe(403);
-  });
-
-  it('should return 400 when file or userId missing', async () => {
-    mockRequireAnyRole.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN' } } as any);
-    mockIsErrorResponse.mockReturnValue(false);
-
-    const req = makeRequest({ userId: 'u1' }); // no file
-    const res = await POST(req);
-    const body = await res.json();
-
-    expect(res.status).toBe(400);
-    expect(body.error).toContain('File');
-  });
-
-  it('should return 404 when target user not found', async () => {
-    mockRequireAnyRole.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN' } } as any);
-    mockIsErrorResponse.mockReturnValue(false);
-    prisma.user.findUnique.mockResolvedValue(null);
-
-    const file = new File(['content'], 'test.pdf', { type: 'application/pdf' });
-    const req = makeRequest({ userId: 'nonexistent', file });
-    const res = await POST(req);
-    const body = await res.json();
-
-    expect(res.status).toBe(404);
-    expect(body.error).toContain('user not found');
-  });
-
-  it('should upload document successfully', async () => {
-    mockRequireAnyRole.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN' } } as any);
-    mockIsErrorResponse.mockReturnValue(false);
-    prisma.user.findUnique.mockResolvedValue({ id: 'u1', email: 'u@t.com' });
-    prisma.userDocument.create.mockResolvedValue({
-      id: 'mock-cuid-123',
-      title: 'test.pdf',
-      originalName: 'test.pdf',
-      mimeType: 'application/pdf',
-      sizeBytes: 7,
-      localPath: '/app/storage/documents/mock-cuid-123.pdf',
-      userId: 'u1',
-      uploadedById: 'a1',
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireAnyRole as jest.Mock).mockResolvedValue({
+      user: { id: 'admin-1', role: 'ADMIN' },
     });
-
-    const fakeFile = {
-      name: 'test.pdf',
-      type: 'application/pdf',
-      size: 7,
-      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(7)),
-    };
-    const req = makeRequest({ userId: 'u1', file: fakeFile });
-    const res = await POST(req);
-    const body = await res.json();
-
-    expect(res.status).toBe(201);
-    expect(body.id).toBe('mock-cuid-123');
-    expect(body.originalName).toBe('test.pdf');
+    (isErrorResponse as unknown as jest.Mock).mockImplementation((value: unknown) => value instanceof Response);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'user-1' });
+    (prisma.userDocument.create as jest.Mock).mockResolvedValue({
+      id: 'doc-secure-id',
+      title: 'bulletin.pdf',
+      originalName: 'bulletin.pdf',
+      mimeType: 'application/pdf',
+      sizeBytes: 8,
+      localPath: '/app/storage/documents/doc-secure-id.pdf',
+      userId: 'user-1',
+      uploadedById: 'admin-1',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
   });
 
-  it('should return 500 on internal error', async () => {
-    mockRequireAnyRole.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN' } } as any);
-    mockIsErrorResponse.mockReturnValue(false);
-    prisma.user.findUnique.mockRejectedValue(new Error('DB error'));
+  it('requires ADMIN or ASSISTANTE role', async () => {
+    const guardResponse = new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 });
+    (requireAnyRole as jest.Mock).mockResolvedValue(guardResponse);
+    (isErrorResponse as unknown as jest.Mock).mockReturnValue(true);
 
-    const file = new File(['content'], 'test.pdf', { type: 'application/pdf' });
-    const req = makeRequest({ userId: 'u1', file });
-    const res = await POST(req);
-    expect(res.status).toBe(500);
+    const response = await POST(uploadRequest(mockFile('bulletin.pdf', 'application/pdf')));
+
+    expect(response.status).toBe(403);
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported MIME types before writing files', async () => {
+    const response = await POST(uploadRequest(mockFile('bad.exe', 'application/x-msdownload', 'bad')));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Type ou taille de fichier invalide');
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it('stores an allowed file and returns a projection without localPath', async () => {
+    const response = await POST(uploadRequest(mockFile('bulletin.pdf', 'application/pdf')));
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(mkdir).toHaveBeenCalled();
+    expect(writeFile).toHaveBeenCalled();
+    expect(body.document).toEqual(expect.objectContaining({
+      id: 'doc-secure-id',
+      originalName: 'bulletin.pdf',
+      mimeType: 'application/pdf',
+    }));
+    expect(JSON.stringify(body)).not.toContain('localPath');
+    expect(JSON.stringify(body)).not.toContain('/app/storage');
   });
 });

--- a/__tests__/api/admin.invoices.route.test.ts
+++ b/__tests__/api/admin.invoices.route.test.ts
@@ -124,6 +124,36 @@ describe('GET /api/admin/invoices', () => {
     );
   });
 
+  it('rejects invalid list filters before querying invoices', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN' } } as any);
+
+    const res = await GET(makeGetRequest('status=HACKED&limit=500'));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.invoice.findMany).not.toHaveBeenCalled();
+  });
+
+  it('uses an explicit projection for invoice listing', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN' } } as any);
+    prisma.invoice.findMany.mockResolvedValue([]);
+    prisma.invoice.count.mockResolvedValue(0);
+
+    await GET(makeGetRequest());
+
+    expect(prisma.invoice.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({
+          id: true,
+          number: true,
+          items: expect.any(Object),
+        }),
+      })
+    );
+    expect(prisma.invoice.findMany.mock.calls[0][0]).not.toHaveProperty('include');
+  });
+
   it('should return 500 on DB error', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN' } } as any);
     prisma.invoice.findMany.mockRejectedValue(new Error('DB error'));
@@ -165,7 +195,7 @@ describe('POST /api/admin/invoices', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('customer.name');
+    expect(body.error).toContain('Données');
   });
 
   it('should return 400 for empty items', async () => {
@@ -173,6 +203,21 @@ describe('POST /api/admin/invoices', () => {
 
     const res = await POST(makePostRequest({ customer: { name: 'Karim' }, items: [] }));
     expect(res.status).toBe(400);
+  });
+
+  it('rejects unknown invoice payload fields before creating anything', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN' } } as any);
+
+    const res = await POST(makePostRequest({
+      customer: { name: 'Karim' },
+      items: [{ label: 'Abonnement Hybride', qty: 1, unitPrice: 450000 }],
+      metadata: { raw: true },
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.invoice.create).not.toHaveBeenCalled();
   });
 
   it('should create invoice successfully', async () => {

--- a/__tests__/api/admin.recompute-ssn.route.test.ts
+++ b/__tests__/api/admin.recompute-ssn.route.test.ts
@@ -6,8 +6,13 @@
  * Source: app/api/admin/recompute-ssn/route.ts
  */
 
-jest.mock('@/auth', () => ({
-  auth: jest.fn(),
+jest.mock('@/lib/guards', () => ({
+  requireRole: jest.fn(),
+  isErrorResponse: jest.fn((result) => result && typeof result === 'object' && 'status' in result),
+}));
+
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: jest.fn().mockResolvedValue(null),
 }));
 
 jest.mock('@/lib/core/ssn/computeSSN', () => ({
@@ -19,17 +24,23 @@ jest.mock('@/lib/core/statistics/cohort', () => ({
 }));
 
 import { POST } from '@/app/api/admin/recompute-ssn/route';
-import { auth } from '@/auth';
+import { requireRole } from '@/lib/guards';
 import { recomputeSSNBatch } from '@/lib/core/ssn/computeSSN';
 import { computeCohortStatsWithAudit } from '@/lib/core/statistics/cohort';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
 import { NextRequest } from 'next/server';
 
-const mockAuth = auth as jest.Mock;
+const mockRequireRole = requireRole as jest.Mock;
 const mockRecompute = recomputeSSNBatch as jest.Mock;
 const mockAudit = computeCohortStatsWithAudit as jest.Mock;
+const mockGuardRateLimit = guardRateLimitAsync as jest.Mock;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockRequireRole.mockResolvedValue({
+    user: { id: 'a1', role: 'ADMIN', email: 'admin@test.com' },
+  });
+  mockGuardRateLimit.mockResolvedValue(null);
 });
 
 function makeRequest(body: Record<string, unknown>): NextRequest {
@@ -41,26 +52,28 @@ function makeRequest(body: Record<string, unknown>): NextRequest {
 }
 
 describe('POST /api/admin/recompute-ssn', () => {
-  it('should return 403 when not authenticated', async () => {
-    mockAuth.mockResolvedValue(null as any);
+  it('should return 401 when not authenticated', async () => {
+    mockRequireRole.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+    );
 
     const res = await POST(makeRequest({ type: 'MATHS' }));
     const body = await res.json();
 
-    expect(res.status).toBe(403);
-    expect(body.success).toBe(false);
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('Unauthorized');
   });
 
   it('should return 403 for non-ADMIN role', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
+    mockRequireRole.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 })
+    );
 
     const res = await POST(makeRequest({ type: 'MATHS' }));
     expect(res.status).toBe(403);
   });
 
   it('should return 400 for invalid type', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'admin@test.com' } } as any);
-
     const res = await POST(makeRequest({ type: 'INVALID' }));
     const body = await res.json();
 
@@ -68,15 +81,34 @@ describe('POST /api/admin/recompute-ssn', () => {
     expect(body.error).toContain('Type invalide');
   });
 
-  it('should return 400 for missing type', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'admin@test.com' } } as any);
+  it('rejects unexpected payload fields before recomputing', async () => {
+    const res = await POST(makeRequest({ type: 'MATHS', rawPayload: true }));
+    const body = await res.json();
 
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Type invalide');
+    expect(mockAudit).not.toHaveBeenCalled();
+    expect(mockRecompute).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 before recomputing when rate limit is exceeded', async () => {
+    mockGuardRateLimit.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'rate limited' }), { status: 429 })
+    );
+
+    const res = await POST(makeRequest({ type: 'MATHS' }));
+
+    expect(res.status).toBe(429);
+    expect(mockAudit).not.toHaveBeenCalled();
+    expect(mockRecompute).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 for missing type', async () => {
     const res = await POST(makeRequest({}));
     expect(res.status).toBe(400);
   });
 
   it('should recompute SSN for MATHS', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'admin@test.com' } } as any);
     mockAudit.mockResolvedValue({
       previousStats: { mean: 50, std: 15 },
       stats: { mean: 52, std: 14 },
@@ -100,7 +132,6 @@ describe('POST /api/admin/recompute-ssn', () => {
   });
 
   it('should accept NSI and GENERAL types', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'admin@test.com' } } as any);
     mockAudit.mockResolvedValue({ stats: { mean: 50, std: 10 } } as any);
     mockRecompute.mockResolvedValue({ updated: 10, cohort: { mean: 50, std: 10, sampleSize: 10 } } as any);
 
@@ -111,7 +142,6 @@ describe('POST /api/admin/recompute-ssn', () => {
   });
 
   it('should return 500 on service error', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'admin@test.com' } } as any);
     mockAudit.mockRejectedValue(new Error('DB error'));
 
     const res = await POST(makeRequest({ type: 'MATHS' }));

--- a/__tests__/api/admin.subscriptions.route.test.ts
+++ b/__tests__/api/admin.subscriptions.route.test.ts
@@ -70,6 +70,21 @@ describe('GET /api/admin/subscriptions', () => {
     expect(body.subscriptions).toHaveLength(1);
     expect(body.pagination.total).toBe(1);
   });
+
+  it('bounds pagination and rejects unknown query fields', async () => {
+    (auth as jest.Mock).mockResolvedValue({
+      user: { id: 'admin-1', role: 'ADMIN', email: 'admin@test.com' },
+    });
+
+    const response = await GET(
+      makeRequest('http://localhost:3000/api/admin/subscriptions?limit=500&rawPayload=true')
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Invalid query');
+    expect(prisma.subscription.findMany).not.toHaveBeenCalled();
+  });
 });
 
 describe('PUT /api/admin/subscriptions', () => {
@@ -100,6 +115,25 @@ describe('PUT /api/admin/subscriptions', () => {
 
     expect(response.status).toBe(400);
     expect(body.error).toBe('Invalid status value');
+  });
+
+  it('rejects unexpected update payload fields', async () => {
+    (auth as jest.Mock).mockResolvedValue({
+      user: { id: 'admin-1', role: 'ADMIN', email: 'admin@test.com' },
+    });
+
+    const response = await PUT(
+      makeRequest('http://localhost:3000/api/admin/subscriptions', {
+        subscriptionId: 'sub-1',
+        status: 'ACTIVE',
+        rawPayload: true,
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Invalid payload');
+    expect(prisma.subscription.update).not.toHaveBeenCalled();
   });
 
   it('returns 400 for missing subscriptionId', async () => {

--- a/__tests__/api/admin.test-email.route.test.ts
+++ b/__tests__/api/admin.test-email.route.test.ts
@@ -43,9 +43,20 @@ describe('admin test email', () => {
     expect(body.configuration).toBeDefined();
   });
 
-  it('tests SMTP config via POST', async () => {
+  it('blocks assistant access to admin test email actions', async () => {
     (auth as jest.Mock).mockResolvedValue({
       user: { id: 'assistant-1', role: 'ASSISTANTE' },
+    });
+
+    const response = await POST(makeRequest({ action: 'test_config' }));
+
+    expect(response.status).toBe(403);
+    expect(testEmailConfiguration).not.toHaveBeenCalled();
+  });
+
+  it('tests SMTP config via POST for admin only', async () => {
+    (auth as jest.Mock).mockResolvedValue({
+      user: { id: 'admin-1', role: 'ADMIN' },
     });
     (testEmailConfiguration as jest.Mock).mockResolvedValue({ success: true });
 
@@ -59,7 +70,7 @@ describe('admin test email', () => {
 
   it('requires testEmail for send_test', async () => {
     (auth as jest.Mock).mockResolvedValue({
-      user: { id: 'assistant-1', role: 'ASSISTANTE' },
+      user: { id: 'admin-1', role: 'ADMIN' },
     });
 
     const response = await POST(makeRequest({ action: 'send_test' }));
@@ -71,7 +82,7 @@ describe('admin test email', () => {
 
   it('sends test email', async () => {
     (auth as jest.Mock).mockResolvedValue({
-      user: { id: 'assistant-1', role: 'ASSISTANTE' },
+      user: { id: 'admin-1', role: 'ADMIN' },
     });
 
     const response = await POST(makeRequest({ action: 'send_test', testEmail: 'a@test.com' }));
@@ -80,5 +91,22 @@ describe('admin test email', () => {
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
     expect(sendWelcomeEmail).toHaveBeenCalled();
+  });
+
+  it('rejects unexpected payload fields and invalid recipient emails', async () => {
+    (auth as jest.Mock).mockResolvedValue({
+      user: { id: 'admin-1', role: 'ADMIN' },
+    });
+
+    const response = await POST(makeRequest({
+      action: 'send_test',
+      testEmail: 'not-an-email',
+      rawPayload: true,
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Payload invalide');
+    expect(sendWelcomeEmail).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/api/assessments-rbac.test.ts
+++ b/__tests__/api/assessments-rbac.test.ts
@@ -8,6 +8,7 @@
 
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
+import { NextRequest } from 'next/server';
 
 jest.mock('@/auth', () => ({
   auth: jest.fn(),
@@ -31,16 +32,15 @@ describe('GET /api/admin/directeur/stats', () => {
     jest.clearAllMocks();
   });
 
-  it('returns 403 without session', async () => {
+  it('returns 401 without session', async () => {
     mockGetServerSession.mockResolvedValue(null);
 
-    const request = new Request('http://localhost/api/admin/directeur/stats');
+    const request = new NextRequest('http://localhost/api/admin/directeur/stats');
     const response = await GET(request);
     const data = await response.json();
 
-    expect(response.status).toBe(403);
-    expect(data.success).toBe(false);
-    expect(data.error).toContain('ADMIN');
+    expect(response.status).toBe(401);
+    expect(data.error).toBe('Unauthorized');
   });
 
   it('returns 403 for non-ADMIN user', async () => {
@@ -48,12 +48,12 @@ describe('GET /api/admin/directeur/stats', () => {
       user: { id: 'user-1', email: 'coach@test.com', role: 'COACH' },
     });
 
-    const request = new Request('http://localhost/api/admin/directeur/stats');
+    const request = new NextRequest('http://localhost/api/admin/directeur/stats');
     const response = await GET(request);
     const data = await response.json();
 
     expect(response.status).toBe(403);
-    expect(data.success).toBe(false);
+    expect(data.error).toBe('Forbidden');
   });
 
   it('returns 200 for ADMIN user', async () => {
@@ -72,7 +72,7 @@ describe('GET /api/admin/directeur/stats', () => {
     (prisma.stageReservation.count as jest.Mock).mockResolvedValue(0);
     (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValue([]);
 
-    const request = new Request('http://localhost/api/admin/directeur/stats');
+    const request = new NextRequest('http://localhost/api/admin/directeur/stats');
     const response = await GET(request);
     const data = await response.json();
 
@@ -96,10 +96,10 @@ describe('POST /api/admin/recompute-ssn', () => {
     jest.clearAllMocks();
   });
 
-  it('returns 403 without session', async () => {
+  it('returns 401 without session', async () => {
     mockGetServerSession.mockResolvedValue(null);
 
-    const request = new Request('http://localhost/api/admin/recompute-ssn', {
+    const request = new NextRequest('http://localhost/api/admin/recompute-ssn', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ type: 'MATHS' }),
@@ -108,8 +108,8 @@ describe('POST /api/admin/recompute-ssn', () => {
     const response = await POST(request);
     const data = await response.json();
 
-    expect(response.status).toBe(403);
-    expect(data.success).toBe(false);
+    expect(response.status).toBe(401);
+    expect(data.error).toBe('Unauthorized');
   });
 
   it('returns 200 for ADMIN user with valid type', async () => {
@@ -126,7 +126,7 @@ describe('POST /api/admin/recompute-ssn', () => {
     (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValue([]);
     (prisma.$executeRawUnsafe as jest.Mock).mockResolvedValue(2);
 
-    const request = new Request('http://localhost/api/admin/recompute-ssn', {
+    const request = new NextRequest('http://localhost/api/admin/recompute-ssn', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ type: 'MATHS' }),

--- a/__tests__/api/assistant.credit-requests.route.test.ts
+++ b/__tests__/api/assistant.credit-requests.route.test.ts
@@ -86,7 +86,7 @@ describe('assistant credit-requests', () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toBe('Missing required fields');
+    expect(body.error).toBe('Invalid credit request payload');
   });
 
   it('POST approves credit request', async () => {

--- a/__tests__/api/assistant.students.credits.route.test.ts
+++ b/__tests__/api/assistant.students.credits.route.test.ts
@@ -96,7 +96,7 @@ describe('assistant students credits', () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toBe('Missing required fields');
+    expect(body.error).toBe('Invalid credit payload');
   });
 
   it('POST rejects unsupported credit transaction type', async () => {
@@ -108,7 +108,7 @@ describe('assistant students credits', () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toContain('Invalid credit type');
+    expect(body.error).toContain('Invalid credit payload');
     expect(prisma.creditTransaction.create).not.toHaveBeenCalled();
   });
 
@@ -121,7 +121,7 @@ describe('assistant students credits', () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toContain('Invalid credit amount');
+    expect(body.error).toContain('Invalid credit payload');
     expect(prisma.creditTransaction.create).not.toHaveBeenCalled();
   });
 

--- a/__tests__/api/assistant.subscription-requests.route.test.ts
+++ b/__tests__/api/assistant.subscription-requests.route.test.ts
@@ -76,6 +76,34 @@ describe('assistant subscription-requests', () => {
     expect(body.error).toBe('Invalid subscription request payload');
   });
 
+  it('PATCH validates requestId strictly', async () => {
+    (auth as jest.Mock).mockResolvedValue({
+      user: { id: 'assistant-1', role: 'ASSISTANTE' },
+    });
+
+    const response = await PATCH(makeRequest({ requestId: '../req-1', action: 'APPROVED' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Invalid subscription request payload');
+    expect(prisma.subscriptionRequest.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('PATCH rejects unknown payload fields', async () => {
+    (auth as jest.Mock).mockResolvedValue({
+      user: { id: 'assistant-1', role: 'ASSISTANTE' },
+    });
+
+    const response = await PATCH(
+      makeRequest({ requestId: 'req-1', action: 'APPROVED', role: 'ADMIN' })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Invalid subscription request payload');
+    expect(prisma.subscriptionRequest.findUnique).not.toHaveBeenCalled();
+  });
+
   it('PATCH approves plan change atomically with server catalog price and credits', async () => {
     (auth as jest.Mock).mockResolvedValue({
       user: { id: 'assistant-1', role: 'ASSISTANTE', firstName: 'A', lastName: 'S' },
@@ -101,7 +129,7 @@ describe('assistant subscription-requests', () => {
       })
     );
 
-    const response = await PATCH(makeRequest({ requestId: 'req-1', action: 'APPROVED' }));
+    const response = await PATCH(makeRequest({ requestId: 'req-1', action: 'APPROVED', reason: null }));
     const body = await response.json();
 
     expect(response.status).toBe(200);

--- a/__tests__/api/assistant.subscription-requests.route.test.ts
+++ b/__tests__/api/assistant.subscription-requests.route.test.ts
@@ -73,7 +73,7 @@ describe('assistant subscription-requests', () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toBe('Invalid action');
+    expect(body.error).toBe('Invalid subscription request payload');
   });
 
   it('PATCH approves plan change atomically with server catalog price and credits', async () => {

--- a/__tests__/api/assistant.subscriptions.route.test.ts
+++ b/__tests__/api/assistant.subscriptions.route.test.ts
@@ -71,7 +71,7 @@ describe('assistant subscriptions', () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toBe('Missing required fields');
+    expect(body.error).toBe('Invalid subscription payload');
   });
 
   it('POST returns 404 when subscription missing', async () => {

--- a/__tests__/api/assistante.quotes.pdf.route.test.ts
+++ b/__tests__/api/assistante.quotes.pdf.route.test.ts
@@ -99,4 +99,20 @@ describe('POST /api/assistante/quotes/pdf', () => {
       offer: expect.objectContaining({ label: 'Excellence Terminale' }),
     }));
   });
+
+  it('rejects unexpected fields before rendering a PDF', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'assistant-1', email: 'assistante@nexus-reussite.com', role: 'ASSISTANTE' },
+    });
+
+    const response = await POST(makeRequest({
+      ...quotePayload,
+      metadata: { rawPayload: true },
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Invalid quote payload');
+    expect(mockRenderQuotePDF).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/api/bilans.id.route.test.ts
+++ b/__tests__/api/bilans.id.route.test.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { GET, PUT } from '@/app/api/bilans/[id]/route';
-import { GET as EXPORT_GET } from '@/app/api/bilans/[id]/export/route';
+import { GET as EXPORT_GET, POST as EXPORT_POST } from '@/app/api/bilans/[id]/export/route';
 import { requireAnyRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
 
@@ -77,6 +77,19 @@ describe('/api/bilans/[id] — ownership', () => {
     expect(body.data.analysisJson).toBeUndefined();
   });
 
+  it('rejects unsafe bilan ids before querying', async () => {
+    mockRequireAnyRole.mockResolvedValue({
+      user: { id: 'admin-1', role: 'ADMIN', email: 'admin@test.local' },
+    });
+
+    const res = await GET(makeRequest('/api/bilans/../secret'), params('../secret'));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.bilan.findFirst).not.toHaveBeenCalled();
+  });
+
   it('requires a coach-owned or assigned bilan before update', async () => {
     mockRequireAnyRole.mockResolvedValue({
       user: { id: 'coach-user-1', role: 'COACH', email: 'coach@test.local' },
@@ -93,6 +106,20 @@ describe('/api/bilans/[id] — ownership', () => {
         OR: expect.any(Array),
       }),
     }));
+  });
+
+  it('rejects unknown update fields before mutating a bilan', async () => {
+    mockRequireAnyRole.mockResolvedValue({
+      user: { id: 'admin-1', role: 'ADMIN', email: 'admin@test.local' },
+    });
+
+    const res = await PUT(makePutRequest({ status: 'COMPLETED', metadata: { raw: true } }), params());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.bilan.findFirst).not.toHaveBeenCalled();
+    expect(prisma.bilan.update).not.toHaveBeenCalled();
   });
 
   it('does not export Nexus markdown to parent audience=all', async () => {
@@ -155,6 +182,42 @@ describe('/api/bilans/[id] — ownership', () => {
     );
 
     expect(res.status).toBe(404);
+  });
+
+  it('rejects unsupported export audience before loading the bilan', async () => {
+    mockRequireAnyRole.mockResolvedValue({
+      user: { id: 'admin-1', role: 'ADMIN', email: 'admin@test.local' },
+    });
+
+    const res = await EXPORT_GET(
+      makeRequest('/api/bilans/bilan-1/export?format=markdown&audience=raw'),
+      params()
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.bilan.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported export generation formats before loading the bilan', async () => {
+    mockRequireAnyRole.mockResolvedValue({
+      user: { id: 'admin-1', role: 'ADMIN', email: 'admin@test.local' },
+    });
+
+    const res = await EXPORT_POST(
+      new NextRequest('http://localhost:3000/api/bilans/bilan-1/export', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ format: 'zip' }),
+      }),
+      params()
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.bilan.findFirst).not.toHaveBeenCalled();
   });
 
   it('returns guard response unchanged when auth fails', async () => {

--- a/__tests__/api/bilans.idor.test.ts
+++ b/__tests__/api/bilans.idor.test.ts
@@ -79,6 +79,17 @@ describe('/api/bilans — IDOR Prevention', () => {
     }));
   });
 
+  it('rejects invalid list filters before querying bilans', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN', email: 'admin@test.com' } });
+
+    const response = await GET(makeGetRequest('?limit=500&isPublished=maybe'));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.bilan.findMany).not.toHaveBeenCalled();
+  });
+
   it('🔴 COACH tente de créer un bilan pour un autre coach — 403', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'coach-1', role: 'COACH', email: 'coach@test.com' } });
     (prisma.coachProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'coach-profile-1', userId: 'coach-1' });

--- a/__tests__/api/bilans/crud.test.ts
+++ b/__tests__/api/bilans/crud.test.ts
@@ -173,7 +173,7 @@ describe('F50: /api/bilans CRUD', () => {
 
       expect(response.status).toBe(400);
       expect(body.success).toBe(false);
-      expect(body.error).toContain('Missing required fields');
+      expect(body.error).toContain('Données invalides');
     });
   });
 });

--- a/__tests__/api/bilans/generate.test.ts
+++ b/__tests__/api/bilans/generate.test.ts
@@ -102,6 +102,20 @@ describe('F50: /api/bilans/generate', () => {
       expect(body.error).toContain('bilanId');
     });
 
+    it('rejects unsafe bilan ids before loading the bilan', async () => {
+      const request = new NextRequest('http://localhost:3000/api/bilans/generate', {
+        method: 'POST',
+        body: JSON.stringify({ bilanId: '../secret' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toContain('Données');
+      expect(mockPrisma.bilan.findUnique).not.toHaveBeenCalled();
+    });
+
     it('should return 404 for non-existent bilan', async () => {
       mockPrisma.bilan.findUnique.mockResolvedValue(null);
 
@@ -179,6 +193,16 @@ describe('F50: /api/bilans/generate', () => {
       const response = await GET(request);
 
       expect(response.status).toBe(400);
+    });
+
+    it('rejects unsafe bilan ids before querying generation status', async () => {
+      const request = new NextRequest('http://localhost:3000/api/bilans/generate?bilanId=../secret');
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toContain('Données');
+      expect(mockPrisma.bilan.findUnique).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/api/coach.bilan-diagnostic-maths-terminale.security.test.ts
+++ b/__tests__/api/coach.bilan-diagnostic-maths-terminale.security.test.ts
@@ -1,0 +1,76 @@
+jest.mock('@/lib/guards', () => ({
+  requireRole: jest.fn(),
+  isErrorResponse: jest.fn((result) => result && typeof result === 'object' && 'status' in result),
+}));
+
+jest.mock('@/lib/rbac/coach-student-access', () => ({
+  assertCoachCanAccessStudent: jest.fn(),
+}));
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    bilan: {
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+    coachProfile: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/lib/diagnostic/maths-terminale/scoring', () => ({
+  computeDiagnostics: jest.fn(),
+}));
+
+jest.mock('@/lib/diagnostic/maths-terminale/data', () => ({
+  DOMAINS: [],
+}));
+
+jest.mock('@/lib/utils/serialize-error', () => ({
+  serializeError: jest.fn(() => ({ name: 'Error', message: 'redacted' })),
+}));
+
+import {
+  GET,
+  PATCH,
+} from '@/app/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale/route';
+import { requireRole } from '@/lib/guards';
+import { assertCoachCanAccessStudent } from '@/lib/rbac/coach-student-access';
+import { prisma } from '@/lib/prisma';
+
+describe('/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireRole as jest.Mock).mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+  });
+
+  it('rejects unsafe student ids on GET before checking assignment', async () => {
+    const res = await GET(new Request('http://localhost/'), {
+      params: Promise.resolve({ studentId: '../student' }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(assertCoachCanAccessStudent).not.toHaveBeenCalled();
+    expect(prisma.bilan.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsafe student ids on PATCH before parsing body or mutating', async () => {
+    const res = await PATCH(
+      new Request('http://localhost/', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ teacherGrades: {} }),
+      }),
+      { params: Promise.resolve({ studentId: '../student' }) }
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(assertCoachCanAccessStudent).not.toHaveBeenCalled();
+    expect(prisma.bilan.update).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/coach.eaf-preparation-report.validate.test.ts
+++ b/__tests__/api/coach.eaf-preparation-report.validate.test.ts
@@ -64,6 +64,16 @@ describe('POST /api/coach/students/[studentId]/eaf-preparation-report/validate',
     (getCoachProfileForUser as jest.Mock).mockResolvedValue({ id: 'coach-1' });
   });
 
+  it('rejects unsafe student ids before checking coach assignment', async () => {
+    const res = await POST(new Request('http://localhost/', { method: 'POST' }), params('../student'));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(assertCoachCanAccessStudent).not.toHaveBeenCalled();
+    expect(prisma.eafPreparationReport.findUnique).not.toHaveBeenCalled();
+  });
+
   it('refuses incomplete coach reports', async () => {
     (prisma.eafPreparationReport.findUnique as jest.Mock).mockResolvedValue({
       ...completeReport,

--- a/__tests__/api/coach.eaf-stage-regenerate.security.test.ts
+++ b/__tests__/api/coach.eaf-stage-regenerate.security.test.ts
@@ -1,0 +1,60 @@
+jest.mock('@/lib/guards', () => ({
+  requireRole: jest.fn(),
+  isErrorResponse: jest.fn((result) => result && typeof result === 'object' && 'status' in result),
+}));
+
+jest.mock('@/lib/rbac/coach-student-access', () => {
+  class CoachNotAssignedError extends Error {
+    constructor(message = "Vous n'êtes pas assigné à cet élève") {
+      super(message);
+      this.name = 'CoachNotAssignedError';
+    }
+  }
+
+  return {
+    assertCoachCanAccessStudent: jest.fn(),
+    getCoachProfileForUser: jest.fn(),
+    CoachNotAssignedError,
+  };
+});
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    bilan: {
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/lib/coach/eaf-stage-printemps/llm-report', () => ({
+  generateLLMParentEafReport: jest.fn(),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}));
+
+import { POST } from '@/app/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate/route';
+import { requireRole } from '@/lib/guards';
+import { assertCoachCanAccessStudent } from '@/lib/rbac/coach-student-access';
+import { prisma } from '@/lib/prisma';
+
+describe('POST /api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireRole as jest.Mock).mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+  });
+
+  it('rejects unsafe student ids before checking coach assignment or loading bilans', async () => {
+    const res = await POST(new Request('http://localhost/', { method: 'POST' }), {
+      params: Promise.resolve({ studentId: '../student' }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(assertCoachCanAccessStudent).not.toHaveBeenCalled();
+    expect(prisma.bilan.findFirst).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/coach.generated-reports.route.test.ts
+++ b/__tests__/api/coach.generated-reports.route.test.ts
@@ -137,6 +137,20 @@ describe('POST /api/coach/students/[studentId]/generated-reports/[reportId]/rege
     jest.clearAllMocks();
   });
 
+  it('rejects unsafe route params before checking coach assignment', async () => {
+    (requireRole as jest.Mock).mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
+
+    const res = await REGENERATE(new Request('http://localhost/', { method: 'POST' }), {
+      params: Promise.resolve({ studentId: '../student', reportId: '../report' }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(assertCoachCanAccessStudent).not.toHaveBeenCalled();
+    expect(processGeneratedReportJob).not.toHaveBeenCalled();
+  });
+
   it('does not expose internal generated report payloads after regeneration', async () => {
     (requireRole as jest.Mock).mockResolvedValue({ user: { id: 'coach-user-1', role: 'COACH' } });
     (assertCoachCanAccessStudent as jest.Mock).mockResolvedValue(undefined);

--- a/__tests__/api/coach.trajectory.security.test.ts
+++ b/__tests__/api/coach.trajectory.security.test.ts
@@ -1,0 +1,100 @@
+import { NextRequest } from 'next/server';
+
+import { POST } from '@/app/api/coach/trajectory/route';
+import { auth } from '@/auth';
+import { prisma } from '@/lib/prisma';
+import { isCoachRattachedToStudent } from '@/lib/rbac/coach-student-access';
+
+jest.mock('@/auth', () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock('@/lib/rbac/coach-student-access', () => ({
+  isCoachRattachedToStudent: jest.fn(),
+}));
+
+function request(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/coach/trajectory', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/coach/trajectory — security', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects unexpected payload fields before any mutation', async () => {
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'coach-1', role: 'COACH' } });
+
+    const response = await POST(request({
+      studentId: 'student-1',
+      title: 'Trajectoire',
+      horizon: '3_MONTHS',
+      metadata: { rawPayload: true },
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Invalid trajectory payload');
+    expect(prisma.trajectory.updateMany).not.toHaveBeenCalled();
+    expect(prisma.trajectory.create).not.toHaveBeenCalled();
+  });
+
+  it('prevents a coach from creating a trajectory for an unassigned student', async () => {
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'coach-1', role: 'COACH' } });
+    (isCoachRattachedToStudent as jest.Mock).mockResolvedValue(false);
+
+    const response = await POST(request({
+      studentId: 'student-b',
+      title: 'Trajectoire hors scope',
+      horizon: '6_MONTHS',
+      targetScore: 15,
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe('Forbidden');
+    expect(isCoachRattachedToStudent).toHaveBeenCalledWith('coach-1', 'student-b');
+    expect(prisma.trajectory.updateMany).not.toHaveBeenCalled();
+    expect(prisma.trajectory.create).not.toHaveBeenCalled();
+  });
+
+  it('allows an assigned coach and persists a projected trajectory', async () => {
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'coach-1', role: 'COACH' } });
+    (isCoachRattachedToStudent as jest.Mock).mockResolvedValue(true);
+    (prisma.trajectory.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+    (prisma.trajectory.create as jest.Mock).mockResolvedValue({
+      id: 'traj-1',
+      studentId: 'student-1',
+      title: 'Trajectoire',
+      targetScore: 16,
+      horizon: '3_MONTHS',
+      createdBy: 'coach-1',
+      status: 'ACTIVE',
+    });
+
+    const response = await POST(request({
+      studentId: 'student-1',
+      title: 'Trajectoire',
+      horizon: '3_MONTHS',
+      targetScore: 16,
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.id).toBe('traj-1');
+    expect(prisma.trajectory.updateMany).toHaveBeenCalledWith({
+      where: { studentId: 'student-1', status: 'ACTIVE' },
+      data: { status: 'COMPLETED' },
+    });
+    expect(prisma.trajectory.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        studentId: 'student-1',
+        createdBy: 'coach-1',
+      }),
+    }));
+  });
+});

--- a/__tests__/api/documents-access.test.ts
+++ b/__tests__/api/documents-access.test.ts
@@ -124,6 +124,7 @@ describe('Documents Access Control', () => {
       const data = await response.json();
       expect(data.success).toBe(true);
       expect(data.documents).toHaveLength(1);
+      expect(data.documents[0]).not.toHaveProperty('localPath');
     });
 
     it('should deny coach access to non-assigned student (403)', async () => {
@@ -213,6 +214,7 @@ describe('Documents Access Control', () => {
       const data = await response.json();
       expect(data.success).toBe(true);
       expect(data.document.title).toBe('New Exercise');
+      expect(data.document).not.toHaveProperty('localPath');
     });
 
     it('should validate documentType enum (400)', async () => {
@@ -238,7 +240,7 @@ describe('Documents Access Control', () => {
       expect(response.status).toBe(400);
     });
 
-    it('should require url or localPath (400)', async () => {
+    it('should require url for JSON metadata documents (400)', async () => {
       coachSession();
       (assertCoachCanAccessStudent as jest.Mock).mockResolvedValue(undefined);
       mockPrisma.student.findFirst.mockResolvedValue(mockStudent);
@@ -259,7 +261,7 @@ describe('Documents Access Control', () => {
 
       expect(response.status).toBe(400);
       const data = await response.json();
-      expect(data.message).toContain('URL ou chemin local requis');
+      expect(data.message).toContain('URL requise');
     });
   });
 

--- a/__tests__/api/documents.id.route.test.ts
+++ b/__tests__/api/documents.id.route.test.ts
@@ -34,6 +34,11 @@ beforeEach(async () => {
   jest.clearAllMocks();
 });
 
+function mockDocumentLookup(document: unknown) {
+  prisma.userDocument.findUnique.mockResolvedValue(document);
+  prisma.userDocument.findFirst.mockResolvedValue(document);
+}
+
 function makeRequest(id: string): [NextRequest, { params: Promise<{ id: string }> }] {
   const req = new NextRequest(`http://localhost:3000/api/documents/${id}`, { method: 'GET' });
   return [req, { params: Promise.resolve({ id }) }];
@@ -49,26 +54,27 @@ describe('GET /api/documents/[id]', () => {
 
   it('should return 404 when document not found', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
-    prisma.userDocument.findUnique.mockResolvedValue(null);
+    mockDocumentLookup(null);
 
     const res = await GET(...makeRequest('nonexistent'));
     expect(res.status).toBe(404);
   });
 
-  it('should return 403 when user is not owner and not staff', async () => {
+  it('should return 404 when user is not owner and not staff without reading file', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'other-user', role: 'ELEVE' } } as any);
-    prisma.userDocument.findUnique.mockResolvedValue({
+    mockDocumentLookup({
       id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/test.pdf',
       mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
     });
 
     const res = await GET(...makeRequest('doc-1'));
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
+    expect(mockReadFile).not.toHaveBeenCalled();
   });
 
   it('should return document for owner', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
-    prisma.userDocument.findUnique.mockResolvedValue({
+    mockDocumentLookup({
       id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/test.pdf',
       mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
     });
@@ -84,7 +90,7 @@ describe('GET /api/documents/[id]', () => {
 
   it('should return document for ADMIN', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } } as any);
-    prisma.userDocument.findUnique.mockResolvedValue({
+    mockDocumentLookup({
       id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/test.pdf',
       mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
     });
@@ -96,7 +102,7 @@ describe('GET /api/documents/[id]', () => {
 
   it('should return document for ASSISTANTE', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'assist-1', role: 'ASSISTANTE' } } as any);
-    prisma.userDocument.findUnique.mockResolvedValue({
+    mockDocumentLookup({
       id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/test.pdf',
       mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
     });
@@ -108,7 +114,7 @@ describe('GET /api/documents/[id]', () => {
 
   it('should return 404 when file missing on disk', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
-    prisma.userDocument.findUnique.mockResolvedValue({
+    mockDocumentLookup({
       id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/missing.pdf',
       mimeType: 'application/pdf', originalName: 'missing.pdf', sizeBytes: 1024,
     });
@@ -118,9 +124,28 @@ describe('GET /api/documents/[id]', () => {
     expect(res.status).toBe(404);
   });
 
+  it('should not log local file paths when file content is missing', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
+    mockDocumentLookup({
+      id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/private/missing.pdf',
+      mimeType: 'application/pdf', originalName: 'missing.pdf', sizeBytes: 1024,
+    });
+    mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT: /app/storage/documents/private/missing.pdf'), { code: 'ENOENT' }));
+
+    const res = await GET(...makeRequest('doc-1'));
+
+    expect(res.status).toBe(404);
+    const serializedLogs = JSON.stringify(errorSpy.mock.calls);
+    expect(serializedLogs).not.toContain('/app/storage');
+    expect(serializedLogs).not.toContain('private/missing.pdf');
+    errorSpy.mockRestore();
+  });
+
   it('should return 500 on DB error', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
     prisma.userDocument.findUnique.mockRejectedValue(new Error('DB error'));
+    prisma.userDocument.findFirst.mockRejectedValue(new Error('DB error'));
 
     const res = await GET(...makeRequest('doc-1'));
     expect(res.status).toBe(500);

--- a/__tests__/api/eleve.bilan-diagnostic-maths-terminale.security.test.ts
+++ b/__tests__/api/eleve.bilan-diagnostic-maths-terminale.security.test.ts
@@ -1,0 +1,40 @@
+import { NextRequest } from 'next/server';
+
+import { POST } from '@/app/api/eleve/bilan-diagnostic-maths-terminale/route';
+import { prisma } from '@/lib/prisma';
+import { requireRole } from '@/lib/guards';
+
+jest.mock('@/lib/guards', () => ({
+  requireRole: jest.fn(),
+  isErrorResponse: jest.fn((value) => value instanceof Response),
+}));
+
+function request(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/eleve/bilan-diagnostic-maths-terminale', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/eleve/bilan-diagnostic-maths-terminale — security', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireRole as jest.Mock).mockResolvedValue({ user: { id: 'student-user-1', role: 'ELEVE' } });
+  });
+
+  it('rejects unexpected fields before DB access', async () => {
+    const response = await POST(request({
+      progress: {},
+      qcmAnswers: {},
+      openAnswers: {},
+      step: 'progress',
+      metadata: { rawPayload: true },
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Invalid diagnostic payload');
+    expect(prisma.student.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/invoices.pdf.route.test.ts
+++ b/__tests__/api/invoices.pdf.route.test.ts
@@ -22,18 +22,18 @@ jest.mock('@/lib/invoice/not-found', () => ({
       headers: { 'Content-Type': 'application/json' },
     })
   ),
-  buildInvoiceScopeWhere: jest.fn(),
+  buildInvoiceAccessWhere: jest.fn(),
 }));
 
 import { GET } from '@/app/api/invoices/[id]/pdf/route';
 import { auth } from '@/auth';
 import { verifyAccessToken } from '@/lib/invoice';
-import { buildInvoiceScopeWhere } from '@/lib/invoice/not-found';
+import { buildInvoiceAccessWhere } from '@/lib/invoice/not-found';
 import { NextRequest } from 'next/server';
 
 const mockAuth = auth as jest.Mock;
 const mockVerifyToken = verifyAccessToken as jest.Mock;
-const mockBuildScope = buildInvoiceScopeWhere as jest.Mock;
+const mockBuildScope = buildInvoiceAccessWhere as jest.Mock;
 
 let prisma: any;
 
@@ -99,7 +99,7 @@ describe('GET /api/invoices/[id]/pdf — Session-based access', () => {
 
   it('should return 404 for unauthorized role', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE', email: 'e@t.com' } } as any);
-    mockBuildScope.mockReturnValue(null as any);
+    mockBuildScope.mockResolvedValue(null as any);
 
     const res = await GET(...makeRequest('inv-1'));
     expect(res.status).toBe(404);
@@ -107,7 +107,7 @@ describe('GET /api/invoices/[id]/pdf — Session-based access', () => {
 
   it('should stream PDF for ADMIN', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'a@t.com' } } as any);
-    mockBuildScope.mockReturnValue({ id: 'inv-1' } as any);
+    mockBuildScope.mockResolvedValue({ id: 'inv-1' } as any);
     prisma.invoice.findFirst.mockResolvedValue({
       id: 'inv-1', number: 'NXS-2026-0001', pdfPath: '/storage/invoices/NXS-2026-0001.pdf',
     });
@@ -121,7 +121,7 @@ describe('GET /api/invoices/[id]/pdf — Session-based access', () => {
 
   it('should return 404 when invoice not found in scope', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'p1', role: 'PARENT', email: 'p@t.com' } } as any);
-    mockBuildScope.mockReturnValue({ id: 'inv-1', customerEmail: 'p@t.com' } as any);
+    mockBuildScope.mockResolvedValue({ id: 'inv-1', OR: [{ customerEmail: 'p@t.com' }] } as any);
     prisma.invoice.findFirst.mockResolvedValue(null);
 
     const res = await GET(...makeRequest('inv-1'));

--- a/__tests__/api/invoices.receipt.pdf.route.test.ts
+++ b/__tests__/api/invoices.receipt.pdf.route.test.ts
@@ -23,16 +23,16 @@ jest.mock('@/lib/invoice/not-found', () => ({
       headers: { 'Content-Type': 'application/json' },
     })
   ),
-  buildInvoiceScopeWhere: jest.fn(),
+  buildInvoiceAccessWhere: jest.fn(),
 }));
 
 import { GET } from '@/app/api/invoices/[id]/receipt/pdf/route';
 import { auth } from '@/auth';
-import { buildInvoiceScopeWhere } from '@/lib/invoice/not-found';
+import { buildInvoiceAccessWhere } from '@/lib/invoice/not-found';
 import { NextRequest } from 'next/server';
 
 const mockAuth = auth as jest.Mock;
-const mockBuildScope = buildInvoiceScopeWhere as jest.Mock;
+const mockBuildScope = buildInvoiceAccessWhere as jest.Mock;
 
 let prisma: any;
 
@@ -57,7 +57,7 @@ describe('GET /api/invoices/[id]/receipt/pdf', () => {
 
   it('should return 404 for unauthorized role', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE', email: 'e@t.com' } } as any);
-    mockBuildScope.mockReturnValue(null as any);
+    mockBuildScope.mockResolvedValue(null as any);
 
     const res = await GET(...makeRequest('inv-1'));
     expect(res.status).toBe(404);
@@ -65,7 +65,7 @@ describe('GET /api/invoices/[id]/receipt/pdf', () => {
 
   it('should return 404 when invoice not found', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'a@t.com' } } as any);
-    mockBuildScope.mockReturnValue({ id: 'inv-1' } as any);
+    mockBuildScope.mockResolvedValue({ id: 'inv-1' } as any);
     prisma.invoice.findFirst.mockResolvedValue(null);
 
     const res = await GET(...makeRequest('inv-1'));
@@ -74,7 +74,7 @@ describe('GET /api/invoices/[id]/receipt/pdf', () => {
 
   it('should return 409 when invoice not PAID', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'a@t.com' } } as any);
-    mockBuildScope.mockReturnValue({ id: 'inv-1' } as any);
+    mockBuildScope.mockResolvedValue({ id: 'inv-1' } as any);
     prisma.invoice.findFirst.mockResolvedValue({
       id: 'inv-1', number: 'NXS-2026-0001', status: 'SENT',
       paidAt: null, paidAmount: null, events: [],
@@ -89,7 +89,7 @@ describe('GET /api/invoices/[id]/receipt/pdf', () => {
 
   it('should stream receipt PDF for PAID invoice', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'a@t.com' } } as any);
-    mockBuildScope.mockReturnValue({ id: 'inv-1' } as any);
+    mockBuildScope.mockResolvedValue({ id: 'inv-1' } as any);
     prisma.invoice.findFirst.mockResolvedValue({
       id: 'inv-1', number: 'NXS-2026-0001', status: 'PAID',
       issuedAt: new Date('2026-02-01'), paidAt: new Date('2026-02-15'),
@@ -110,7 +110,7 @@ describe('GET /api/invoices/[id]/receipt/pdf', () => {
 
   it('should return 404 on DB error', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ADMIN', email: 'a@t.com' } } as any);
-    mockBuildScope.mockReturnValue({ id: 'inv-1' } as any);
+    mockBuildScope.mockResolvedValue({ id: 'inv-1' } as any);
     prisma.invoice.findFirst.mockRejectedValue(new Error('DB error'));
 
     const res = await GET(...makeRequest('inv-1'));

--- a/__tests__/api/lamis.teacher-report.route.test.ts
+++ b/__tests__/api/lamis.teacher-report.route.test.ts
@@ -1,0 +1,75 @@
+import { GET, POST } from '@/app/api/lamis/teacher-report/route';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: jest.fn().mockResolvedValue(null),
+}));
+
+const mockGuardRateLimit = guardRateLimitAsync as jest.Mock;
+
+const validAttempt = {
+  exerciseId: 'pct-coef-baisse-25',
+  answer: '0.75',
+  isCorrect: true,
+  attemptNumber: 1,
+  timeSpentSeconds: 45,
+  usedHint1: false,
+  usedHint2: false,
+  viewedCorrection: false,
+  tooFast: false,
+  timestamp: '2026-07-02T12:00:00.000Z',
+};
+
+function postRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3000/api/lamis/teacher-report', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('Lamis teacher-report API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGuardRateLimit.mockResolvedValue(null);
+  });
+
+  it('returns a report for a valid attempts payload', async () => {
+    const res = await POST(postRequest({ attempts: [validAttempt] }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.report).toContain('Lamis');
+  });
+
+  it('rejects unexpected payload fields', async () => {
+    const res = await POST(postRequest({ attempts: [validAttempt], studentEmail: 'child@example.test' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('Payload invalide');
+  });
+
+  it('rejects malformed attempts', async () => {
+    const res = await POST(postRequest({ attempts: [{ ...validAttempt, answer: 42 }] }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 429 before parsing when rate limit is exceeded', async () => {
+    mockGuardRateLimit.mockResolvedValue(new Response(JSON.stringify({ error: 'rate limited' }), { status: 429 }));
+
+    const res = await POST(postRequest({ attempts: [validAttempt] }));
+
+    expect(res.status).toBe(429);
+  });
+
+  it('rate limits GET report generation', async () => {
+    mockGuardRateLimit.mockResolvedValue(new Response(JSON.stringify({ error: 'rate limited' }), { status: 429 }));
+
+    const res = await GET(new NextRequest('http://localhost:3000/api/lamis/teacher-report', { method: 'GET' }));
+
+    expect(res.status).toBe(429);
+  });
+});

--- a/__tests__/api/lamis.teacher-report.route.test.ts
+++ b/__tests__/api/lamis.teacher-report.route.test.ts
@@ -1,11 +1,19 @@
 import { GET, POST } from '@/app/api/lamis/teacher-report/route';
+import { isErrorResponse, requireAnyRole } from '@/lib/guards';
 import { guardRateLimitAsync } from '@/lib/rate-limit';
 import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/guards', () => ({
+  requireAnyRole: jest.fn(),
+  isErrorResponse: jest.fn((result): result is Response => result instanceof Response),
+}));
 
 jest.mock('@/lib/rate-limit', () => ({
   guardRateLimitAsync: jest.fn().mockResolvedValue(null),
 }));
 
+const mockRequireAnyRole = requireAnyRole as jest.Mock;
+const mockIsErrorResponse = isErrorResponse as unknown as jest.Mock;
 const mockGuardRateLimit = guardRateLimitAsync as jest.Mock;
 
 const validAttempt = {
@@ -32,7 +40,32 @@ function postRequest(body: unknown): NextRequest {
 describe('Lamis teacher-report API', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRequireAnyRole.mockResolvedValue({ user: { id: 'coach-1', role: 'COACH' } });
+    mockIsErrorResponse.mockImplementation((result: unknown): result is Response => result instanceof Response);
     mockGuardRateLimit.mockResolvedValue(null);
+  });
+
+  it('returns 401 for anonymous requests before rate limiting or parsing', async () => {
+    const unauthorized = new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+    mockRequireAnyRole.mockResolvedValue(unauthorized);
+    mockIsErrorResponse.mockReturnValue(true);
+
+    const res = await POST(postRequest({ attempts: [validAttempt] }));
+
+    expect(res.status).toBe(401);
+    expect(mockGuardRateLimit).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 for roles outside staff and coach', async () => {
+    const forbidden = new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 });
+    mockRequireAnyRole.mockResolvedValue(forbidden);
+    mockIsErrorResponse.mockReturnValue(true);
+
+    const res = await GET(new NextRequest('http://localhost:3000/api/lamis/teacher-report', { method: 'GET' }));
+
+    expect(res.status).toBe(403);
+    expect(mockRequireAnyRole).toHaveBeenCalledWith(['ADMIN', 'ASSISTANTE', 'COACH']);
+    expect(mockGuardRateLimit).not.toHaveBeenCalled();
   });
 
   it('returns a report for a valid attempts payload', async () => {
@@ -41,6 +74,10 @@ describe('Lamis teacher-report API', () => {
 
     expect(res.status).toBe(200);
     expect(body.report).toContain('Lamis');
+    expect(mockGuardRateLimit).toHaveBeenCalledWith(expect.any(Request), expect.objectContaining({
+      keySuffix: 'lamis-teacher-report',
+      userId: 'coach-1',
+    }));
   });
 
   it('rejects unexpected payload fields', async () => {
@@ -71,5 +108,13 @@ describe('Lamis teacher-report API', () => {
     const res = await GET(new NextRequest('http://localhost:3000/api/lamis/teacher-report', { method: 'GET' }));
 
     expect(res.status).toBe(429);
+  });
+
+  it('returns a GET report for an authorized coach', async () => {
+    const res = await GET(new NextRequest('http://localhost:3000/api/lamis/teacher-report', { method: 'GET' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.report).toContain('Lamis');
   });
 });

--- a/__tests__/api/npc.documents.route.test.ts
+++ b/__tests__/api/npc.documents.route.test.ts
@@ -1,5 +1,5 @@
 import { GET, POST } from '@/app/api/npc/submissions/[submissionId]/documents/route';
-import { DELETE } from '@/app/api/npc/submissions/[submissionId]/documents/[documentId]/route';
+import { DELETE, PATCH } from '@/app/api/npc/submissions/[submissionId]/documents/[documentId]/route';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import * as npcStorage from '@/lib/npc/storage';
@@ -100,6 +100,18 @@ describe('NPC correction documents API', () => {
     expect(body.error).toBe('No file provided');
   });
 
+  it('rejects invalid submission ids before reading the submission', async () => {
+    const response = await GET(
+      new NextRequest('http://localhost/api/npc/submissions/../secret/documents'),
+      params('../secret')
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('Invalid');
+    expect(prisma.copySubmission.findUnique).not.toHaveBeenCalled();
+  });
+
   it('rejects forbidden MIME types', async () => {
     const response = await POST(
       makeUploadRequest({
@@ -190,6 +202,23 @@ describe('NPC correction documents API', () => {
     expect(body.documents[0]).not.toHaveProperty('ocrText');
   });
 
+  it('denies listing documents to a coach who is not assigned to the submission', async () => {
+    (prisma.copySubmission.findUnique as jest.Mock).mockResolvedValue({
+      id: 'submission-1',
+      studentId: 'student-1',
+      coachId: 'coach-2',
+      pages: [],
+    });
+    (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET(
+      new NextRequest('http://localhost/api/npc/submissions/submission-1/documents'),
+      params()
+    );
+
+    expect(response.status).toBe(403);
+  });
+
   it('does not expose storage paths after uploading documents', async () => {
     (prisma.copyPage.create as jest.Mock).mockResolvedValue({
       id: 'doc-1',
@@ -216,6 +245,21 @@ describe('NPC correction documents API', () => {
     expect(body.document).not.toHaveProperty('convertedFilePaths');
     expect(body.document).not.toHaveProperty('ocrText');
     expect(body.documents[0]).not.toHaveProperty('originalFilePath');
+  });
+
+  it('rejects document updates when documentId is not a safe route id', async () => {
+    const response = await PATCH(
+      new NextRequest('http://localhost/api/npc/submissions/submission-1/documents/../doc', {
+        method: 'PATCH',
+        body: JSON.stringify({ documentType: 'SUBJECT' }),
+      }),
+      documentParams('submission-1', '../doc')
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('Invalid');
+    expect(prisma.copySubmission.findUnique).not.toHaveBeenCalled();
   });
 
   it('does not overwrite existing student copy metadata when attaching a rubric', async () => {
@@ -261,6 +305,28 @@ describe('NPC correction documents API', () => {
     );
   });
 
+  it('denies uploading documents to a submission owned by another coach', async () => {
+    (prisma.copySubmission.findUnique as jest.Mock).mockResolvedValue({
+      id: 'submission-1',
+      studentId: 'student-1',
+      coachId: 'coach-2',
+      pages: [],
+    });
+    (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const response = await POST(
+      makeUploadRequest({
+        documentType: 'STUDENT_COPY',
+        file: new File(['%PDF-1.4'], 'copie.pdf', { type: 'application/pdf' }),
+      }),
+      params()
+    );
+
+    expect(response.status).toBe(403);
+    expect(npcStorage.saveUploadedFile).not.toHaveBeenCalled();
+    expect(prisma.copyPage.create).not.toHaveBeenCalled();
+  });
+
   it('deletes a document only when the coach can access the submission', async () => {
     (prisma.copyPage.findFirst as jest.Mock).mockResolvedValue({
       id: 'doc-1',
@@ -278,5 +344,23 @@ describe('NPC correction documents API', () => {
     expect(response.status).toBe(200);
     expect(prisma.copyPage.delete).toHaveBeenCalledWith({ where: { id: 'doc-1' } });
     expect(npcStorage.deleteSecureFile).toHaveBeenCalledWith('student/sub/page_1/copie.pdf');
+  });
+
+  it('denies deleting a document from a submission owned by another coach', async () => {
+    (prisma.copySubmission.findUnique as jest.Mock).mockResolvedValue({
+      id: 'submission-1',
+      studentId: 'student-1',
+      coachId: 'coach-2',
+    });
+    (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const response = await DELETE(
+      new NextRequest('http://localhost/api/npc/submissions/submission-1/documents/doc-1'),
+      documentParams()
+    );
+
+    expect(response.status).toBe(403);
+    expect(prisma.copyPage.findFirst).not.toHaveBeenCalled();
+    expect(npcStorage.deleteSecureFile).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/api/npc.files.route.test.ts
+++ b/__tests__/api/npc.files.route.test.ts
@@ -78,4 +78,26 @@ describe('GET /api/npc/files/[...path]', () => {
     expect(response.status).toBe(200);
     expect(readSecureFile).toHaveBeenCalledWith('student/sub/page_1/copie.pdf');
   });
+
+  it('denies a coach who is not assigned before reading disk', async () => {
+    (prisma.copyPage.findFirst as jest.Mock).mockResolvedValue({
+      id: 'doc-1',
+      originalFilePath: 'student/sub/page_1/copie.pdf',
+      mimeType: 'application/pdf',
+      submission: {
+        id: 'submission-1',
+        studentId: 'student-1',
+        coachId: 'coach-2',
+      },
+    });
+    (prisma.coachStudentAssignment.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET(
+      new NextRequest('http://localhost/api/npc/files/student/sub/page_1/copie.pdf'),
+      params(['student', 'sub', 'page_1', 'copie.pdf'])
+    );
+
+    expect(response.status).toBe(403);
+    expect(readSecureFile).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/api/npc.generate.test.ts
+++ b/__tests__/api/npc.generate.test.ts
@@ -77,6 +77,25 @@ describe('POST /api/npc/submissions/[submissionId]/generate', () => {
     expect(response.status).toBe(404);
   });
 
+  it('rejects unsafe submission ids before reading the submission', async () => {
+    const { auth } = require('@/auth');
+    auth.mockResolvedValue({
+      user: { id: 'user-1', role: UserRole.COACH },
+    });
+
+    const request = new NextRequest('http://localhost/api/npc/submissions/../secret/generate', {
+      method: 'POST',
+    });
+    const params = Promise.resolve({ submissionId: '../secret' });
+
+    const response = await POST(request, { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('Invalid');
+    expect(prisma.copySubmission.findUnique).not.toHaveBeenCalled();
+  });
+
   it('returns 403 if coach not assigned to student', async () => {
     const { auth } = require('@/auth');
     auth.mockResolvedValue({

--- a/__tests__/api/npc.submissions.security.test.ts
+++ b/__tests__/api/npc.submissions.security.test.ts
@@ -1,0 +1,61 @@
+import { GET, POST } from '@/app/api/npc/submissions/route';
+import { auth } from '@/auth';
+import { prisma } from '@/lib/prisma';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/auth', () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    student: { findUnique: jest.fn(), findFirst: jest.fn() },
+    parentProfile: { findUnique: jest.fn() },
+    coachProfile: { findUnique: jest.fn(), findFirst: jest.fn() },
+    coachStudentAssignment: { findFirst: jest.fn(), findMany: jest.fn() },
+    copySubmission: { create: jest.fn(), findMany: jest.fn() },
+    npcAuditLog: { create: jest.fn() },
+  },
+}));
+
+function postRequest(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/npc/submissions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('/api/npc/submissions security validation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (auth as jest.Mock).mockResolvedValue({
+      user: { id: 'coach-user-1', role: 'COACH' },
+    });
+  });
+
+  it('rejects unsafe student ids before checking student ownership', async () => {
+    const response = await POST(postRequest({
+      studentId: '../student',
+      title: 'Copie',
+      subject: 'MATHEMATIQUES',
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.student.findUnique).not.toHaveBeenCalled();
+    expect(prisma.copySubmission.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsafe list filters before querying submissions', async () => {
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/npc/submissions?studentId=../student'),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.copySubmission.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/npc.uploads.route.test.ts
+++ b/__tests__/api/npc.uploads.route.test.ts
@@ -86,4 +86,19 @@ describe('POST /api/npc/uploads', () => {
     });
     expect(body).not.toHaveProperty('filePath');
   });
+
+  it('rejects invalid metadata before ownership and file handling', async () => {
+    const response = await POST(makeUploadRequest({
+      studentId: '../student',
+      title: 'Copie bac blanc',
+      subject: 'MATHEMATIQUES',
+      file: new File(['%PDF-1.4'], 'copie.pdf', { type: 'application/pdf' }),
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('Données');
+    expect(prisma.coachProfile.findFirst).not.toHaveBeenCalled();
+    expect(npcStorage.saveUploadedFile).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/api/parent.children.activation.route.test.ts
+++ b/__tests__/api/parent.children.activation.route.test.ts
@@ -69,7 +69,10 @@ describe('POST /api/parent/children — P0-03 hardening', () => {
 
     expect(response.status).toBe(200);
     expect(json.success).toBe(true);
-    expect(json.activation.token).toMatch(/^act_/);
+    expect(JSON.stringify(json)).not.toContain('activationToken');
+    expect(JSON.stringify(json)).not.toContain('tokenHash');
+    expect(JSON.stringify(json)).not.toContain('act_');
+    expect(json.activation.message).toContain("n'est pas retourné");
     expect(userCreate).toHaveBeenCalledTimes(1);
     expect(userCreate).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({

--- a/__tests__/api/parent.children.activation.route.test.ts
+++ b/__tests__/api/parent.children.activation.route.test.ts
@@ -69,10 +69,11 @@ describe('POST /api/parent/children — P0-03 hardening', () => {
 
     expect(response.status).toBe(200);
     expect(json.success).toBe(true);
+    expect(json.activation.activationUrl).toContain('/auth/activate?token=act_');
     expect(JSON.stringify(json)).not.toContain('activationToken');
     expect(JSON.stringify(json)).not.toContain('tokenHash');
-    expect(JSON.stringify(json)).not.toContain('act_');
-    expect(json.activation.message).toContain("n'est pas retourné");
+    expect(json.activation).not.toHaveProperty('token');
+    expect(json.activation.message).toContain('parent authentifié');
     expect(userCreate).toHaveBeenCalledTimes(1);
     expect(userCreate).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({

--- a/__tests__/api/parent.children.route.test.ts
+++ b/__tests__/api/parent.children.route.test.ts
@@ -97,7 +97,7 @@ describe('parent children routes', () => {
       const body = await response.json();
 
       expect(response.status).toBe(400);
-      expect(body.error).toBe('Missing required fields');
+      expect(body.error).toBe('Invalid child payload');
     });
 
     it('rejects existing child email', async () => {
@@ -131,7 +131,7 @@ describe('parent children routes', () => {
       expect(body.error).toBe('Parent profile not found');
     });
 
-    it('ignores an injected parentPassword and creates an inactive child', async () => {
+    it('rejects injected fields and does not create a child', async () => {
       (auth as jest.Mock).mockResolvedValue({
         user: { id: 'parent-1', role: 'PARENT' },
       });
@@ -166,10 +166,9 @@ describe('parent children routes', () => {
       );
       const body = await response.json();
 
-      expect(response.status).toBe(200);
-      expect(body.success).toBe(true);
-      expect(body.child.email).toContain('@nexus-student.local');
-      expect(body.activation.token).toMatch(/^act_/);
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('Invalid child payload');
+      expect(prisma.$transaction).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/api/parent.subscription-requests.route.test.ts
+++ b/__tests__/api/parent.subscription-requests.route.test.ts
@@ -47,7 +47,7 @@ describe('parent subscription-requests', () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toBe('Missing required fields');
+    expect(body.error).toBe('Invalid subscription request payload');
   });
 
   it('POST rejects a plan change with an unknown plan key', async () => {
@@ -60,7 +60,6 @@ describe('parent subscription-requests', () => {
         studentId: 'student-1',
         requestType: 'PLAN_CHANGE',
         planName: 'Plan A',
-        monthlyPrice: 1,
       })
     );
     const body = await response.json();
@@ -88,7 +87,6 @@ describe('parent subscription-requests', () => {
         studentId: 'student-1',
         requestType: 'PLAN_CHANGE',
         planName: 'HYBRIDE',
-        monthlyPrice: 1,
         reason: 'Upgrade',
       })
     );
@@ -125,7 +123,6 @@ describe('parent subscription-requests', () => {
         studentId: 'student-1',
         requestType: 'ARIA_ADDON',
         planName: 'MATIERE_SUPPLEMENTAIRE',
-        monthlyPrice: 1,
       })
     );
     const body = await response.json();
@@ -158,7 +155,7 @@ describe('parent subscription-requests', () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toContain('Type');
+    expect(body.error).toBe('Invalid subscription request payload');
     expect(prisma.subscriptionRequest.create).not.toHaveBeenCalled();
   });
 

--- a/__tests__/api/parent.subscriptions.route.test.ts
+++ b/__tests__/api/parent.subscriptions.route.test.ts
@@ -97,7 +97,7 @@ describe('parent subscriptions', () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toContain('Missing required fields');
+    expect(body.error).toBe('Invalid subscription payload');
   });
 
   it('POST returns 404 when parent profile missing', async () => {
@@ -106,9 +106,7 @@ describe('parent subscriptions', () => {
     });
     (prisma.parentProfile.findUnique as jest.Mock).mockResolvedValue(null);
 
-    const response = await POST(
-      makeRequest({ studentId: 'student-1', planName: 'HYBRIDE', monthlyPrice: 100 })
-    );
+    const response = await POST(makeRequest({ studentId: 'student-1', planName: 'HYBRIDE' }));
     const body = await response.json();
 
     expect(response.status).toBe(404);
@@ -122,9 +120,7 @@ describe('parent subscriptions', () => {
     (prisma.parentProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'parent-profile-1' });
     (prisma.student.findFirst as jest.Mock).mockResolvedValue(null);
 
-    const response = await POST(
-      makeRequest({ studentId: 'student-1', planName: 'HYBRIDE', monthlyPrice: 100 })
-    );
+    const response = await POST(makeRequest({ studentId: 'student-1', planName: 'HYBRIDE' }));
     const body = await response.json();
 
     expect(response.status).toBe(404);
@@ -136,9 +132,7 @@ describe('parent subscriptions', () => {
       user: { id: 'parent-1', role: 'PARENT' },
     });
 
-    const response = await POST(
-      makeRequest({ studentId: 'student-1', planName: 'Plan A', monthlyPrice: 1, creditsPerMonth: 99 })
-    );
+    const response = await POST(makeRequest({ studentId: 'student-1', planName: 'Plan A' }));
     const body = await response.json();
 
     expect(response.status).toBe(400);
@@ -160,9 +154,7 @@ describe('parent subscriptions', () => {
     (prisma.user.findMany as jest.Mock).mockResolvedValue([{ id: 'assistant-1' }]);
     (prisma.notification.create as jest.Mock).mockResolvedValue({});
 
-    const response = await POST(
-      makeRequest({ studentId: 'student-1', planName: 'HYBRIDE', monthlyPrice: 1, creditsPerMonth: 99 })
-    );
+    const response = await POST(makeRequest({ studentId: 'student-1', planName: 'HYBRIDE' }));
     const body = await response.json();
 
     expect(response.status).toBe(200);

--- a/__tests__/api/programme.maths-1ere-stmg.stage-progress.test.ts
+++ b/__tests__/api/programme.maths-1ere-stmg.stage-progress.test.ts
@@ -45,7 +45,6 @@ const existingProgrammeProgress = {
 };
 
 const stageState = {
-  eleveId: 'u-stmg',
   diagnosticAnswers: { qcm: { 'diag-q1': 1 }, exercises: {} },
   profile: {
     diagnosticDate: '2026-05-30T10:00:00.000Z',
@@ -80,7 +79,7 @@ describe('Maths 1ere STMG stage progress API', () => {
   });
 
   it('returns only the stage sub-state from programme diagnostic_results', async () => {
-    (auth as jest.Mock).mockResolvedValue({ user: { id: 'u-stmg' } });
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'u-stmg', role: 'ELEVE' } });
     (prisma.mathsProgress.findUnique as jest.Mock).mockResolvedValue({
       ...existingProgrammeProgress,
       diagnosticResults: { programme: { score: 72 }, stage_eam_stmg: stageState },
@@ -94,7 +93,7 @@ describe('Maths 1ere STMG stage progress API', () => {
   });
 
   it('updates only diagnostic_results.stage_eam_stmg and preserves programme fields', async () => {
-    (auth as jest.Mock).mockResolvedValue({ user: { id: 'u-stmg' } });
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'u-stmg', role: 'ELEVE' } });
     (prisma.mathsProgress.findUnique as jest.Mock).mockResolvedValue(existingProgrammeProgress);
     (prisma.mathsProgress.update as jest.Mock).mockResolvedValue({
       ...existingProgrammeProgress,
@@ -120,7 +119,7 @@ describe('Maths 1ere STMG stage progress API', () => {
   });
 
   it('creates a programme row with defaults only when no programme progress exists', async () => {
-    (auth as jest.Mock).mockResolvedValue({ user: { id: 'u-stmg' } });
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'u-stmg', role: 'ELEVE' } });
     (prisma.mathsProgress.findUnique as jest.Mock).mockResolvedValue(null);
     (prisma.mathsProgress.create as jest.Mock).mockResolvedValue({ id: 'new-progress' });
 

--- a/__tests__/api/sessions.cancel.route.test.ts
+++ b/__tests__/api/sessions.cancel.route.test.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { POST } from '@/app/api/sessions/cancel/route';
 import { requireAnyRole, isErrorResponse } from '@/lib/guards';
 import { RateLimitPresets } from '@/lib/middleware/rateLimit';
-import { parseBody } from '@/lib/api/helpers';
+import { parseBody, safeJsonParse } from '@/lib/api/helpers';
 import { createLogger } from '@/lib/middleware/logger';
 import { prisma } from '@/lib/prisma';
 import { refundSessionBookingById, canCancelBooking } from '@/lib/credits';
@@ -21,6 +21,7 @@ jest.mock('@/lib/middleware/rateLimit', () => ({
 
 jest.mock('@/lib/api/helpers', () => ({
   parseBody: jest.fn(),
+  safeJsonParse: jest.fn(),
   assertExists: jest.requireActual('@/lib/api/helpers').assertExists,
 }));
 
@@ -50,6 +51,8 @@ const mockStudentSession = {
   },
 };
 
+const VALID_SESSION_ID = 'clh1234567890abcdefghij';
+
 function createMockRequest(url: string, options?: RequestInit): NextRequest {
   const request = new NextRequest(url, options as any);
   Object.defineProperty(request, 'nextUrl', {
@@ -70,7 +73,7 @@ function mockLogger() {
 
 function buildSession(overrides: Partial<Record<string, any>> = {}) {
   return {
-    id: 'session-1',
+    id: VALID_SESSION_ID,
     studentId: 'student-1',
     coachId: 'coach-1',
     status: 'SCHEDULED',
@@ -90,7 +93,8 @@ describe('POST /api/sessions/cancel', () => {
     (RateLimitPresets.expensive as jest.Mock).mockReturnValue(null);
     (requireAnyRole as jest.Mock).mockResolvedValue(mockStudentSession);
     (isErrorResponse as unknown as jest.Mock).mockReturnValue(false);
-    (parseBody as jest.Mock).mockResolvedValue({ sessionId: 'session-1', reason: 'Change' });
+    (parseBody as jest.Mock).mockResolvedValue({ sessionId: VALID_SESSION_ID, reason: 'Change' });
+    (safeJsonParse as jest.Mock).mockResolvedValue({ sessionId: VALID_SESSION_ID, reason: 'Change' });
     (createLogger as jest.Mock).mockReturnValue(mockLogger());
     (prisma.sessionBooking.findUnique as jest.Mock).mockResolvedValue(buildSession());
     (prisma.sessionBooking.update as jest.Mock).mockResolvedValue({});
@@ -186,7 +190,7 @@ describe('POST /api/sessions/cancel', () => {
 
     expect(response.status).toBe(200);
     expect(body.refunded).toBe(true);
-    expect(refundSessionBookingById).toHaveBeenCalledWith('session-1', 'Change');
+    expect(refundSessionBookingById).toHaveBeenCalledWith(VALID_SESSION_ID, 'Change');
   });
 
   it('assistant role overrides refund policy', async () => {

--- a/__tests__/api/sessions.video.route.test.ts
+++ b/__tests__/api/sessions.video.route.test.ts
@@ -1,6 +1,7 @@
 import { auth } from '@/auth';
 import { POST } from '@/app/api/sessions/video/route';
 import { prisma } from '@/lib/prisma';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
 import { SessionStatus } from '@prisma/client';
 
 jest.mock('@/auth', () => ({
@@ -14,6 +15,10 @@ jest.mock('@/lib/prisma', () => ({
       update: jest.fn(),
     },
   },
+}));
+
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: jest.fn().mockResolvedValue(null),
 }));
 
 const baseSession = {
@@ -52,6 +57,7 @@ describe('POST /api/sessions/video', () => {
     jest.useFakeTimers().setSystemTime(new Date(2025, 0, 2, 10, 0, 0));
     jest.clearAllMocks();
     (auth as jest.Mock).mockResolvedValue(baseSession);
+    (guardRateLimitAsync as jest.Mock).mockResolvedValue(null);
     (prisma.sessionBooking.findFirst as jest.Mock).mockResolvedValue(buildBooking());
   });
 
@@ -67,10 +73,36 @@ describe('POST /api/sessions/video', () => {
     expect(response.status).toBe(401);
   });
 
+  it('returns 429 before reading the body when rate limited', async () => {
+    (guardRateLimitAsync as jest.Mock).mockResolvedValue(
+      new Response(JSON.stringify({ error: 'RATE_LIMIT' }), { status: 429 })
+    );
+    const request = {
+      json: jest.fn(),
+    } as unknown as Request;
+
+    const response = await POST(request as any);
+
+    expect(response.status).toBe(429);
+    expect(request.json).not.toHaveBeenCalled();
+    expect(prisma.sessionBooking.findFirst).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when missing params', async () => {
     const response = await POST(makeRequest({ sessionId: '', action: '' }) as any);
 
     expect(response.status).toBe(400);
+  });
+
+  it('rejects unexpected payload fields', async () => {
+    const response = await POST(makeRequest({
+      sessionId: 'session-1',
+      action: 'JOIN',
+      localPath: '/srv/private/session.log',
+    }) as any);
+
+    expect(response.status).toBe(400);
+    expect(prisma.sessionBooking.findFirst).not.toHaveBeenCalled();
   });
 
   it('returns 404 when session not found', async () => {

--- a/__tests__/api/stages.inscrire.security.test.ts
+++ b/__tests__/api/stages.inscrire.security.test.ts
@@ -45,6 +45,8 @@ const validBody = {
   parentEmail: 'parent@example.com',
   parentPhone: '+216 22 333 444',
   notes: 'Besoin de suivi maths',
+  stageTermsAccepted: true,
+  dataProcessingAccepted: true,
 };
 
 const publicStage = {
@@ -102,5 +104,22 @@ describe('POST /api/stages/[stageSlug]/inscrire security', () => {
     expect(serialized).not.toContain('activationToken');
     expect(serialized).not.toContain('internal note');
     expect(body.reservation).toEqual({ status: 'PENDING' });
+  });
+
+  it('ne renvoie pas reservationId lorsqu’une inscription existe déjà', async () => {
+    prisma.stage.findUnique.mockResolvedValue(publicStage);
+    prisma.stageReservation.findFirst.mockResolvedValue({
+      id: 'reservation-secret-id',
+      email: validBody.email,
+    });
+
+    const res = await POST(makeRequest(validBody), { params });
+    const body = await res.json();
+    const serialized = JSON.stringify(body);
+
+    expect(res.status).toBe(409);
+    expect(serialized).not.toContain('reservation-secret-id');
+    expect(body).not.toHaveProperty('reservationId');
+    expect(prisma.stageReservation.create).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/api/stages/confirm.test.ts
+++ b/__tests__/api/stages/confirm.test.ts
@@ -88,6 +88,19 @@ describe('POST /api/stages/[slug]/reservations/[id]/confirm', () => {
     }));
   });
 
+  it('refuse des paramètres route invalides avant accès DB', async () => {
+    mockAuth.mockResolvedValue(session('ASSISTANTE'));
+
+    const res = await POST(makeRequest(), {
+      params: Promise.resolve({ stageSlug: '../secret', reservationId: 'res-1' }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('invalides');
+    expect(prisma.stageReservation.findFirst).not.toHaveBeenCalled();
+  });
+
   it('retourne 409 si réservation déjà CONFIRMED', async () => {
     mockAuth.mockResolvedValue(session('ADMIN'));
     prisma.stageReservation.findFirst.mockResolvedValue({

--- a/__tests__/api/stages/inscriptions.test.ts
+++ b/__tests__/api/stages/inscriptions.test.ts
@@ -39,6 +39,8 @@ const validBody = {
   email: 'aya@example.com',
   phone: '+21699192829',
   level: 'Terminale',
+  stageTermsAccepted: true,
+  dataProcessingAccepted: true,
 };
 
 describe('POST /api/stages/[slug]/inscrire', () => {

--- a/__tests__/api/student.activate.lifecycle-security.test.ts
+++ b/__tests__/api/student.activate.lifecycle-security.test.ts
@@ -1,0 +1,72 @@
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findFirst: jest.fn(),
+      update: jest.fn(),
+      create: jest.fn(),
+    },
+    stageReservation: {
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+import crypto from 'crypto';
+import { prisma } from '@/lib/prisma';
+import {
+  completeStudentActivation,
+  verifyActivationToken,
+} from '@/lib/services/student-activation.service';
+
+function sha256(token: string) {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+describe('student activation token lifecycle security', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('looks up only the hashed token with an expiry and never the raw token', async () => {
+    const rawToken = 'act_raw_token_from_url';
+    (prisma.user.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.stageReservation.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const result = await verifyActivationToken(rawToken);
+
+    expect(result).toEqual({ valid: false });
+    expect(prisma.user.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        activationToken: sha256(rawToken),
+        activationExpiry: { gt: expect.any(Date) },
+        activatedAt: null,
+      }),
+    }));
+    expect(JSON.stringify((prisma.user.findFirst as jest.Mock).mock.calls)).not.toContain(rawToken);
+  });
+
+  it('invalidates the activation token after successful password setup', async () => {
+    (prisma.user.findFirst as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      firstName: 'Nour',
+      lastName: 'Test',
+      email: 'nour@example.com',
+      activatedAt: null,
+      student: { id: 'student-1' },
+    });
+    (prisma.user.update as jest.Mock).mockResolvedValue({});
+
+    const result = await completeStudentActivation('act_valid_token', 'securePass123');
+
+    expect(result.success).toBe(true);
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: expect.objectContaining({
+        activationToken: null,
+        activationExpiry: null,
+        activatedAt: expect.any(Date),
+      }),
+    });
+  });
+});

--- a/__tests__/api/student.activate.route.test.ts
+++ b/__tests__/api/student.activate.route.test.ts
@@ -12,15 +12,22 @@ jest.mock('@/lib/services/student-activation.service', () => ({
   completeStudentActivation: jest.fn(),
 }));
 
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: jest.fn().mockResolvedValue(null),
+}));
+
 import { GET, POST } from '@/app/api/student/activate/route';
 import { verifyActivationToken, completeStudentActivation } from '@/lib/services/student-activation.service';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
 import { NextRequest } from 'next/server';
 
 const mockVerify = verifyActivationToken as jest.Mock;
 const mockComplete = completeStudentActivation as jest.Mock;
+const mockGuardRateLimit = guardRateLimitAsync as jest.Mock;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockGuardRateLimit.mockResolvedValue(null);
 });
 
 // ─── GET /api/student/activate ───────────────────────────────────────────────
@@ -34,6 +41,16 @@ describe('GET /api/student/activate', () => {
     expect(res.status).toBe(400);
     expect(body.valid).toBe(false);
     expect(body.error).toContain('Token');
+  });
+
+  it('should return 429 when rate limit is exceeded', async () => {
+    mockGuardRateLimit.mockResolvedValue(new Response(JSON.stringify({ error: 'rate limited' }), { status: 429 }));
+
+    const req = new NextRequest('http://localhost:3000/api/student/activate?token=valid-token', { method: 'GET' });
+    const res = await GET(req);
+
+    expect(res.status).toBe(429);
+    expect(mockVerify).not.toHaveBeenCalled();
   });
 
   it('should verify valid token', async () => {
@@ -95,12 +112,35 @@ describe('POST /api/student/activate', () => {
     expect(body.redirectUrl).toBe('/auth/signin');
   });
 
+  it('should return 429 when activation POST rate limit is exceeded', async () => {
+    mockGuardRateLimit.mockResolvedValue(new Response(JSON.stringify({ error: 'rate limited' }), { status: 429 }));
+
+    const res = await POST(makePostRequest({ token: 'valid-token', password: 'securePass123' }));
+
+    expect(res.status).toBe(429);
+    expect(mockComplete).not.toHaveBeenCalled();
+  });
+
   it('should return 400 for short password', async () => {
     const res = await POST(makePostRequest({ token: 'valid-token', password: '123' }));
     const body = await res.json();
 
     expect(res.status).toBe(400);
     expect(body.error).toContain('invalides');
+    expect(JSON.stringify(body)).not.toContain('password');
+  });
+
+  it('rejects unexpected activation payload fields before service call', async () => {
+    const res = await POST(makePostRequest({
+      token: 'valid-token',
+      password: 'securePass123',
+      activationToken: 'raw-token',
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('invalides');
+    expect(mockComplete).not.toHaveBeenCalled();
   });
 
   it('should return 400 for missing token', async () => {

--- a/__tests__/lib/invoice/access-scope.test.ts
+++ b/__tests__/lib/invoice/access-scope.test.ts
@@ -1,0 +1,67 @@
+import { buildInvoiceAccessWhere } from '@/lib/invoice/not-found';
+import { prisma } from '@/lib/prisma';
+
+const mockParentProfileFindUnique = prisma.parentProfile.findUnique as jest.Mock;
+
+describe('buildInvoiceAccessWhere', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('allows ADMIN and ASSISTANTE to scope by invoice id only', async () => {
+    await expect(
+      buildInvoiceAccessWhere('inv-1', { id: 'admin-1', role: 'ADMIN', email: 'admin@test.tn' }),
+    ).resolves.toEqual({ id: 'inv-1' });
+
+    await expect(
+      buildInvoiceAccessWhere('inv-1', { id: 'staff-1', role: 'ASSISTANTE', email: null }),
+    ).resolves.toEqual({ id: 'inv-1' });
+  });
+
+  it('scopes PARENT invoices by child beneficiary ids and email fallback', async () => {
+    mockParentProfileFindUnique.mockResolvedValue({
+      children: [{ userId: 'child-user-1' }, { userId: 'child-user-2' }],
+    });
+
+    await expect(
+      buildInvoiceAccessWhere('inv-1', { id: 'parent-user-1', role: 'PARENT', email: 'parent@test.tn' }),
+    ).resolves.toEqual({
+      id: 'inv-1',
+      OR: [
+        { beneficiaryUserId: { in: ['child-user-1', 'child-user-2'] } },
+        { customerEmail: 'parent@test.tn' },
+      ],
+    });
+  });
+
+  it('keeps a legacy email fallback for PARENT when no child beneficiary exists', async () => {
+    mockParentProfileFindUnique.mockResolvedValue({ children: [] });
+
+    await expect(
+      buildInvoiceAccessWhere('inv-1', { id: 'parent-user-1', role: 'PARENT', email: 'parent@test.tn' }),
+    ).resolves.toEqual({
+      id: 'inv-1',
+      OR: [{ customerEmail: 'parent@test.tn' }],
+    });
+  });
+
+  it('denies PARENT when no beneficiary and no email scope is available', async () => {
+    mockParentProfileFindUnique.mockResolvedValue({ children: [] });
+
+    await expect(
+      buildInvoiceAccessWhere('inv-1', { id: 'parent-user-1', role: 'PARENT', email: null }),
+    ).resolves.toBeNull();
+  });
+
+  it('denies ELEVE, COACH and unknown roles on public invoice PDFs', async () => {
+    await expect(
+      buildInvoiceAccessWhere('inv-1', { id: 'student-1', role: 'ELEVE', email: 'student@test.tn' }),
+    ).resolves.toBeNull();
+    await expect(
+      buildInvoiceAccessWhere('inv-1', { id: 'coach-1', role: 'COACH', email: 'coach@test.tn' }),
+    ).resolves.toBeNull();
+    await expect(
+      buildInvoiceAccessWhere('inv-1', { id: 'x-1', role: 'SUPERADMIN', email: 'x@test.tn' }),
+    ).resolves.toBeNull();
+  });
+});

--- a/__tests__/lib/invoice/access-scope.test.ts
+++ b/__tests__/lib/invoice/access-scope.test.ts
@@ -8,13 +8,9 @@ describe('buildInvoiceAccessWhere', () => {
     jest.clearAllMocks();
   });
 
-  it('allows ADMIN and ASSISTANTE to scope by invoice id only', async () => {
+  it('allows ADMIN to scope by invoice id only', async () => {
     await expect(
       buildInvoiceAccessWhere('inv-1', { id: 'admin-1', role: 'ADMIN', email: 'admin@test.tn' }),
-    ).resolves.toEqual({ id: 'inv-1' });
-
-    await expect(
-      buildInvoiceAccessWhere('inv-1', { id: 'staff-1', role: 'ASSISTANTE', email: null }),
     ).resolves.toEqual({ id: 'inv-1' });
   });
 
@@ -53,7 +49,10 @@ describe('buildInvoiceAccessWhere', () => {
     ).resolves.toBeNull();
   });
 
-  it('denies ELEVE, COACH and unknown roles on public invoice PDFs', async () => {
+  it('denies ASSISTANTE, ELEVE, COACH and unknown roles on public invoice PDFs', async () => {
+    await expect(
+      buildInvoiceAccessWhere('inv-1', { id: 'staff-1', role: 'ASSISTANTE', email: null }),
+    ).resolves.toBeNull();
     await expect(
       buildInvoiceAccessWhere('inv-1', { id: 'student-1', role: 'ELEVE', email: 'student@test.tn' }),
     ).resolves.toBeNull();

--- a/__tests__/lib/invoice/no-leak.test.ts
+++ b/__tests__/lib/invoice/no-leak.test.ts
@@ -16,7 +16,7 @@ function buildInvoiceScopeWhere(
   role: string | undefined,
   email: string | null | undefined
 ): Record<string, unknown> | null {
-  if (role === 'ADMIN' || role === 'ASSISTANTE') {
+  if (role === 'ADMIN') {
     return { id };
   }
   if (role === 'PARENT' && email) {
@@ -58,8 +58,8 @@ describe('buildInvoiceScopeWhere', () => {
     expect(buildInvoiceScopeWhere(id, 'ADMIN', null)).toEqual({ id });
   });
 
-  it('ASSISTANTE → returns { id } (full access)', () => {
-    expect(buildInvoiceScopeWhere(id, 'ASSISTANTE', null)).toEqual({ id });
+  it('ASSISTANTE → returns null on public invoice scopes', () => {
+    expect(buildInvoiceScopeWhere(id, 'ASSISTANTE', null)).toBeNull();
   });
 
   it('PARENT with email → returns { id, customerEmail }', () => {
@@ -97,6 +97,7 @@ describe('buildInvoiceScopeWhere', () => {
     const denyCases = [
       buildInvoiceScopeWhere(id, 'ELEVE', 'e@t.com'),
       buildInvoiceScopeWhere(id, 'COACH', 'c@t.com'),
+      buildInvoiceScopeWhere(id, 'ASSISTANTE', null),
       buildInvoiceScopeWhere(id, 'PARENT', null),
       buildInvoiceScopeWhere(id, undefined, null),
       buildInvoiceScopeWhere(id, '', null),

--- a/__tests__/scripts/audit-api-guards.classification.test.ts
+++ b/__tests__/scripts/audit-api-guards.classification.test.ts
@@ -1,0 +1,155 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+function writeRoute(root: string, routeFile: string, source: string) {
+  const fullPath = join(root, routeFile);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, source);
+}
+
+function inventoryRows(markdown: string) {
+  const rows = new Map<string, { risk: string; methods: string }>();
+  for (const line of markdown.split('\n')) {
+    if (!line.startsWith('| `app/api/') || !line.includes('/route.ts` |')) continue;
+    const cells = line.split('|').slice(1, -1).map((cell) => cell.trim());
+    rows.set(cells[0].replace(/`/g, ''), {
+      methods: cells[1],
+      risk: cells[8],
+    });
+  }
+  return rows;
+}
+
+function runAuditOnFixtures(fixtures: Record<string, string>) {
+  const root = mkdtempSync(join(tmpdir(), 'nexus-audit-fixtures-'));
+  try {
+    mkdirSync(join(root, 'docs/security'), { recursive: true });
+    for (const [routeFile, source] of Object.entries(fixtures)) {
+      writeRoute(root, routeFile, source);
+    }
+
+    execFileSync(process.execPath, [join(process.cwd(), 'scripts/security/audit-api-guards.mjs')], {
+      cwd: root,
+      env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
+      stdio: 'pipe',
+    });
+
+    return inventoryRows(readFileSync(join(root, 'docs/security/API_GUARD_INVENTORY.md'), 'utf8'));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe('audit-api-guards route classification', () => {
+  it('keeps dynamic sensitive routes without ownership at P0', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/documents/[id]/route.ts': `
+        import { auth } from '@/auth';
+        export async function GET() {
+          const session = await auth();
+          if (!session?.user?.id) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+          return Response.json({ ok: true });
+        }
+      `,
+    });
+
+    expect(rows.get('app/api/documents/[id]/route.ts')).toEqual(expect.objectContaining({ risk: 'P0' }));
+  });
+
+  it('does not treat comment-only rate limit mentions as a public route control', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/assessments/comment-only/route.ts': `
+        import { z } from 'zod';
+        const schema = z.object({ email: z.string().email() });
+        export async function POST(request: Request) {
+          // TODO: add rateLimit before launch.
+          schema.parse(await request.json());
+          return Response.json({ ok: true });
+        }
+      `,
+    });
+
+    expect(rows.get('app/api/assessments/comment-only/route.ts')).toEqual(expect.objectContaining({ risk: 'P0' }));
+  });
+
+  it('keeps public sensitive routes with Zod and rate limit at P1, not OK', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/assessments/submit/route.ts': `
+        import { z } from 'zod';
+        import { guardRateLimitAsync } from '@/lib/rate-limit';
+        const schema = z.object({ email: z.string().email() });
+        export async function POST(request: Request) {
+          const blocked = await guardRateLimitAsync(request, { preset: 'api' });
+          if (blocked) return blocked;
+          schema.parse(await request.json());
+          return Response.json({ ok: true });
+        }
+      `,
+    });
+
+    expect(rows.get('app/api/assessments/submit/route.ts')).toEqual(expect.objectContaining({ risk: 'P1' }));
+  });
+
+  it('does not promote disabled ClicToPay webhook beyond P1', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/payments/clictopay/webhook/route.ts': `
+        export async function POST() {
+          return Response.json({ code: 'CLICTOPAY_NOT_CONFIGURED' }, { status: 501 });
+        }
+      `,
+    });
+
+    expect(rows.get('app/api/payments/clictopay/webhook/route.ts')).toEqual(expect.objectContaining({ risk: 'P1' }));
+  });
+
+  it('keeps fixed public documents at P2, not OK', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/public-documents/corrige/route.ts': `
+        const FILE_NAME = 'corrige.pdf';
+        export async function GET() {
+          return new Response(FILE_NAME);
+        }
+      `,
+    });
+
+    expect(rows.get('app/api/public-documents/corrige/route.ts')).toEqual(expect.objectContaining({ risk: 'P2' }));
+  });
+
+  it('follows route reexports before classifying guards', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/coach/reexport/[studentId]/route.ts': `
+        export { POST } from './handler';
+      `,
+      'app/api/coach/reexport/[studentId]/handler.ts': `
+        import { requireRole } from '@/lib/guards';
+        import { assertCoachCanAccessStudent } from '@/lib/rbac/coach-student-access';
+        export async function POST() {
+          const session = await requireRole('COACH');
+          await assertCoachCanAccessStudent({ coachUserId: session.user.id, studentId: 'student-1' });
+          return Response.json({ ok: true });
+        }
+      `,
+    });
+
+    expect(rows.get('app/api/coach/reexport/[studentId]/route.ts')?.methods).toBe('POST');
+    expect(rows.get('app/api/coach/reexport/[studentId]/route.ts')?.risk).not.toBe('P0');
+    expect(rows.get('app/api/coach/reexport/[studentId]/route.ts')?.risk).not.toBe('OK');
+  });
+
+  it('keeps staff-only sensitive mutations out of P0 but not OK', () => {
+    const rows = runAuditOnFixtures({
+      'app/api/admin/documents/route.ts': `
+        import { requireAnyRole } from '@/lib/guards';
+        export async function POST() {
+          await requireAnyRole(['ADMIN', 'ASSISTANTE']);
+          return Response.json({ ok: true });
+        }
+      `,
+    });
+
+    expect(rows.get('app/api/admin/documents/route.ts')?.risk).not.toBe('P0');
+    expect(rows.get('app/api/admin/documents/route.ts')?.risk).not.toBe('OK');
+  });
+});

--- a/app/api/admin/config/rollback/route.ts
+++ b/app/api/admin/config/rollback/route.ts
@@ -11,6 +11,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
 import {
   applyWrite,
   SCHEMA_VERSION,
@@ -20,6 +21,10 @@ import {
 } from '@/lib/config';
 import type { AuthSession } from '@/lib/guards';
 
+const rollbackPayloadSchema = z.object({
+  namespace: z.string().trim().min(1).max(120),
+  key: z.string().trim().min(1).max(180),
+}).strict();
 
 
 export async function POST(request: NextRequest) {
@@ -27,20 +32,21 @@ export async function POST(request: NextRequest) {
   if (isErrorResponse(auth)) return auth;
   const session = auth as AuthSession;
 
-  let body: { namespace: string; key: string };
+  let json: unknown;
   try {
-    body = await request.json();
+    json = await request.json();
   } catch {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const { namespace, key } = body;
-  if (typeof namespace !== 'string' || !namespace || typeof key !== 'string' || !key) {
+  const parsedBody = rollbackPayloadSchema.safeParse(json);
+  if (!parsedBody.success) {
     return NextResponse.json(
       { error: 'Missing required fields: namespace, key' },
       { status: 400 },
     );
   }
+  const { namespace, key } = parsedBody.data;
 
   const result = await prisma.$transaction(async (tx) => {
     await tx.$queryRawUnsafe('SELECT pg_advisory_xact_lock($1)', CONFIG_ADVISORY_LOCK_KEY);

--- a/app/api/admin/config/route.ts
+++ b/app/api/admin/config/route.ts
@@ -7,6 +7,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireRole, requireAnyRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
 import {
   getAllEntries,
   applyWrite,
@@ -25,6 +26,12 @@ import type { AuthSession } from '@/lib/guards';
 // share the same lock — config changes are rare (admin-only), so
 // serialization is the simplest correct solution for cross-key invariants.
  // arbitrary stable int
+
+const configPatchSchema = z.object({
+  namespace: z.string().trim().min(1).max(120),
+  key: z.string().trim().min(1).max(180),
+  value: z.unknown(),
+}).strict();
 
 export async function GET() {
   const auth = await requireAnyRole(['ADMIN', 'ASSISTANTE']);
@@ -73,20 +80,21 @@ export async function PATCH(request: NextRequest) {
   if (isErrorResponse(auth)) return auth;
   const session = auth as AuthSession;
 
-  let body: { namespace: string; key: string; value: unknown };
+  let json: unknown;
   try {
-    body = await request.json();
+    json = await request.json();
   } catch {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const { namespace, key, value } = body;
-  if (typeof namespace !== 'string' || !namespace || typeof key !== 'string' || !key || value === undefined) {
+  const parsedBody = configPatchSchema.safeParse(json);
+  if (!parsedBody.success) {
     return NextResponse.json(
       { error: 'Missing required fields: namespace, key, value' },
       { status: 400 },
     );
   }
+  const { namespace, key, value } = parsedBody.data;
 
   // Per-key Zod validation (stateless — can run outside transaction)
   const validation = validateConfigEntry(namespace, key, value);

--- a/app/api/admin/directeur/stats/route.ts
+++ b/app/api/admin/directeur/stats/route.ts
@@ -8,8 +8,11 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
+import { isErrorResponse, requireRole } from '@/lib/guards';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { UserRole } from '@prisma/client';
+import { z } from 'zod';
 
 interface KPIData {
   totalAssessments: number;
@@ -36,18 +39,27 @@ interface AlertEntry {
   assessmentId: string;
 }
 
+const statsQuerySchema = z.object({}).strict();
+
 export async function GET(request: NextRequest) {
   try {
     // RBAC Guard: ADMIN only
-    const session = await auth();
-    const userRole = (session?.user as { role?: string })?.role;
+    const sessionOrError = await requireRole(UserRole.ADMIN);
+    if (isErrorResponse(sessionOrError)) return sessionOrError;
 
-    if (!session || userRole !== 'ADMIN') {
+    const query = Object.fromEntries(request.nextUrl.searchParams.entries());
+    if (!statsQuerySchema.safeParse(query).success) {
       return NextResponse.json(
-        { success: false, error: 'Accès non autorisé. Rôle ADMIN requis.' },
-        { status: 403 }
+        { success: false, error: 'Paramètres invalides' },
+        { status: 400 }
       );
     }
+
+    const rateLimited = await guardRateLimitAsync(request, {
+      preset: 'api',
+      keySuffix: 'admin-directeur-stats',
+    });
+    if (rateLimited) return rateLimited;
 
     // ─── KPIs ─────────────────────────────────────────────────────────────
 

--- a/app/api/admin/documents/route.ts
+++ b/app/api/admin/documents/route.ts
@@ -6,9 +6,46 @@ import { createId } from '@paralleldrive/cuid2';
 import path from 'path';
 import { mkdir, writeFile } from 'fs/promises';
 import { serializeError } from '@/lib/utils/serialize-error';
+import { z } from 'zod';
 
 // Secure storage root (mapped to volume in docker-compose)
 const STORAGE_ROOT = '/app/storage/documents';
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+const ALLOWED_UPLOAD_MIME_TYPES = new Set([
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'text/plain',
+]);
+
+const targetUserIdSchema = z.string().min(1).max(128);
+
+const safeDocumentSelect = {
+  id: true,
+  title: true,
+  originalName: true,
+  mimeType: true,
+  sizeBytes: true,
+  userId: true,
+  uploadedById: true,
+  createdAt: true,
+} as const;
+
+function sanitizeOriginalName(value: string): string {
+  return value.replace(/[\\/\r\n"]/g, '_').slice(0, 200) || 'document';
+}
+
+function safeErrorSummary(error: unknown) {
+  const serialized = serializeError(error);
+  if (serialized && typeof serialized === 'object' && !Array.isArray(serialized)) {
+    return {
+      name: typeof serialized.name === 'string' ? serialized.name : 'Error',
+      message: typeof serialized.message === 'string' ? serialized.message : 'unknown',
+    };
+  }
+  return { name: 'Error', message: String(serialized) };
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -20,14 +57,22 @@ export async function POST(request: NextRequest) {
     // 2. Parse FormData
     const formData = await request.formData();
     const file = formData.get('file') as File | null;
-    const userId = formData.get('userId') as string | null;
+    const parsedUserId = targetUserIdSchema.safeParse(formData.get('userId'));
 
-    if (!file || !userId) {
+    if (!file || !parsedUserId.success) {
       return NextResponse.json({ error: 'File and userId required' }, { status: 400 });
+    }
+    const userId = parsedUserId.data;
+
+    if (!ALLOWED_UPLOAD_MIME_TYPES.has(file.type) || file.size > MAX_UPLOAD_BYTES) {
+      return NextResponse.json({ error: 'Type ou taille de fichier invalide' }, { status: 400 });
     }
 
     // 3. Validate Target User
-    const targetUser = await prisma.user.findUnique({ where: { id: userId } });
+    const targetUser = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true },
+    });
     if (!targetUser) {
       return NextResponse.json({ error: 'Target user not found' }, { status: 404 });
     }
@@ -41,6 +86,7 @@ export async function POST(request: NextRequest) {
     // Using path.join ensures we stick to the OS separator, 
     // and combined with uniqueId prevents directory traversal like ../../
     const localPath = path.join(STORAGE_ROOT, secureFilename);
+    const originalName = sanitizeOriginalName(file.name);
 
     // Ensure directory exists
     await mkdir(STORAGE_ROOT, { recursive: true });
@@ -53,20 +99,24 @@ export async function POST(request: NextRequest) {
     const document = await prisma.userDocument.create({
       data: {
         id: uniqueId, // Use same ID for consistency
-        title: file.name, // Default title = filename
-        originalName: file.name,
+        title: originalName, // Default title = filename
+        originalName,
         mimeType: file.type,
         sizeBytes: file.size,
         localPath: localPath,
         userId: userId,
         uploadedById: session.user.id,
       },
+      select: safeDocumentSelect,
     });
 
-    return NextResponse.json(document, { status: 201 });
+    const safeDocument = { ...(document as Record<string, unknown>) };
+    delete safeDocument.localPath;
+
+    return NextResponse.json({ success: true, document: safeDocument }, { status: 201 });
 
   } catch (error) {
-    console.error('[Upload Error]', serializeError(error));
+    console.error('[Upload Error]', safeErrorSummary(error));
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
   }
 }

--- a/app/api/admin/invoices/route.ts
+++ b/app/api/admin/invoices/route.ts
@@ -1,4 +1,3 @@
-import { serializeError } from '@/lib/utils/serialize-error';
 /**
  * POST /api/admin/invoices — Create invoice + atomic number + PDF + store.
  * GET  /api/admin/invoices — List invoices (paginated).
@@ -10,7 +9,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import path from 'node:path';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
-import type { InvoiceItem, Prisma } from '@prisma/client';
+import { UserRole, type InvoiceItem, type Prisma } from '@prisma/client';
+import { z } from 'zod';
 import {
   generateInvoiceNumber,
   renderInvoicePDF,
@@ -40,6 +40,68 @@ const DEFAULT_ISSUER = {
   logoPath: path.join(process.cwd(), 'public', 'images', 'logo_slogan_nexus.png'),
 };
 
+const STAFF_ROLES = new Set<string>([UserRole.ADMIN, UserRole.ASSISTANTE]);
+
+const invoiceItemInputSchema = z.object({
+  label: z.string().trim().min(1).max(180),
+  description: z.string().trim().max(600).nullable().optional(),
+  qty: z.number().int().positive().max(100),
+  unitPrice: z.number().int().nonnegative(),
+}).strict();
+
+const invoiceIssuerInputSchema = z.object({
+  name: z.string().trim().min(1).max(180).optional(),
+  address: z.string().trim().min(1).max(500).optional(),
+  mf: z.string().trim().min(1).max(80).optional(),
+  rne: z.string().trim().max(80).nullable().optional(),
+  phone: z.string().trim().max(80).nullable().optional(),
+  email: z.string().trim().email().nullable().optional(),
+  web: z.string().trim().max(180).nullable().optional(),
+  slogan: z.string().trim().max(180).nullable().optional(),
+  logoPath: z.string().trim().max(500).nullable().optional(),
+  stampPath: z.string().trim().max(500).nullable().optional(),
+}).strict();
+
+const createInvoiceBodySchema = z.object({
+  number: z.string().trim().min(1).max(80).optional(),
+  issuedAt: z.string().datetime().optional(),
+  dueAt: z.string().datetime().nullable().optional(),
+  customer: z.object({
+    name: z.string().trim().min(1).max(180),
+    email: z.string().trim().email().nullable().optional(),
+    address: z.string().trim().max(500).nullable().optional(),
+    customerId: z.string().trim().max(120).nullable().optional(),
+  }).strict(),
+  items: z.array(invoiceItemInputSchema).min(1).max(50),
+  discountTotal: z.number().int().nonnegative().optional(),
+  taxRegime: z.enum(['TVA_INCLUSE', 'TVA_NON_APPLICABLE', 'EXONERATION']).optional(),
+  paymentMethod: z.enum(['CASH', 'BANK_TRANSFER', 'CHEQUE', 'CARD', 'CLICTOPAY']).nullable().optional(),
+  paymentDetails: z.record(z.unknown()).nullable().optional(),
+  notes: z.string().trim().max(2000).nullable().optional(),
+  issuer: invoiceIssuerInputSchema.optional(),
+}).strict();
+
+const listInvoicesQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).max(10_000).default(1),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  status: z.enum(['DRAFT', 'SENT', 'PAID', 'CANCELLED']).optional(),
+  search: z.string().trim().min(1).max(120).optional(),
+}).strict();
+
+function hasStaffAccess(role?: string | null) {
+  return !!role && STAFF_ROLES.has(role);
+}
+
+function validationFailed() {
+  return NextResponse.json({ error: 'Données invalides' }, { status: 400 });
+}
+
+function safeErrorSummary(error: unknown) {
+  return error instanceof Error
+    ? { name: error.name, message: error.message }
+    : { name: 'UnknownError', message: 'Unknown error' };
+}
+
 // ─── POST: Create Invoice ───────────────────────────────────────────────────
 
 export async function POST(request: NextRequest) {
@@ -51,20 +113,14 @@ export async function POST(request: NextRequest) {
     }
 
     const userRole = (session.user as { role?: string }).role;
-    if (userRole !== 'ADMIN' && userRole !== 'ASSISTANTE') {
+    if (!hasStaffAccess(userRole)) {
       return NextResponse.json({ error: 'Accès refusé' }, { status: 403 });
     }
 
     // Parse body
-    const body: CreateInvoiceRequest = await request.json();
-
-    // Validate required fields
-    if (!body.customer?.name) {
-      return NextResponse.json({ error: 'customer.name est requis' }, { status: 400 });
-    }
-    if (!body.items || body.items.length === 0) {
-      return NextResponse.json({ error: 'Au moins un item est requis' }, { status: 400 });
-    }
+    const parsedBody = createInvoiceBodySchema.safeParse(await request.json());
+    if (!parsedBody.success) return validationFailed();
+    const body = parsedBody.data as CreateInvoiceRequest;
 
     // ─── Millimes integer validation (422 if non-int) ────────────────
     for (let i = 0; i < body.items.length; i++) {
@@ -223,7 +279,7 @@ export async function POST(request: NextRequest) {
       }, { status: 422 });
     }
 
-    console.error('[POST /api/admin/invoices] Error:', serializeError(error));
+    console.error('[POST /api/admin/invoices] Error:', safeErrorSummary(error));
     return NextResponse.json({ error: 'Erreur interne' }, { status: 500 });
   }
 }
@@ -238,15 +294,14 @@ export async function GET(request: NextRequest) {
     }
 
     const userRole = (session.user as { role?: string }).role;
-    if (userRole !== 'ADMIN' && userRole !== 'ASSISTANTE') {
+    if (!hasStaffAccess(userRole)) {
       return NextResponse.json({ error: 'Accès refusé' }, { status: 403 });
     }
 
     const { searchParams } = new URL(request.url);
-    const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
-    const limit = Math.min(50, Math.max(1, parseInt(searchParams.get('limit') ?? '20', 10)));
-    const status = searchParams.get('status');
-    const search = searchParams.get('search');
+    const parsedQuery = listInvoicesQuerySchema.safeParse(Object.fromEntries(searchParams.entries()));
+    if (!parsedQuery.success) return validationFailed();
+    const { page, limit, status, search } = parsedQuery.data;
 
     const where: Record<string, unknown> = {};
     if (status) {
@@ -263,7 +318,40 @@ export async function GET(request: NextRequest) {
     const [invoices, total] = await Promise.all([
       prisma.invoice.findMany({
         where,
-        include: { items: { orderBy: { sortOrder: 'asc' } } },
+        select: {
+          id: true,
+          number: true,
+          status: true,
+          issuedAt: true,
+          dueAt: true,
+          customerName: true,
+          customerEmail: true,
+          currency: true,
+          subtotal: true,
+          discountTotal: true,
+          taxTotal: true,
+          total: true,
+          taxRegime: true,
+          paymentMethod: true,
+          paidAt: true,
+          paidAmount: true,
+          pdfUrl: true,
+          createdAt: true,
+          updatedAt: true,
+          items: {
+            orderBy: { sortOrder: 'asc' },
+            select: {
+              id: true,
+              label: true,
+              description: true,
+              qty: true,
+              unitPrice: true,
+              total: true,
+              productCode: true,
+              sortOrder: true,
+            },
+          },
+        },
         orderBy: { issuedAt: 'desc' },
         skip: (page - 1) * limit,
         take: limit,
@@ -282,7 +370,7 @@ export async function GET(request: NextRequest) {
     });
 
   } catch (error) {
-    console.error('[GET /api/admin/invoices] Error:', serializeError(error));
+    console.error('[GET /api/admin/invoices] Error:', safeErrorSummary(error));
     return NextResponse.json({ error: 'Erreur interne' }, { status: 500 });
   }
 }

--- a/app/api/admin/recompute-ssn/route.ts
+++ b/app/api/admin/recompute-ssn/route.ts
@@ -9,29 +9,34 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { auth } from '@/auth';
 import { recomputeSSNBatch } from '@/lib/core/ssn/computeSSN';
 import { computeCohortStatsWithAudit } from '@/lib/core/statistics/cohort';
+import { isErrorResponse, requireRole } from '@/lib/guards';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { UserRole } from '@prisma/client';
+import { z } from 'zod';
 
-const VALID_TYPES = ['MATHS', 'NSI', 'GENERAL'];
+const VALID_TYPES = ['MATHS', 'NSI', 'GENERAL'] as const;
+const recomputeSsnSchema = z.object({
+  type: z.enum(VALID_TYPES),
+}).strict();
 
 export async function POST(request: NextRequest) {
   try {
     // RBAC Guard: ADMIN only
-    const session = await auth();
-    const userRole = (session?.user as { role?: string })?.role;
+    const sessionOrError = await requireRole(UserRole.ADMIN);
+    if (isErrorResponse(sessionOrError)) return sessionOrError;
 
-    if (!session || userRole !== 'ADMIN') {
-      return NextResponse.json(
-        { success: false, error: 'Accès non autorisé. Rôle ADMIN requis.' },
-        { status: 403 }
-      );
-    }
+    const rateLimited = await guardRateLimitAsync(request, {
+      preset: 'api',
+      keySuffix: 'admin-recompute-ssn',
+    });
+    if (rateLimited) return rateLimited;
 
-    const body = await request.json();
-    const { type } = body;
-
-    if (!type || !VALID_TYPES.includes(type)) {
+    let json: unknown;
+    try {
+      json = await request.json();
+    } catch {
       return NextResponse.json(
         {
           success: false,
@@ -40,6 +45,18 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+
+    const parsedBody = recomputeSsnSchema.safeParse(json);
+    if (!parsedBody.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Type invalide. Valeurs acceptées : ${VALID_TYPES.join(', ')}`,
+        },
+        { status: 400 }
+      );
+    }
+    const { type } = parsedBody.data;
 
     // Compute audit log (before/after stats)
     const auditEntry = await computeCohortStatsWithAudit(type);

--- a/app/api/admin/subscriptions/route.ts
+++ b/app/api/admin/subscriptions/route.ts
@@ -5,17 +5,42 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { isErrorResponse, requireRole } from '@/lib/guards';
 import { SubscriptionStatus, UserRole, type Prisma } from '@prisma/client';
+import { z } from 'zod';
 
 type SubscriptionWithStudent = Prisma.SubscriptionGetPayload<{
-  include: {
+  select: {
+    id: true;
+    planName: true;
+    monthlyPrice: true;
+    status: true;
+    startDate: true;
+    endDate: true;
+    createdAt: true;
     student: {
-      include: {
-        user: true;
-        parent: { include: { user: true } };
+      select: {
+        id: true;
+        grade: true;
+        school: true;
+        user: { select: { firstName: true; lastName: true; email: true } };
+        parent: { select: { user: { select: { firstName: true; lastName: true; email: true } } } };
       };
     };
   };
 }>;
+
+const statusFilterSchema = z.union([z.nativeEnum(SubscriptionStatus), z.literal('ALL')]);
+const adminSubscriptionsQuerySchema = z.object({
+  status: statusFilterSchema.default(SubscriptionStatus.ACTIVE),
+  page: z.coerce.number().int().min(1).max(10_000).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(10),
+  search: z.string().trim().max(120).default(''),
+}).strict();
+
+const subscriptionUpdateSchema = z.object({
+  subscriptionId: z.string().trim().min(1).max(191),
+  status: z.nativeEnum(SubscriptionStatus).optional(),
+  endDate: z.string().trim().regex(/^\d{4}-\d{2}-\d{2}/).nullable().optional(),
+}).strict();
 
 export async function GET(request: NextRequest) {
   try {
@@ -23,10 +48,13 @@ export async function GET(request: NextRequest) {
     if (isErrorResponse(sessionOrError)) return sessionOrError;
 
     const { searchParams } = new URL(request.url);
-    const statusParam = (searchParams.get('status') || 'ACTIVE') as SubscriptionStatus | 'ALL';
-    const page = parseInt(searchParams.get('page') || '1');
-    const limit = parseInt(searchParams.get('limit') || '10');
-    const search = searchParams.get('search') || '';
+    const parsedQuery = adminSubscriptionsQuerySchema.safeParse(
+      Object.fromEntries(searchParams.entries())
+    );
+    if (!parsedQuery.success) {
+      return NextResponse.json({ error: 'Invalid query' }, { status: 400 });
+    }
+    const { status: statusParam, page, limit, search } = parsedQuery.data;
 
     const skip = (page - 1) * limit;
 
@@ -65,14 +93,22 @@ export async function GET(request: NextRequest) {
         orderBy: {
           createdAt: 'desc'
         },
-        include: {
+        select: {
+          id: true,
+          planName: true,
+          monthlyPrice: true,
+          status: true,
+          startDate: true,
+          endDate: true,
+          createdAt: true,
           student: {
-            include: {
-              user: true,
+            select: {
+              id: true,
+              grade: true,
+              school: true,
+              user: { select: { firstName: true, lastName: true, email: true } },
               parent: {
-                include: {
-                  user: true
-                }
+                select: { user: { select: { firstName: true, lastName: true, email: true } } }
               }
             }
           }
@@ -128,22 +164,29 @@ export async function PUT(request: NextRequest) {
     const sessionOrError = await requireRole(UserRole.ADMIN);
     if (isErrorResponse(sessionOrError)) return sessionOrError;
 
-    const body = (await request.json()) as {
-      subscriptionId?: string;
-      status?: string;
-      endDate?: string | null;
-    };
-    const { subscriptionId, status, endDate } = body;
-    const statusValue = status && Object.values(SubscriptionStatus).includes(status as SubscriptionStatus)
-      ? (status as SubscriptionStatus)
-      : undefined;
+    let json: unknown;
+    try {
+      json = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
 
-    if (status && !statusValue) {
+    const parsedBody = subscriptionUpdateSchema.safeParse(json);
+    if (!parsedBody.success) {
+      const hasInvalidStatus = parsedBody.error.issues.some((issue) => issue.path[0] === 'status');
+      const hasMissingSubscriptionId = parsedBody.error.issues.some((issue) => issue.path[0] === 'subscriptionId');
       return NextResponse.json(
-        { error: 'Invalid status value' },
+        {
+          error: hasInvalidStatus
+            ? 'Invalid status value'
+            : hasMissingSubscriptionId
+              ? 'Subscription ID is required'
+              : 'Invalid payload',
+        },
         { status: 400 }
       );
     }
+    const { subscriptionId, status, endDate } = parsedBody.data;
 
     if (!subscriptionId) {
       return NextResponse.json(
@@ -156,14 +199,15 @@ export async function PUT(request: NextRequest) {
     const updatedSubscription = await prisma.subscription.update({
       where: { id: subscriptionId },
       data: {
-        status: statusValue,
+        status,
         endDate: endDate ? new Date(endDate) : undefined
       },
-      include: {
+      select: {
+        id: true,
+        status: true,
+        endDate: true,
         student: {
-          include: {
-            user: true
-          }
+          select: { user: { select: { firstName: true, lastName: true } } }
         }
       }
     });

--- a/app/api/admin/test-email/route.ts
+++ b/app/api/admin/test-email/route.ts
@@ -3,22 +3,46 @@ export const dynamic = 'force-dynamic';
 
 import { auth } from '@/auth';
 import { sendWelcomeEmail, testEmailConfiguration } from '@/lib/email-service';
+import type { AuthSession } from '@/lib/guards';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const testEmailBodySchema = z.discriminatedUnion('action', [
+  z.object({ action: z.literal('test_config') }).strict(),
+  z.object({
+    action: z.literal('send_test'),
+    testEmail: z.string().trim().email().max(254),
+  }).strict(),
+]);
+
+function requireAdmin(session: AuthSession | null) {
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Non autorisé' }, { status: 401 });
+  }
+  if (session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Non autorisé' }, { status: 403 });
+  }
+  return null;
+}
 
 export async function POST(request: NextRequest) {
   try {
     const session = await auth();
+    const guard = requireAdmin(session as AuthSession | null);
+    if (guard) return guard;
 
-    // Vérifier que l'utilisateur est admin ou assistante
-    if (!session?.user || !['ADMIN', 'ASSISTANTE'].includes(session.user.role)) {
-      return NextResponse.json({ error: 'Non autorisé' }, { status: 401 });
+    let json: unknown;
+    try {
+      json = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Payload invalide' }, { status: 400 });
     }
-
-    const body = (await request.json()) as {
-      action?: 'test_config' | 'send_test';
-      testEmail?: string;
-    };
-    const { action, testEmail } = body;
+    const parsedBody = testEmailBodySchema.safeParse(json);
+    if (!parsedBody.success) {
+      return NextResponse.json({ success: false, error: 'Payload invalide' }, { status: 400 });
+    }
+    const body = parsedBody.data;
+    const { action } = body;
 
     switch (action) {
       case 'test_config':
@@ -28,30 +52,22 @@ export async function POST(request: NextRequest) {
 
       case 'send_test':
         // Envoyer un email de test
-        if (!testEmail) {
-          return NextResponse.json({
-            success: false,
-            error: 'Adresse email requise pour le test'
-          }, { status: 400 });
-        }
-
         try {
           await sendWelcomeEmail({
             firstName: 'Test',
             lastName: 'User',
-            email: testEmail
+            email: body.testEmail
           });
 
           return NextResponse.json({
             success: true,
-            message: `Email de test envoyé à ${testEmail}`
+            message: 'Email de test envoyé'
           });
         } catch (emailError: unknown) {
-          const message =
-            emailError instanceof Error ? emailError.message : 'Erreur inconnue';
+          console.error('Erreur envoi email test:', serializeError(emailError));
           return NextResponse.json({
             success: false,
-            error: `Erreur envoi email: ${message}`
+            error: 'Erreur envoi email'
           });
         }
 
@@ -73,10 +89,8 @@ export async function POST(request: NextRequest) {
 export async function GET(request: NextRequest) {
   try {
     const session = await auth();
-
-    if (!session?.user || !['ADMIN', 'ASSISTANTE'].includes(session.user.role)) {
-      return NextResponse.json({ error: 'Non autorisé' }, { status: 401 });
-    }
+    const guard = requireAdmin(session as AuthSession | null);
+    if (guard) return guard;
 
     // Retourner l'état de la configuration email
     const envVars = [

--- a/app/api/assistante/credit-requests/route.ts
+++ b/app/api/assistante/credit-requests/route.ts
@@ -4,8 +4,15 @@ export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
+import { z } from 'zod';
 
 class AlreadyProcessedError extends Error {}
+
+const creditRequestDecisionSchema = z.object({
+  requestId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/),
+  action: z.enum(['approve', 'reject']),
+  reason: z.string().trim().max(500).optional(),
+}).strict();
 
 export async function GET(request: NextRequest) {
   try {
@@ -83,19 +90,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = (await request.json()) as {
-      requestId?: string;
-      action?: 'approve' | 'reject';
-      reason?: string;
-    };
-    const { requestId, action, reason } = body;
-
-    if (!requestId || !action) {
+    const rawBody = await request.json().catch(() => null);
+    const parsedBody = creditRequestDecisionSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: 'Missing required fields' },
+        { error: 'Invalid credit request payload' },
         { status: 400 }
       );
     }
+    const { requestId, action, reason } = parsedBody.data;
 
     // Get the credit request
     const creditRequest = await prisma.creditTransaction.findUnique({

--- a/app/api/assistante/quotes/pdf/route.ts
+++ b/app/api/assistante/quotes/pdf/route.ts
@@ -4,12 +4,59 @@ import { NextRequest, NextResponse } from 'next/server';
 import { isErrorResponse, requireAnyRole } from '@/lib/guards';
 import { renderQuotePDF, type QuotePDFData } from '@/lib/quote/pdf';
 import { guardRateLimit } from '@/lib/rate-limit';
+import { z } from 'zod';
 
 export const dynamic = 'force-dynamic';
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
+const quoteInstallmentSchema = z.object({
+  label: z.string().trim().min(1).max(120),
+  amount: z.coerce.number().finite().nonnegative().max(1_000_000),
+}).strict();
+
+const quoteOfferSchema = z.object({
+  label: z.string().trim().min(1).max(160),
+  desc: z.string().trim().max(500),
+  annualDisplay: z.string().trim().min(1).max(80),
+  inc: z.array(z.string().trim().min(1).max(180)).max(20).default([]),
+  ech: z.array(quoteInstallmentSchema).max(12).default([]),
+}).strict();
+
+const quoteAlternativeSchema = z.object({
+  label: z.string().trim().min(1).max(160),
+  desc: z.string().trim().max(500),
+  annualDisplay: z.string().trim().min(1).max(80),
+}).strict();
+
+const quotePayloadSchema = z.object({
+  quoteNumber: z.string().trim().min(1).max(80),
+  generatedAt: z.string().trim().min(1).max(80),
+  validUntil: z.string().trim().min(1).max(80),
+  studentName: z.string().trim().min(1).max(160),
+  parentName: z.string().trim().min(1).max(160),
+  whatsapp: z.string().trim().max(80),
+  email: z.string().trim().email().max(180),
+  advisor: z.string().trim().max(160),
+  level: z.string().trim().max(120),
+  status: z.string().trim().max(120),
+  establishment: z.string().trim().max(180),
+  languages: z.string().trim().max(180),
+  currentLevel: z.string().trim().max(180),
+  specialites: z.array(z.string().trim().max(120)).max(10).default([]),
+  options: z.array(z.string().trim().max(120)).max(10).default([]),
+  modalite: z.string().trim().max(120),
+  objectif: z.string().trim().max(500),
+  budget: z.string().trim().max(120),
+  mode: z.string().trim().max(120),
+  reduction: z.string().trim().max(80),
+  reductionLabels: z.array(z.string().trim().max(160)).max(10).default([]),
+  hasDirectionOverride: z.boolean(),
+  publicAnnual: z.coerce.number().finite().nonnegative().max(1_000_000).nullable().optional(),
+  monthlyDisplay: z.string().trim().max(120).nullable().optional(),
+  economie: z.coerce.number().finite().nonnegative().max(1_000_000).nullable().optional(),
+  internalNotes: z.string().trim().max(1000).optional(),
+  offer: quoteOfferSchema,
+  alternatives: z.array(quoteAlternativeSchema).max(10).default([]),
+}).strict();
 
 function sanitizeFilenamePart(value: string) {
   const normalized = value
@@ -19,23 +66,6 @@ function sanitizeFilenamePart(value: string) {
     .replace(/^-+|-+$/g, '');
 
   return normalized || 'eleve';
-}
-
-function validateQuotePayload(value: unknown): QuotePDFData | NextResponse {
-  if (!isRecord(value) || !isRecord(value.offer)) {
-    return NextResponse.json({ error: 'Invalid quote payload' }, { status: 400 });
-  }
-
-  const required = ['quoteNumber', 'studentName', 'parentName', 'offer'];
-  const missing = required.filter(key => value[key] == null || value[key] === '');
-  if (missing.length > 0) {
-    return NextResponse.json(
-      { error: 'Invalid quote payload', missing },
-      { status: 400 }
-    );
-  }
-
-  return value as unknown as QuotePDFData;
 }
 
 export async function POST(request: NextRequest) {
@@ -52,8 +82,11 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
 
-  const quoteData = validateQuotePayload(payload);
-  if (isErrorResponse(quoteData)) return quoteData;
+  const parsedPayload = quotePayloadSchema.safeParse(payload);
+  if (!parsedPayload.success) {
+    return NextResponse.json({ error: 'Invalid quote payload' }, { status: 400 });
+  }
+  const quoteData = parsedPayload.data as QuotePDFData;
 
   const pdfBuffer = await renderQuotePDF(quoteData);
   const student = sanitizeFilenamePart(quoteData.studentName);

--- a/app/api/assistante/students/credits/route.ts
+++ b/app/api/assistante/students/credits/route.ts
@@ -5,6 +5,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
 import type { CreditTransaction } from '@prisma/client';
+import { z } from 'zod';
 
 const ALLOWED_STAFF_CREDIT_TYPES = new Set([
   'CREDIT_ADD',
@@ -12,6 +13,22 @@ const ALLOWED_STAFF_CREDIT_TYPES = new Set([
   'MANUAL_ADJUSTMENT',
   'MONTHLY_ALLOCATION',
 ]);
+const staffCreditTypeSchema = z.enum([
+  'CREDIT_ADD',
+  'CREDIT_REFUND',
+  'MANUAL_ADJUSTMENT',
+  'MONTHLY_ALLOCATION',
+]);
+const idSchema = z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/);
+const studentCreditsQuerySchema = z.object({
+  studentId: idSchema.optional(),
+}).strict();
+const addStudentCreditsSchema = z.object({
+  studentId: idSchema,
+  amount: z.coerce.number().finite().positive().max(1000),
+  type: staffCreditTypeSchema,
+  description: z.string().trim().min(1).max(500),
+}).strict();
 
 export async function GET(request: NextRequest) {
   try {
@@ -25,7 +42,16 @@ export async function GET(request: NextRequest) {
     }
 
     const { searchParams } = new URL(request.url);
-    const studentId = searchParams.get('studentId');
+    const parsedQuery = studentCreditsQuerySchema.safeParse({
+      studentId: searchParams.get('studentId') ?? undefined,
+    });
+    if (!parsedQuery.success) {
+      return NextResponse.json(
+        { error: 'Invalid query parameters' },
+        { status: 400 }
+      );
+    }
+    const { studentId } = parsedQuery.data;
 
     if (studentId) {
       // Get specific student credits
@@ -118,15 +144,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
-    const { studentId, amount, type, description } = body;
-
-    if (!studentId || amount === undefined || amount === null || !type || !description) {
+    const rawBody = await request.json().catch(() => null);
+    const parsedBody = addStudentCreditsSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: 'Missing required fields' },
+        { error: 'Invalid credit payload' },
         { status: 400 }
       );
     }
+    const { studentId, amount, type, description } = parsedBody.data;
 
     if (!ALLOWED_STAFF_CREDIT_TYPES.has(type)) {
       return NextResponse.json(
@@ -135,7 +161,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const parsedAmount = Number(amount);
+    const parsedAmount = amount;
     if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
       return NextResponse.json(
         { error: 'Invalid credit amount' },

--- a/app/api/assistante/subscription-requests/route.ts
+++ b/app/api/assistante/subscription-requests/route.ts
@@ -19,7 +19,7 @@ const subscriptionRequestsQuerySchema = z.object({
 const subscriptionRequestDecisionSchema = z.object({
   requestId: idSchema,
   action: z.enum(['APPROVED', 'REJECTED']),
-  reason: z.string().trim().max(1000).optional(),
+  reason: z.string().trim().max(1000).nullable().optional(),
 }).strict();
 
 function getRequestCatalogFields(request: { requestType: string; planName: string | null; monthlyPrice: number }) {

--- a/app/api/assistante/subscription-requests/route.ts
+++ b/app/api/assistante/subscription-requests/route.ts
@@ -5,9 +5,22 @@ import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 import { getAriaAddonCatalogItem, getOperationalSubscriptionPlan } from '@/lib/operational-catalog';
+import { z } from 'zod';
 
 class AlreadyProcessedError extends Error {}
 class NoActiveSubscriptionError extends Error {}
+
+const idSchema = z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/);
+const subscriptionRequestsQuerySchema = z.object({
+  status: z.enum(['PENDING', 'APPROVED', 'REJECTED']).default('PENDING'),
+  page: z.coerce.number().int().min(1).max(500).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+}).strict();
+const subscriptionRequestDecisionSchema = z.object({
+  requestId: idSchema,
+  action: z.enum(['APPROVED', 'REJECTED']),
+  reason: z.string().trim().max(1000).optional(),
+}).strict();
 
 function getRequestCatalogFields(request: { requestType: string; planName: string | null; monthlyPrice: number }) {
   if (request.requestType === 'PLAN_CHANGE') {
@@ -47,9 +60,15 @@ export async function GET(request: NextRequest) {
     }
 
     const { searchParams } = new URL(request.url);
-    const status = searchParams.get('status') || 'PENDING';
-    const page = parseInt(searchParams.get('page') || '1');
-    const limit = parseInt(searchParams.get('limit') || '20');
+    const parsedQuery = subscriptionRequestsQuerySchema.safeParse({
+      status: searchParams.get('status') ?? undefined,
+      page: searchParams.get('page') ?? undefined,
+      limit: searchParams.get('limit') ?? undefined,
+    });
+    if (!parsedQuery.success) {
+      return NextResponse.json({ error: 'Invalid query parameters' }, { status: 400 });
+    }
+    const { status, page, limit } = parsedQuery.data;
 
     const skip = (page - 1) * limit;
 
@@ -118,22 +137,15 @@ export async function PATCH(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
-    const { requestId, action, reason } = body;
-
-    if (!requestId || !action) {
+    const rawBody = await request.json().catch(() => null);
+    const parsedBody = subscriptionRequestDecisionSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: 'Missing required fields' },
+        { error: 'Invalid subscription request payload' },
         { status: 400 }
       );
     }
-
-    if (!['APPROVED', 'REJECTED'].includes(action)) {
-      return NextResponse.json(
-        { error: 'Invalid action' },
-        { status: 400 }
-      );
-    }
+    const { requestId, action, reason } = parsedBody.data;
 
     // Get the request
     const subscriptionRequest = await prisma.subscriptionRequest.findUnique({

--- a/app/api/assistante/subscriptions/route.ts
+++ b/app/api/assistante/subscriptions/route.ts
@@ -5,8 +5,15 @@ import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 import { getOperationalSubscriptionPlan } from '@/lib/operational-catalog';
+import { z } from 'zod';
 
 class AlreadyProcessedError extends Error {}
+
+const subscriptionDecisionSchema = z.object({
+  subscriptionId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/),
+  action: z.enum(['approve', 'reject']),
+  reason: z.string().trim().max(1000).optional(),
+}).strict();
 
 function getPlanCatalog(planName: string) {
   return getOperationalSubscriptionPlan(planName);
@@ -143,19 +150,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = (await request.json()) as {
-      subscriptionId?: string;
-      action?: 'approve' | 'reject';
-      reason?: string;
-    };
-    const { subscriptionId, action, reason: _reason } = body;
-
-    if (!subscriptionId || !action) {
+    const rawBody = await request.json().catch(() => null);
+    const parsedBody = subscriptionDecisionSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: 'Missing required fields' },
+        { error: 'Invalid subscription payload' },
         { status: 400 }
       );
     }
+    const { subscriptionId, action } = parsedBody.data;
 
     // Get the subscription
     const subscription = await prisma.subscription.findUnique({

--- a/app/api/bilans/[id]/export/route.ts
+++ b/app/api/bilans/[id]/export/route.ts
@@ -13,11 +13,29 @@ import {
   buildBilanWriteWhere,
   canSeeInternalBilan,
 } from '@/lib/security/ownership';
+import { z } from 'zod';
 
 export const dynamic = 'force-dynamic';
 
 interface RouteParams {
   params: Promise<{ id: string }>;
+}
+
+const routeParamsSchema = z.object({
+  id: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+}).strict();
+
+const exportQuerySchema = z.object({
+  format: z.enum(['pdf', 'markdown']).default('markdown'),
+  audience: z.enum(['student', 'parents', 'nexus', 'all']).default('all'),
+}).strict();
+
+const exportBodySchema = z.object({
+  format: z.enum(['pdf', 'markdown']).default('pdf'),
+}).strict();
+
+function validationFailed() {
+  return NextResponse.json({ success: false, error: 'Données invalides' }, { status: 400 });
 }
 
 /**
@@ -30,10 +48,13 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   if (isErrorResponse(authResponse)) return authResponse;
 
   try {
-    const { id } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
     const { searchParams } = new URL(request.url);
-    const format = searchParams.get('format') || 'markdown';
-    const audience = searchParams.get('audience') || 'all';
+    const parsedQuery = exportQuerySchema.safeParse(Object.fromEntries(searchParams.entries()));
+    if (!parsedQuery.success) return validationFailed();
+    const { id } = parsedParams.data;
+    const { format, audience } = parsedQuery.data;
     const where = buildBilanReadWhere(id, authResponse.user);
     if (!where) {
       return NextResponse.json(
@@ -160,9 +181,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   if (isErrorResponse(authResponse)) return authResponse;
 
   try {
-    const { id } = await params;
-    const body = await request.json();
-    const { format = 'pdf' } = body;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
+    const parsedBody = exportBodySchema.safeParse(await request.json());
+    if (!parsedBody.success) return validationFailed();
+    const { id } = parsedParams.data;
+    const { format } = parsedBody.data;
     const where = buildBilanWriteWhere(id, authResponse.user);
     if (!where) {
       return NextResponse.json(

--- a/app/api/bilans/[id]/route.ts
+++ b/app/api/bilans/[id]/route.ts
@@ -15,11 +15,42 @@ import {
   buildBilanWriteWhere,
   sanitizeBilanForRole,
 } from '@/lib/security/ownership';
+import { z } from 'zod';
 
 export const dynamic = 'force-dynamic';
 
 interface RouteParams {
   params: Promise<{ id: string }>;
+}
+
+const routeParamsSchema = z.object({
+  id: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+}).strict();
+
+const updateBilanBodySchema = z.object({
+  status: z.string().trim().min(1).max(80).optional(),
+  progress: z.number().int().min(0).max(100).optional(),
+  globalScore: z.number().min(0).max(100).optional(),
+  confidenceIndex: z.number().min(0).max(100).optional(),
+  ssn: z.number().optional(),
+  uai: z.number().optional(),
+  domainScores: z.unknown().optional(),
+  studentMarkdown: z.string().max(80_000).optional(),
+  parentsMarkdown: z.string().max(80_000).optional(),
+  nexusMarkdown: z.string().max(80_000).optional(),
+  analysisJson: z.unknown().optional(),
+  isPublished: z.boolean().optional(),
+  errorCode: z.string().trim().max(120).nullable().optional(),
+  errorDetails: z.string().trim().max(2000).nullable().optional(),
+  retryCount: z.number().int().min(0).max(20).optional(),
+  ragUsed: z.boolean().optional(),
+  ragCollections: z.array(z.string().trim().min(1).max(120)).max(20).optional(),
+  sourceVersion: z.string().trim().max(120).optional(),
+  engineVersion: z.string().trim().max(120).optional(),
+}).strict();
+
+function validationFailed() {
+  return NextResponse.json({ success: false, error: 'Données invalides' }, { status: 400 });
 }
 
 /**
@@ -31,7 +62,9 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   if (isErrorResponse(authResponse)) return authResponse;
 
   try {
-    const { id } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
+    const { id } = parsedParams.data;
     const where = buildBilanReadWhere(id, authResponse.user);
     if (!where) {
       return NextResponse.json(
@@ -86,8 +119,12 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
   if (isErrorResponse(authResponse)) return authResponse;
 
   try {
-    const { id } = await params;
-    const body = await request.json();
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
+    const parsedBody = updateBilanBodySchema.safeParse(await request.json());
+    if (!parsedBody.success) return validationFailed();
+    const { id } = parsedParams.data;
+    const body = parsedBody.data;
     const where = buildBilanWriteWhere(id, authResponse.user);
     if (!where) {
       return NextResponse.json(
@@ -162,7 +199,9 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
   if (isErrorResponse(authResponse)) return authResponse;
 
   try {
-    const { id } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
+    const { id } = parsedParams.data;
 
     // Check bilan exists
     const existing = await prisma.bilan.findUnique({ where: { id } });

--- a/app/api/bilans/generate/route.ts
+++ b/app/api/bilans/generate/route.ts
@@ -9,8 +9,27 @@ import { prisma } from '@/lib/prisma';
 import { requireAnyRole, isErrorResponse } from '@/lib/guards';
 import { BilanGenerator } from '@/lib/bilan/generator';
 import type { BilanGenerationContext } from '@/lib/bilan/generator';
+import { z } from 'zod';
 
 export const dynamic = 'force-dynamic';
+
+const safeIdSchema = z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/);
+
+const generateBilanBodySchema = z.object({
+  bilanId: safeIdSchema,
+  enableRAG: z.boolean().default(true),
+  ragCollections: z.array(z.string().trim().min(1).max(120)).max(20).optional(),
+  ragQuery: z.string().trim().max(500).optional(),
+  force: z.boolean().optional(),
+}).strict();
+
+const generationStatusQuerySchema = z.object({
+  bilanId: safeIdSchema,
+}).strict();
+
+function validationFailed(message = 'Données invalides') {
+  return NextResponse.json({ success: false, error: message }, { status: 400 });
+}
 
 /**
  * POST /api/bilans/generate
@@ -22,15 +41,13 @@ export async function POST(request: NextRequest) {
   if (isErrorResponse(authResponse)) return authResponse;
 
   try {
-    const body = await request.json();
-    const { bilanId, enableRAG = true, ragCollections, ragQuery } = body;
-
-    if (!bilanId) {
-      return NextResponse.json(
-        { success: false, error: 'Missing required field: bilanId' },
-        { status: 400 }
-      );
+    const rawBody = await request.json();
+    const parsedBody = generateBilanBodySchema.safeParse(rawBody);
+    if (!parsedBody.success) {
+      const hasBilanId = rawBody && typeof rawBody === 'object' && 'bilanId' in rawBody;
+      return validationFailed(hasBilanId ? undefined : 'Missing required field: bilanId');
     }
+    const { bilanId, enableRAG, ragCollections, ragQuery, force } = parsedBody.data;
 
     // Fetch bilan
     const bilan = await prisma.bilan.findUnique({
@@ -53,7 +70,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Check if already completed
-    if (bilan.status === 'COMPLETED' && !body.force) {
+    if (bilan.status === 'COMPLETED' && !force) {
       return NextResponse.json(
         { success: false, error: 'Bilan already completed. Use force=true to regenerate.' },
         { status: 409 }
@@ -122,14 +139,12 @@ export async function GET(request: NextRequest) {
 
   try {
     const { searchParams } = new URL(request.url);
-    const bilanId = searchParams.get('bilanId');
-
-    if (!bilanId) {
-      return NextResponse.json(
-        { success: false, error: 'Missing required param: bilanId' },
-        { status: 400 }
-      );
+    const queryObject = Object.fromEntries(searchParams.entries());
+    const parsedQuery = generationStatusQuerySchema.safeParse(queryObject);
+    if (!parsedQuery.success) {
+      return validationFailed('bilanId' in queryObject ? undefined : 'Missing required param: bilanId');
     }
+    const { bilanId } = parsedQuery.data;
 
     const bilan = await prisma.bilan.findUnique({
       where: { id: bilanId },

--- a/app/api/bilans/route.ts
+++ b/app/api/bilans/route.ts
@@ -8,9 +8,40 @@ import { serializeError } from '@/lib/utils/serialize-error';
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { requireAnyRole, isErrorResponse } from '@/lib/guards';
-import type { BilanType, BilanStatus, CreateBilanInput } from '@/lib/bilan/types';
+import { z } from 'zod';
 
 export const dynamic = 'force-dynamic';
+
+const listBilansQuerySchema = z.object({
+  type: z.string().trim().min(1).max(80).optional(),
+  status: z.string().trim().min(1).max(80).optional(),
+  subject: z.string().trim().min(1).max(80).optional(),
+  studentId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/).optional(),
+  stageId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/).optional(),
+  coachId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/).optional(),
+  isPublished: z.enum(['true', 'false']).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  offset: z.coerce.number().int().min(0).max(100_000).default(0),
+}).strict();
+
+const createBilanBodySchema = z.object({
+  type: z.string().trim().min(1).max(80),
+  subject: z.string().trim().min(1).max(80),
+  studentEmail: z.string().trim().email(),
+  studentName: z.string().trim().min(1).max(180),
+  studentPhone: z.string().trim().max(80).optional(),
+  studentId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/).optional(),
+  stageId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/).optional(),
+  coachId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/).optional(),
+  sourceData: z.record(z.unknown()).optional(),
+  globalScore: z.number().min(0).max(100).optional(),
+  confidenceIndex: z.number().min(0).max(100).optional(),
+  domainScores: z.unknown().optional(),
+}).strict();
+
+function validationFailed() {
+  return NextResponse.json({ success: false, error: 'Données invalides' }, { status: 400 });
+}
 
 /**
  * GET /api/bilans
@@ -24,16 +55,9 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
 
-    // Parse filters
-    const type = searchParams.get('type') as BilanType | null;
-    const status = searchParams.get('status') as BilanStatus | null;
-    const subject = searchParams.get('subject');
-    const studentId = searchParams.get('studentId');
-    const stageId = searchParams.get('stageId');
-    const coachId = searchParams.get('coachId');
-    const isPublished = searchParams.get('isPublished');
-    const limit = parseInt(searchParams.get('limit') || '50');
-    const offset = parseInt(searchParams.get('offset') || '0');
+    const parsedQuery = listBilansQuerySchema.safeParse(Object.fromEntries(searchParams.entries()));
+    if (!parsedQuery.success) return validationFailed();
+    const { type, status, subject, studentId, stageId, coachId, isPublished, limit, offset } = parsedQuery.data;
 
     // RBAC: Force coachId if role is COACH
     const userRole = (authResponse as any).user.role;
@@ -62,7 +86,7 @@ export async function GET(request: NextRequest) {
       where.coachId = coachId;
     }
     
-    if (isPublished !== null) where.isPublished = isPublished === 'true';
+    if (isPublished !== undefined) where.isPublished = isPublished === 'true';
 
     // Fetch bilans
     const [bilans, total] = await Promise.all([
@@ -109,15 +133,9 @@ export async function POST(request: NextRequest) {
   if (isErrorResponse(authResponse)) return authResponse;
 
   try {
-    const body = await request.json();
-
-    // Validate required fields
-    if (!body.type || !body.subject || !body.studentEmail || !body.studentName) {
-      return NextResponse.json(
-        { success: false, error: 'Missing required fields: type, subject, studentEmail, studentName' },
-        { status: 400 }
-      );
-    }
+    const parsedBody = createBilanBodySchema.safeParse(await request.json());
+    if (!parsedBody.success) return validationFailed();
+    const body = parsedBody.data;
 
     // RBAC: Validate coachId if role is COACH
     const userRole = (authResponse as any).user.role;
@@ -140,7 +158,7 @@ export async function POST(request: NextRequest) {
     // Create bilan
     const bilan = await prisma.bilan.create({
       data: {
-        type: body.type as BilanType,
+        type: body.type as any,
         subject: body.subject,
         studentEmail: body.studentEmail,
         studentName: body.studentName,
@@ -148,10 +166,10 @@ export async function POST(request: NextRequest) {
         studentId: body.studentId,
         stageId: body.stageId,
         coachId: body.coachId,
-        sourceData: body.sourceData || {},
+        sourceData: (body.sourceData || {}) as any,
         globalScore: body.globalScore,
         confidenceIndex: body.confidenceIndex,
-        domainScores: body.domainScores,
+        domainScores: body.domainScores as any,
         status: 'PENDING',
         progress: 0,
         isPublished: false,

--- a/app/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate/route.ts
+++ b/app/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate/route.ts
@@ -19,9 +19,9 @@ import {
 } from '@/lib/rbac/coach-student-access';
 import { prisma } from '@/lib/prisma';
 import { logger } from '@/lib/logger';
-import { COACH_EAF_META } from '@/lib/coach/eaf-stage-printemps/types';
 import type { CoachEafSourceData } from '@/lib/coach/eaf-stage-printemps/types';
 import { generateLLMParentEafReport } from '@/lib/coach/eaf-stage-printemps/llm-report';
+import { z } from 'zod';
 
 export const maxDuration = 200;
 
@@ -33,13 +33,23 @@ interface RouteParams {
   params: Promise<{ studentId: string }>;
 }
 
+const routeParamsSchema = z.object({
+  studentId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+}).strict();
+
+function validationFailed() {
+  return NextResponse.json({ error: 'Données invalides' }, { status: 400 });
+}
+
 export async function POST(_request: Request, { params }: RouteParams) {
   try {
-    const { studentId } = await params;
-
     const sessionOrError = await requireRole('COACH');
     if (isErrorResponse(sessionOrError)) return sessionOrError;
     const authSession = sessionOrError;
+
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
+    const { studentId } = parsedParams.data;
 
     try {
       await assertCoachCanAccessStudent({ coachUserId: authSession.user.id, studentId });

--- a/app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent/route.ts
+++ b/app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent/route.ts
@@ -10,6 +10,7 @@ import { prisma } from '@/lib/prisma';
 import { logger } from '@/lib/logger';
 import { generateBilan, adaptMathsPremiereStagePrintemps } from '@/lib/bilan-generation';
 import { MistralConfigurationError, MistralGenerationError } from '@/lib/llm/mistral';
+import { z } from 'zod';
 
 interface RouteParams {
   params: Promise<{ studentId: string }>;
@@ -18,10 +19,17 @@ interface RouteParams {
 const COACH_SOURCE_VERSION = 'coach_maths_premiere_stage_printemps_v1';
 const BILAN_TYPE = 'STAGE_POST' as const;
 const BILAN_SUBJECT_DEFAULT = 'MATHEMATIQUES';
+const routeParamsSchema = z.object({
+  studentId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/),
+}).strict();
 
 export async function POST(_request: Request, { params }: RouteParams) {
   try {
-    const { studentId } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) {
+      return NextResponse.json({ error: 'Invalid route params' }, { status: 400 });
+    }
+    const { studentId } = parsedParams.data;
 
     // Auth
     const sessionOrError = await requireRole('COACH');

--- a/app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student/route.ts
+++ b/app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student/route.ts
@@ -10,6 +10,7 @@ import { prisma } from '@/lib/prisma';
 import { logger } from '@/lib/logger';
 import { generateBilan, adaptMathsPremiereStagePrintemps } from '@/lib/bilan-generation';
 import { MistralConfigurationError, MistralGenerationError } from '@/lib/llm/mistral';
+import { z } from 'zod';
 
 interface RouteParams {
   params: Promise<{ studentId: string }>;
@@ -18,10 +19,17 @@ interface RouteParams {
 const COACH_SOURCE_VERSION = 'coach_maths_premiere_stage_printemps_v1';
 const BILAN_TYPE = 'STAGE_POST' as const;
 const BILAN_SUBJECT_DEFAULT = 'MATHEMATIQUES';
+const routeParamsSchema = z.object({
+  studentId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/),
+}).strict();
 
 export async function POST(_request: Request, { params }: RouteParams) {
   try {
-    const { studentId } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) {
+      return NextResponse.json({ error: 'Invalid route params' }, { status: 400 });
+    }
+    const { studentId } = parsedParams.data;
 
     // Auth
     const sessionOrError = await requireRole('COACH');

--- a/app/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale/route.ts
+++ b/app/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale/route.ts
@@ -6,9 +6,22 @@ import { computeDiagnostics } from '@/lib/diagnostic/maths-terminale/scoring';
 import { DOMAINS } from '@/lib/diagnostic/maths-terminale/data';
 import type { DiagnosticSourceData, TeacherGrade } from '@/lib/diagnostic/maths-terminale/types';
 import { serializeError } from '@/lib/utils/serialize-error';
+import { z } from 'zod';
 
 interface RouteParams {
   params: Promise<{ studentId: string }>;
+}
+
+const routeParamsSchema = z.object({
+  studentId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+}).strict();
+
+const teacherGradesSchema = z.object({
+  teacherGrades: z.record(z.unknown()),
+}).strict();
+
+function validationFailed() {
+  return NextResponse.json({ error: 'Données invalides' }, { status: 400 });
 }
 
 /**
@@ -17,11 +30,13 @@ interface RouteParams {
  */
 export async function GET(_request: Request, { params }: RouteParams) {
   try {
-    const { studentId } = await params;
-
     const sessionOrError = await requireRole('COACH');
     if (isErrorResponse(sessionOrError)) return sessionOrError;
     const authSession = sessionOrError;
+
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
+    const { studentId } = parsedParams.data;
 
     // Verify coach assignment
     try {
@@ -61,11 +76,13 @@ export async function GET(_request: Request, { params }: RouteParams) {
  */
 export async function PATCH(request: Request, { params }: RouteParams) {
   try {
-    const { studentId } = await params;
-
     const sessionOrError = await requireRole('COACH');
     if (isErrorResponse(sessionOrError)) return sessionOrError;
     const authSession = sessionOrError;
+
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
+    const { studentId } = parsedParams.data;
 
     // Verify coach assignment
     try {
@@ -77,12 +94,9 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       );
     }
 
-    const body = await request.json();
-    const { teacherGrades }: { teacherGrades: Record<string, TeacherGrade> } = body;
-
-    if (!teacherGrades || typeof teacherGrades !== 'object') {
-      return NextResponse.json({ error: 'teacherGrades required' }, { status: 400 });
-    }
+    const parsedBody = teacherGradesSchema.safeParse(await request.json());
+    if (!parsedBody.success) return validationFailed();
+    const { teacherGrades } = parsedBody.data as { teacherGrades: Record<string, TeacherGrade> };
 
     // Find the bilan
     const existingBilan = await prisma.bilan.findFirst({
@@ -101,7 +115,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
 
     // Get existing source data
     const existingSourceData = existingBilan.sourceData as unknown as DiagnosticSourceData;
-    const { progress = {}, qcmAnswers = {}, openAnswers = {} } = existingSourceData;
+    const { progress = {}, qcmAnswers = {} } = existingSourceData;
 
     // Recompute with teacher grades
     const evaluatedData = computeDiagnostics(progress, qcmAnswers, teacherGrades, true);

--- a/app/api/coach/students/[studentId]/documents/route.ts
+++ b/app/api/coach/students/[studentId]/documents/route.ts
@@ -15,9 +15,63 @@ const createDocumentSchema = z.object({
   title: z.string().min(1, 'Titre requis').max(200),
   description: z.string().max(1000).optional(),
   url: z.string().url().optional(),
-  localPath: z.string().optional(),
   visibilityScope: z.nativeEnum(DocumentVisibilityScope).default(DocumentVisibilityScope.STUDENT_AND_COACH),
+}).strict();
+
+const routeParamsSchema = z.object({
+  studentId: z.string().min(1).max(128),
 });
+
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+const ALLOWED_UPLOAD_MIME_TYPES = new Set([
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+]);
+
+const documentSafeSelect = {
+  id: true,
+  title: true,
+  originalName: true,
+  mimeType: true,
+  sizeBytes: true,
+  documentType: true,
+  visibilityScope: true,
+  subject: true,
+  description: true,
+  expiresAt: true,
+  createdAt: true,
+  updatedAt: true,
+  userId: true,
+  uploadedById: true,
+} as const;
+
+type DocumentMutationData = {
+  title: string;
+  documentType: DocumentType;
+  subject: Subject | null;
+  description?: string | null;
+  localPath: string;
+  originalName: string;
+  mimeType: string;
+  sizeBytes: number;
+  visibilityScope: DocumentVisibilityScope;
+};
+
+function sanitizeDocument(document: Record<string, unknown>) {
+  const { localPath: _localPath, ...safeDocument } = document;
+  return safeDocument;
+}
+
+function optionalFormString(value: FormDataEntryValue | null): string | undefined {
+  if (typeof value !== 'string' || value.length === 0) return undefined;
+  return value;
+}
+
+function sanitizeFilenamePart(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 80) || 'document';
+}
 
 interface RouteParams {
   params: Promise<{ studentId: string }>;
@@ -31,7 +85,8 @@ interface RouteParams {
  */
 export async function GET(request: Request, { params }: RouteParams) {
   try {
-    const { studentId } = await params;
+    const parsedParams = routeParamsSchema.parse(await params);
+    const { studentId } = parsedParams;
     
     const sessionOrError = await requireRole('COACH');
     if (isErrorResponse(sessionOrError)) return sessionOrError;
@@ -80,13 +135,21 @@ export async function GET(request: Request, { params }: RouteParams) {
         },
       },
       orderBy: { createdAt: 'desc' },
+      select: documentSafeSelect,
     });
 
     return NextResponse.json({
       success: true,
-      documents,
+      documents: documents.map((document) => sanitizeDocument(document)),
     });
   } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Validation Error', message: error.errors },
+        { status: 400 }
+      );
+    }
+
     console.error('[API Coach Documents GET] Error:', serializeError(error));
     return NextResponse.json(
       { error: 'Internal Server Error', message: 'Erreur lors de la récupération' },
@@ -104,7 +167,8 @@ export async function GET(request: Request, { params }: RouteParams) {
  */
 export async function POST(request: Request, { params }: RouteParams) {
   try {
-    const { studentId } = await params;
+    const parsedParams = routeParamsSchema.parse(await params);
+    const { studentId } = parsedParams;
     
     const sessionOrError = await requireRole('COACH');
     if (isErrorResponse(sessionOrError)) return sessionOrError;
@@ -144,7 +208,7 @@ export async function POST(request: Request, { params }: RouteParams) {
 
     // Check if request is FormData (file upload) or JSON (URL)
     const contentType = request.headers.get('content-type');
-    let documentData: any;
+    let documentData: DocumentMutationData;
 
     if (contentType?.includes('multipart/form-data')) {
       // Handle file upload
@@ -158,10 +222,26 @@ export async function POST(request: Request, { params }: RouteParams) {
         );
       }
 
+      if (!ALLOWED_UPLOAD_MIME_TYPES.has(file.type) || file.size > MAX_UPLOAD_BYTES) {
+        return NextResponse.json(
+          { error: 'Bad Request', message: 'Type ou taille de fichier invalide' },
+          { status: 400 }
+        );
+      }
+
+      const validatedMeta = createDocumentSchema.parse({
+        title: optionalFormString(formData.get('title')) ?? file.name,
+        documentType: optionalFormString(formData.get('documentType')),
+        subject: optionalFormString(formData.get('subject')),
+        description: optionalFormString(formData.get('description')),
+        visibilityScope: optionalFormString(formData.get('visibilityScope')) ?? DocumentVisibilityScope.STUDENT_AND_COACH,
+        url: 'https://nexusreussite.academy/internal-upload-placeholder',
+      });
+
       // Generate a unique filename
       const timestamp = Date.now();
-      const sanitizedTitle = (formData.get('title') as string || 'document').replace(/[^a-zA-Z0-9]/g, '_');
-      const extension = file.name.split('.').pop() || 'pdf';
+      const sanitizedTitle = sanitizeFilenamePart(validatedMeta.title);
+      const extension = sanitizeFilenamePart(file.name.split('.').pop() || 'pdf');
       const filename = `${sanitizedTitle}-${timestamp}.${extension}`;
       const localPath = `/app/storage/documents/${student.userId}/${filename}`;
 
@@ -173,10 +253,11 @@ export async function POST(request: Request, { params }: RouteParams) {
       await writeFile(path.join(uploadDir, filename), buffer);
 
       documentData = {
-        title: formData.get('title') as string,
-        documentType: formData.get('documentType') as string,
-        subject: formData.get('subject') as string,
-        visibilityScope: formData.get('visibilityScope') as string,
+        title: validatedMeta.title,
+        documentType: validatedMeta.documentType,
+        subject: validatedMeta.subject ?? null,
+        description: validatedMeta.description ?? null,
+        visibilityScope: validatedMeta.visibilityScope,
         localPath,
         originalName: file.name,
         mimeType: file.type,
@@ -187,16 +268,16 @@ export async function POST(request: Request, { params }: RouteParams) {
       const body = await request.json();
       const validated = createDocumentSchema.parse(body);
 
-      // Require either url or localPath
-      if (!validated.url && !validated.localPath) {
+      // URL documents are metadata only; direct localPath is reserved for server-side uploads.
+      if (!validated.url) {
         return NextResponse.json(
-          { error: 'Bad Request', message: 'URL ou chemin local requis' },
+          { error: 'Bad Request', message: 'URL requise' },
           { status: 400 }
         );
       }
 
       // Build data ensuring localPath is always provided (required by Prisma schema)
-      const localPath = validated.localPath || validated.url || `/app/storage/documents/${student.userId}/${Date.now()}-${validated.title.replace(/[^a-zA-Z0-9]/g, '_')}`;
+      const localPath = validated.url;
       
       documentData = {
         title: validated.title,
@@ -225,12 +306,13 @@ export async function POST(request: Request, { params }: RouteParams) {
         sizeBytes: documentData.sizeBytes,
         visibilityScope: documentData.visibilityScope,
       },
+      select: documentSafeSelect,
     });
 
     return NextResponse.json({
       success: true,
       message: 'Document créé',
-      document,
+      document: sanitizeDocument(document),
     }, { status: 201 });
   } catch (error) {
     if (error instanceof z.ZodError) {

--- a/app/api/coach/students/[studentId]/eaf-preparation-report/validate/route.ts
+++ b/app/api/coach/students/[studentId]/eaf-preparation-report/validate/route.ts
@@ -9,18 +9,29 @@ import { prisma } from '@/lib/prisma';
 import { maybeCreateGeneratedReportJob } from '@/lib/reports/stage/maybeCreateGeneratedReportJob';
 import { getEafCoachReportCompletion } from '@/lib/reports/stage/completeness';
 import { logger } from '@/lib/logger';
+import { z } from 'zod';
 
 interface RouteParams {
   params: Promise<{ studentId: string }>;
 }
 
+const routeParamsSchema = z.object({
+  studentId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+}).strict();
+
+function validationFailed() {
+  return NextResponse.json({ error: 'Données invalides' }, { status: 400 });
+}
+
 export async function POST(_request: Request, { params }: RouteParams) {
   try {
-    const { studentId } = await params;
-
     const sessionOrError = await requireRole('COACH');
     if (isErrorResponse(sessionOrError)) return sessionOrError;
     const authSession = sessionOrError;
+
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
+    const { studentId } = parsedParams.data;
 
     // Verify coach assignment
     try {

--- a/app/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate/route.ts
+++ b/app/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate/route.ts
@@ -6,9 +6,19 @@ import {
 } from '@/lib/rbac/coach-student-access';
 import { processGeneratedReportJob } from '@/lib/reports/stage/processGeneratedReportJob';
 import { logger } from '@/lib/logger';
+import { z } from 'zod';
 
 interface RouteParams {
   params: Promise<{ studentId: string; reportId: string }>;
+}
+
+const routeParamsSchema = z.object({
+  studentId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+  reportId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+}).strict();
+
+function validationFailed() {
+  return NextResponse.json({ error: 'Données invalides' }, { status: 400 });
 }
 
 function projectGeneratedReport(report: Record<string, unknown>) {
@@ -25,11 +35,13 @@ function projectGeneratedReport(report: Record<string, unknown>) {
 
 export async function POST(_request: Request, { params }: RouteParams) {
   try {
-    const { studentId, reportId } = await params;
-
     const sessionOrError = await requireRole('COACH');
     if (isErrorResponse(sessionOrError)) return sessionOrError;
     const authSession = sessionOrError;
+
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return validationFailed();
+    const { studentId, reportId } = parsedParams.data;
 
     try {
       await assertCoachCanAccessStudent({ coachUserId: authSession.user.id, studentId });

--- a/app/api/coach/students/[studentId]/notes/route.ts
+++ b/app/api/coach/students/[studentId]/notes/route.ts
@@ -5,8 +5,16 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { isCoachRattachedToStudent } from '@/lib/rbac/coach-student-access';
+import { z } from 'zod';
 
 const MAX_BODY_LENGTH = 4000;
+const routeParamsSchema = z.object({
+  studentId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/),
+}).strict();
+const createNoteSchema = z.object({
+  body: z.string().trim().min(1).max(MAX_BODY_LENGTH),
+  pinned: z.boolean().optional().default(false),
+}).strict();
 
 /**
  * GET /api/coach/students/[studentId]/notes
@@ -30,10 +38,11 @@ export async function GET(
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
-    const { studentId } = await context.params;
-    if (!studentId) {
+    const parsedParams = routeParamsSchema.safeParse(await context.params);
+    if (!parsedParams.success) {
       return NextResponse.json({ error: 'studentId required' }, { status: 400 });
     }
+    const { studentId } = parsedParams.data;
 
     if (role === 'COACH') {
       const allowed = await isCoachRattachedToStudent(session.user.id, studentId);
@@ -90,10 +99,11 @@ export async function POST(
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
-    const { studentId } = await context.params;
-    if (!studentId) {
+    const parsedParams = routeParamsSchema.safeParse(await context.params);
+    if (!parsedParams.success) {
       return NextResponse.json({ error: 'studentId required' }, { status: 400 });
     }
+    const { studentId } = parsedParams.data;
 
     const allowed = await isCoachRattachedToStudent(session.user.id, studentId);
     if (!allowed) {
@@ -107,24 +117,18 @@ export async function POST(
       return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
     }
 
-    const data = payload as { body?: unknown; pinned?: unknown };
-    if (typeof data.body !== 'string' || data.body.trim().length === 0) {
-      return NextResponse.json({ error: 'body must be a non-empty string' }, { status: 400 });
+    const parsedPayload = createNoteSchema.safeParse(payload);
+    if (!parsedPayload.success) {
+      return NextResponse.json({ error: 'Invalid note payload' }, { status: 400 });
     }
-    if (data.body.length > MAX_BODY_LENGTH) {
-      return NextResponse.json(
-        { error: `body too long (max ${MAX_BODY_LENGTH} chars)` },
-        { status: 400 },
-      );
-    }
-    const pinned = typeof data.pinned === 'boolean' ? data.pinned : false;
+    const data = parsedPayload.data;
 
     const note = await prisma.coachNote.create({
       data: {
         studentId,
         coachId: session.user.id,
-        body: data.body.trim(),
-        pinned,
+        body: data.body,
+        pinned: data.pinned,
       },
       select: {
         id: true,

--- a/app/api/coach/students/[studentId]/survival-mode/route.ts
+++ b/app/api/coach/students/[studentId]/survival-mode/route.ts
@@ -6,14 +6,17 @@ import { AcademicTrack } from '@prisma/client';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { isCoachRattachedToStudent } from '@/lib/rbac/coach-student-access';
+import { z } from 'zod';
 
 const ALLOWED_ROLES = new Set(['COACH', 'ADMIN', 'ASSISTANTE']);
 const MAX_REASON_LENGTH = 1000;
-
-type SurvivalModePayload = {
-  enabled?: unknown;
-  reason?: unknown;
-};
+const survivalModeParamsSchema = z.object({
+  studentId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/),
+}).strict();
+const survivalModePayloadSchema = z.object({
+  enabled: z.boolean(),
+  reason: z.string().trim().max(MAX_REASON_LENGTH).optional().nullable(),
+}).strict();
 
 export async function POST(
   request: Request,
@@ -30,10 +33,11 @@ export async function POST(
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
-    const { studentId } = await context.params;
-    if (!studentId) {
+    const parsedParams = survivalModeParamsSchema.safeParse(await context.params);
+    if (!parsedParams.success) {
       return NextResponse.json({ error: 'studentId required' }, { status: 400 });
     }
+    const { studentId } = parsedParams.data;
 
     if (role === 'COACH') {
       const allowed = await isCoachRattachedToStudent(session.user.id, studentId);
@@ -42,21 +46,12 @@ export async function POST(
       }
     }
 
-    let payload: SurvivalModePayload;
-    try {
-      payload = (await request.json()) as SurvivalModePayload;
-    } catch {
-      return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+    const parsedPayload = survivalModePayloadSchema.safeParse(await request.json().catch(() => null));
+    if (!parsedPayload.success) {
+      return NextResponse.json({ error: 'Invalid survival mode payload' }, { status: 400 });
     }
-
-    if (typeof payload.enabled !== 'boolean') {
-      return NextResponse.json({ error: 'enabled must be a boolean' }, { status: 400 });
-    }
-
-    const reason = typeof payload.reason === 'string' ? payload.reason.trim() : null;
-    if (reason && reason.length > MAX_REASON_LENGTH) {
-      return NextResponse.json({ error: `reason too long (max ${MAX_REASON_LENGTH} chars)` }, { status: 400 });
-    }
+    const payload = parsedPayload.data;
+    const reason = payload.reason ?? null;
 
     const student = await prisma.student.findUnique({
       where: { userId: studentId },

--- a/app/api/coach/trajectory/route.ts
+++ b/app/api/coach/trajectory/route.ts
@@ -2,6 +2,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@/auth";
 import { serializeError } from '@/lib/utils/serialize-error';
+import { isCoachRattachedToStudent } from '@/lib/rbac/coach-student-access';
+import { z } from 'zod';
+
+const createTrajectorySchema = z.object({
+  studentId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/),
+  title: z.string().trim().min(1).max(160),
+  targetScore: z.coerce.number().finite().min(0).max(20).optional(),
+  horizon: z.enum(['3_MONTHS', '6_MONTHS', '12_MONTHS']),
+}).strict();
 
 export async function POST(request: NextRequest) {
   try {
@@ -10,10 +19,17 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { studentId, title, targetScore, horizon } = await request.json();
+    const parsedBody = createTrajectorySchema.safeParse(await request.json().catch(() => null));
+    if (!parsedBody.success) {
+      return NextResponse.json({ error: "Invalid trajectory payload" }, { status: 400 });
+    }
+    const { studentId, title, targetScore, horizon } = parsedBody.data;
 
-    if (!studentId || !title || !horizon) {
-      return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+    if (session.user.role === "COACH") {
+      const assigned = await isCoachRattachedToStudent(session.user.id, studentId);
+      if (!assigned) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
     }
 
     // Calculate endDate based on horizon

--- a/app/api/documents/[id]/route.ts
+++ b/app/api/documents/[id]/route.ts
@@ -4,6 +4,60 @@ import { NextRequest, NextResponse } from 'next/server';
 import { readFile } from 'fs/promises';
 import { UserRole } from '@prisma/client';
 import { serializeError } from '@/lib/utils/serialize-error';
+import { z } from 'zod';
+
+const routeParamsSchema = z.object({
+  id: z.string().min(1).max(128).regex(/^[A-Za-z0-9_-]+$/),
+});
+
+const documentDownloadSelect = {
+  id: true,
+  userId: true,
+  localPath: true,
+  mimeType: true,
+  originalName: true,
+  sizeBytes: true,
+} as const;
+
+type DocumentDownloadRecord = {
+  id: string;
+  userId: string;
+  localPath: string;
+  mimeType: string;
+  originalName: string;
+  sizeBytes: number;
+};
+
+function isStaffRole(role: string | undefined): boolean {
+  return role === UserRole.ADMIN || role === UserRole.ASSISTANTE;
+}
+
+function buildDocumentOwnershipWhere(id: string, userId: string, role: string | undefined) {
+  if (isStaffRole(role)) {
+    return { id };
+  }
+  return { id, userId };
+}
+
+function hasDocumentOwnership(document: DocumentDownloadRecord, userId: string, role: string | undefined): boolean {
+  return isStaffRole(role) || document.userId === userId;
+}
+
+function safeFilename(name: string): string {
+  return encodeURIComponent(name.replace(/[\\/\r\n"]/g, '_'));
+}
+
+function safeContentType(mimeType: string | null | undefined): string {
+  if (!mimeType) return 'application/octet-stream';
+  const allowed = new Set([
+    'application/pdf',
+    'image/jpeg',
+    'image/png',
+    'image/webp',
+    'text/plain',
+  ]);
+  return allowed.has(mimeType) ? mimeType : 'application/octet-stream';
+}
 
 export async function GET(
   request: NextRequest,
@@ -15,47 +69,43 @@ export async function GET(
       return new NextResponse('Unauthorized', { status: 401 });
     }
 
-    const { id } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) {
+      return new NextResponse('Bad Request', { status: 400 });
+    }
+    const { id } = parsedParams.data;
+    const userRole = session.user.role as UserRole | undefined;
 
-    // 1. Get Metadata
-    const document = await prisma.userDocument.findUnique({
-      where: { id },
+    // Scope the metadata query before any file-system read.
+    const document = await prisma.userDocument.findFirst({
+      where: buildDocumentOwnershipWhere(id, session.user.id, userRole),
+      select: documentDownloadSelect,
     });
 
     if (!document) {
       return new NextResponse('Document not found', { status: 404 });
     }
 
-    // 2. Strict RBAC (Owner OR Staff)
-    const userRole = session.user.role as UserRole;
-    const isOwner = document.userId === session.user.id;
-    // Allow COACH to see documents? The prompt said "Admin/Assistante or Owner".
-    // I will stick to Admin/Assistante + Owner to be strict as requested.
-    const isStaff = ([UserRole.ADMIN, UserRole.ASSISTANTE] as UserRole[]).includes(userRole);
-
-    if (!isOwner && !isStaff) {
-      return new NextResponse('Forbidden', { status: 403 });
+    if (!hasDocumentOwnership(document, session.user.id, userRole)) {
+      return new NextResponse('Document not found', { status: 404 });
     }
 
-    // 3. Read File from Secure Storage
     try {
       const fileBuffer = await readFile(document.localPath);
 
-      // 4. Return with Headers
-      // 'inline' allows viewing in browser (PDF), 'attachment' forces download.
-      // Use inline for UX, browser will handle download option.
       return new NextResponse(fileBuffer, {
         headers: {
-          'Content-Type': document.mimeType,
-          'Content-Disposition': `inline; filename="${encodeURIComponent(document.originalName)}"`,
+          'Content-Type': safeContentType(document.mimeType),
+          'Content-Disposition': `inline; filename="${safeFilename(document.originalName)}"`,
           'Content-Length': document.sizeBytes.toString(),
-          // Security headers
           'X-Content-Type-Options': 'nosniff',
         },
       });
     } catch (fsError) {
-      console.error('[File Read Error] File missing on disk:', document.localPath);
-      // Don't leak path in production response
+      const code = fsError instanceof Error && 'code' in fsError
+        ? String((fsError as NodeJS.ErrnoException).code)
+        : 'UNKNOWN';
+      console.error('[File Read Error] File content unavailable', { documentId: document.id, code });
       return new NextResponse('File content not found', { status: 404 });
     }
 

--- a/app/api/eleve/bilan-diagnostic-maths-terminale/route.ts
+++ b/app/api/eleve/bilan-diagnostic-maths-terminale/route.ts
@@ -2,11 +2,26 @@ import { NextResponse } from 'next/server';
 import { requireRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
 import { computeDiagnostics } from '@/lib/diagnostic/maths-terminale/scoring';
-import type { DiagnosticSourceData } from '@/lib/diagnostic/maths-terminale/types';
+import type { ChapterProgress, DiagnosticSourceData, OpenAnswer } from '@/lib/diagnostic/maths-terminale/types';
 import { DOMAINS } from '@/lib/diagnostic/maths-terminale/data';
 import { serializeError } from '@/lib/utils/serialize-error';
+import { z } from 'zod';
 
 const BILAN_SOURCE_VERSION = 'maths_terminale_v1';
+const chapterProgressSchema = z.object({
+  declared: z.number().int().min(0).max(5).nullable(),
+  confidence: z.number().int().min(1).max(5),
+}).strict();
+const openAnswerSchema = z.object({
+  text: z.string().max(5000),
+  status: z.string().max(200),
+}).strict();
+const diagnosticPayloadSchema = z.object({
+  progress: z.record(z.string(), chapterProgressSchema).default({}),
+  qcmAnswers: z.record(z.string(), z.coerce.number().int()).default({}),
+  openAnswers: z.record(z.string(), openAnswerSchema).default({}),
+  step: z.enum(['progress', 'qcm', 'open', 'results']).default('progress'),
+}).strict();
 
 /**
  * GET /api/eleve/bilan-diagnostic-maths-terminale
@@ -82,8 +97,14 @@ export async function POST(request: Request) {
     if (isErrorResponse(sessionOrError)) return sessionOrError;
     const authSession = sessionOrError;
 
-    const body = await request.json();
-    const { progress = {}, qcmAnswers = {}, openAnswers = {}, step = 'progress' } = body;
+    const parsedBody = diagnosticPayloadSchema.safeParse(await request.json().catch(() => null));
+    if (!parsedBody.success) {
+      return NextResponse.json({ error: 'Invalid diagnostic payload' }, { status: 400 });
+    }
+    const progress = parsedBody.data.progress as Record<string, ChapterProgress>;
+    const qcmAnswers = parsedBody.data.qcmAnswers;
+    const openAnswers = parsedBody.data.openAnswers as Record<string, OpenAnswer>;
+    const step = parsedBody.data.step;
 
     // Find the student record
     const student = await prisma.student.findUnique({

--- a/app/api/invoices/[id]/pdf/route.ts
+++ b/app/api/invoices/[id]/pdf/route.ts
@@ -3,7 +3,7 @@ import { serializeError } from '@/lib/utils/serialize-error';
  * GET /api/invoices/:id/pdf — Stream invoice PDF with RBAC + token access.
  *
  * Two access paths:
- * 1. Session-based (RBAC): ADMIN/ASSISTANTE see all, PARENT scoped by email
+ * 1. Session-based (RBAC): ADMIN sees all, PARENT scoped by child beneficiary/email
  * 2. Token-based (?token=...): signed link from email, 72h expiry
  *
  * No-leak design:

--- a/app/api/invoices/[id]/pdf/route.ts
+++ b/app/api/invoices/[id]/pdf/route.ts
@@ -16,7 +16,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { readInvoicePDF, verifyAccessToken } from '@/lib/invoice';
-import { notFoundResponse, buildInvoiceScopeWhere } from '@/lib/invoice/not-found';
+import { notFoundResponse, buildInvoiceAccessWhere } from '@/lib/invoice/not-found';
 
 /**
  * Stream a PDF response from a buffer.
@@ -68,10 +68,11 @@ export async function GET(
       return notFoundResponse();
     }
 
-    const userRole = (session.user as { role?: string }).role;
-    const userEmail = session.user.email;
-
-    const scopeWhere = buildInvoiceScopeWhere(id, userRole, userEmail);
+    const scopeWhere = await buildInvoiceAccessWhere(id, {
+      id: session.user.id,
+      role: (session.user as { role?: string }).role,
+      email: session.user.email,
+    });
     if (!scopeWhere) {
       return notFoundResponse();
     }

--- a/app/api/invoices/[id]/receipt/pdf/route.ts
+++ b/app/api/invoices/[id]/receipt/pdf/route.ts
@@ -21,7 +21,7 @@ import {
   createInvoiceEvent,
   appendInvoiceEvent,
 } from '@/lib/invoice';
-import { notFoundResponse, buildInvoiceScopeWhere } from '@/lib/invoice/not-found';
+import { notFoundResponse, buildInvoiceAccessWhere } from '@/lib/invoice/not-found';
 import type { InvoiceEvent, ReceiptData } from '@/lib/invoice';
 
 export async function GET(
@@ -35,10 +35,11 @@ export async function GET(
     }
 
     const { id } = await params;
-    const userRole = (session.user as { role?: string }).role;
-    const userEmail = session.user.email;
-
-    const scopeWhere = buildInvoiceScopeWhere(id, userRole, userEmail);
+    const scopeWhere = await buildInvoiceAccessWhere(id, {
+      id: session.user.id,
+      role: (session.user as { role?: string }).role,
+      email: session.user.email,
+    });
     if (!scopeWhere) {
       return notFoundResponse();
     }

--- a/app/api/invoices/[id]/receipt/pdf/route.ts
+++ b/app/api/invoices/[id]/receipt/pdf/route.ts
@@ -2,7 +2,7 @@ import { serializeError } from '@/lib/utils/serialize-error';
 /**
  * GET /api/invoices/:id/receipt/pdf — Stream payment receipt PDF.
  *
- * RBAC: same as invoice PDF (ADMIN/ASSISTANTE see all, PARENT scoped).
+ * RBAC: same as invoice PDF (ADMIN sees all, PARENT scoped).
  * Precondition: invoice.status === 'PAID' with paidAt + paidAmount.
  * Appends RECEIPT_RENDERED audit event on success only.
  *

--- a/app/api/lamis/teacher-report/route.ts
+++ b/app/api/lamis/teacher-report/route.ts
@@ -2,13 +2,49 @@ import { NextResponse } from "next/server";
 import { lamisExercises } from "@/src/data/lamisExercises";
 import { buildPedagogicalReport } from "@/lib/lamis/progress";
 import type { LamisAttempt } from "@/lib/lamis/types";
+import { guardRateLimitAsync } from "@/lib/rate-limit";
+import { z } from "zod";
+
+const lamisAttemptSchema = z.object({
+  exerciseId: z.string().min(1).max(120),
+  answer: z.string().max(1000),
+  isCorrect: z.boolean(),
+  attemptNumber: z.number().int().min(1).max(20),
+  timeSpentSeconds: z.number().int().min(0).max(3600),
+  usedHint1: z.boolean(),
+  usedHint2: z.boolean(),
+  viewedCorrection: z.boolean(),
+  tooFast: z.boolean(),
+  timestamp: z.string().min(1).max(80),
+}).strict();
+
+const teacherReportBodySchema = z.object({
+  attempts: z.array(lamisAttemptSchema).max(300).default([]),
+}).strict();
 
 export async function POST(request: Request) {
-  const body = await request.json().catch(() => ({}));
-  const attempts = Array.isArray(body.attempts) ? (body.attempts as LamisAttempt[]) : [];
+  const rateLimited = await guardRateLimitAsync(request, {
+    preset: "api",
+    keySuffix: "lamis-teacher-report",
+  });
+  if (rateLimited) return rateLimited;
+
+  const body = await request.json().catch(() => null);
+  const parsed = teacherReportBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Payload invalide" }, { status: 400 });
+  }
+
+  const attempts = parsed.data.attempts as LamisAttempt[];
   return NextResponse.json({ report: buildPedagogicalReport(lamisExercises, attempts) });
 }
 
-export function GET() {
+export async function GET(request: Request) {
+  const rateLimited = await guardRateLimitAsync(request, {
+    preset: "api",
+    keySuffix: "lamis-teacher-report",
+  });
+  if (rateLimited) return rateLimited;
+
   return NextResponse.json({ report: buildPedagogicalReport(lamisExercises, []) });
 }

--- a/app/api/lamis/teacher-report/route.ts
+++ b/app/api/lamis/teacher-report/route.ts
@@ -2,7 +2,9 @@ import { NextResponse } from "next/server";
 import { lamisExercises } from "@/src/data/lamisExercises";
 import { buildPedagogicalReport } from "@/lib/lamis/progress";
 import type { LamisAttempt } from "@/lib/lamis/types";
+import { isErrorResponse, requireAnyRole } from "@/lib/guards";
 import { guardRateLimitAsync } from "@/lib/rate-limit";
+import { UserRole } from "@prisma/client";
 import { z } from "zod";
 
 const lamisAttemptSchema = z.object({
@@ -23,9 +25,13 @@ const teacherReportBodySchema = z.object({
 }).strict();
 
 export async function POST(request: Request) {
+  const sessionOrError = await requireAnyRole([UserRole.ADMIN, UserRole.ASSISTANTE, UserRole.COACH]);
+  if (isErrorResponse(sessionOrError)) return sessionOrError;
+
   const rateLimited = await guardRateLimitAsync(request, {
     preset: "api",
     keySuffix: "lamis-teacher-report",
+    userId: sessionOrError.user.id,
   });
   if (rateLimited) return rateLimited;
 
@@ -40,9 +46,13 @@ export async function POST(request: Request) {
 }
 
 export async function GET(request: Request) {
+  const sessionOrError = await requireAnyRole([UserRole.ADMIN, UserRole.ASSISTANTE, UserRole.COACH]);
+  if (isErrorResponse(sessionOrError)) return sessionOrError;
+
   const rateLimited = await guardRateLimitAsync(request, {
     preset: "api",
     keySuffix: "lamis-teacher-report",
+    userId: sessionOrError.user.id,
   });
   if (rateLimited) return rateLimited;
 

--- a/app/api/npc/submissions/[submissionId]/documents/[documentId]/route.ts
+++ b/app/api/npc/submissions/[submissionId]/documents/[documentId]/route.ts
@@ -6,9 +6,23 @@ import { deleteSecureFile } from '@/lib/npc/storage';
 import { canManageSubmissionDocuments } from '@/lib/npc/access';
 import { isCorrectionDocumentType } from '@/lib/npc/document-types';
 import { serializeError } from '@/lib/utils/serialize-error';
+import { z } from 'zod';
 
 interface RouteParams {
   params: Promise<{ submissionId: string; documentId: string }>;
+}
+
+const routeParamsSchema = z.object({
+  submissionId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+  documentId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+}).strict();
+
+const patchBodySchema = z.object({
+  documentType: z.string().refine(isCorrectionDocumentType),
+}).strict();
+
+function invalidParamsResponse() {
+  return NextResponse.json({ error: 'Invalid route params' }, { status: 400 });
 }
 
 function sanitizeCopyPage(page: Record<string, unknown>) {
@@ -44,7 +58,9 @@ export async function PATCH(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { submissionId, documentId } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return invalidParamsResponse();
+    const { submissionId, documentId } = parsedParams.data;
     const submission = await prisma.copySubmission.findUnique({
       where: { id: submissionId },
       select: { id: true, studentId: true, coachId: true, pages: true },
@@ -66,15 +82,14 @@ export async function PATCH(
       return NextResponse.json({ error: 'Document not found' }, { status: 404 });
     }
 
-    const body = await request.json();
-    const { documentType } = body;
-
-    if (!documentType || !isCorrectionDocumentType(documentType)) {
+    const parsedBody = patchBodySchema.safeParse(await request.json());
+    if (!parsedBody.success) {
       return NextResponse.json(
         { error: 'Invalid document type' },
         { status: 400 }
       );
     }
+    const { documentType } = parsedBody.data;
 
     const updatedDocument = await prisma.copyPage.update({
       where: { id: document.id },
@@ -136,7 +151,9 @@ export async function DELETE(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { submissionId, documentId } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return invalidParamsResponse();
+    const { submissionId, documentId } = parsedParams.data;
     const submission = await prisma.copySubmission.findUnique({
       where: { id: submissionId },
       select: { id: true, studentId: true, coachId: true },

--- a/app/api/npc/submissions/[submissionId]/documents/route.ts
+++ b/app/api/npc/submissions/[submissionId]/documents/route.ts
@@ -14,12 +14,22 @@ import {
 import type { FileMetadata } from '@/lib/npc/storage';
 import { isCorrectionDocumentType } from '@/lib/npc/document-types';
 import { canManageSubmissionDocuments, canReadSubmission } from '@/lib/npc/access';
+import { z } from 'zod';
 
 interface RouteParams {
   params: Promise<{ submissionId: string }>;
 }
 
 const MAX_FILES_PER_SUBMISSION = 20;
+const routeParamsSchema = z.object({
+  submissionId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+}).strict();
+
+const documentTypeSchema = z.string().refine(isCorrectionDocumentType);
+
+function invalidParamsResponse() {
+  return NextResponse.json({ error: 'Invalid route params' }, { status: 400 });
+}
 
 function sanitizeCopyPage(page: Record<string, unknown>) {
   const {
@@ -92,7 +102,9 @@ export async function GET(
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const { submissionId } = await params;
+  const parsedParams = routeParamsSchema.safeParse(await params);
+  if (!parsedParams.success) return invalidParamsResponse();
+  const { submissionId } = parsedParams.data;
   const submission = await prisma.copySubmission.findUnique({
     where: { id: submissionId },
     select: {
@@ -130,7 +142,9 @@ export async function POST(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { submissionId } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return invalidParamsResponse();
+    const { submissionId } = parsedParams.data;
     const submission = await getSubmission(submissionId);
     if (!submission) {
       return NextResponse.json({ error: 'Submission not found' }, { status: 404 });
@@ -141,13 +155,14 @@ export async function POST(
     }
 
     const formData = await request.formData();
-    const documentType = formData.get('documentType') || 'STUDENT_COPY';
-    if (!isCorrectionDocumentType(documentType)) {
+    const parsedDocumentType = documentTypeSchema.safeParse(formData.get('documentType') || 'STUDENT_COPY');
+    if (!parsedDocumentType.success) {
       return NextResponse.json(
         { error: 'Invalid document type' },
         { status: 400 }
       );
     }
+    const documentType = parsedDocumentType.data;
 
     const files = formData.getAll('file').filter((value): value is File => value instanceof File);
     if (files.length === 0) {

--- a/app/api/npc/submissions/[submissionId]/generate/route.ts
+++ b/app/api/npc/submissions/[submissionId]/generate/route.ts
@@ -9,9 +9,18 @@ import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { CopySubmissionStatus, UserRole, AiJobType, AiJobStatus } from '@prisma/client';
 import { canManageSubmissionDocuments } from '@/lib/npc/access';
+import { z } from 'zod';
 
 interface RouteParams {
   params: Promise<{ submissionId: string }>;
+}
+
+const routeParamsSchema = z.object({
+  submissionId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+}).strict();
+
+function invalidParamsResponse() {
+  return NextResponse.json({ error: 'Invalid route params' }, { status: 400 });
 }
 
 async function getActor() {
@@ -37,7 +46,9 @@ export async function POST(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { submissionId } = await params;
+    const parsedParams = routeParamsSchema.safeParse(await params);
+    if (!parsedParams.success) return invalidParamsResponse();
+    const { submissionId } = parsedParams.data;
     const submission = await prisma.copySubmission.findUnique({
       where: { id: submissionId },
       include: {

--- a/app/api/npc/submissions/route.ts
+++ b/app/api/npc/submissions/route.ts
@@ -8,10 +8,23 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { Subject, GradeLevel, CopySubmissionStatus } from '@prisma/client';
+import { z } from 'zod';
 // No checkPermission import
 
-const VALID_SUBJECTS = Object.values(Subject);
-const VALID_GRADE_LEVELS = Object.values(GradeLevel);
+const safeIdSchema = z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/);
+
+const createSubmissionBodySchema = z.object({
+  studentId: safeIdSchema,
+  title: z.string().trim().min(1).max(180),
+  description: z.string().trim().max(2000).optional(),
+  subject: z.nativeEnum(Subject),
+  gradeLevel: z.nativeEnum(GradeLevel).optional(),
+}).strict();
+
+const listSubmissionsQuerySchema = z.object({
+  studentId: safeIdSchema.optional(),
+  status: z.nativeEnum(CopySubmissionStatus).optional(),
+}).strict();
 
 interface CreateSubmissionBody {
   studentId: string;
@@ -63,31 +76,11 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const body = await req.json() as CreateSubmissionBody;
-
-    // Validate required fields
-    if (!body.studentId || !body.title || !body.subject) {
-      return NextResponse.json(
-        { error: 'Missing required fields: studentId, title, subject' },
-        { status: 400 }
-      );
+    const parsedBody = createSubmissionBodySchema.safeParse(await req.json());
+    if (!parsedBody.success) {
+      return NextResponse.json({ error: 'Données invalides' }, { status: 400 });
     }
-
-    // Validate subject
-    if (!VALID_SUBJECTS.includes(body.subject)) {
-      return NextResponse.json(
-        { error: `Invalid subject. Valid: ${VALID_SUBJECTS.join(', ')}` },
-        { status: 400 }
-      );
-    }
-
-    // Validate grade level if provided
-    if (body.gradeLevel && !VALID_GRADE_LEVELS.includes(body.gradeLevel)) {
-      return NextResponse.json(
-        { error: `Invalid grade level. Valid: ${VALID_GRADE_LEVELS.join(', ')}` },
-        { status: 400 }
-      );
-    }
+    const body = parsedBody.data as CreateSubmissionBody;
 
     // Check if student exists
     const student = await prisma.student.findUnique({
@@ -194,8 +187,11 @@ export async function GET(req: NextRequest) {
     }
 
     const { searchParams } = new URL(req.url);
-    const studentId = searchParams.get('studentId');
-    const status = searchParams.get('status');
+    const parsedQuery = listSubmissionsQuerySchema.safeParse(Object.fromEntries(searchParams.entries()));
+    if (!parsedQuery.success) {
+      return NextResponse.json({ error: 'Données invalides' }, { status: 400 });
+    }
+    const { studentId, status } = parsedQuery.data;
 
     const where: Record<string, unknown> = {};
 

--- a/app/api/npc/uploads/route.ts
+++ b/app/api/npc/uploads/route.ts
@@ -11,10 +11,18 @@ import {
   FILE_VALIDATION_ERRORS,
 } from '@/lib/npc';
 import type { FileMetadata } from '@/lib/npc';
+import { z } from 'zod';
 
 // ─── Constants ───
 
 const MAX_REQUEST_SIZE = 11 * 1024 * 1024; // 11MB (slightly above file limit for overhead)
+
+const uploadMetadataSchema = z.object({
+  studentId: z.string().trim().regex(/^[A-Za-z0-9_-]{1,191}$/),
+  title: z.string().trim().min(1).max(180),
+  description: z.string().trim().max(2000).optional(),
+  subject: z.nativeEnum(Subject),
+}).strict();
 
 // ─── Auth Helper ───
 
@@ -119,18 +127,20 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // Parse multipart form data
     const formData = await request.formData();
 
-    // Extract metadata
-    const studentId = formData.get('studentId') as string;
-    const title = formData.get('title') as string;
-    const description = formData.get('description') as string | undefined;
-    const subject = formData.get('subject') as string;
+    const parsedMetadata = uploadMetadataSchema.safeParse({
+      studentId: formData.get('studentId'),
+      title: formData.get('title'),
+      description: formData.get('description') || undefined,
+      subject: formData.get('subject'),
+    });
 
-    if (!studentId || !title || !subject) {
+    if (!parsedMetadata.success) {
       return NextResponse.json(
-        { error: 'Missing required fields: studentId, title, subject' },
+        { error: 'Données invalides' },
         { status: 400 }
       );
     }
+    const { studentId, title, description, subject } = parsedMetadata.data;
 
     // Authenticate and authorize
     const authorization = await authenticateAndAuthorize(sessionUser, studentId);

--- a/app/api/parent/children/route.ts
+++ b/app/api/parent/children/route.ts
@@ -197,6 +197,9 @@ export async function POST(request: NextRequest) {
       return student;
     });
 
+    const baseUrl = process.env.NEXTAUTH_URL || 'https://nexusreussite.academy';
+    const activationUrl = `${baseUrl}/auth/activate?token=${encodeURIComponent(rawActivationToken)}`;
+
     return NextResponse.json({
       success: true,
       child: {
@@ -208,8 +211,9 @@ export async function POST(request: NextRequest) {
         school: result.school
       },
       activation: {
+        activationUrl,
         expiresAt: activationExpiry.toISOString(),
-        message: "Un token d'activation a été généré et stocké de manière sécurisée. Il n'est pas retourné par cette API."
+        message: "Lien d'activation généré pour le parent authentifié. À transmettre uniquement à l'élève concerné."
       }
     });
 

--- a/app/api/parent/children/route.ts
+++ b/app/api/parent/children/route.ts
@@ -7,6 +7,14 @@ import { NextRequest, NextResponse } from 'next/server';
 import type { CreditTransaction } from '@prisma/client';
 import { normalizeStudentLevelAndTrack } from '@/lib/utils/grade-utils';
 import crypto from 'crypto';
+import { z } from 'zod';
+
+const createChildSchema = z.object({
+  firstName: z.string().trim().min(1).max(80),
+  lastName: z.string().trim().min(1).max(80),
+  grade: z.string().trim().min(1).max(80),
+  school: z.string().trim().max(120).optional().default(''),
+}).strict();
 
 export async function GET(_request: NextRequest) {
   try {
@@ -102,21 +110,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
-    const {
-      firstName,
-      lastName,
-      grade,
-      school
-    } = body;
-
-    // Validate required fields
-    if (!firstName || !lastName || !grade) {
+    const rawBody = await request.json().catch(() => null);
+    const parsedBody = createChildSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: 'Missing required fields' },
+        { error: 'Invalid child payload' },
         { status: 400 }
       );
     }
+    const { firstName, lastName, grade, school } = parsedBody.data;
 
     // Generate email in the same format as bilan-gratuit
     const email = `${firstName.toLowerCase()}.${lastName.toLowerCase()}@nexus-student.local`;
@@ -206,9 +208,8 @@ export async function POST(request: NextRequest) {
         school: result.school
       },
       activation: {
-        token: rawActivationToken,
         expiresAt: activationExpiry.toISOString(),
-        message: "Ce token permet à l'élève d'activer son compte et de choisir son propre mot de passe. Partagez-le de manière sécurisée."
+        message: "Un token d'activation a été généré et stocké de manière sécurisée. Il n'est pas retourné par cette API."
       }
     });
 

--- a/app/api/parent/subscription-requests/route.ts
+++ b/app/api/parent/subscription-requests/route.ts
@@ -5,8 +5,21 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
 import { getAriaAddonCatalogItem, getOperationalSubscriptionPlan } from '@/lib/operational-catalog';
+import { z } from 'zod';
 
 const ALLOWED_REQUEST_TYPES = ['PLAN_CHANGE', 'ARIA_ADDON'] as const;
+
+const idSchema = z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/);
+const subscriptionRequestBodySchema = z.object({
+  studentId: idSchema,
+  requestType: z.enum(ALLOWED_REQUEST_TYPES),
+  planName: z.string().trim().min(1).max(120).optional().nullable(),
+  reason: z.string().trim().max(1000).optional(),
+}).strict();
+
+const subscriptionRequestQuerySchema = z.object({
+  studentId: idSchema,
+}).strict();
 
 export async function POST(request: NextRequest) {
   try {
@@ -19,28 +32,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = (await request.json()) as {
-      studentId?: string;
-      requestType?: 'PLAN_CHANGE' | 'ARIA_ADDON' | 'INVOICE_DETAILS';
-      planName?: string | null;
-      monthlyPrice?: number;
-      reason?: string;
-    };
-    const { studentId, requestType, planName, reason } = body;
-
-    if (!studentId || !requestType) {
+    const rawBody = await request.json().catch(() => null);
+    const parsedBody = subscriptionRequestBodySchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: 'Missing required fields' },
+        { error: 'Invalid subscription request payload' },
         { status: 400 }
       );
     }
-
-    if (!ALLOWED_REQUEST_TYPES.includes(requestType as (typeof ALLOWED_REQUEST_TYPES)[number])) {
-      return NextResponse.json(
-        { error: 'Type de demande invalide' },
-        { status: 400 }
-      );
-    }
+    const { studentId, requestType, planName, reason } = parsedBody.data;
 
     let safePlanName = planName || null;
     let safeMonthlyPrice = 0;
@@ -179,14 +179,16 @@ export async function GET(request: NextRequest) {
     }
 
     const { searchParams } = new URL(request.url);
-    const studentId = searchParams.get('studentId');
-
-    if (!studentId) {
+    const parsedQuery = subscriptionRequestQuerySchema.safeParse({
+      studentId: searchParams.get('studentId') ?? undefined,
+    });
+    if (!parsedQuery.success) {
       return NextResponse.json(
         { error: 'Student ID is required' },
         { status: 400 }
       );
     }
+    const { studentId } = parsedQuery.data;
 
     // Verify student belongs to parent
     const userId = session.user.id;

--- a/app/api/parent/subscriptions/route.ts
+++ b/app/api/parent/subscriptions/route.ts
@@ -5,6 +5,12 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
 import { getOperationalSubscriptionPlan } from '@/lib/operational-catalog';
+import { z } from 'zod';
+
+const parentSubscriptionRequestSchema = z.object({
+  studentId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/),
+  planName: z.string().trim().min(1).max(120),
+}).strict();
 
 export async function GET(request: NextRequest) {
   try {
@@ -103,20 +109,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = (await request.json()) as {
-      studentId?: string;
-      planName?: string;
-      monthlyPrice?: number;
-      creditsPerMonth?: number;
-    };
-    const { studentId, planName } = body;
-
-    if (!studentId || !planName) {
+    const rawBody = await request.json().catch(() => null);
+    const parsedBody = parentSubscriptionRequestSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: 'Missing required fields: studentId, planName' },
+        { error: 'Invalid subscription payload' },
         { status: 400 }
       );
     }
+    const { studentId, planName } = parsedBody.data;
 
     const plan = getOperationalSubscriptionPlan(planName);
     if (!plan) {

--- a/app/api/programme/maths-1ere-stmg/stage-progress/route.ts
+++ b/app/api/programme/maths-1ere-stmg/stage-progress/route.ts
@@ -4,22 +4,26 @@ import type { Prisma } from '@prisma/client';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { serializeError } from '@/lib/utils/serialize-error';
+import { z } from 'zod';
 
 type JsonRecord = Record<string, unknown>;
+
+const stageProgressSchema = z.object({
+  updatedAt: z.string().trim().min(1).max(80),
+  diagnosticAnswers: z.record(z.string(), z.unknown()),
+  profile: z.record(z.string(), z.unknown()),
+  validatedNotions: z.record(z.string(), z.unknown()),
+  automatismHistory: z.array(z.unknown()).max(500),
+  settings: z.record(z.string(), z.unknown()),
+}).strict();
 
 function asRecord(value: unknown): JsonRecord {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonRecord : {};
 }
 
 function parseStageState(raw: unknown): JsonRecord | null {
-  const input = asRecord(raw);
-  if (typeof input.updatedAt !== 'string') return null;
-  if (!asRecord(input.diagnosticAnswers)) return null;
-  if (!asRecord(input.profile)) return null;
-  if (!asRecord(input.validatedNotions)) return null;
-  if (!Array.isArray(input.automatismHistory)) return null;
-  if (!asRecord(input.settings)) return null;
-  return input;
+  const parsed = stageProgressSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
 }
 
 const whereStmgPremiere = (userId: string) => ({
@@ -32,11 +36,10 @@ const whereStmgPremiere = (userId: string) => ({
 
 export async function GET() {
   const session = await auth();
-  const user = session?.user as { id?: string } | undefined;
-  if (!user?.id) {
+  if (!session?.user?.id || session.user.role !== 'ELEVE') {
     return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
   }
-  const userId = user.id;
+  const userId = session.user.id;
 
   try {
     const progress = await prisma.mathsProgress.findUnique({
@@ -53,11 +56,10 @@ export async function GET() {
 
 export async function POST(request: Request) {
   const session = await auth();
-  const user = session?.user as { id?: string } | undefined;
-  if (!user?.id) {
+  if (!session?.user?.id || session.user.role !== 'ELEVE') {
     return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
   }
-  const userId = user.id;
+  const userId = session.user.id;
 
   let body: unknown = null;
   try {

--- a/app/api/sessions/cancel/route.ts
+++ b/app/api/sessions/cancel/route.ts
@@ -6,7 +6,7 @@ import { NextRequest } from 'next/server';
 import { SessionStatus } from '@prisma/client';
 import { requireAnyRole, isErrorResponse } from '@/lib/guards';
 import { cancelSessionSchema } from '@/lib/validation';
-import { parseBody, assertExists } from '@/lib/api/helpers';
+import { safeJsonParse, assertExists } from '@/lib/api/helpers';
 import { successResponse, handleApiError, ApiError } from '@/lib/api/errors';
 import { RateLimitPresets } from '@/lib/middleware/rateLimit';
 import { createLogger } from '@/lib/middleware/logger';
@@ -37,7 +37,11 @@ export async function POST(request: NextRequest) {
     logger.info('Cancelling session');
 
     // Parse and validate request body
-    const { sessionId, reason } = await parseBody(request, cancelSessionSchema);
+    const parsedBody = cancelSessionSchema.strict().safeParse(await safeJsonParse(request));
+    if (!parsedBody.success) {
+      throw ApiError.badRequest('Validation failed');
+    }
+    const { sessionId, reason } = parsedBody.data;
 
     // Fetch session
     const sessionToCancel = await prisma.sessionBooking.findUnique({

--- a/app/api/sessions/video/route.ts
+++ b/app/api/sessions/video/route.ts
@@ -3,22 +3,47 @@ export const dynamic = 'force-dynamic';
 
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
 import { SessionStatus } from '@prisma/client';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const videoSessionActionSchema = z.object({
+  sessionId: z.string().min(1).max(128),
+  action: z.enum(['JOIN', 'LEAVE']),
+}).strict();
+
+function safeErrorSummary(error: unknown) {
+  const serialized = serializeError(error);
+  if (serialized && typeof serialized === 'object' && !Array.isArray(serialized)) {
+    return {
+      name: typeof serialized.name === 'string' ? serialized.name : 'Error',
+      message: typeof serialized.message === 'string' ? serialized.message : 'unknown',
+    };
+  }
+  return { name: 'Error', message: String(serialized) };
+}
 
 export async function POST(request: NextRequest) {
   try {
+    const blocked = await guardRateLimitAsync(request, {
+      preset: 'api',
+      keySuffix: 'session-video',
+    });
+    if (blocked) return blocked;
+
     const session = await auth();
 
     if (!session?.user) {
       return NextResponse.json({ error: 'Non autorisé' }, { status: 401 });
     }
 
-    const { sessionId, action } = await request.json();
-
-    if (!sessionId || !action) {
+    const body = await request.json().catch(() => null);
+    const parsedBody = videoSessionActionSchema.safeParse(body);
+    if (!parsedBody.success) {
       return NextResponse.json({ error: 'Paramètres manquants' }, { status: 400 });
     }
+    const { sessionId, action } = parsedBody.data;
 
     // Vérifier que la session existe et que l'utilisateur y a accès (SessionBooking canonique)
     const bookingSession = await prisma.sessionBooking.findFirst({
@@ -30,10 +55,19 @@ export async function POST(request: NextRequest) {
           { parentId: session.user.id }
         ]
       },
-      include: {
-        student: true,
-        coach: true,
-        parent: true
+      select: {
+        id: true,
+        studentId: true,
+        coachId: true,
+        parentId: true,
+        scheduledDate: true,
+        startTime: true,
+        duration: true,
+        status: true,
+        subject: true,
+        student: { select: { firstName: true, lastName: true } },
+        coach: { select: { firstName: true, lastName: true } },
+        parent: { select: { firstName: true, lastName: true } },
       }
     });
 
@@ -104,7 +138,7 @@ export async function POST(request: NextRequest) {
     }
 
   } catch (error) {
-    console.error('Erreur lors de la gestion de la session vidéo:', serializeError(error));
+    console.error('Erreur lors de la gestion de la session vidéo:', safeErrorSummary(error));
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/app/api/stages/[stageSlug]/inscrire/route.ts
+++ b/app/api/stages/[stageSlug]/inscrire/route.ts
@@ -7,12 +7,21 @@ import { telegramSendMessage } from '@/lib/telegram/client';
 import { computeReservationStatus } from '@/lib/stages/capacity';
 import { publicStageInscriptionSchema } from '@/lib/stages/inscription-schema';
 import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { z } from 'zod';
+
+const stageInscriptionParamsSchema = z.object({
+  stageSlug: z.string().trim().min(1).max(120).regex(/^[a-z0-9][a-z0-9-]*$/),
+}).strict();
 
 export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ stageSlug: string }> }
 ) {
-  const { stageSlug } = await params;
+  const parsedParams = stageInscriptionParamsSchema.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: 'Paramètres de stage invalides' }, { status: 400 });
+  }
+  const { stageSlug } = parsedParams.data;
 
   const blocked = await guardRateLimitAsync(req, { preset: 'api', keySuffix: `stage-inscrire:${stageSlug}` });
   if (blocked) return blocked;
@@ -40,6 +49,8 @@ export async function POST(
     parentEmail,
     parentPhone,
     notes,
+    stageTermsAccepted,
+    dataProcessingAccepted,
   } = parsed.data;
 
   try {
@@ -58,7 +69,7 @@ export async function POST(
     });
     if (existing) {
       return NextResponse.json(
-        { error: 'Une inscription existe déjà pour cet email sur ce stage.', reservationId: existing.id },
+        { error: 'Une inscription existe déjà pour cet email sur ce stage.' },
         { status: 409 }
       );
     }
@@ -77,9 +88,11 @@ export async function POST(
       notes?.trim(),
       parentEmail ? `Email parent: ${parentEmail}` : null,
       parentPhone ? `Téléphone parent: ${parentPhone}` : null,
+      stageTermsAccepted ? 'Modalités stage acceptées: oui' : null,
+      dataProcessingAccepted ? 'Consentement données: oui' : null,
     ].filter(Boolean).join('\n');
 
-    const reservation = await prisma.stageReservation.create({
+    await prisma.stageReservation.create({
       data: {
         stageId: stage.id,
         email,

--- a/app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts
+++ b/app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts
@@ -9,6 +9,12 @@ import { sendMail } from '@/lib/email/mailer';
 import { GradeLevel, AcademicTrack } from '@prisma/client';
 import { normalizeGradeLevel, getDefaultTrackForLevel, normalizeStudentLevelAndTrack } from '@/lib/utils/grade-utils';
 import crypto from 'crypto';
+import { z } from 'zod';
+
+const confirmReservationParamsSchema = z.object({
+  stageSlug: z.string().trim().min(1).max(120).regex(/^[a-z0-9][a-z0-9-]*$/),
+  reservationId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/),
+}).strict();
 
 export async function POST(
   req: NextRequest,
@@ -17,7 +23,11 @@ export async function POST(
   const sessionOrError = await requireAnyRole(['ADMIN', 'ASSISTANTE']);
   if (sessionOrError instanceof NextResponse) return sessionOrError;
 
-  const { stageSlug, reservationId } = await params;
+  const parsedParams = confirmReservationParamsSchema.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: 'Paramètres de réservation invalides' }, { status: 400 });
+  }
+  const { stageSlug, reservationId } = parsedParams.data;
 
   try {
     const reservation = await prisma.stageReservation.findFirst({

--- a/app/api/stages/[stageSlug]/route.ts
+++ b/app/api/stages/[stageSlug]/route.ts
@@ -1,14 +1,23 @@
 export const dynamic = 'force-dynamic';
 
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { getPublicStageBySlug } from '@/lib/stages/public';
+
+const paramsSchema = z.object({
+  stageSlug: z.string().min(1).max(160).regex(/^[a-z0-9-]+$/i),
+});
 
 export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ stageSlug: string }> }
 ) {
-  const { stageSlug } = await params;
+  const parsedParams = paramsSchema.safeParse(await params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: 'Paramètres invalides' }, { status: 400 });
+  }
+  const { stageSlug } = parsedParams.data;
 
   try {
     const stage = await getPublicStageBySlug(stageSlug);

--- a/app/api/student/activate/route.ts
+++ b/app/api/student/activate/route.ts
@@ -1,4 +1,3 @@
-import { serializeError } from '@/lib/utils/serialize-error';
 /**
  * POST /api/student/activate
  *
@@ -20,15 +19,22 @@ import {
   completeStudentActivation,
   verifyActivationToken,
 } from '@/lib/services/student-activation.service';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
 import { z } from 'zod';
 
 const setPasswordSchema = z.object({
   token: z.string().min(1, 'Token requis'),
   password: z.string().min(8, 'Le mot de passe doit contenir au moins 8 caractères'),
-});
+}).strict();
 
 export async function GET(request: NextRequest) {
   try {
+    const rateLimited = await guardRateLimitAsync(request, {
+      preset: 'auth',
+      keySuffix: 'student-activate',
+    });
+    if (rateLimited) return rateLimited;
+
     const { searchParams } = new URL(request.url);
     const token = searchParams.get('token');
 
@@ -42,7 +48,7 @@ export async function GET(request: NextRequest) {
     const result = await verifyActivationToken(token);
     return NextResponse.json(result);
   } catch (error) {
-    console.error('[API] verify activation token error:', serializeError(error));
+    console.error('[API] verify activation token error', error instanceof Error ? error.name : 'unknown');
     return NextResponse.json(
       { valid: false, error: 'Erreur interne' },
       { status: 500 }
@@ -52,12 +58,18 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
+    const rateLimited = await guardRateLimitAsync(request, {
+      preset: 'auth',
+      keySuffix: 'student-activate',
+    });
+    if (rateLimited) return rateLimited;
+
     const body = await request.json();
     const parsed = setPasswordSchema.safeParse(body);
 
     if (!parsed.success) {
       return NextResponse.json(
-        { error: 'Données invalides', details: parsed.error.flatten().fieldErrors },
+        { error: 'Données invalides' },
         { status: 400 }
       );
     }
@@ -80,7 +92,7 @@ export async function POST(request: NextRequest) {
       message: 'Compte activé avec succès ! Vous pouvez maintenant vous connecter.',
     });
   } catch (error) {
-    console.error('[API] complete activation error:', serializeError(error));
+    console.error('[API] complete activation error', error instanceof Error ? error.name : 'unknown');
     return NextResponse.json(
       { error: 'Erreur interne du serveur' },
       { status: 500 }

--- a/app/api/student/automatismes/attempts/route.ts
+++ b/app/api/student/automatismes/attempts/route.ts
@@ -4,6 +4,13 @@ import { auth } from "@/auth";
 import { PREMIERE_EDS_SIMULATIONS } from "@/data/automatismes/premiere-eds/simulations";
 import { calculateAutomatismeScore } from "@/lib/automatismes/scoring";
 import { serializeError } from '@/lib/utils/serialize-error';
+import { z } from 'zod';
+
+const attemptSchema = z.object({
+  seriesId: z.string().trim().min(1).max(80),
+  answers: z.record(z.string().trim().min(1).max(80), z.string().trim().min(1).max(80)),
+  durationSeconds: z.coerce.number().finite().nonnegative().max(24 * 60 * 60).default(0),
+}).strict();
 
 export async function POST(request: NextRequest) {
   try {
@@ -13,15 +20,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const body = await request.json();
-    const { seriesId, answers, durationSeconds } = body;
-
-    if (!seriesId || !answers) {
+    const rawBody = await request.json().catch(() => null);
+    const parsedBody = attemptSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: "Missing required fields" },
+        { error: "Invalid attempt payload" },
         { status: 400 }
       );
     }
+    const { seriesId, answers, durationSeconds } = parsedBody.data;
 
     const series = PREMIERE_EDS_SIMULATIONS.find(s => s.id === seriesId);
     if (!series) {

--- a/app/api/student/automatismes/check-answer/route.ts
+++ b/app/api/student/automatismes/check-answer/route.ts
@@ -2,6 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { PREMIERE_EDS_SIMULATIONS } from "@/data/automatismes/premiere-eds/simulations";
 import { serializeError } from '@/lib/utils/serialize-error';
+import { z } from 'zod';
+
+const checkAnswerSchema = z.object({
+  seriesId: z.string().trim().min(1).max(80),
+  questionId: z.string().trim().min(1).max(80),
+  selectedChoiceId: z.string().trim().min(1).max(80),
+}).strict();
 
 /**
  * POST /api/student/automatismes/check-answer
@@ -20,15 +27,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const body = await request.json();
-    const { seriesId, questionId, selectedChoiceId } = body;
-
-    if (!seriesId || !questionId || !selectedChoiceId) {
+    const rawBody = await request.json().catch(() => null);
+    const parsedBody = checkAnswerSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: "Missing required fields: seriesId, questionId, selectedChoiceId" },
+        { error: "Invalid answer payload" },
         { status: 400 }
       );
     }
+    const { seriesId, questionId, selectedChoiceId } = parsedBody.data;
 
     const series = PREMIERE_EDS_SIMULATIONS.find((s) => s.id === seriesId);
     if (!series) {

--- a/app/api/student/automatismes/series/[id]/route.ts
+++ b/app/api/student/automatismes/series/[id]/route.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { PREMIERE_EDS_SIMULATIONS } from "@/data/automatismes/premiere-eds/simulations";
 import { serializeError } from '@/lib/utils/serialize-error';
+import { z } from "zod";
+
+const paramsSchema = z.object({
+  id: z.string().min(1).max(120).regex(/^[a-z0-9-]+$/i),
+});
 
 export async function GET(
   request: NextRequest,
@@ -13,7 +18,11 @@ export async function GET(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { id } = await params;
+    const parsedParams = paramsSchema.safeParse(await params);
+    if (!parsedParams.success) {
+      return NextResponse.json({ error: "Bad Request" }, { status: 400 });
+    }
+    const { id } = parsedParams.data;
     const series = PREMIERE_EDS_SIMULATIONS.find(s => s.id === id);
 
     if (!series) {

--- a/app/api/student/documents/[id]/download/route.ts
+++ b/app/api/student/documents/[id]/download/route.ts
@@ -49,7 +49,10 @@ export async function GET(
       },
     });
   } catch (err) {
-    console.error('[documents/download] file read failed', { id, err });
+    const code = err instanceof Error && 'code' in err
+      ? String((err as NodeJS.ErrnoException).code)
+      : 'UNKNOWN';
+    console.error('[documents/download] file read failed', { documentId: id, code });
     return NextResponse.json({ error: 'File unavailable' }, { status: 500 });
   }
 }

--- a/app/api/student/nexus-index/route.ts
+++ b/app/api/student/nexus-index/route.ts
@@ -5,6 +5,11 @@ import { auth } from '@/auth';
 import { computeNexusIndex } from '@/lib/nexus-index';
 import { resolveStudentScope } from '@/lib/scopes';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const nexusIndexQuerySchema = z.object({
+  studentId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/).optional(),
+}).strict();
 
 /**
  * GET /api/student/nexus-index?studentId=...
@@ -26,7 +31,8 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const { role, id: userId } = session.user;
+    const role = session.user.role;
+    const userId = session.user.id;
 
     // Only students, parents, admin, and assistants can access
     if (!['ELEVE', 'PARENT', 'ADMIN', 'ASSISTANTE'].includes(role)) {
@@ -37,7 +43,13 @@ export async function GET(request: NextRequest) {
     }
 
     // Extract optional studentId from query params
-    const studentId = request.nextUrl.searchParams.get('studentId') || undefined;
+    const parsedQuery = nexusIndexQuerySchema.safeParse({
+      studentId: request.nextUrl.searchParams.get('studentId') || undefined,
+    });
+    if (!parsedQuery.success) {
+      return NextResponse.json({ error: 'Paramètres invalides' }, { status: 400 });
+    }
+    const { studentId } = parsedQuery.data;
 
     const scope = await resolveStudentScope(
       { id: userId, role },

--- a/app/api/student/survival/phrases/[phraseId]/copied/route.ts
+++ b/app/api/student/survival/phrases/[phraseId]/copied/route.ts
@@ -6,8 +6,12 @@ import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { getPhraseMagique } from '@/lib/survival/phrases';
 import { DEFAULT_EXAM_DATE, snapshotFromStoredProgress, toPrismaSurvivalData } from '@/lib/survival/progress';
+import { z } from 'zod';
 
 const lastCopyByUserAndPhrase = new Map<string, number>();
+const copiedParamsSchema = z.object({
+  phraseId: z.string().trim().min(1).max(80).regex(/^phrase_[0-9]+$/),
+}).strict();
 
 export async function POST(
   _request: Request,
@@ -19,7 +23,11 @@ export async function POST(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { phraseId } = await context.params;
+    const parsedParams = copiedParamsSchema.safeParse(await context.params);
+    if (!parsedParams.success) {
+      return NextResponse.json({ error: 'Invalid phrase' }, { status: 400 });
+    }
+    const { phraseId } = parsedParams.data;
     const phrase = getPhraseMagique(phraseId);
     if (!phrase) {
       return NextResponse.json({ error: 'Unknown phrase' }, { status: 404 });

--- a/app/api/student/survival/progress/route.ts
+++ b/app/api/student/survival/progress/route.ts
@@ -6,6 +6,18 @@ import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { DEFAULT_EXAM_DATE, normalizeSurvivalSnapshot, snapshotFromStoredProgress, toPrismaSurvivalData } from '@/lib/survival/progress';
 import type { SurvivalState } from '@/lib/survival/types';
+import { z } from 'zod';
+
+const survivalStateSchema = z.enum(['ACQUIS', 'REVOIR', 'PAS_VU']);
+const survivalProgressPayloadSchema = z.object({
+  reflexesState: z.record(z.string().trim().min(1).max(80), survivalStateSchema).optional(),
+  phrasesState: z.record(z.string().trim().min(1).max(80), z.coerce.number().int().min(0).max(10_000)).optional(),
+  rituals: z.array(z.object({
+    date: z.string().trim().min(1).max(40),
+    taskId: z.string().trim().min(1).max(120),
+    completed: z.boolean(),
+  }).strict()).max(500).optional(),
+}).strict();
 
 async function getCurrentSurvivalStudent() {
   const session = await auth();
@@ -61,15 +73,16 @@ export async function POST(request: Request) {
     const current = await getCurrentSurvivalStudent();
     if ('error' in current) return current.error;
 
-    const payload = await request.json().catch(() => null) as Partial<{
+    const rawPayload = await request.json().catch(() => null);
+    const parsedPayload = survivalProgressPayloadSchema.safeParse(rawPayload);
+    if (!parsedPayload.success) {
+      return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+    }
+    const payload = parsedPayload.data as Partial<{
       reflexesState: Record<string, SurvivalState>;
       phrasesState: Record<string, number>;
       rituals: Array<{ date: string; taskId: string; completed: boolean }>;
-    }> | null;
-
-    if (!payload || typeof payload !== 'object') {
-      return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
-    }
+    }>;
 
     const currentSnapshot = snapshotFromStoredProgress(current.student.survivalProgress);
     const nextSnapshot = normalizeSurvivalSnapshot({

--- a/app/api/student/survival/qcm/attempt/route.ts
+++ b/app/api/student/survival/qcm/attempt/route.ts
@@ -6,6 +6,13 @@ import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { DEFAULT_EXAM_DATE, snapshotFromStoredProgress, toPrismaSurvivalData } from '@/lib/survival/progress';
 import { QCM_BANK } from '@/lib/survival/qcm-bank';
+import { z } from 'zod';
+
+const qcmAttemptSchema = z.object({
+  itemId: z.string().trim().min(1).max(80),
+  givenAnswer: z.string().trim().min(1).max(20),
+  timeSpentSec: z.coerce.number().finite().nonnegative().max(24 * 60 * 60).optional(),
+}).strict();
 
 export async function POST(request: Request) {
   try {
@@ -14,14 +21,15 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const payload = await request.json().catch(() => null) as {
-      itemId?: string;
-      givenAnswer?: string;
-      timeSpentSec?: number;
-    } | null;
+    const parsedPayload = qcmAttemptSchema.safeParse(await request.json().catch(() => null));
 
-    const question = QCM_BANK.find((item) => item.id === payload?.itemId);
-    if (!question || typeof payload?.givenAnswer !== 'string') {
+    if (!parsedPayload.success) {
+      return NextResponse.json({ error: 'Invalid QCM attempt payload' }, { status: 400 });
+    }
+    const payload = parsedPayload.data;
+
+    const question = QCM_BANK.find((item) => item.id === payload.itemId);
+    if (!question) {
       return NextResponse.json({ error: 'Invalid QCM attempt payload' }, { status: 400 });
     }
 

--- a/app/api/student/survival/reflexes/[reflexId]/attempt/route.ts
+++ b/app/api/student/survival/reflexes/[reflexId]/attempt/route.ts
@@ -6,6 +6,16 @@ import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { getReflex } from '@/lib/survival/reflex-data';
 import { DEFAULT_EXAM_DATE, snapshotFromStoredProgress, toPrismaSurvivalData } from '@/lib/survival/progress';
+import { z } from 'zod';
+
+const reflexParamsSchema = z.object({
+  reflexId: z.string().trim().min(1).max(80).regex(/^reflex_[0-9]+$/),
+}).strict();
+const reflexAttemptSchema = z.object({
+  itemId: z.string().trim().min(1).max(80),
+  givenAnswer: z.string().trim().min(1).max(200),
+  timeSpentSec: z.coerce.number().finite().nonnegative().max(24 * 60 * 60).optional(),
+}).strict();
 
 export async function POST(
   request: Request,
@@ -17,21 +27,21 @@ export async function POST(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { reflexId } = await context.params;
+    const parsedParams = reflexParamsSchema.safeParse(await context.params);
+    if (!parsedParams.success) {
+      return NextResponse.json({ error: 'Invalid reflex' }, { status: 400 });
+    }
+    const { reflexId } = parsedParams.data;
     const reflex = getReflex(reflexId);
     if (!reflex) {
       return NextResponse.json({ error: 'Unknown reflex' }, { status: 404 });
     }
 
-    const payload = await request.json().catch(() => null) as {
-      itemId?: string;
-      givenAnswer?: string;
-      timeSpentSec?: number;
-    } | null;
-
-    if (!payload?.itemId || typeof payload.givenAnswer !== 'string') {
+    const parsedPayload = reflexAttemptSchema.safeParse(await request.json().catch(() => null));
+    if (!parsedPayload.success) {
       return NextResponse.json({ error: 'Invalid attempt payload' }, { status: 400 });
     }
+    const payload = parsedPayload.data;
 
     const student = await prisma.student.findUnique({
       where: { userId: session.user.id },

--- a/app/api/student/trajectory/route.ts
+++ b/app/api/student/trajectory/route.ts
@@ -5,6 +5,11 @@ import { auth } from '@/auth';
 import { resolveStudentScope } from '@/lib/scopes';
 import { getActiveTrajectory } from '@/lib/trajectory';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const trajectoryQuerySchema = z.object({
+  studentId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9_-]+$/).optional(),
+}).strict();
 
 /**
  * GET /api/student/trajectory?studentId=...
@@ -30,7 +35,8 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const { role, id: userId } = session.user;
+    const role = session.user.role;
+    const userId = session.user.id;
 
     if (!['ELEVE', 'PARENT', 'ADMIN', 'ASSISTANTE'].includes(role)) {
       return NextResponse.json(
@@ -39,7 +45,13 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const studentId = request.nextUrl.searchParams.get('studentId') || undefined;
+    const parsedQuery = trajectoryQuerySchema.safeParse({
+      studentId: request.nextUrl.searchParams.get('studentId') || undefined,
+    });
+    if (!parsedQuery.success) {
+      return NextResponse.json({ error: 'Paramètres invalides' }, { status: 400 });
+    }
+    const { studentId } = parsedQuery.data;
 
     const scope = await resolveStudentScope(
       { id: userId, role },

--- a/app/dashboard/parent/add-child-dialog.tsx
+++ b/app/dashboard/parent/add-child-dialog.tsx
@@ -44,8 +44,15 @@ export default function AddChildDialog({ onChildAdded }: AddChildDialogProps) {
         body: JSON.stringify(formData),
       });
 
+      const responseData = await response.json().catch(() => null);
+
       if (response.ok) {
-        alert("Enfant ajouté avec succès!");
+        const activationUrl = responseData?.activation?.activationUrl;
+        alert(
+          activationUrl
+            ? `Enfant ajouté avec succès. Transmettez ce lien d'activation uniquement à l'élève concerné : ${activationUrl}`
+            : "Enfant ajouté avec succès!"
+        );
         setOpen(false);
         setFormData({
           firstName: "",
@@ -55,8 +62,7 @@ export default function AddChildDialog({ onChildAdded }: AddChildDialogProps) {
         });
         onChildAdded();
       } else {
-        const errorData = await response.json();
-        alert(`Erreur: ${errorData.error}`);
+        alert(`Erreur: ${responseData?.error ?? "Impossible d'ajouter l'enfant"}`);
       }
     } catch {
       alert('Une erreur est survenue lors de l\'ajout de l\'enfant');
@@ -84,7 +90,7 @@ export default function AddChildDialog({ onChildAdded }: AddChildDialogProps) {
             L'email sera automatiquement généré au format : prénom.nom@nexus-student.local
           </p>
           <p className="text-sm text-neutral-400">
-            L'enfant utilisera le même mot de passe que vous pour se connecter.
+            Un lien d'activation élève sera généré après la création.
           </p>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/components/stages/StageInscriptionForm.tsx
+++ b/components/stages/StageInscriptionForm.tsx
@@ -13,7 +13,7 @@ const confirmationSchema = publicStageInscriptionSchema.extend({
   dataProcessingAccepted: z.literal(true),
 });
 
-type ConfirmationData = PublicStageInscriptionInput & {
+type ConfirmationData = Omit<PublicStageInscriptionInput, 'stageTermsAccepted' | 'dataProcessingAccepted'> & {
   stageTermsAccepted: boolean;
   dataProcessingAccepted: boolean;
 };
@@ -139,6 +139,8 @@ export function StageInscriptionForm({ stage }: { stage: StageSummary }) {
           parentEmail: formData.parentEmail,
           parentPhone: formData.parentPhone,
           notes: formData.notes,
+          stageTermsAccepted: formData.stageTermsAccepted,
+          dataProcessingAccepted: formData.dataProcessingAccepted,
         }),
       });
 

--- a/docs/go-live/api-security-matrix.full.md
+++ b/docs/go-live/api-security-matrix.full.md
@@ -1,7 +1,7 @@
 # Annexe matrice API sécurité complète
 
 Source : `docs/security/API_GUARD_INVENTORY.md`.
-Généré le : 2026-07-06T20:47:11.266Z.
+Généré le : 2026-07-07T07:03:08.659Z.
 
 Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Zod détecté` et `Ownership requis` sont des indices de pilotage. `À vérifier` signifie qu’aucune preuve suffisante n’a été établie dans ce lot.
 
@@ -10,18 +10,20 @@ Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Z
 | Priorité | Nombre |
 | --- | ---: |
 | P0 | 0 |
-| P1 | 6 |
-| P2 | 144 |
-| OK | 28 |
-| Total | 178 |
+| P1 | 8 |
+| P2 | 141 |
+| OK | 27 |
+| Total | 176 |
 
 ## Top 20 à corriger en priorité (P1)
 
 | Priorité | Route | Domaine | Risque dominant | Action Lot suivant |
 | --- | --- | --- | --- | --- |
+| P1 | `/api/payments/clictopay/init` | Paiement | Facture/paiement | Durcir avant bêta élargie |
 | P1 | `/api/payments/clictopay/webhook` | Paiement | Facture/paiement | Durcir avant bêta élargie |
 | P1 | `/api/assessments/submit` | Bilans/assessments | Données pédagogiques mineur | Durcir avant bêta élargie |
 | P1 | `/api/bilan-gratuit` | Bilans/assessments | Données pédagogiques mineur | Durcir avant bêta élargie |
+| P1 | `/api/bilan-gratuit/dismiss` | Bilans/assessments | Données pédagogiques mineur | Durcir avant bêta élargie |
 | P1 | `/api/lamis/teacher-report` | Bilans/assessments | Données pédagogiques mineur | Durcir avant bêta élargie |
 | P1 | `/api/stages/[stageSlug]/inscrire` | Stages | Réservation/session | Durcir avant bêta élargie |
 | P1 | `/api/student/activate` | Élève | PII/utilisateur | Durcir avant bêta élargie |
@@ -59,7 +61,6 @@ Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Z
 | P2 | `/api/assessments/[id]/result` | GET | Bilans/assessments | Auth | À vérifier | Oui | Oui | Non | Non | Non | Données pédagogiques mineur | Suivi qualité P2 |
 | P2 | `/api/assessments/[id]/status` | GET | Bilans/assessments | Auth | À vérifier | Oui | Oui | Non | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
 | P2 | `/api/assessments/predict` | POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
-| P2 | `/api/assessments/public-token` | POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Oui | Données pédagogiques mineur | Suivi qualité P2 |
 | P1 | `/api/assessments/submit` | POST | Bilans/assessments | Public | N/A | N/A | Non | Non | Oui | Oui | Données pédagogiques mineur | Durcir avant bêta élargie |
 | P2 | `/api/assessments/test` | GET | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | Données pédagogiques mineur | Suivi qualité P2 |
 | P2 | `/api/assistante/activate-student` | POST | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
@@ -83,8 +84,8 @@ Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Z
 | OK | `/api/auth/[...nextauth]` | - | Auth | Public/À vérifier | N/A | Oui | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
 | OK | `/api/auth/resend-activation` | POST | Auth | Public/À vérifier | N/A | N/A | Non | Non | Oui | Oui | À vérifier | Maintenir tests de non-régression |
 | OK | `/api/auth/reset-password` | POST | Auth | Public/À vérifier | N/A | N/A | Non | Non | Oui | Oui | À vérifier | Maintenir tests de non-régression |
-| P2 | `/api/bilan-gratuit/dismiss` | POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
-| P1 | `/api/bilan-gratuit` | POST | Bilans/assessments | Public | N/A | N/A | Non | Non | Oui | Oui | Données pédagogiques mineur | Durcir avant bêta élargie |
+| P1 | `/api/bilan-gratuit/dismiss` | POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | Données pédagogiques mineur | Durcir avant bêta élargie |
+| P1 | `/api/bilan-gratuit` | POST | Bilans/assessments | Public | Rôle détecté, à qualifier | N/A | Non | Oui | Oui | Oui | Données pédagogiques mineur | Durcir avant bêta élargie |
 | P2 | `/api/bilan-gratuit/status` | GET | Bilans/assessments | Auth | À vérifier | Oui | Oui | Non | Non | Non | Données pédagogiques mineur | Suivi qualité P2 |
 | P2 | `/api/bilan-pallier2-maths/retry` | POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
 | P2 | `/api/bilan-pallier2-maths` | POST, GET | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Oui | Données pédagogiques mineur | Suivi qualité P2 |
@@ -132,7 +133,6 @@ Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Z
 | P2 | `/api/eleve/stages` | GET | Stages | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
 | OK | `/api/health` | GET | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
 | OK | `/api/internal/health` | GET | Autre | Auth | Rôle détecté, à qualifier | À vérifier | Oui | Oui | Non | Non | À vérifier | Maintenir tests de non-régression |
-| OK | `/api/internal/rate-limit-probe` | GET | Autre | Auth | Rôle détecté, à qualifier | À vérifier | Oui | Oui | Non | Oui | À vérifier | Maintenir tests de non-régression |
 | P2 | `/api/invoices/[id]/pdf` | GET | Facturation | Auth | À vérifier | Oui | Oui | Non | Non | Non | Facture/paiement, Document/fichier | Suivi qualité P2 |
 | P2 | `/api/invoices/[id]/receipt/pdf` | GET | Facturation | Auth | À vérifier | Oui | Oui | Non | Oui | Non | Facture/paiement, Document/fichier | Suivi qualité P2 |
 | OK | `/api/lamis/attempt` | POST | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
@@ -161,7 +161,7 @@ Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Z
 | P2 | `/api/parent/subscriptions` | GET, POST | Parent | Auth | Parent | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
 | P2 | `/api/payments/bank-transfer/confirm` | POST | Paiement | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Facture/paiement | Suivi qualité P2 |
 | P2 | `/api/payments/check-pending` | GET | Paiement | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | Facture/paiement | Suivi qualité P2 |
-| P2 | `/api/payments/clictopay/init` | POST | Paiement | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Facture/paiement | Suivi qualité P2 |
+| P1 | `/api/payments/clictopay/init` | POST | Paiement | Auth | À vérifier | Oui | Oui | Non | Non | Non | Facture/paiement | Durcir avant bêta élargie |
 | P1 | `/api/payments/clictopay/webhook` | POST | Paiement | Public webhook | N/A | N/A | Non | Non | Non | Non | Facture/paiement | Durcir avant bêta élargie |
 | P2 | `/api/payments/pending` | GET | Paiement | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | Facture/paiement | Suivi qualité P2 |
 | P2 | `/api/payments/validate` | POST | Paiement | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Facture/paiement | Suivi qualité P2 |

--- a/docs/go-live/api-security-matrix.full.md
+++ b/docs/go-live/api-security-matrix.full.md
@@ -1,7 +1,7 @@
 # Annexe matrice API sécurité complète
 
 Source : `docs/security/API_GUARD_INVENTORY.md`.
-Généré le : 2026-07-07T07:03:08.659Z.
+Généré le : 2026-07-07T12:38:10.542Z.
 
 Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Zod détecté` et `Ownership requis` sont des indices de pilotage. `À vérifier` signifie qu’aucune preuve suffisante n’a été établie dans ce lot.
 
@@ -10,8 +10,8 @@ Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Z
 | Priorité | Nombre |
 | --- | ---: |
 | P0 | 0 |
-| P1 | 8 |
-| P2 | 141 |
+| P1 | 7 |
+| P2 | 142 |
 | OK | 27 |
 | Total | 176 |
 
@@ -24,7 +24,6 @@ Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Z
 | P1 | `/api/assessments/submit` | Bilans/assessments | Données pédagogiques mineur | Durcir avant bêta élargie |
 | P1 | `/api/bilan-gratuit` | Bilans/assessments | Données pédagogiques mineur | Durcir avant bêta élargie |
 | P1 | `/api/bilan-gratuit/dismiss` | Bilans/assessments | Données pédagogiques mineur | Durcir avant bêta élargie |
-| P1 | `/api/lamis/teacher-report` | Bilans/assessments | Données pédagogiques mineur | Durcir avant bêta élargie |
 | P1 | `/api/stages/[stageSlug]/inscrire` | Stages | Réservation/session | Durcir avant bêta élargie |
 | P1 | `/api/student/activate` | Élève | PII/utilisateur | Durcir avant bêta élargie |
 
@@ -139,7 +138,7 @@ Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Z
 | OK | `/api/lamis/exercises` | - | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
 | OK | `/api/lamis/export` | POST | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
 | OK | `/api/lamis/progress` | POST | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
-| P1 | `/api/lamis/teacher-report` | POST, GET | Bilans/assessments | Public/À vérifier | N/A | N/A | Non | Non | Oui | Oui | Données pédagogiques mineur | Durcir avant bêta élargie |
+| P2 | `/api/lamis/teacher-report` | POST, GET | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Oui | Données pédagogiques mineur | Suivi qualité P2 |
 | OK | `/api/me/next-step` | GET | Autre | Auth | À vérifier | À vérifier | Oui | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
 | OK | `/api/messages/conversations` | GET | Autre | Auth | À vérifier | Oui | Oui | Non | Non | Non | Conversation IA | Maintenir tests de non-régression |
 | OK | `/api/messages/send` | POST | Autre | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Conversation IA | Maintenir tests de non-régression |

--- a/docs/go-live/api-security-matrix.full.md
+++ b/docs/go-live/api-security-matrix.full.md
@@ -1,0 +1,216 @@
+# Annexe matrice API sécurité complète
+
+Source : `docs/security/API_GUARD_INVENTORY.md`.
+Généré le : 2026-07-06T20:47:11.266Z.
+
+Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Zod détecté` et `Ownership requis` sont des indices de pilotage. `À vérifier` signifie qu’aucune preuve suffisante n’a été établie dans ce lot.
+
+## Synthèse
+
+| Priorité | Nombre |
+| --- | ---: |
+| P0 | 0 |
+| P1 | 6 |
+| P2 | 144 |
+| OK | 28 |
+| Total | 178 |
+
+## Top 20 à corriger en priorité (P1)
+
+| Priorité | Route | Domaine | Risque dominant | Action Lot suivant |
+| --- | --- | --- | --- | --- |
+| P1 | `/api/payments/clictopay/webhook` | Paiement | Facture/paiement | Durcir avant bêta élargie |
+| P1 | `/api/assessments/submit` | Bilans/assessments | Données pédagogiques mineur | Durcir avant bêta élargie |
+| P1 | `/api/bilan-gratuit` | Bilans/assessments | Données pédagogiques mineur | Durcir avant bêta élargie |
+| P1 | `/api/lamis/teacher-report` | Bilans/assessments | Données pédagogiques mineur | Durcir avant bêta élargie |
+| P1 | `/api/stages/[stageSlug]/inscrire` | Stages | Réservation/session | Durcir avant bêta élargie |
+| P1 | `/api/student/activate` | Élève | PII/utilisateur | Durcir avant bêta élargie |
+
+## Matrice route par route
+
+| Priorité | Route | Méthodes | Domaine | Public/Auth | Rôle requis | Ownership requis | Auth guard détecté | Role guard détecté | Zod détecté | Rate limit détecté | Données sensibles | Action Lot suivant |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| P2 | `/api/admin/activities` | GET | Admin | Auth | Admin/staff | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/analytics` | GET | Admin | Auth | Admin/staff | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/config/history` | GET | Admin | Auth | Admin/staff | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/config/rollback` | POST | Admin | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/config` | GET, PATCH | Admin | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/dashboard` | GET | Admin | Auth | Admin/staff | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/directeur/stats` | GET | Admin | Auth | Admin/staff | Oui | Oui | Oui | Oui | Oui | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/documents` | POST | Documents | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | Document/fichier, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/invoices/[id]` | PATCH | Facturation | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | Facture/paiement, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/invoices/[id]/send` | POST | Facturation | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | Facture/paiement, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/invoices` | POST, GET | Facturation | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | Facture/paiement, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/recompute-ssn` | POST | Admin | Auth | Admin/staff | Oui | Oui | Oui | Oui | Oui | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/stages/[stageId]/coaches` | GET, POST, DELETE | Stages | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/admin/stages/[stageId]` | GET, PATCH, DELETE | Stages | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/admin/stages/[stageId]/sessions/[sessionId]` | PATCH, DELETE | Stages | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/admin/stages/[stageId]/sessions` | GET, POST | Stages | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/admin/stages` | GET, POST | Stages | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/admin/subscriptions` | GET, PUT | Admin | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/test-email` | POST, GET | Admin | Auth | Admin/staff | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/users` | GET, POST, PATCH, DELETE | Admin | Auth | Admin/staff | Oui | Oui | Oui | Oui | Oui | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/admin/users/search` | GET | Admin | Auth | Admin/staff | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| OK | `/api/analytics/event` | POST | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| P2 | `/api/aria/chat` | POST | ARIA/RAG | Auth | Élève/abonné à vérifier | Oui | Oui | Oui | Oui | Non | Conversation IA | Suivi qualité P2 |
+| P2 | `/api/aria/conversations` | GET | ARIA/RAG | Auth | Élève/abonné à vérifier | Oui | Oui | Oui | Non | Non | Conversation IA | Suivi qualité P2 |
+| P2 | `/api/aria/feedback` | POST | ARIA/RAG | Auth | Élève/abonné à vérifier | Oui | Oui | Oui | Oui | Non | Conversation IA | Suivi qualité P2 |
+| P2 | `/api/assessments/[id]/export` | GET | Bilans/assessments | Auth | À vérifier | Oui | Oui | Non | Non | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/assessments/[id]/result` | GET | Bilans/assessments | Auth | À vérifier | Oui | Oui | Non | Non | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/assessments/[id]/status` | GET | Bilans/assessments | Auth | À vérifier | Oui | Oui | Non | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/assessments/predict` | POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/assessments/public-token` | POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Oui | Données pédagogiques mineur | Suivi qualité P2 |
+| P1 | `/api/assessments/submit` | POST | Bilans/assessments | Public | N/A | N/A | Non | Non | Oui | Oui | Données pédagogiques mineur | Durcir avant bêta élargie |
+| P2 | `/api/assessments/test` | GET | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/assistante/activate-student` | POST | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/assignments/[id]` | GET, PATCH | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/assignments` | GET, POST | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/coaches/manage/[id]` | PUT, DELETE | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/coaches/manage` | GET, POST | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/coaches` | GET | Assistante | Auth | Assistante | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/credit-requests` | GET, POST | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/dashboard` | GET | Assistante | Auth | Assistante | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/planning` | GET | Assistante | Auth | Assistante | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/quotes/pdf` | POST | Documents | Auth | Assistante | Oui | Oui | Oui | Oui | Oui | Document/fichier, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/sessions` | POST | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/assistante/stages` | GET | Stages | Auth | Assistante | Oui | Oui | Oui | Non | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/assistante/students/[studentId]/documents` | GET, POST | Documents | Auth | Assistante | Oui | Oui | Oui | Oui | Non | Document/fichier, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/students/[studentId]` | GET | Assistante | Auth | Assistante | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/students/credits` | GET, POST | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/students` | GET, POST | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/subscription-requests` | GET, PATCH | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/assistante/subscriptions` | GET, POST | Assistante | Auth | Assistante | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| OK | `/api/auth/[...nextauth]` | - | Auth | Public/À vérifier | N/A | Oui | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/auth/resend-activation` | POST | Auth | Public/À vérifier | N/A | N/A | Non | Non | Oui | Oui | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/auth/reset-password` | POST | Auth | Public/À vérifier | N/A | N/A | Non | Non | Oui | Oui | À vérifier | Maintenir tests de non-régression |
+| P2 | `/api/bilan-gratuit/dismiss` | POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P1 | `/api/bilan-gratuit` | POST | Bilans/assessments | Public | N/A | N/A | Non | Non | Oui | Oui | Données pédagogiques mineur | Durcir avant bêta élargie |
+| P2 | `/api/bilan-gratuit/status` | GET | Bilans/assessments | Auth | À vérifier | Oui | Oui | Non | Non | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/bilan-pallier2-maths/retry` | POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/bilan-pallier2-maths` | POST, GET | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Oui | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/bilans/[id]/export` | GET, POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/bilans/[id]` | GET, PUT, DELETE | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/bilans/generate` | POST, GET | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/bilans` | GET, POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/coach/dashboard` | GET | Coach | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate` | POST | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/coach/eaf-stage-printemps/students/[studentId]/report` | GET, POST, PATCH | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/coach/eaf-stage-printemps/students` | GET | Stages | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent` | POST | Stages | Auth | Coach | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student` | POST | Stages | Auth | Coach | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/coach/maths-premiere-stage-printemps/students/[studentId]/report` | GET, POST, PATCH | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/coach/maths-premiere-stage-printemps/students` | GET | Stages | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/coach/nsi-pratique-2026/students/[studentId]/progress` | GET | Coach | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/nsi-pratique-2026/students` | GET | Coach | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/sessions/[sessionId]/report` | POST, GET | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/coach/stages` | GET | Stages | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale` | GET, PATCH | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/documents` | GET, POST | Documents | Auth | Coach | Oui | Oui | Oui | Oui | Non | Document/fichier, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/dossier` | GET | Coach | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/eaf-preparation-report` | GET, PUT | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/eaf-preparation-report/validate` | POST | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/generated-reports/[reportId]/download` | GET | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Non | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/generated-reports/[reportId]/generate` | POST | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate` | POST | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/generated-reports` | GET, POST | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/notes` | GET, POST | Coach | Auth | Coach | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]` | GET | Coach | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/survival-mode` | POST | Coach | Auth | Coach | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/eam-summary` | GET | Coach | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students` | GET | Coach | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/trajectory` | POST | Coach | Auth | Coach | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coaches/availability` | POST, GET, DELETE | Coach | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coaches/available` | GET | Coach | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| OK | `/api/contact` | POST | Leads/messages | Public | N/A | N/A | Non | Non | Non | Oui | Lead/contact | Maintenir tests de non-régression |
+| OK | `/api/diagnostics/definitions` | GET | Bilans/assessments | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | Données pédagogiques mineur | Maintenir tests de non-régression |
+| P2 | `/api/documents/[id]` | GET | Documents | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Document/fichier | Suivi qualité P2 |
+| OK | `/api/eam/progress` | GET, POST | Autre | Auth | À vérifier | À vérifier | Oui | Non | Oui | Non | À vérifier | Maintenir tests de non-régression |
+| P2 | `/api/eleve/bilan-diagnostic-maths-terminale` | GET, POST | Bilans/assessments | Auth | Élève | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| OK | `/api/eleve/nsi-pratique-2026/progress` | GET, PUT | Élève | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur | Maintenir tests de non-régression |
+| P2 | `/api/eleve/questionnaire-eaf-stage-printemps` | GET, POST | Stages | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/eleve/questionnaire-maths-premiere-stage-printemps` | GET, POST | Stages | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/eleve/stages` | GET | Stages | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| OK | `/api/health` | GET | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/internal/health` | GET | Autre | Auth | Rôle détecté, à qualifier | À vérifier | Oui | Oui | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/internal/rate-limit-probe` | GET | Autre | Auth | Rôle détecté, à qualifier | À vérifier | Oui | Oui | Non | Oui | À vérifier | Maintenir tests de non-régression |
+| P2 | `/api/invoices/[id]/pdf` | GET | Facturation | Auth | À vérifier | Oui | Oui | Non | Non | Non | Facture/paiement, Document/fichier | Suivi qualité P2 |
+| P2 | `/api/invoices/[id]/receipt/pdf` | GET | Facturation | Auth | À vérifier | Oui | Oui | Non | Oui | Non | Facture/paiement, Document/fichier | Suivi qualité P2 |
+| OK | `/api/lamis/attempt` | POST | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/lamis/exercises` | - | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/lamis/export` | POST | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/lamis/progress` | POST | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| P1 | `/api/lamis/teacher-report` | POST, GET | Bilans/assessments | Public/À vérifier | N/A | N/A | Non | Non | Oui | Oui | Données pédagogiques mineur | Durcir avant bêta élargie |
+| OK | `/api/me/next-step` | GET | Autre | Auth | À vérifier | À vérifier | Oui | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/messages/conversations` | GET | Autre | Auth | À vérifier | Oui | Oui | Non | Non | Non | Conversation IA | Maintenir tests de non-régression |
+| OK | `/api/messages/send` | POST | Autre | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Conversation IA | Maintenir tests de non-régression |
+| OK | `/api/newsletter` | POST | Leads/messages | Public | N/A | N/A | Non | Non | Non | Oui | Lead/contact | Maintenir tests de non-régression |
+| OK | `/api/notifications` | GET, PATCH | Autre | Auth | À vérifier | À vérifier | Oui | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/notify/email` | POST | Leads/messages | Public | N/A | N/A | Non | Non | Oui | Oui | Lead/contact | Maintenir tests de non-régression |
+| P2 | `/api/npc/files/[...path]` | GET | Documents | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | Document/fichier | Suivi qualité P2 |
+| P2 | `/api/npc/submissions/[submissionId]/documents/[documentId]` | PATCH, DELETE | Documents | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Document/fichier, Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/npc/submissions/[submissionId]/documents` | GET, POST | Documents | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Document/fichier, Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/npc/submissions/[submissionId]/generate` | POST | NPC | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/npc/submissions` | POST, GET | NPC | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/npc/uploads` | POST | NPC | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Document/fichier | Suivi qualité P2 |
+| P2 | `/api/parent/bilans/[id]/pdf` | GET | Documents | Auth | Parent | Oui | Oui | Oui | Non | Non | Document/fichier, Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/parent/children` | GET, POST | Parent | Auth | Parent | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/parent/credit-request` | POST | Parent | Auth | Parent | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/parent/dashboard` | GET | Parent | Auth | Parent | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/parent/stages` | GET | Stages | Auth | Parent | Oui | Oui | Oui | Non | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/parent/subscription-requests` | POST, GET | Parent | Auth | Parent | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/parent/subscriptions` | GET, POST | Parent | Auth | Parent | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/payments/bank-transfer/confirm` | POST | Paiement | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Facture/paiement | Suivi qualité P2 |
+| P2 | `/api/payments/check-pending` | GET | Paiement | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | Facture/paiement | Suivi qualité P2 |
+| P2 | `/api/payments/clictopay/init` | POST | Paiement | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Facture/paiement | Suivi qualité P2 |
+| P1 | `/api/payments/clictopay/webhook` | POST | Paiement | Public webhook | N/A | N/A | Non | Non | Non | Non | Facture/paiement | Durcir avant bêta élargie |
+| P2 | `/api/payments/pending` | GET | Paiement | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | Facture/paiement | Suivi qualité P2 |
+| P2 | `/api/payments/validate` | POST | Paiement | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Facture/paiement | Suivi qualité P2 |
+| OK | `/api/programme/maths-1ere/progress` | POST, GET | Autre | Auth | À vérifier | À vérifier | Oui | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/programme/maths-1ere/rag` | POST | ARIA/RAG | Auth | À vérifier | À vérifier | Oui | Non | Oui | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/programme/maths-1ere-stmg/progress` | POST, GET | Autre | Auth | À vérifier | À vérifier | Oui | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| OK | `/api/programme/maths-1ere-stmg/rag` | POST | ARIA/RAG | Auth | À vérifier | À vérifier | Oui | Non | Oui | Non | À vérifier | Maintenir tests de non-régression |
+| P2 | `/api/programme/maths-1ere-stmg/stage-progress` | GET, POST | Stages | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Réservation/session | Suivi qualité P2 |
+| OK | `/api/programme/maths-terminale/progress` | POST, GET | Autre | Auth | À vérifier | À vérifier | Oui | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
+| P2 | `/api/public-documents/corrige-dnb-maths-2026` | GET | Documents | Public | N/A | N/A | Non | Non | Non | Non | Document/fichier | Suivi qualité P2 |
+| OK | `/api/reservation` | POST, GET, PATCH | Autre | Auth | À vérifier | Oui | Oui | Non | Oui | Oui | Réservation/session | Maintenir tests de non-régression |
+| OK | `/api/reservation/verify` | POST | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | Réservation/session | Maintenir tests de non-régression |
+| P2 | `/api/sessions/book` | POST | Autre | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Oui | Réservation/session | Suivi qualité P2 |
+| P2 | `/api/sessions/cancel` | POST | Autre | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Oui | Réservation/session | Suivi qualité P2 |
+| P2 | `/api/sessions/video` | POST | Autre | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Oui | Réservation/session | Suivi qualité P2 |
+| P2 | `/api/stages/[stageSlug]/bilans` | GET, POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, Réservation/session | Suivi qualité P2 |
+| P1 | `/api/stages/[stageSlug]/inscrire` | POST | Stages | Public | N/A | Oui | Non | Non | Oui | Oui | Réservation/session | Durcir avant bêta élargie |
+| P2 | `/api/stages/[stageSlug]/reservations/[reservationId]/confirm` | POST | Stages | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Réservation/session | Suivi qualité P2 |
+| P2 | `/api/stages/[stageSlug]/reservations` | GET | Stages | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | Réservation/session | Suivi qualité P2 |
+| P2 | `/api/stages/[stageSlug]` | GET | Stages | Public/À vérifier | N/A | Oui | Non | Non | Oui | Non | Réservation/session | Suivi qualité P2 |
+| P2 | `/api/stages` | GET | Stages | Public/À vérifier | N/A | N/A | Non | Non | Oui | Non | Réservation/session | Suivi qualité P2 |
+| P1 | `/api/student/activate` | GET, POST | Élève | Public | N/A | N/A | Non | Non | Oui | Oui | PII/utilisateur | Durcir avant bêta élargie |
+| P2 | `/api/student/automatismes/attempts/[id]` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/automatismes/attempts` | POST, GET | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/automatismes/check-answer` | POST | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/automatismes/series/[id]` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/automatismes/series` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/bilans/[publicShareId]` | GET | Bilans/assessments | Auth | Élève | Oui | Oui | Oui | Non | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/credits` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Non | Oui | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/dashboard` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/documents/[id]/download` | GET | Documents | Auth | Élève | Oui | Oui | Oui | Non | Non | Document/fichier, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/documents` | GET | Documents | Auth | Élève | Oui | Oui | Oui | Non | Non | Document/fichier, PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/nexus-index` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/resources/official/[slug]` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/resources` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/sessions` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Non | Oui | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/student/stages` | GET | Stages | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
+| P2 | `/api/student/survival/phrases/[phraseId]/copied` | POST | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/survival/progress` | GET, POST | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/survival/qcm/attempt` | POST | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/survival/reflexes/[reflexId]/attempt` | POST | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/survival/ritual` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/student/trajectory` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/students/[studentId]/badges` | GET | Élève | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/subscriptions/aria-addon` | POST | ARIA/RAG | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | Conversation IA | Suivi qualité P2 |
+| P2 | `/api/subscriptions/change` | POST | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Suivi qualité P2 |
+
+## Limites
+
+- Les guards détectés proviennent de motifs statiques ; ils ne prouvent pas l’absence d’IDOR.
+- Le rate limiting est détecté par motifs de code locaux ; une protection middleware, reverse proxy ou provider externe reste `À vérifier` sans preuve runtime.
+- Les routes `OK` ne sont pas déclarées go-live ready ; elles sont seulement moins prioritaires dans l’inventaire statique.

--- a/docs/security/API_GUARD_INVENTORY.md
+++ b/docs/security/API_GUARD_INVENTORY.md
@@ -1,14 +1,14 @@
 # Inventaire initial des guards API
 
-Généré le : 2026-07-07T07:02:59.238Z
+Généré le : 2026-07-07T12:38:10.481Z
 
 Lecture statique uniquement. La colonne `Ownership explicit` signale des indices de filtrage propriétaire dans le fichier; elle ne remplace pas un audit manuel IDOR.
 
 ## Synthèse
 
 - P0 : 0
-- P1 : 8
-- P2 : 141
+- P1 : 7
+- P2 : 142
 - OK : 27
 - Total routes : 176
 
@@ -19,13 +19,13 @@ Lecture statique uniquement. La colonne `Ownership explicit` signale des indices
 | `app/api/assessments/submit/route.ts` | POST | P1 | pédagogique sensible |
 | `app/api/bilan-gratuit/dismiss/route.ts` | POST | P1 | pédagogique sensible; guard manuel |
 | `app/api/bilan-gratuit/route.ts` | POST | P1 | pédagogique sensible |
-| `app/api/lamis/teacher-report/route.ts` | POST, GET | P1 | pédagogique sensible |
 | `app/api/payments/clictopay/init/route.ts` | POST | P1 | finance; guard manuel |
 | `app/api/payments/clictopay/webhook/route.ts` | POST | P1 | finance |
 | `app/api/stages/[stageSlug]/inscrire/route.ts` | POST | P1 | - |
 | `app/api/student/activate/route.ts` | GET, POST | P1 | - |
 | `app/api/admin/activities/route.ts` | GET | P2 | staff/admin |
 | `app/api/admin/analytics/route.ts` | GET | P2 | staff/admin |
+| `app/api/admin/config/history/route.ts` | GET | P2 | staff/admin |
 
 ## Inventaire complet
 
@@ -138,7 +138,7 @@ Lecture statique uniquement. La colonne `Ownership explicit` signale des indices
 | `app/api/lamis/exercises/route.ts` | - | no | no | no | no | no | no | OK | - |
 | `app/api/lamis/export/route.ts` | POST | no | no | no | no | no | no | OK | - |
 | `app/api/lamis/progress/route.ts` | POST | no | no | no | no | no | no | OK | - |
-| `app/api/lamis/teacher-report/route.ts` | POST, GET | no | no | no | no | yes | no | P1 | pédagogique sensible |
+| `app/api/lamis/teacher-report/route.ts` | POST, GET | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
 | `app/api/me/next-step/route.ts` | GET | no | yes | no | no | no | no | OK | guard manuel |
 | `app/api/messages/conversations/route.ts` | GET | no | yes | no | no | no | no | OK | guard manuel |
 | `app/api/messages/send/route.ts` | POST | no | yes | yes | no | yes | no | OK | guard manuel |

--- a/docs/security/API_GUARD_INVENTORY.md
+++ b/docs/security/API_GUARD_INVENTORY.md
@@ -1,31 +1,31 @@
 # Inventaire initial des guards API
 
-Généré le : 2026-07-06T20:47:06.898Z
+Généré le : 2026-07-07T07:02:59.238Z
 
 Lecture statique uniquement. La colonne `Ownership explicit` signale des indices de filtrage propriétaire dans le fichier; elle ne remplace pas un audit manuel IDOR.
 
 ## Synthèse
 
 - P0 : 0
-- P1 : 6
-- P2 : 144
-- OK : 28
-- Total routes : 178
+- P1 : 8
+- P2 : 141
+- OK : 27
+- Total routes : 176
 
 ## 10 routes à auditer en priorité
 
 | Route | Methods | Risk | Notes |
 |---|---|---|---|
 | `app/api/assessments/submit/route.ts` | POST | P1 | pédagogique sensible |
+| `app/api/bilan-gratuit/dismiss/route.ts` | POST | P1 | pédagogique sensible; guard manuel |
 | `app/api/bilan-gratuit/route.ts` | POST | P1 | pédagogique sensible |
 | `app/api/lamis/teacher-report/route.ts` | POST, GET | P1 | pédagogique sensible |
+| `app/api/payments/clictopay/init/route.ts` | POST | P1 | finance; guard manuel |
 | `app/api/payments/clictopay/webhook/route.ts` | POST | P1 | finance |
 | `app/api/stages/[stageSlug]/inscrire/route.ts` | POST | P1 | - |
 | `app/api/student/activate/route.ts` | GET, POST | P1 | - |
 | `app/api/admin/activities/route.ts` | GET | P2 | staff/admin |
 | `app/api/admin/analytics/route.ts` | GET | P2 | staff/admin |
-| `app/api/admin/config/history/route.ts` | GET | P2 | staff/admin |
-| `app/api/admin/config/rollback/route.ts` | POST | P2 | staff/admin |
 
 ## Inventaire complet
 
@@ -60,7 +60,6 @@ Lecture statique uniquement. La colonne `Ownership explicit` signale des indices
 | `app/api/assessments/[id]/result/route.ts` | GET | yes | yes | no | no | no | yes | P2 | pédagogique sensible; guard manuel |
 | `app/api/assessments/[id]/status/route.ts` | GET | yes | yes | no | no | yes | yes | P2 | pédagogique sensible; guard manuel |
 | `app/api/assessments/predict/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | pédagogique sensible; guard manuel |
-| `app/api/assessments/public-token/route.ts` | POST | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
 | `app/api/assessments/submit/route.ts` | POST | no | no | no | no | yes | no | P1 | pédagogique sensible |
 | `app/api/assessments/test/route.ts` | GET | no | yes | yes | no | no | no | P2 | pédagogique sensible; guard manuel |
 | `app/api/assistante/activate-student/route.ts` | POST | no | yes | yes | no | yes | no | P2 | assistante; guard manuel |
@@ -84,8 +83,8 @@ Lecture statique uniquement. La colonne `Ownership explicit` signale des indices
 | `app/api/auth/[...nextauth]/route.ts` | - | yes | no | no | no | no | no | OK | - |
 | `app/api/auth/resend-activation/route.ts` | POST | no | no | no | no | yes | no | OK | - |
 | `app/api/auth/reset-password/route.ts` | POST | no | no | no | no | yes | yes | OK | - |
-| `app/api/bilan-gratuit/dismiss/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | pédagogique sensible; guard manuel |
-| `app/api/bilan-gratuit/route.ts` | POST | no | no | no | no | yes | no | P1 | pédagogique sensible |
+| `app/api/bilan-gratuit/dismiss/route.ts` | POST | no | yes | yes | no | no | yes | P1 | pédagogique sensible; guard manuel |
+| `app/api/bilan-gratuit/route.ts` | POST | no | no | yes | no | yes | no | P1 | pédagogique sensible |
 | `app/api/bilan-gratuit/status/route.ts` | GET | no | yes | no | no | no | yes | P2 | pédagogique sensible; guard manuel |
 | `app/api/bilan-pallier2-maths/retry/route.ts` | POST | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
 | `app/api/bilan-pallier2-maths/route.ts` | POST, GET | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
@@ -133,7 +132,6 @@ Lecture statique uniquement. La colonne `Ownership explicit` signale des indices
 | `app/api/eleve/stages/route.ts` | GET | no | yes | yes | no | no | yes | P2 | - |
 | `app/api/health/route.ts` | GET | no | no | no | no | no | no | OK | - |
 | `app/api/internal/health/route.ts` | GET | no | yes | yes | no | no | no | OK | - |
-| `app/api/internal/rate-limit-probe/route.ts` | GET | no | yes | yes | no | no | no | OK | - |
 | `app/api/invoices/[id]/pdf/route.ts` | GET | yes | yes | no | no | no | yes | P2 | finance; guard manuel |
 | `app/api/invoices/[id]/receipt/pdf/route.ts` | GET | yes | yes | no | no | yes | yes | P2 | finance; guard manuel |
 | `app/api/lamis/attempt/route.ts` | POST | no | no | no | no | no | no | OK | - |
@@ -162,7 +160,7 @@ Lecture statique uniquement. La colonne `Ownership explicit` signale des indices
 | `app/api/parent/subscriptions/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | guard manuel |
 | `app/api/payments/bank-transfer/confirm/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | finance; guard manuel |
 | `app/api/payments/check-pending/route.ts` | GET | no | yes | yes | no | no | yes | P2 | finance; guard manuel |
-| `app/api/payments/clictopay/init/route.ts` | POST | no | yes | yes | no | yes | no | P2 | finance; guard manuel |
+| `app/api/payments/clictopay/init/route.ts` | POST | no | yes | no | no | no | no | P1 | finance; guard manuel |
 | `app/api/payments/clictopay/webhook/route.ts` | POST | no | no | no | no | no | no | P1 | finance |
 | `app/api/payments/pending/route.ts` | GET | no | yes | yes | no | no | no | P2 | finance; guard manuel |
 | `app/api/payments/validate/route.ts` | POST | no | yes | yes | no | yes | no | P2 | finance; guard manuel |

--- a/docs/security/API_GUARD_INVENTORY.md
+++ b/docs/security/API_GUARD_INVENTORY.md
@@ -1,31 +1,31 @@
 # Inventaire initial des guards API
 
-Généré le : 2026-05-29T19:21:45.562Z
+Généré le : 2026-07-06T20:47:06.898Z
 
 Lecture statique uniquement. La colonne `Ownership explicit` signale des indices de filtrage propriétaire dans le fichier; elle ne remplace pas un audit manuel IDOR.
 
 ## Synthèse
 
-- P0 : 42
-- P1 : 38
-- P2 : 62
-- OK : 22
-- Total routes : 164
+- P0 : 0
+- P1 : 6
+- P2 : 144
+- OK : 28
+- Total routes : 178
 
 ## 10 routes à auditer en priorité
 
 | Route | Methods | Risk | Notes |
 |---|---|---|---|
-| `app/api/admin/invoices/[id]/route.ts` | PATCH | P0 | staff/admin; finance; audit manuel prioritaire; guard manuel |
-| `app/api/admin/invoices/[id]/send/route.ts` | POST | P0 | staff/admin; finance; audit manuel prioritaire; guard manuel |
-| `app/api/admin/stages/[stageId]/coaches/route.ts` | GET, POST, DELETE | P0 | staff/admin; audit manuel prioritaire |
-| `app/api/admin/stages/[stageId]/route.ts` | GET, PATCH, DELETE | P0 | staff/admin; audit manuel prioritaire |
-| `app/api/admin/stages/[stageId]/sessions/[sessionId]/route.ts` | PATCH, DELETE | P0 | staff/admin; audit manuel prioritaire |
-| `app/api/admin/stages/[stageId]/sessions/route.ts` | GET, POST | P0 | staff/admin; audit manuel prioritaire |
-| `app/api/assessments/submit/route.ts` | POST | P0 | pédagogique sensible; audit manuel prioritaire |
-| `app/api/assistante/assignments/[id]/route.ts` | GET, PATCH | P0 | assistante; audit manuel prioritaire |
-| `app/api/assistante/coaches/manage/[id]/route.ts` | PUT, DELETE | P0 | assistante; audit manuel prioritaire; guard manuel |
-| `app/api/assistante/students/[studentId]/documents/route.ts` | GET, POST | P0 | assistante; documents/PII; audit manuel prioritaire |
+| `app/api/assessments/submit/route.ts` | POST | P1 | pédagogique sensible |
+| `app/api/bilan-gratuit/route.ts` | POST | P1 | pédagogique sensible |
+| `app/api/lamis/teacher-report/route.ts` | POST, GET | P1 | pédagogique sensible |
+| `app/api/payments/clictopay/webhook/route.ts` | POST | P1 | finance |
+| `app/api/stages/[stageSlug]/inscrire/route.ts` | POST | P1 | - |
+| `app/api/student/activate/route.ts` | GET, POST | P1 | - |
+| `app/api/admin/activities/route.ts` | GET | P2 | staff/admin |
+| `app/api/admin/analytics/route.ts` | GET | P2 | staff/admin |
+| `app/api/admin/config/history/route.ts` | GET | P2 | staff/admin |
+| `app/api/admin/config/rollback/route.ts` | POST | P2 | staff/admin |
 
 ## Inventaire complet
 
@@ -33,20 +33,23 @@ Lecture statique uniquement. La colonne `Ownership explicit` signale des indices
 |---|---|---|---|---|---|---|---|---|---|
 | `app/api/admin/activities/route.ts` | GET | no | yes | yes | no | no | no | P2 | staff/admin |
 | `app/api/admin/analytics/route.ts` | GET | no | yes | yes | no | no | no | P2 | staff/admin |
+| `app/api/admin/config/history/route.ts` | GET | no | yes | yes | no | no | no | P2 | staff/admin |
+| `app/api/admin/config/rollback/route.ts` | POST | no | yes | yes | no | yes | no | P2 | staff/admin |
+| `app/api/admin/config/route.ts` | GET, PATCH | no | yes | yes | no | yes | no | P2 | staff/admin |
 | `app/api/admin/dashboard/route.ts` | GET | no | yes | yes | no | no | no | P2 | staff/admin |
-| `app/api/admin/directeur/stats/route.ts` | GET | no | yes | no | no | no | no | P1 | staff/admin; guard manuel |
-| `app/api/admin/documents/route.ts` | POST | no | yes | yes | no | no | yes | P1 | staff/admin; documents/PII |
-| `app/api/admin/invoices/[id]/route.ts` | PATCH | yes | yes | no | no | yes | no | P0 | staff/admin; finance; audit manuel prioritaire; guard manuel |
-| `app/api/admin/invoices/[id]/send/route.ts` | POST | yes | yes | yes | no | yes | no | P0 | staff/admin; finance; audit manuel prioritaire; guard manuel |
-| `app/api/admin/invoices/route.ts` | POST, GET | no | yes | no | no | yes | no | P1 | staff/admin; finance; guard manuel |
-| `app/api/admin/recompute-ssn/route.ts` | POST | no | yes | no | no | no | no | P1 | staff/admin; guard manuel |
-| `app/api/admin/stages/[stageId]/coaches/route.ts` | GET, POST, DELETE | yes | yes | yes | no | yes | no | P0 | staff/admin; audit manuel prioritaire |
-| `app/api/admin/stages/[stageId]/route.ts` | GET, PATCH, DELETE | yes | yes | yes | no | yes | no | P0 | staff/admin; audit manuel prioritaire |
-| `app/api/admin/stages/[stageId]/sessions/[sessionId]/route.ts` | PATCH, DELETE | yes | yes | yes | no | yes | no | P0 | staff/admin; audit manuel prioritaire |
-| `app/api/admin/stages/[stageId]/sessions/route.ts` | GET, POST | yes | yes | yes | no | yes | no | P0 | staff/admin; audit manuel prioritaire |
+| `app/api/admin/directeur/stats/route.ts` | GET | no | yes | yes | no | yes | no | P2 | staff/admin |
+| `app/api/admin/documents/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | staff/admin; documents/PII |
+| `app/api/admin/invoices/[id]/route.ts` | PATCH | yes | yes | yes | no | yes | no | P2 | staff/admin; finance; guard manuel |
+| `app/api/admin/invoices/[id]/send/route.ts` | POST | yes | yes | yes | no | yes | no | P2 | staff/admin; finance; guard manuel |
+| `app/api/admin/invoices/route.ts` | POST, GET | no | yes | yes | no | yes | no | P2 | staff/admin; finance; guard manuel |
+| `app/api/admin/recompute-ssn/route.ts` | POST | no | yes | yes | no | yes | no | P2 | staff/admin |
+| `app/api/admin/stages/[stageId]/coaches/route.ts` | GET, POST, DELETE | yes | yes | yes | no | yes | yes | P2 | staff/admin |
+| `app/api/admin/stages/[stageId]/route.ts` | GET, PATCH, DELETE | yes | yes | yes | no | yes | no | P2 | staff/admin |
+| `app/api/admin/stages/[stageId]/sessions/[sessionId]/route.ts` | PATCH, DELETE | yes | yes | yes | no | yes | yes | P2 | staff/admin |
+| `app/api/admin/stages/[stageId]/sessions/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | staff/admin |
 | `app/api/admin/stages/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | staff/admin |
-| `app/api/admin/subscriptions/route.ts` | GET, PUT | no | yes | yes | no | no | no | P1 | staff/admin |
-| `app/api/admin/test-email/route.ts` | POST, GET | no | yes | yes | no | no | no | P1 | staff/admin; guard manuel |
+| `app/api/admin/subscriptions/route.ts` | GET, PUT | no | yes | yes | no | yes | no | P2 | staff/admin |
+| `app/api/admin/test-email/route.ts` | POST, GET | no | yes | yes | no | yes | no | P2 | staff/admin; guard manuel |
 | `app/api/admin/users/route.ts` | GET, POST, PATCH, DELETE | no | yes | yes | no | yes | no | P2 | staff/admin |
 | `app/api/admin/users/search/route.ts` | GET | no | yes | yes | no | no | no | P2 | staff/admin |
 | `app/api/analytics/event/route.ts` | POST | no | no | no | no | no | no | OK | - |
@@ -57,144 +60,155 @@ Lecture statique uniquement. La colonne `Ownership explicit` signale des indices
 | `app/api/assessments/[id]/result/route.ts` | GET | yes | yes | no | no | no | yes | P2 | pédagogique sensible; guard manuel |
 | `app/api/assessments/[id]/status/route.ts` | GET | yes | yes | no | no | yes | yes | P2 | pédagogique sensible; guard manuel |
 | `app/api/assessments/predict/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | pédagogique sensible; guard manuel |
-| `app/api/assessments/submit/route.ts` | POST | no | no | no | no | yes | no | P0 | pédagogique sensible; audit manuel prioritaire |
+| `app/api/assessments/public-token/route.ts` | POST | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
+| `app/api/assessments/submit/route.ts` | POST | no | no | no | no | yes | no | P1 | pédagogique sensible |
 | `app/api/assessments/test/route.ts` | GET | no | yes | yes | no | no | no | P2 | pédagogique sensible; guard manuel |
 | `app/api/assistante/activate-student/route.ts` | POST | no | yes | yes | no | yes | no | P2 | assistante; guard manuel |
-| `app/api/assistante/assignments/[id]/route.ts` | GET, PATCH | yes | yes | yes | no | yes | no | P0 | assistante; audit manuel prioritaire |
+| `app/api/assistante/assignments/[id]/route.ts` | GET, PATCH | yes | yes | yes | no | yes | no | P2 | assistante |
 | `app/api/assistante/assignments/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | assistante |
-| `app/api/assistante/coaches/manage/[id]/route.ts` | PUT, DELETE | yes | yes | yes | no | yes | no | P0 | assistante; audit manuel prioritaire; guard manuel |
+| `app/api/assistante/coaches/manage/[id]/route.ts` | PUT, DELETE | yes | yes | yes | no | yes | no | P2 | assistante; guard manuel |
 | `app/api/assistante/coaches/manage/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | assistante; guard manuel |
 | `app/api/assistante/coaches/route.ts` | GET | no | yes | yes | no | no | no | P2 | assistante |
-| `app/api/assistante/credit-requests/route.ts` | GET, POST | no | yes | yes | no | no | no | P1 | assistante; guard manuel |
+| `app/api/assistante/credit-requests/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | assistante; guard manuel |
 | `app/api/assistante/dashboard/route.ts` | GET | no | yes | yes | no | no | no | P2 | assistante; guard manuel |
 | `app/api/assistante/planning/route.ts` | GET | no | yes | yes | no | no | no | P2 | assistante |
+| `app/api/assistante/quotes/pdf/route.ts` | POST | no | yes | yes | no | yes | no | P2 | assistante |
 | `app/api/assistante/sessions/route.ts` | POST | no | yes | yes | no | yes | no | P2 | assistante |
 | `app/api/assistante/stages/route.ts` | GET | no | yes | yes | no | no | no | P2 | assistante |
-| `app/api/assistante/students/[studentId]/documents/route.ts` | GET, POST | yes | yes | yes | no | yes | no | P0 | assistante; documents/PII; audit manuel prioritaire |
-| `app/api/assistante/students/[studentId]/route.ts` | GET | yes | yes | yes | no | no | no | P0 | assistante; audit manuel prioritaire |
-| `app/api/assistante/students/credits/route.ts` | GET, POST | no | yes | yes | no | no | no | P1 | assistante; guard manuel |
+| `app/api/assistante/students/[studentId]/documents/route.ts` | GET, POST | yes | yes | yes | no | yes | no | P2 | assistante; documents/PII |
+| `app/api/assistante/students/[studentId]/route.ts` | GET | yes | yes | yes | no | no | no | P2 | assistante |
+| `app/api/assistante/students/credits/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | assistante; guard manuel |
 | `app/api/assistante/students/route.ts` | GET, POST | no | yes | yes | no | yes | yes | P2 | assistante |
-| `app/api/assistante/subscription-requests/route.ts` | GET, PATCH | no | yes | yes | no | no | no | P1 | assistante; guard manuel |
-| `app/api/assistante/subscriptions/route.ts` | GET, POST | no | yes | yes | no | no | no | P1 | assistante; guard manuel |
+| `app/api/assistante/subscription-requests/route.ts` | GET, PATCH | no | yes | yes | no | yes | no | P2 | assistante; guard manuel |
+| `app/api/assistante/subscriptions/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | assistante; guard manuel |
 | `app/api/auth/[...nextauth]/route.ts` | - | yes | no | no | no | no | no | OK | - |
 | `app/api/auth/resend-activation/route.ts` | POST | no | no | no | no | yes | no | OK | - |
 | `app/api/auth/reset-password/route.ts` | POST | no | no | no | no | yes | yes | OK | - |
-| `app/api/bilan-gratuit/dismiss/route.ts` | POST | no | yes | yes | no | no | yes | P1 | pédagogique sensible; guard manuel |
-| `app/api/bilan-gratuit/route.ts` | POST | no | no | yes | no | yes | no | P0 | pédagogique sensible; audit manuel prioritaire |
+| `app/api/bilan-gratuit/dismiss/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | pédagogique sensible; guard manuel |
+| `app/api/bilan-gratuit/route.ts` | POST | no | no | no | no | yes | no | P1 | pédagogique sensible |
 | `app/api/bilan-gratuit/status/route.ts` | GET | no | yes | no | no | no | yes | P2 | pédagogique sensible; guard manuel |
 | `app/api/bilan-pallier2-maths/retry/route.ts` | POST | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
 | `app/api/bilan-pallier2-maths/route.ts` | POST, GET | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
-| `app/api/bilans/[id]/export/route.ts` | GET, POST | yes | yes | yes | no | no | yes | P1 | pédagogique sensible |
-| `app/api/bilans/[id]/route.ts` | GET, PUT, DELETE | yes | yes | yes | no | no | yes | P1 | pédagogique sensible |
-| `app/api/bilans/generate/route.ts` | POST, GET | no | yes | yes | no | no | no | P1 | pédagogique sensible |
-| `app/api/bilans/route.ts` | GET, POST | no | yes | yes | no | no | no | P1 | pédagogique sensible |
+| `app/api/bilans/[id]/export/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | pédagogique sensible |
+| `app/api/bilans/[id]/route.ts` | GET, PUT, DELETE | yes | yes | yes | no | yes | yes | P2 | pédagogique sensible |
+| `app/api/bilans/generate/route.ts` | POST, GET | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
+| `app/api/bilans/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
 | `app/api/coach/dashboard/route.ts` | GET | no | yes | yes | no | no | no | P2 | coach; guard manuel |
-| `app/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate/route.ts` | POST | yes | yes | yes | no | no | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
-| `app/api/coach/eaf-stage-printemps/students/[studentId]/report/route.ts` | GET, POST, PATCH | yes | yes | yes | no | yes | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
+| `app/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
+| `app/api/coach/eaf-stage-printemps/students/[studentId]/report/route.ts` | GET, POST, PATCH | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
 | `app/api/coach/eaf-stage-printemps/students/route.ts` | GET | no | yes | yes | no | no | no | P2 | coach |
-| `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent/route.ts` | POST | yes | yes | yes | no | no | no | P0 | coach; audit manuel prioritaire |
-| `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student/route.ts` | POST | yes | yes | yes | no | no | no | P0 | coach; audit manuel prioritaire |
-| `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/report/route.ts` | GET, POST, PATCH | yes | yes | yes | no | yes | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
+| `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-parent/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | coach |
+| `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/regenerate-student/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | coach |
+| `app/api/coach/maths-premiere-stage-printemps/students/[studentId]/report/route.ts` | GET, POST, PATCH | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
 | `app/api/coach/maths-premiere-stage-printemps/students/route.ts` | GET | no | yes | yes | no | no | no | P2 | coach |
-| `app/api/coach/nsi-pratique-2026/students/[studentId]/progress/route.ts` | GET | yes | yes | yes | no | no | no | P0 | coach; audit manuel prioritaire |
+| `app/api/coach/nsi-pratique-2026/students/[studentId]/progress/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | coach |
 | `app/api/coach/nsi-pratique-2026/students/route.ts` | GET | no | yes | yes | no | no | no | P2 | coach |
-| `app/api/coach/sessions/[sessionId]/report/route.ts` | POST, GET | yes | yes | yes | no | yes | no | P0 | coach; pédagogique sensible; audit manuel prioritaire; guard manuel |
+| `app/api/coach/sessions/[sessionId]/report/route.ts` | POST, GET | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible; guard manuel |
 | `app/api/coach/stages/route.ts` | GET | no | yes | yes | no | no | no | P2 | coach |
-| `app/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale/route.ts` | GET, PATCH | yes | yes | yes | no | no | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
-| `app/api/coach/students/[studentId]/documents/route.ts` | GET, POST | yes | yes | yes | no | yes | no | P0 | coach; documents/PII; audit manuel prioritaire |
+| `app/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale/route.ts` | GET, PATCH | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
+| `app/api/coach/students/[studentId]/documents/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | coach; documents/PII |
 | `app/api/coach/students/[studentId]/dossier/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | coach; guard manuel |
-| `app/api/coach/students/[studentId]/eaf-preparation-report/route.ts` | GET, PUT | yes | yes | yes | no | yes | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
-| `app/api/coach/students/[studentId]/eaf-preparation-report/validate/route.ts` | POST | yes | yes | yes | no | no | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
-| `app/api/coach/students/[studentId]/generated-reports/[reportId]/download/route.ts` | GET | yes | yes | yes | no | no | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
-| `app/api/coach/students/[studentId]/generated-reports/[reportId]/generate/route.ts` | - | yes | no | no | no | no | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
-| `app/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate/route.ts` | POST | yes | yes | yes | no | no | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
-| `app/api/coach/students/[studentId]/generated-reports/route.ts` | GET, POST | yes | yes | yes | no | yes | no | P0 | coach; pédagogique sensible; audit manuel prioritaire |
-| `app/api/coach/students/[studentId]/notes/route.ts` | GET, POST | yes | yes | yes | no | no | yes | P1 | coach; guard manuel |
+| `app/api/coach/students/[studentId]/eaf-preparation-report/route.ts` | GET, PUT | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
+| `app/api/coach/students/[studentId]/eaf-preparation-report/validate/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
+| `app/api/coach/students/[studentId]/generated-reports/[reportId]/download/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | coach; pédagogique sensible |
+| `app/api/coach/students/[studentId]/generated-reports/[reportId]/generate/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
+| `app/api/coach/students/[studentId]/generated-reports/[reportId]/regenerate/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
+| `app/api/coach/students/[studentId]/generated-reports/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
+| `app/api/coach/students/[studentId]/notes/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | coach; guard manuel |
 | `app/api/coach/students/[studentId]/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | coach |
-| `app/api/coach/students/[studentId]/survival-mode/route.ts` | POST | yes | yes | yes | no | no | yes | P1 | coach; guard manuel |
+| `app/api/coach/students/[studentId]/survival-mode/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | coach; guard manuel |
 | `app/api/coach/students/eam-summary/route.ts` | GET | no | yes | yes | no | no | yes | P2 | coach; guard manuel |
 | `app/api/coach/students/route.ts` | GET | no | yes | yes | no | no | no | P2 | coach |
-| `app/api/coach/trajectory/route.ts` | POST | no | yes | yes | no | no | no | P1 | coach; guard manuel |
+| `app/api/coach/trajectory/route.ts` | POST | no | yes | yes | no | yes | no | P2 | coach; guard manuel |
 | `app/api/coaches/availability/route.ts` | POST, GET, DELETE | no | yes | yes | no | yes | yes | P2 | guard manuel |
 | `app/api/coaches/available/route.ts` | GET | no | yes | yes | no | no | no | P2 | guard manuel |
 | `app/api/contact/route.ts` | POST | no | no | no | no | no | no | OK | - |
 | `app/api/diagnostics/definitions/route.ts` | GET | no | no | no | no | no | no | OK | - |
-| `app/api/documents/[id]/route.ts` | GET | yes | yes | yes | no | no | no | P0 | documents/PII; audit manuel prioritaire; guard manuel |
+| `app/api/documents/[id]/route.ts` | GET | yes | yes | yes | no | yes | yes | P2 | documents/PII; guard manuel |
 | `app/api/eam/progress/route.ts` | GET, POST | no | yes | no | no | yes | no | OK | guard manuel |
-| `app/api/eleve/bilan-diagnostic-maths-terminale/route.ts` | GET, POST | no | yes | yes | no | no | yes | P1 | pédagogique sensible |
+| `app/api/eleve/bilan-diagnostic-maths-terminale/route.ts` | GET, POST | no | yes | yes | no | yes | yes | P2 | pédagogique sensible |
 | `app/api/eleve/nsi-pratique-2026/progress/route.ts` | GET, PUT | no | yes | yes | no | no | yes | OK | - |
 | `app/api/eleve/questionnaire-eaf-stage-printemps/route.ts` | GET, POST | no | yes | yes | no | yes | yes | P2 | - |
 | `app/api/eleve/questionnaire-maths-premiere-stage-printemps/route.ts` | GET, POST | no | yes | yes | no | yes | yes | P2 | - |
 | `app/api/eleve/stages/route.ts` | GET | no | yes | yes | no | no | yes | P2 | - |
 | `app/api/health/route.ts` | GET | no | no | no | no | no | no | OK | - |
-| `app/api/invoices/[id]/pdf/route.ts` | GET | yes | yes | no | no | no | no | P0 | finance; audit manuel prioritaire; guard manuel |
-| `app/api/invoices/[id]/receipt/pdf/route.ts` | GET | yes | yes | no | no | yes | no | P0 | finance; audit manuel prioritaire; guard manuel |
+| `app/api/internal/health/route.ts` | GET | no | yes | yes | no | no | no | OK | - |
+| `app/api/internal/rate-limit-probe/route.ts` | GET | no | yes | yes | no | no | no | OK | - |
+| `app/api/invoices/[id]/pdf/route.ts` | GET | yes | yes | no | no | no | yes | P2 | finance; guard manuel |
+| `app/api/invoices/[id]/receipt/pdf/route.ts` | GET | yes | yes | no | no | yes | yes | P2 | finance; guard manuel |
+| `app/api/lamis/attempt/route.ts` | POST | no | no | no | no | no | no | OK | - |
+| `app/api/lamis/exercises/route.ts` | - | no | no | no | no | no | no | OK | - |
+| `app/api/lamis/export/route.ts` | POST | no | no | no | no | no | no | OK | - |
+| `app/api/lamis/progress/route.ts` | POST | no | no | no | no | no | no | OK | - |
+| `app/api/lamis/teacher-report/route.ts` | POST, GET | no | no | no | no | yes | no | P1 | pédagogique sensible |
 | `app/api/me/next-step/route.ts` | GET | no | yes | no | no | no | no | OK | guard manuel |
 | `app/api/messages/conversations/route.ts` | GET | no | yes | no | no | no | no | OK | guard manuel |
 | `app/api/messages/send/route.ts` | POST | no | yes | yes | no | yes | no | OK | guard manuel |
+| `app/api/newsletter/route.ts` | POST | no | no | no | no | no | no | OK | - |
 | `app/api/notifications/route.ts` | GET, PATCH | no | yes | no | no | no | yes | OK | guard manuel |
 | `app/api/notify/email/route.ts` | POST | no | no | no | no | yes | no | OK | - |
-| `app/api/npc/files/[...path]/route.ts` | GET | yes | yes | no | no | no | no | P0 | audit manuel prioritaire; guard manuel |
-| `app/api/npc/submissions/[submissionId]/documents/[documentId]/route.ts` | PATCH, DELETE | yes | yes | yes | no | no | yes | P1 | documents/PII; pédagogique sensible; guard manuel |
-| `app/api/npc/submissions/[submissionId]/documents/route.ts` | GET, POST | yes | yes | yes | no | no | yes | P1 | documents/PII; pédagogique sensible; guard manuel |
-| `app/api/npc/submissions/[submissionId]/generate/route.ts` | POST | yes | yes | yes | no | no | yes | P1 | pédagogique sensible; guard manuel |
-| `app/api/npc/submissions/route.ts` | POST, GET | no | yes | yes | no | no | yes | P1 | pédagogique sensible; guard manuel |
-| `app/api/npc/uploads/route.ts` | POST | no | yes | yes | no | no | yes | P1 | guard manuel |
-| `app/api/parent/bilans/[id]/pdf/route.ts` | GET | yes | yes | yes | no | no | no | P0 | pédagogique sensible; audit manuel prioritaire |
-| `app/api/parent/children/route.ts` | GET, POST | no | yes | yes | no | no | yes | P1 | guard manuel |
+| `app/api/npc/files/[...path]/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | guard manuel |
+| `app/api/npc/submissions/[submissionId]/documents/[documentId]/route.ts` | PATCH, DELETE | yes | yes | yes | no | yes | yes | P2 | documents/PII; pédagogique sensible; guard manuel |
+| `app/api/npc/submissions/[submissionId]/documents/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | documents/PII; pédagogique sensible; guard manuel |
+| `app/api/npc/submissions/[submissionId]/generate/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | pédagogique sensible; guard manuel |
+| `app/api/npc/submissions/route.ts` | POST, GET | no | yes | yes | no | yes | yes | P2 | pédagogique sensible; guard manuel |
+| `app/api/npc/uploads/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | guard manuel |
+| `app/api/parent/bilans/[id]/pdf/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | pédagogique sensible |
+| `app/api/parent/children/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | guard manuel |
 | `app/api/parent/credit-request/route.ts` | POST | no | yes | yes | no | yes | no | P2 | guard manuel |
 | `app/api/parent/dashboard/route.ts` | GET | no | yes | yes | no | no | yes | P2 | guard manuel |
-| `app/api/parent/stages/route.ts` | GET | no | yes | yes | no | no | no | P2 | - |
-| `app/api/parent/subscription-requests/route.ts` | POST, GET | no | yes | yes | no | no | no | P1 | guard manuel |
-| `app/api/parent/subscriptions/route.ts` | GET, POST | no | yes | yes | no | no | no | P1 | guard manuel |
+| `app/api/parent/stages/route.ts` | GET | no | yes | yes | no | no | yes | P2 | - |
+| `app/api/parent/subscription-requests/route.ts` | POST, GET | no | yes | yes | no | yes | no | P2 | guard manuel |
+| `app/api/parent/subscriptions/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | guard manuel |
 | `app/api/payments/bank-transfer/confirm/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | finance; guard manuel |
 | `app/api/payments/check-pending/route.ts` | GET | no | yes | yes | no | no | yes | P2 | finance; guard manuel |
-| `app/api/payments/clictopay/init/route.ts` | POST | no | yes | no | no | no | no | P1 | finance; guard manuel |
-| `app/api/payments/clictopay/webhook/route.ts` | POST | no | no | no | no | no | no | P0 | finance; audit manuel prioritaire |
+| `app/api/payments/clictopay/init/route.ts` | POST | no | yes | yes | no | yes | no | P2 | finance; guard manuel |
+| `app/api/payments/clictopay/webhook/route.ts` | POST | no | no | no | no | no | no | P1 | finance |
 | `app/api/payments/pending/route.ts` | GET | no | yes | yes | no | no | no | P2 | finance; guard manuel |
 | `app/api/payments/validate/route.ts` | POST | no | yes | yes | no | yes | no | P2 | finance; guard manuel |
 | `app/api/programme/maths-1ere/progress/route.ts` | POST, GET | no | yes | no | no | no | no | OK | guard manuel |
 | `app/api/programme/maths-1ere/rag/route.ts` | POST | no | yes | no | no | yes | no | OK | guard manuel |
 | `app/api/programme/maths-1ere-stmg/progress/route.ts` | POST, GET | no | yes | no | no | no | no | OK | guard manuel |
 | `app/api/programme/maths-1ere-stmg/rag/route.ts` | POST | no | yes | no | no | yes | no | OK | guard manuel |
+| `app/api/programme/maths-1ere-stmg/stage-progress/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | guard manuel |
 | `app/api/programme/maths-terminale/progress/route.ts` | POST, GET | no | yes | no | no | no | no | OK | guard manuel |
+| `app/api/public-documents/corrige-dnb-maths-2026/route.ts` | GET | no | no | no | no | no | no | P2 | - |
 | `app/api/reservation/route.ts` | POST, GET, PATCH | no | yes | no | no | yes | no | OK | guard manuel |
 | `app/api/reservation/verify/route.ts` | POST | no | no | no | no | no | no | OK | - |
 | `app/api/sessions/book/route.ts` | POST | no | yes | yes | yes | yes | no | P2 | - |
-| `app/api/sessions/cancel/route.ts` | POST | no | yes | yes | no | no | no | P1 | - |
-| `app/api/sessions/video/route.ts` | POST | no | yes | yes | no | no | yes | P1 | guard manuel |
-| `app/api/stages/[stageSlug]/bilans/route.ts` | GET, POST | yes | yes | yes | no | yes | no | P0 | pédagogique sensible; audit manuel prioritaire |
-| `app/api/stages/[stageSlug]/inscrire/route.ts` | POST | yes | no | no | no | yes | no | P0 | audit manuel prioritaire |
-| `app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts` | POST | yes | yes | yes | no | no | no | P0 | audit manuel prioritaire |
-| `app/api/stages/[stageSlug]/reservations/route.ts` | GET | yes | yes | yes | no | no | no | P0 | audit manuel prioritaire |
-| `app/api/stages/[stageSlug]/route.ts` | GET | yes | no | no | no | no | no | P0 | audit manuel prioritaire |
-| `app/api/stages/route.ts` | GET | no | no | no | no | yes | no | P0 | audit manuel prioritaire |
-| `app/api/stages/submit-diagnostic/route.ts` | POST | no | no | no | no | yes | no | P0 | audit manuel prioritaire |
-| `app/api/student/activate/route.ts` | GET, POST | no | no | no | no | yes | no | P0 | audit manuel prioritaire |
+| `app/api/sessions/cancel/route.ts` | POST | no | yes | yes | no | yes | no | P2 | - |
+| `app/api/sessions/video/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | guard manuel |
+| `app/api/stages/[stageSlug]/bilans/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | pédagogique sensible |
+| `app/api/stages/[stageSlug]/inscrire/route.ts` | POST | yes | no | no | no | yes | no | P1 | - |
+| `app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | - |
+| `app/api/stages/[stageSlug]/reservations/route.ts` | GET | yes | yes | yes | no | no | no | P2 | - |
+| `app/api/stages/[stageSlug]/route.ts` | GET | yes | no | no | no | yes | no | P2 | - |
+| `app/api/stages/route.ts` | GET | no | no | no | no | yes | no | P2 | - |
+| `app/api/student/activate/route.ts` | GET, POST | no | no | no | no | yes | no | P1 | - |
 | `app/api/student/automatismes/attempts/[id]/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | guard manuel |
-| `app/api/student/automatismes/attempts/route.ts` | POST, GET | no | yes | yes | no | no | yes | P1 | guard manuel |
-| `app/api/student/automatismes/check-answer/route.ts` | POST | no | yes | yes | no | no | no | P1 | guard manuel |
-| `app/api/student/automatismes/series/[id]/route.ts` | GET | yes | yes | yes | no | no | no | P0 | audit manuel prioritaire; guard manuel |
+| `app/api/student/automatismes/attempts/route.ts` | POST, GET | no | yes | yes | no | yes | yes | P2 | guard manuel |
+| `app/api/student/automatismes/check-answer/route.ts` | POST | no | yes | yes | no | yes | no | P2 | guard manuel |
+| `app/api/student/automatismes/series/[id]/route.ts` | GET | yes | yes | yes | no | yes | no | P2 | guard manuel |
 | `app/api/student/automatismes/series/route.ts` | GET | no | yes | yes | no | no | no | P2 | guard manuel |
 | `app/api/student/bilans/[publicShareId]/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | pédagogique sensible |
 | `app/api/student/credits/route.ts` | GET | no | yes | yes | no | no | no | P2 | - |
 | `app/api/student/dashboard/route.ts` | GET | no | yes | yes | no | no | no | P2 | - |
 | `app/api/student/documents/[id]/download/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | documents/PII |
 | `app/api/student/documents/route.ts` | GET | no | yes | yes | no | no | yes | P2 | documents/PII; guard manuel |
-| `app/api/student/nexus-index/route.ts` | GET | no | yes | no | no | no | no | P1 | guard manuel |
+| `app/api/student/nexus-index/route.ts` | GET | no | yes | yes | no | yes | no | P2 | guard manuel |
 | `app/api/student/resources/official/[slug]/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | - |
 | `app/api/student/resources/route.ts` | GET | no | yes | yes | no | no | no | P2 | guard manuel |
 | `app/api/student/sessions/route.ts` | GET | no | yes | yes | no | no | no | P2 | - |
 | `app/api/student/stages/route.ts` | GET | no | yes | yes | no | no | yes | P2 | - |
-| `app/api/student/survival/phrases/[phraseId]/copied/route.ts` | POST | yes | yes | yes | no | no | yes | P1 | guard manuel |
-| `app/api/student/survival/progress/route.ts` | GET, POST | no | yes | yes | no | no | yes | P1 | guard manuel |
-| `app/api/student/survival/qcm/attempt/route.ts` | POST | no | yes | yes | no | no | yes | P1 | guard manuel |
-| `app/api/student/survival/reflexes/[reflexId]/attempt/route.ts` | POST | yes | yes | yes | no | no | yes | P1 | guard manuel |
+| `app/api/student/survival/phrases/[phraseId]/copied/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | guard manuel |
+| `app/api/student/survival/progress/route.ts` | GET, POST | no | yes | yes | no | yes | yes | P2 | guard manuel |
+| `app/api/student/survival/qcm/attempt/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | guard manuel |
+| `app/api/student/survival/reflexes/[reflexId]/attempt/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | guard manuel |
 | `app/api/student/survival/ritual/route.ts` | GET | no | yes | yes | no | no | yes | P2 | guard manuel |
-| `app/api/student/trajectory/route.ts` | GET | no | yes | no | no | no | no | P1 | guard manuel |
+| `app/api/student/trajectory/route.ts` | GET | no | yes | yes | no | yes | no | P2 | guard manuel |
 | `app/api/students/[studentId]/badges/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | guard manuel |
-| `app/api/subscriptions/aria-addon/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | ARIA; guard manuel |
-| `app/api/subscriptions/change/route.ts` | POST | no | yes | yes | no | yes | yes | OK | guard manuel |
+| `app/api/subscriptions/aria-addon/route.ts` | POST | no | no | no | no | no | no | P2 | ARIA |
+| `app/api/subscriptions/change/route.ts` | POST | no | no | no | no | no | no | P2 | - |
 
 ## Prochaines étapes
 

--- a/lib/invoice/index.ts
+++ b/lib/invoice/index.ts
@@ -25,7 +25,7 @@ export type {
 export { createInvoiceEvent, appendInvoiceEvent, assertMillimes, MillimesValidationError, PAYMENT_METHOD_LABELS } from './types';
 export type { InvoiceEventDetails } from './types';
 export { sanitizeEventDetails, MAX_EVENT_DETAILS_SIZE } from './types';
-export { notFoundResponse, buildInvoiceScopeWhere } from './not-found';
+export { notFoundResponse, buildInvoiceScopeWhere, buildInvoiceAccessWhere } from './not-found';
 export {
   validateTransition,
   canPerformStatusAction,

--- a/lib/invoice/not-found.ts
+++ b/lib/invoice/not-found.ts
@@ -9,6 +9,7 @@
  */
 
 import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
 
 /** Canonical 404 JSON body — frozen, never varies. */
 const NOT_FOUND_BODY = { error: 'NOT_FOUND' } as const;
@@ -48,4 +49,56 @@ export function buildInvoiceScopeWhere(
     return { id, customerEmail: email };
   }
   return null;
+}
+
+type InvoiceAccessUser = {
+  id: string;
+  role?: string | null;
+  email?: string | null;
+};
+
+/**
+ * Build a Prisma WHERE clause scoped to the authenticated user.
+ *
+ * Parent access is based on child beneficiary user ids when available, with a
+ * legacy customerEmail fallback for older invoices that predate beneficiaryUserId.
+ */
+export async function buildInvoiceAccessWhere(
+  id: string,
+  user: InvoiceAccessUser
+): Promise<Record<string, unknown> | null> {
+  if (user.role === 'ADMIN' || user.role === 'ASSISTANTE') {
+    return { id };
+  }
+
+  if (user.role !== 'PARENT') {
+    return null;
+  }
+
+  const parentProfile = await prisma.parentProfile.findUnique({
+    where: { userId: user.id },
+    select: {
+      children: {
+        select: { userId: true },
+      },
+    },
+  });
+
+  const childUserIds = parentProfile?.children
+    .map((child) => child.userId)
+    .filter((childUserId): childUserId is string => Boolean(childUserId)) ?? [];
+
+  const ownershipFilters: Record<string, unknown>[] = [];
+  if (childUserIds.length > 0) {
+    ownershipFilters.push({ beneficiaryUserId: { in: childUserIds } });
+  }
+  if (user.email) {
+    ownershipFilters.push({ customerEmail: user.email });
+  }
+
+  if (ownershipFilters.length === 0) {
+    return null;
+  }
+
+  return { id, OR: ownershipFilters };
 }

--- a/lib/invoice/not-found.ts
+++ b/lib/invoice/not-found.ts
@@ -42,7 +42,7 @@ export function buildInvoiceScopeWhere(
   role: string | undefined,
   email: string | null | undefined
 ): Record<string, unknown> | null {
-  if (role === 'ADMIN' || role === 'ASSISTANTE') {
+  if (role === 'ADMIN') {
     return { id };
   }
   if (role === 'PARENT' && email) {
@@ -67,7 +67,7 @@ export async function buildInvoiceAccessWhere(
   id: string,
   user: InvoiceAccessUser
 ): Promise<Record<string, unknown> | null> {
-  if (user.role === 'ADMIN' || user.role === 'ASSISTANTE') {
+  if (user.role === 'ADMIN') {
     return { id };
   }
 

--- a/lib/stages/inscription-schema.ts
+++ b/lib/stages/inscription-schema.ts
@@ -11,6 +11,8 @@ export const publicStageInscriptionSchema = z.object({
   parentEmail: z.union([z.string().trim().email(), z.literal('')]).optional(),
   parentPhone: z.string().trim().max(30).optional(),
   notes: z.string().trim().max(500).optional(),
+  stageTermsAccepted: z.literal(true),
+  dataProcessingAccepted: z.literal(true),
 }).strict();
 
 export type PublicStageInscriptionInput = z.infer<typeof publicStageInscriptionSchema>;

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -28,6 +28,7 @@ export const bilanGratuitSchema = z.object({
   studentLastName: z.string().min(2, 'Le nom doit contenir au moins 2 caractères').optional(),
   studentGrade: z.string().min(1, 'Veuillez sélectionner une classe'),
   studentSchool: z.string().optional(),
+  studentBirthDate: z.string().optional(),
 
   // Besoins et objectifs
   subjects: z.array(z.enum(Object.values(Subject) as [string, ...string[]])).min(1, 'Sélectionnez au moins une matière'),

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -28,7 +28,6 @@ export const bilanGratuitSchema = z.object({
   studentLastName: z.string().min(2, 'Le nom doit contenir au moins 2 caractères').optional(),
   studentGrade: z.string().min(1, 'Veuillez sélectionner une classe'),
   studentSchool: z.string().optional(),
-  studentBirthDate: z.string().optional(),
 
   // Besoins et objectifs
   subjects: z.array(z.enum(Object.values(Subject) as [string, ...string[]])).min(1, 'Sélectionnez au moins une matière'),

--- a/scripts/check-bundle-weight.sh
+++ b/scripts/check-bundle-weight.sh
@@ -49,8 +49,9 @@ for route in "${!BASELINES[@]}"; do
   baseline="${BASELINES[$route]}"
   budget=$((baseline + TOLERANCE_KB))
 
-  # Match the route in build output — handles both ┌ and ├ prefixes
-  line=$(grep -E "○ ${route} " "$BUILD_LOG" | head -1 || true)
+  # Match the route in build output regardless of whether Next marks it as
+  # static (○) or dynamic (ƒ). Some protected marketing flows read cookies.
+  line=$(grep -F " ${route} " "$BUILD_LOG" | head -1 || true)
   if [ -z "$line" ]; then
     echo "✗  ${route}: not found in build output (protected route vanished from build)"
     FAILURES=$((FAILURES + 1))

--- a/scripts/go-live/generate-api-security-matrix.mjs
+++ b/scripts/go-live/generate-api-security-matrix.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = process.cwd();
+const inventoryPath = join(root, 'docs/security/API_GUARD_INVENTORY.md');
+const outPath = join(root, 'docs/go-live/api-security-matrix.full.md');
+
+const inventory = readFileSync(inventoryPath, 'utf8');
+
+const fullInventory = inventory.split('## Inventaire complet')[1] ?? '';
+
+const rows = fullInventory
+  .split('\n')
+  .filter((line) => line.startsWith('| `app/api/') && line.includes('/route.ts` |'))
+  .map((line) => {
+    const cells = line.split('|').slice(1, -1).map((cell) => cell.trim());
+    const routeFile = cells[0].replace(/`/g, '');
+    return {
+      routeFile,
+      route: `/${routeFile.replace(/^app\//, '').replace(/\/route\.ts$/, '')}`,
+      methods: cells[1],
+      dynamic: cells[2],
+      authGuard: cells[3],
+      roleGuard: cells[4],
+      featureGuard: cells[5],
+      zod: cells[6],
+      ownershipDetected: cells[7],
+      priority: cells[8],
+      notes: cells[9] || '-',
+    };
+  });
+
+const domainRules = [
+  [/invoice|facturation|billing/i, 'Facturation'],
+  [/payment|clictopay/i, 'Paiement'],
+  [/document|pdf|files/i, 'Documents'],
+  [/bilan|assessment|diagnostic|report/i, 'Bilans/assessments'],
+  [/aria|rag/i, 'ARIA/RAG'],
+  [/npc|submission|upload/i, 'NPC'],
+  [/stage/i, 'Stages'],
+  [/admin/i, 'Admin'],
+  [/assistante/i, 'Assistante'],
+  [/coach/i, 'Coach'],
+  [/parent/i, 'Parent'],
+  [/student|eleve/i, 'Élève'],
+  [/auth|activate|reset-password/i, 'Auth'],
+  [/contact|newsletter|notify/i, 'Leads/messages'],
+];
+
+const sensitiveRules = [
+  [/invoice|payment|billing|facturation/i, 'Facture/paiement'],
+  [/document|pdf|files|upload/i, 'Document/fichier'],
+  [/bilan|assessment|diagnostic|report|submission/i, 'Données pédagogiques mineur'],
+  [/aria|conversation|message/i, 'Conversation IA'],
+  [/student|eleve|parent|coach|assistante|admin|user/i, 'PII/utilisateur'],
+  [/stage|reservation|session/i, 'Réservation/session'],
+  [/contact|newsletter|notify/i, 'Lead/contact'],
+];
+
+const p0DomainOrder = [
+  'Documents',
+  'Facturation',
+  'Paiement',
+  'Bilans/assessments',
+  'NPC',
+  'Coach',
+  'Stages',
+  'Assistante',
+  'Auth',
+  'ARIA/RAG',
+  'Admin',
+  'Parent',
+  'Élève',
+  'Leads/messages',
+];
+
+function escapeCell(value) {
+  return String(value ?? '')
+    .replaceAll('|', '\\|')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function domainFor(route, notes) {
+  const haystack = `${route} ${notes}`;
+  return domainRules.find(([pattern]) => pattern.test(haystack))?.[1] ?? 'Autre';
+}
+
+function sensitiveFor(route, notes) {
+  const haystack = `${route} ${notes}`;
+  const labels = sensitiveRules
+    .filter(([pattern]) => pattern.test(haystack))
+    .map(([, label]) => label);
+  return labels.length ? [...new Set(labels)].join(', ') : 'À vérifier';
+}
+
+function publicAuthFor(row) {
+  if (row.authGuard === 'yes') return 'Auth';
+  if (/webhook/i.test(row.route)) return 'Public webhook';
+  if (/contact|newsletter|notify|bilan-gratuit$|stages\/\[stageSlug\]\/inscrire|assessments\/submit|public-documents|student\/activate/i.test(row.route)) {
+    return 'Public';
+  }
+  return 'Public/À vérifier';
+}
+
+function roleFor(row) {
+  const route = row.route;
+  if (row.roleGuard !== 'yes') return row.authGuard === 'yes' ? 'À vérifier' : 'N/A';
+  if (/\/admin\//.test(route)) return 'Admin/staff';
+  if (/\/assistante\//.test(route)) return 'Assistante';
+  if (/\/coach\//.test(route)) return 'Coach';
+  if (/\/parent\//.test(route)) return 'Parent';
+  if (/\/student\/|\/eleve\//.test(route)) return 'Élève';
+  if (/\/aria\//.test(route)) return 'Élève/abonné à vérifier';
+  return 'Rôle détecté, à qualifier';
+}
+
+function ownershipRequired(row, domain, sensitiveData) {
+  if (row.dynamic === 'yes') return 'Oui';
+  if (row.authGuard === 'yes' && /Document|Facture|paiement|Données pédagogiques|Conversation|PII|Réservation/.test(sensitiveData)) {
+    return 'Oui';
+  }
+  if (row.publicAuth.startsWith?.('Public')) return 'N/A';
+  if (['Admin', 'Leads/messages', 'Autre'].includes(domain)) return 'À vérifier';
+  return 'À vérifier';
+}
+
+function rateLimitDetected(routeFile) {
+  const full = join(root, routeFile);
+  if (!existsSync(full)) return 'À vérifier';
+  const source = readFileSync(full, 'utf8');
+  return (
+    /\bguardRateLimitAsync\s*\(/.test(source) ||
+    /\bguardRateLimit\s*\(/.test(source) ||
+    /\bcheckRateLimitAsync\s*\(/.test(source) ||
+    /\bcheckRateLimit\s*\(/.test(source) ||
+    /\brateLimitResponse\s*\(/.test(source) ||
+    /\bRateLimitPresets\.[A-Za-z0-9_]+\s*\(/.test(source) ||
+    /\bwithRateLimit\s*\(/.test(source) ||
+    /\bapplyRateLimit\s*\(/.test(source) ||
+    /\bpublicLeadRateLimit\s*\(/.test(source) ||
+    /\benforceRateLimit\s*\(/.test(source)
+  )
+    ? 'Oui'
+    : 'Non';
+}
+
+function actionFor(row, domain, rateLimit) {
+  if (row.priority === 'OK') return 'Maintenir tests de non-régression';
+  if (row.priority === 'P0') {
+    if (domain === 'Paiement') return 'Lot 1/4 : signature, idempotence, auth et non-exposition publique';
+    if (domain === 'Facturation') return 'Lot 1 : ownership facture/PDF + tests IDOR';
+    if (domain === 'Documents') return 'Lot 1 : ownership strict, path no-leak, tests IDOR';
+    if (domain === 'Bilans/assessments') return 'Lot 1 : auth/token signé + ownership résultats';
+    if (domain === 'NPC') return 'Lot 1 : traversal + ownership soumission/document';
+    if (domain === 'Stages') return 'Lot 1 : scope stage, role staff, anti-spam public';
+    if (domain === 'Coach') return 'Lot 1 : assignment actif obligatoire';
+    if (domain === 'Assistante') return 'Lot 1 : périmètre assistante + audit IDOR';
+    if (domain === 'Auth') return 'Lot 1 : token, expiration, rate limit';
+    if (rateLimit === 'Non' && publicAuthFor(row).startsWith('Public')) return 'Lot 1 : ajouter rate limit public';
+    return 'Lot 1 : audit manuel prioritaire + tests IDOR';
+  }
+  if (row.priority === 'P1') return 'Durcir avant bêta élargie';
+  return 'Suivi qualité P2';
+}
+
+const enriched = rows.map((row) => {
+  const domain = domainFor(row.route, row.notes);
+  const sensitiveData = sensitiveFor(row.route, row.notes);
+  const publicAuth = publicAuthFor(row);
+  const ownershipRequiredValue = ownershipRequired({ ...row, publicAuth }, domain, sensitiveData);
+  const rateLimit = rateLimitDetected(row.routeFile);
+  return {
+    ...row,
+    domain,
+    sensitiveData,
+    publicAuth,
+    roleRequired: roleFor(row),
+    ownershipRequired: ownershipRequiredValue,
+    rateLimit,
+    action: actionFor(row, domain, rateLimit),
+  };
+});
+
+const counts = ['P0', 'P1', 'P2', 'OK'].map((priority) => [
+  priority,
+  enriched.filter((row) => row.priority === priority).length,
+]);
+
+const topPriority = enriched.some((row) => row.priority === 'P0') ? 'P0' : 'P1';
+const top20 = enriched
+  .filter((row) => row.priority === topPriority)
+  .sort((a, b) => {
+    const domainDelta = p0DomainOrder.indexOf(a.domain) - p0DomainOrder.indexOf(b.domain);
+    if (domainDelta !== 0) return domainDelta;
+    return a.route.localeCompare(b.route);
+  })
+  .slice(0, 20);
+
+const lines = [];
+lines.push('# Annexe matrice API sécurité complète');
+lines.push('');
+lines.push(`Source : \`${inventoryPath.replace(`${root}/`, '')}\`.`);
+lines.push(`Généré le : ${new Date().toISOString()}.`);
+lines.push('');
+lines.push('Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Zod détecté` et `Ownership requis` sont des indices de pilotage. `À vérifier` signifie qu’aucune preuve suffisante n’a été établie dans ce lot.');
+lines.push('');
+lines.push('## Synthèse');
+lines.push('');
+lines.push('| Priorité | Nombre |');
+lines.push('| --- | ---: |');
+for (const [priority, count] of counts) lines.push(`| ${priority} | ${count} |`);
+lines.push(`| Total | ${enriched.length} |`);
+lines.push('');
+lines.push(`## Top 20 à corriger en priorité (${topPriority})`);
+lines.push('');
+lines.push('| Priorité | Route | Domaine | Risque dominant | Action Lot suivant |');
+lines.push('| --- | --- | --- | --- | --- |');
+for (const row of top20) {
+  lines.push(`| ${row.priority} | \`${row.route}\` | ${row.domain} | ${escapeCell(row.sensitiveData)} | ${escapeCell(row.action)} |`);
+}
+lines.push('');
+lines.push('## Matrice route par route');
+lines.push('');
+lines.push('| Priorité | Route | Méthodes | Domaine | Public/Auth | Rôle requis | Ownership requis | Auth guard détecté | Role guard détecté | Zod détecté | Rate limit détecté | Données sensibles | Action Lot suivant |');
+lines.push('| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |');
+for (const row of enriched) {
+  lines.push([
+    row.priority,
+    `\`${row.route}\``,
+    row.methods,
+    row.domain,
+    row.publicAuth,
+    row.roleRequired,
+    row.ownershipRequired,
+    row.authGuard === 'yes' ? 'Oui' : 'Non',
+    row.roleGuard === 'yes' ? 'Oui' : 'Non',
+    row.zod === 'yes' ? 'Oui' : 'Non',
+    row.rateLimit,
+    row.sensitiveData,
+    row.action,
+  ].map(escapeCell).join(' | ').replace(/^/, '| ').concat(' |'));
+}
+lines.push('');
+lines.push('## Limites');
+lines.push('');
+lines.push('- Les guards détectés proviennent de motifs statiques ; ils ne prouvent pas l’absence d’IDOR.');
+lines.push('- Le rate limiting est détecté par motifs de code locaux ; une protection middleware, reverse proxy ou provider externe reste `À vérifier` sans preuve runtime.');
+lines.push('- Les routes `OK` ne sont pas déclarées go-live ready ; elles sont seulement moins prioritaires dans l’inventaire statique.');
+
+writeFileSync(outPath, `${lines.join('\n')}\n`);
+console.log(`Wrote ${outPath.replace(`${root}/`, '')} (${enriched.length} routes)`);
+console.log(counts.map(([priority, count]) => `${priority}: ${count}`).join(', '));

--- a/scripts/security/audit-api-guards.mjs
+++ b/scripts/security/audit-api-guards.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 
 const root = process.cwd();
 const apiRoot = join(root, 'app/api');
@@ -27,11 +27,59 @@ function methodsOf(source) {
   return matches.map((match) => match[1]).join(', ') || '-';
 }
 
+function hasRateLimitGuard(source) {
+  return hasAny(source, [
+    /\bguardRateLimitAsync\s*\(/,
+    /\bguardRateLimit\s*\(/,
+    /\bcheckRateLimitAsync\s*\(/,
+    /\bcheckRateLimit\s*\(/,
+    /\brateLimitResponse\s*\(/,
+    /\bRateLimitPresets\.[A-Za-z0-9_]+\s*\(/,
+    /\bwithRateLimit\s*\(/,
+    /\bapplyRateLimit\s*\(/,
+    /\bpublicLeadRateLimit\s*\(/,
+    /\benforceRateLimit\s*\(/,
+  ]);
+}
+
+function sourceFor(file) {
+  const source = readFileSync(file, 'utf8');
+  const reexportMatches = [...source.matchAll(/export\s*\{\s*([^}]+)\s*\}\s*from\s*['"]([^'"]+)['"]/g)];
+  if (reexportMatches.length === 0) return source;
+
+  const importedSources = reexportMatches
+    .map((match) => {
+      const target = resolve(dirname(file), match[2]);
+      const targetFile = target.endsWith('.ts') ? target : `${target}.ts`;
+      try {
+        return readFileSync(targetFile, 'utf8');
+      } catch {
+        return '';
+      }
+    })
+    .filter(Boolean);
+
+  return [source, ...importedSources].join('\n');
+}
+
 function riskFor(route, source, dynamic, authGuard, roleGuard, ownership, zod) {
   const sensitivePath = /documents|invoice|billing|payment|bilan|assessment|aria|session|stage|coach|assistante|admin|parent|student|npc|submission|report/i.test(route);
   const mutation = /\b(POST|PATCH|PUT|DELETE)\b/.test(methodsOf(source));
+  const staffOnlyRoute = (
+    /app\/api\/(admin|assistante)\//.test(route) ||
+    /requireAnyRole\s*\(\s*\[\s*['"]ADMIN['"]\s*,\s*['"]ASSISTANTE['"]/.test(source)
+  ) && authGuard && roleGuard;
+  const publicSensitiveWithControls = !authGuard && sensitivePath && zod && hasRateLimitGuard(source);
+  const fixedPublicDocument = /app\/api\/public-documents\//.test(route) && methodsOf(source) === 'GET' && /const\s+FILE_NAME\b/.test(source);
+  const disabledWebhook = /webhook/i.test(route) && /status:\s*501/.test(source) && /NOT_CONFIGURED|not configured|en cours de configuration/i.test(source);
+  const deprecatedRoute = /status:\s*410/.test(source);
+  const publicStageCatalog = /^app\/api\/stages(\/\[[^\]]+\])?\/route\.ts$/.test(route) && methodsOf(source) === 'GET';
+  const staticStudentContent = /app\/api\/student\/automatismes\/series\/\[id\]\/route\.ts/.test(route) && methodsOf(source) === 'GET';
 
-  if (dynamic && sensitivePath && authGuard && !ownership) return 'P0';
+  if (fixedPublicDocument || deprecatedRoute || publicStageCatalog || staticStudentContent) return 'P2';
+  if (disabledWebhook) return 'P1';
+  if (dynamic && sensitivePath && authGuard && !ownership && !staffOnlyRoute) return 'P0';
+  if (publicSensitiveWithControls) return mutation ? 'P1' : 'P2';
   if (sensitivePath && !authGuard) return 'P0';
   if (mutation && sensitivePath && !zod) return 'P1';
   if (sensitivePath && authGuard && !roleGuard && !ownership) return 'P1';
@@ -54,11 +102,26 @@ function notesFor(route, source, risk) {
 }
 
 const rows = walk(apiRoot).map((file) => {
-  const source = readFileSync(file, 'utf8');
+  const source = sourceFor(file);
   const route = relative(root, file);
   const dynamic = /\[[^\]]+\]/.test(route) ? 'yes' : 'no';
-  const authGuard = hasAny(source, [/\bauth\s*\(/, /\brequireAuth\b/, /\brequireRole\b/, /\brequireAnyRole\b/]) ? 'yes' : 'no';
-  const roleGuard = hasAny(source, [/\brequireRole\b/, /\brequireAnyRole\b/, /session\.user\.role/, /UserRole\./]) ? 'yes' : 'no';
+  const authGuard = hasAny(source, [
+    /\bauth\s*\(/,
+    /\brequireAuth\b/,
+    /\brequireRole\b/,
+    /\brequireAnyRole\b/,
+    /\benforcePolicy\b/,
+    /\bgetActor\b/,
+  ]) ? 'yes' : 'no';
+  const roleGuard = hasAny(source, [
+    /\brequireRole\b/,
+    /\brequireAnyRole\b/,
+    /\benforcePolicy\b/,
+    /\bcanPerformStatusAction\b/,
+    /\bcan\s*\(\s*role\s*,/,
+    /session\.user\.role/,
+    /UserRole\./,
+  ]) ? 'yes' : 'no';
   const featureGuard = hasAny(source, [/\brequireFeatureApi\b/, /\brequireFeature\b/]) ? 'yes' : 'no';
   const zod = hasAny(source, [/\bzod\b/, /\bz\./, /\.parse\s*\(/, /\.safeParse\s*\(/]) ? 'yes' : 'no';
   const ownership = hasAny(source, [
@@ -68,6 +131,32 @@ const rows = walk(apiRoot).map((file) => {
     /coachId\s*:\s*session\.user\.id/,
     /student\s*:\s*\{[^}]*userId\s*:\s*session\.user\.id/s,
     /where\s*:\s*\{[^}]*id\s*:[^}]*userId/s,
+    /\bbuildDocumentOwnershipWhere\b/,
+    /\bhasDocumentOwnership\b/,
+    /\bassertCoachCanAccessStudent\b/,
+    /\bisCoachAssignedToStudent\b/,
+    /\bcanReadSubmission\b/,
+    /\bcanManageSubmissionDocuments\b/,
+    /\bauthenticateAndAuthorize\b/,
+    /\bverifyStageAccess\b/,
+    /\bstageCoach\.findFirst\b/,
+    /stage\s*:\s*\{\s*slug\s*:\s*stageSlug\s*\}/,
+    /sessionBooking\.coachId\s*!==\s*coachUserId/,
+    /sessionBooking\.coachId\s*!==\s*session\.user\.id/,
+    /sessionBooking\.studentId\s*!==\s*session\.user\.id/,
+    /sessionBooking\.parentId\s*!==\s*session\.user\.id/,
+    /\bbuildInvoiceAccessWhere\b/,
+    /\bbuildInvoiceScopeWhere\b/,
+    /\bbuildAssessmentAccessWhere\b/,
+    /\bbuildBilanReadWhere\b/,
+    /\bbuildBilanWriteWhere\b/,
+    /studentId\s*:\s*\{\s*in\s*:\s*childIds\s*\}/,
+    /parentProfile\.findUnique\s*\([^]*userId\s*:\s*sessionOrError\.user\.id/s,
+    /\brequireParentOwnsStudent\b/,
+    /\brequireParentOwnsInvoice\b/,
+    /\brequireCoachAssignedToStudent\b/,
+    /\brequireStudentOwnsResource\b/,
+    /\benforceOwnership\b/,
     /ownership/i,
   ]) ? 'yes' : 'no';
   const methods = methodsOf(source);


### PR DESCRIPTION
## Scope

Extraction G-SEC de la mega-PR go-live: durcissement des guards API admin/roles et couverture de regression associee, rebased sur `main` apres la mini-PR a11y.

Cette PR ne traite pas les paiements ClicToPay ni le funnel public bilan/assessment. Ces P1 restent explicitement differes vers les PR thematiques prevues.

## P1 disposition

| P1 route | Disposition | Preuve / PR |
|---|---|---|
| `/api/lamis/teacher-report` | Ferme par G-SEC | `app/api/lamis/teacher-report/route.ts`, `__tests__/api/lamis.teacher-report.route.test.ts` |
| `/api/stages/[stageSlug]/inscrire` | Ferme par G-SEC | `app/api/stages/[stageSlug]/inscrire/route.ts`, `lib/stages/inscription-schema.ts`, tests stages |
| `/api/student/activate` | Ferme par G-SEC | `app/api/student/activate/route.ts`, tests activation |
| `/api/payments/clictopay/init` | Differe | PR G-PAY |
| `/api/payments/clictopay/webhook` | Differe | PR G-PAY |
| `/api/assessments/submit` | Differe | PR G-FUNNEL, avec cloture `assessmentId` expose |
| `/api/bilan-gratuit` | Differe | PR G-FUNNEL |
| `/api/bilan-gratuit/dismiss` | Differe | PR G-FUNNEL |

Matrice regeneree sur G-SEC: `P0: 0`, `P1: 8`, aucun P1 orphelin.

## Tests transverses

| Test transverse | PR proprietaire | Decoupe |
|---|---|---|
| `no-sensitive-fields-in-api-responses` | G-FUNNEL principal | Decouper ClicToPay vers G-PAY; G-SEC garde les tests no-leak route par route deja presents. |
| `security-audit-scripts-regression` | G-DOCS / G-INFRA | G-INFRA pour rate-limit probe; G-DOCS pour audit/matrice apres extraction complete. |
| `public-rate-limit.coverage` | G-FUNNEL principal | Extraire une tranche G-SEC limitee a lamis/stage/student si necessaire; garder bilan/assessment avec funnel. |

## Subscription request guard correction

Le guard assistant subscription requests accepte maintenant `reason: null` comme absence de raison, sans assouplissement global.

Preuve par tests dans `__tests__/api/assistant.subscription-requests.route.test.ts`:

- `reason: null` accepte sur un payload d'approbation valide.
- `action` reste strictement validee: action inconnue rejetee en 400.
- `requestId` reste strictement valide: identifiant invalide rejete en 400 sans acces DB.
- Les champs inconnus restent rejetes en 400 sans acces DB.

## Local gate

Run frais sur le HEAD final `fa16c7b6ac703dac161a63939ddaa11ae74aaa04`:

- `npm ci`: PASS.
- `npm run lint`: PASS.
- `npm run typecheck`: PASS.
- `npm run test -- --runInBand`: PASS (`513 passed`, `1 skipped`, `6412 passed tests`, `4 skipped`).
- `npm run build:gate`: PASS.
- `node scripts/security/audit-api-guards.mjs`: PASS (`176 routes`).
- `node scripts/go-live/generate-api-security-matrix.mjs`: PASS (`P0: 0`, `P1: 8`, `P2: 141`, `OK: 27`).
- `npm run audit:site-map`: PASS.
- `npm run check:docs-archive`: PASS.
- `npm run check:no-hardcoded`: PASS.
- `git diff --check`: PASS.
- Public Playwright chromium suite: PASS (`199 passed`).
- Auth Playwright chromium suite: PASS (`42 passed`).

## DB hygiene

Les E2E ont cible uniquement la base de test `nexus-postgres-e2e` sur port local 5435. Le conteneur local nomme `prod` n'est pas expose au host et n'a pas ete cible.

## Decisions maintenues

- Pas de merge sans verdict cubic et Codex sur ce HEAD final (`original_commit_id`).
- Pas de deploiement.
- Pas de migration production.
- ClicToPay reste desactive/differe vers G-PAY.
- G-FUNNEL reste requis pour bilan/assessment et cloture `assessmentId` public.
- `BETA_CONTROLEE_ALLOWED_WITH_RESERVES` seulement.
- `BETA_ELARGIE_BLOCKED`.
- `GO_LIVE_LARGE_BLOCKED`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened API security with strict role guards, safe ID/payload validation, and scoped access across admin/assistant/coach/student routes. Prevents IDOR and data leaks, restricts invoice PDFs to admins/parents, and adds rate limiting to sensitive endpoints.

- **Bug Fixes**
  - Enforce strict `requireRole`/`requireAnyRole` on admin stats, test-email, coach/student/NPC routes; return 401 vs 403 consistently.
  - Add strict `zod` validation (with `.strict()`) for params, query, and bodies; reject unknown fields and unsafe IDs before any DB/disk access across bilans, NPC, coach/student, stages, sessions, admin lists, and LAMIS teacher report.
  - Close IDOR/leaks:
    - Invoices: replace `buildInvoiceScopeWhere` with `buildInvoiceAccessWhere`; restrict session access to ADMIN (full) and PARENT (scoped to children/email); add explicit `select` on admin list.
    - Documents: hide `localPath` from API outputs; use safe projections on reads; validate uploads (size/mime) and sanitize filenames.
    - Activation: expose only `activationUrl` in parent flows; never return raw tokens; verify via hashed tokens with expiry.
    - Coach/NPC: verify coach assignment before any read/regenerate/file I/O; sanitize generated report payloads.
  - Harden coach/student flows: validate route params on all student-scoped endpoints; sanitize trajectory/eaf/notes/survival-mode payloads; bound stage inscriptions, require consents, and hide `reservationId` on conflicts.
  - Add rate limiting to public/auth flows like `student/activate`, `sessions/video`, admin directeur stats, and LAMIS teacher report.
  - Standardize admin listings (invoices/subscriptions) with bounded pagination and strict filter validation; reject invalid filters early.

- **Refactors**
  - Centralize guards and input schemas; standardize 400 “Données invalides” errors and specific “Invalid … payload/params” messages.
  - Unify safe ID patterns and route param schemas; prefer minimal `select` projections on reads.
  - Expand security regression coverage, including guard classification/inventory scripts and new IDOR/file-access tests.

<sup>Written for commit 6060a3e6300123731c2231c8b8aee7af76de0169. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

