### PR TITLE
chore(docs): post-merge matrix + chores tracker

### DIFF
--- a/docs/go-live/POST-MERGE-CHORES.md
+++ b/docs/go-live/POST-MERGE-CHORES.md
@@ -1,0 +1,28 @@
+# Post-merge chores (G-SEC #62 + G-PAY #61)
+
+> Ne pas confondre avec DOC-5 = `docs/architecture/restructuration/05-architecture-migration.md`
+
+## Chores à traiter (un chantier à la fois)
+
+| # | Chore | Scope | Branche cible |
+|---|-------|-------|---------------|
+| 1 | `download-streaming` | Streaming des fichiers volumineux dans `/api/documents/[id]/download` | Lot dédié à planifier |
+| 2 | `audit-per-method-guards` | Généraliser parseJsonBody + gardes par méthode HTTP aux ~13 routes restantes | Lot dédié à planifier |
+| 3 | `instrument-precision-2` | Affiner la classification automatique (réduire P2 → OK sur les routes déjà correctes) | Lot dédié à planifier |
+| 4 | `clictopay-signature-format` | Checklist d'activation paiement : format signature HMAC, secret rotation, webhook 200. Retirer/aligner le flag `NEXT_PUBLIC_ENABLE_CLICTOPAY_PUBLIC` du composant `PaymentMethodsNote` (revenu via #61, dormant fail-closed). | G-FUNNEL |
+| 5 | `stabilize-flaky-tests` | Identifier et stabiliser les tests flaky (P1017, timeouts CI) | Lot dédié à planifier |
+
+## Héritages nominatifs G-FUNNEL (3 items)
+
+1. **Token signé `assessments/submit`** — route P1, nécessite un token HMAC par soumission pour éliminer les soumissions fantômes.
+2. **Minimisation payload HMAC `leadEmailHash`** — le webhook bilan-gratuit ne doit transmettre qu'un hash de l'email, pas l'email en clair.
+3. **Honeypot vérifié par l'instrument** — le champ honeypot des formulaires publics doit être détecté par l'audit automatique (classification → P0 si absent).
+
+## Contexte
+
+- SHA merge #62 (G-SEC) : `b2ea32f0b`
+- SHA merge #61 (G-PAY) : `ac02f548b`
+- HEAD main post-merge : `ac02f548b`
+- Matrice : P0=0, P1=2, PUBLIC=3, P2=144, OK=27
+- Tests gate local (branche g-pay rebasée) : 518 suites, 6496 tests pass
+- PR #58 fermée, branche `feat/lot4-accessors-runtime` supprimée

--- a/docs/go-live/api-security-matrix.full.md
+++ b/docs/go-live/api-security-matrix.full.md
@@ -1,17 +1,26 @@
 # Annexe matrice API sécurité complète
 
 Source : `docs/security/API_GUARD_INVENTORY.md`.
-Généré le : 2026-07-07T13:14:25.009Z.
+Généré le : 2026-07-11T19:27:42.385Z.
 
 Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Zod détecté` et `Ownership requis` sont des indices de pilotage. `À vérifier` signifie qu’aucune preuve suffisante n’a été établie dans ce lot.
+
+## Règles de sévérité (2026-07-10)
+
+- **P0** : (a) sensitive public route without ANY control (no Zod, no rate-limit, no auth) — (b) dynamic sensitive authenticated route without ownership and not staff-only
+- **P1** : (a) sensitive public route with partial controls (Zod and/or rate-limit) but no auth — (b) sensitive mutation without Zod validation — (c) sensitive authenticated route without role guard or ownership — (d) disabled webhook (501 status) — (e) PUBLIC_BY_DESIGN route missing baseline controls
+- **PUBLIC** : allow-listed with Zod + rate-limit + route-specific controls verified
+- **P2** : sensitive authenticated route with guards (includes static public documents, deprecated, catalog)
+- **OK** : non-sensitive route
 
 ## Synthèse
 
 | Priorité | Nombre |
 | --- | ---: |
 | P0 | 0 |
-| P1 | 6 |
-| P2 | 143 |
+| P1 | 2 |
+| PUBLIC | 3 |
+| P2 | 144 |
 | OK | 27 |
 | Total | 176 |
 
@@ -21,10 +30,6 @@ Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Z
 | --- | --- | --- | --- | --- |
 | P1 | `/api/payments/clictopay/webhook` | Paiement | Facture/paiement | Durcir avant bêta élargie |
 | P1 | `/api/assessments/submit` | Bilans/assessments | Données pédagogiques mineur | Durcir avant bêta élargie |
-| P1 | `/api/bilan-gratuit` | Bilans/assessments | Données pédagogiques mineur | Durcir avant bêta élargie |
-| P1 | `/api/bilan-gratuit/dismiss` | Bilans/assessments | Données pédagogiques mineur | Durcir avant bêta élargie |
-| P1 | `/api/stages/[stageSlug]/inscrire` | Stages | Réservation/session | Durcir avant bêta élargie |
-| P1 | `/api/student/activate` | Élève | PII/utilisateur | Durcir avant bêta élargie |
 
 ## Matrice route par route
 
@@ -82,8 +87,8 @@ Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Z
 | OK | `/api/auth/[...nextauth]` | - | Auth | Public/À vérifier | N/A | Oui | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
 | OK | `/api/auth/resend-activation` | POST | Auth | Public/À vérifier | N/A | N/A | Non | Non | Oui | Oui | À vérifier | Maintenir tests de non-régression |
 | OK | `/api/auth/reset-password` | POST | Auth | Public/À vérifier | N/A | N/A | Non | Non | Oui | Oui | À vérifier | Maintenir tests de non-régression |
-| P1 | `/api/bilan-gratuit/dismiss` | POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | Données pédagogiques mineur | Durcir avant bêta élargie |
-| P1 | `/api/bilan-gratuit` | POST | Bilans/assessments | Public | Rôle détecté, à qualifier | N/A | Non | Oui | Oui | Oui | Données pédagogiques mineur | Durcir avant bêta élargie |
+| P2 | `/api/bilan-gratuit/dismiss` | POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| PUBLIC | `/api/bilan-gratuit` | POST | Bilans/assessments | Public | N/A | N/A | Non | Non | Oui | Oui | Données pédagogiques mineur | Maintenir tests de non-régression |
 | P2 | `/api/bilan-gratuit/status` | GET | Bilans/assessments | Auth | À vérifier | Oui | Oui | Non | Non | Non | Données pédagogiques mineur | Suivi qualité P2 |
 | P2 | `/api/bilan-pallier2-maths/retry` | POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
 | P2 | `/api/bilan-pallier2-maths` | POST, GET | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Oui | Données pédagogiques mineur | Suivi qualité P2 |
@@ -105,7 +110,7 @@ Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Z
 | P2 | `/api/coach/stages` | GET | Stages | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur, Réservation/session | Suivi qualité P2 |
 | P2 | `/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale` | GET, PATCH | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
 | P2 | `/api/coach/students/[studentId]/documents` | GET, POST | Documents | Auth | Coach | Oui | Oui | Oui | Oui | Non | Document/fichier, PII/utilisateur | Suivi qualité P2 |
-| P2 | `/api/coach/students/[studentId]/dossier` | GET | Coach | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/dossier` | GET | Coach | Auth | À vérifier | Oui | Oui | Non | Non | Non | PII/utilisateur | Suivi qualité P2 |
 | P2 | `/api/coach/students/[studentId]/eaf-preparation-report` | GET, PUT | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
 | P2 | `/api/coach/students/[studentId]/eaf-preparation-report/validate` | POST | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
 | P2 | `/api/coach/students/[studentId]/generated-reports/[reportId]/download` | GET | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Non | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
@@ -114,7 +119,7 @@ Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Z
 | P2 | `/api/coach/students/[studentId]/generated-reports` | GET, POST | Bilans/assessments | Auth | Coach | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
 | P2 | `/api/coach/students/[studentId]/notes` | GET, POST | Coach | Auth | Coach | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
 | P2 | `/api/coach/students/[studentId]` | GET | Coach | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
-| P2 | `/api/coach/students/[studentId]/survival-mode` | POST | Coach | Auth | Coach | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
+| P2 | `/api/coach/students/[studentId]/survival-mode` | POST | Coach | Auth | À vérifier | Oui | Oui | Non | Oui | Non | PII/utilisateur | Suivi qualité P2 |
 | P2 | `/api/coach/students/eam-summary` | GET | Coach | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
 | P2 | `/api/coach/students` | GET | Coach | Auth | Coach | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
 | P2 | `/api/coach/trajectory` | POST | Coach | Auth | Coach | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
@@ -122,7 +127,8 @@ Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Z
 | P2 | `/api/coaches/available` | GET | Coach | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
 | OK | `/api/contact` | POST | Leads/messages | Public | N/A | N/A | Non | Non | Non | Oui | Lead/contact | Maintenir tests de non-régression |
 | OK | `/api/diagnostics/definitions` | GET | Bilans/assessments | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | Données pédagogiques mineur | Maintenir tests de non-régression |
-| P2 | `/api/documents/[id]` | GET | Documents | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Document/fichier | Suivi qualité P2 |
+| P2 | `/api/documents/[id]/download` | GET | Documents | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Document/fichier | Suivi qualité P2 |
+| P2 | `/api/documents/[id]` | GET | Documents | Auth | À vérifier | Oui | Oui | Non | Oui | Non | Document/fichier | Suivi qualité P2 |
 | OK | `/api/eam/progress` | GET, POST | Autre | Auth | À vérifier | À vérifier | Oui | Non | Oui | Non | À vérifier | Maintenir tests de non-régression |
 | P2 | `/api/eleve/bilan-diagnostic-maths-terminale` | GET, POST | Bilans/assessments | Auth | Élève | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
 | OK | `/api/eleve/nsi-pratique-2026/progress` | GET, PUT | Élève | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur | Maintenir tests de non-régression |
@@ -137,17 +143,16 @@ Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Z
 | OK | `/api/lamis/exercises` | - | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
 | OK | `/api/lamis/export` | POST | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
 | OK | `/api/lamis/progress` | POST | Autre | Public/À vérifier | N/A | N/A | Non | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
-| P2 | `/api/lamis/teacher-report` | POST, GET | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Oui | Données pédagogiques mineur | Suivi qualité P2 |
 | OK | `/api/me/next-step` | GET | Autre | Auth | À vérifier | À vérifier | Oui | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
 | OK | `/api/messages/conversations` | GET | Autre | Auth | À vérifier | Oui | Oui | Non | Non | Non | Conversation IA | Maintenir tests de non-régression |
-| OK | `/api/messages/send` | POST | Autre | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Conversation IA | Maintenir tests de non-régression |
+| OK | `/api/messages/send` | POST | Autre | Auth | À vérifier | Oui | Oui | Non | Oui | Non | Conversation IA | Maintenir tests de non-régression |
 | OK | `/api/newsletter` | POST | Leads/messages | Public | N/A | N/A | Non | Non | Non | Oui | Lead/contact | Maintenir tests de non-régression |
 | OK | `/api/notifications` | GET, PATCH | Autre | Auth | À vérifier | À vérifier | Oui | Non | Non | Non | À vérifier | Maintenir tests de non-régression |
 | OK | `/api/notify/email` | POST | Leads/messages | Public | N/A | N/A | Non | Non | Oui | Oui | Lead/contact | Maintenir tests de non-régression |
 | P2 | `/api/npc/files/[...path]` | GET | Documents | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | Document/fichier | Suivi qualité P2 |
-| P2 | `/api/npc/submissions/[submissionId]/documents/[documentId]` | PATCH, DELETE | Documents | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Document/fichier, Données pédagogiques mineur | Suivi qualité P2 |
-| P2 | `/api/npc/submissions/[submissionId]/documents` | GET, POST | Documents | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Document/fichier, Données pédagogiques mineur | Suivi qualité P2 |
-| P2 | `/api/npc/submissions/[submissionId]/generate` | POST | NPC | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/npc/submissions/[submissionId]/documents/[documentId]` | PATCH, DELETE | Documents | Auth | À vérifier | Oui | Oui | Non | Oui | Non | Document/fichier, Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/npc/submissions/[submissionId]/documents` | GET, POST | Documents | Auth | À vérifier | Oui | Oui | Non | Oui | Non | Document/fichier, Données pédagogiques mineur | Suivi qualité P2 |
+| P2 | `/api/npc/submissions/[submissionId]/generate` | POST | NPC | Auth | À vérifier | Oui | Oui | Non | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
 | P2 | `/api/npc/submissions` | POST, GET | NPC | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur | Suivi qualité P2 |
 | P2 | `/api/npc/uploads` | POST | NPC | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Document/fichier | Suivi qualité P2 |
 | P2 | `/api/parent/bilans/[id]/pdf` | GET | Documents | Auth | Parent | Oui | Oui | Oui | Non | Non | Document/fichier, Données pédagogiques mineur, PII/utilisateur | Suivi qualité P2 |
@@ -176,12 +181,12 @@ Lecture statique uniquement : `Auth guard détecté`, `Role guard détecté`, `Z
 | P2 | `/api/sessions/cancel` | POST | Autre | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Oui | Réservation/session | Suivi qualité P2 |
 | P2 | `/api/sessions/video` | POST | Autre | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Oui | Réservation/session | Suivi qualité P2 |
 | P2 | `/api/stages/[stageSlug]/bilans` | GET, POST | Bilans/assessments | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Données pédagogiques mineur, Réservation/session | Suivi qualité P2 |
-| P1 | `/api/stages/[stageSlug]/inscrire` | POST | Stages | Public | N/A | Oui | Non | Non | Oui | Oui | Réservation/session | Durcir avant bêta élargie |
+| PUBLIC | `/api/stages/[stageSlug]/inscrire` | POST | Stages | Public | N/A | Oui | Non | Non | Oui | Oui | Réservation/session | Maintenir tests de non-régression |
 | P2 | `/api/stages/[stageSlug]/reservations/[reservationId]/confirm` | POST | Stages | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Oui | Non | Réservation/session | Suivi qualité P2 |
 | P2 | `/api/stages/[stageSlug]/reservations` | GET | Stages | Auth | Rôle détecté, à qualifier | Oui | Oui | Oui | Non | Non | Réservation/session | Suivi qualité P2 |
 | P2 | `/api/stages/[stageSlug]` | GET | Stages | Public/À vérifier | N/A | Oui | Non | Non | Oui | Non | Réservation/session | Suivi qualité P2 |
 | P2 | `/api/stages` | GET | Stages | Public/À vérifier | N/A | N/A | Non | Non | Oui | Non | Réservation/session | Suivi qualité P2 |
-| P1 | `/api/student/activate` | GET, POST | Élève | Public | N/A | N/A | Non | Non | Oui | Oui | PII/utilisateur | Durcir avant bêta élargie |
+| PUBLIC | `/api/student/activate` | GET, POST | Élève | Public | N/A | N/A | Non | Non | Oui | Oui | PII/utilisateur | Maintenir tests de non-régression |
 | P2 | `/api/student/automatismes/attempts/[id]` | GET | Élève | Auth | Élève | Oui | Oui | Oui | Non | Non | PII/utilisateur | Suivi qualité P2 |
 | P2 | `/api/student/automatismes/attempts` | POST, GET | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |
 | P2 | `/api/student/automatismes/check-answer` | POST | Élève | Auth | Élève | Oui | Oui | Oui | Oui | Non | PII/utilisateur | Suivi qualité P2 |

--- a/docs/security/API_GUARD_INVENTORY.md
+++ b/docs/security/API_GUARD_INVENTORY.md
@@ -1,31 +1,42 @@
 # Inventaire initial des guards API
 
-Généré le : 2026-07-07T13:14:24.955Z
+Généré le : 2026-07-11T19:27:37.841Z
 
 Lecture statique uniquement. La colonne `Ownership explicit` signale des indices de filtrage propriétaire dans le fichier; elle ne remplace pas un audit manuel IDOR.
 
 ## Synthèse
 
 - P0 : 0
-- P1 : 6
-- P2 : 143
+- P1 : 2
+- P2 : 144
+- PUBLIC : 3
 - OK : 27
 - Total routes : 176
 
-## 10 routes à auditer en priorité
+## 20 routes à auditer en priorité
 
 | Route | Methods | Risk | Notes |
 |---|---|---|---|
 | `app/api/assessments/submit/route.ts` | POST | P1 | pédagogique sensible |
-| `app/api/bilan-gratuit/dismiss/route.ts` | POST | P1 | pédagogique sensible; guard manuel |
-| `app/api/bilan-gratuit/route.ts` | POST | P1 | pédagogique sensible |
 | `app/api/payments/clictopay/webhook/route.ts` | POST | P1 | finance |
-| `app/api/stages/[stageSlug]/inscrire/route.ts` | POST | P1 | - |
-| `app/api/student/activate/route.ts` | GET, POST | P1 | - |
 | `app/api/admin/activities/route.ts` | GET | P2 | staff/admin |
 | `app/api/admin/analytics/route.ts` | GET | P2 | staff/admin |
 | `app/api/admin/config/history/route.ts` | GET | P2 | staff/admin |
 | `app/api/admin/config/rollback/route.ts` | POST | P2 | staff/admin |
+| `app/api/admin/config/route.ts` | GET, PATCH | P2 | staff/admin |
+| `app/api/admin/dashboard/route.ts` | GET | P2 | staff/admin |
+| `app/api/admin/directeur/stats/route.ts` | GET | P2 | staff/admin |
+| `app/api/admin/documents/route.ts` | POST | P2 | staff/admin; documents/PII |
+| `app/api/admin/invoices/[id]/route.ts` | PATCH | P2 | staff/admin; finance; guard manuel |
+| `app/api/admin/invoices/[id]/send/route.ts` | POST | P2 | staff/admin; finance; guard manuel |
+| `app/api/admin/invoices/route.ts` | POST, GET | P2 | staff/admin; finance; guard manuel |
+| `app/api/admin/recompute-ssn/route.ts` | POST | P2 | staff/admin |
+| `app/api/admin/stages/[stageId]/coaches/route.ts` | GET, POST, DELETE | P2 | staff/admin |
+| `app/api/admin/stages/[stageId]/route.ts` | GET, PATCH, DELETE | P2 | staff/admin |
+| `app/api/admin/stages/[stageId]/sessions/[sessionId]/route.ts` | PATCH, DELETE | P2 | staff/admin |
+| `app/api/admin/stages/[stageId]/sessions/route.ts` | GET, POST | P2 | staff/admin |
+| `app/api/admin/stages/route.ts` | GET, POST | P2 | staff/admin |
+| `app/api/admin/subscriptions/route.ts` | GET, PUT | P2 | staff/admin |
 
 ## Inventaire complet
 
@@ -83,14 +94,14 @@ Lecture statique uniquement. La colonne `Ownership explicit` signale des indices
 | `app/api/auth/[...nextauth]/route.ts` | - | yes | no | no | no | no | no | OK | - |
 | `app/api/auth/resend-activation/route.ts` | POST | no | no | no | no | yes | no | OK | - |
 | `app/api/auth/reset-password/route.ts` | POST | no | no | no | no | yes | yes | OK | - |
-| `app/api/bilan-gratuit/dismiss/route.ts` | POST | no | yes | yes | no | no | yes | P1 | pédagogique sensible; guard manuel |
-| `app/api/bilan-gratuit/route.ts` | POST | no | no | yes | no | yes | no | P1 | pédagogique sensible |
+| `app/api/bilan-gratuit/dismiss/route.ts` | POST | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
+| `app/api/bilan-gratuit/route.ts` | POST | no | no | no | no | yes | no | PUBLIC | pédagogique sensible; Formulaire public de bilan stratégique gratuit — Zod + rate-limit + honeypot |
 | `app/api/bilan-gratuit/status/route.ts` | GET | no | yes | no | no | no | yes | P2 | pédagogique sensible; guard manuel |
 | `app/api/bilan-pallier2-maths/retry/route.ts` | POST | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
 | `app/api/bilan-pallier2-maths/route.ts` | POST, GET | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
 | `app/api/bilans/[id]/export/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | pédagogique sensible |
 | `app/api/bilans/[id]/route.ts` | GET, PUT, DELETE | yes | yes | yes | no | yes | yes | P2 | pédagogique sensible |
-| `app/api/bilans/generate/route.ts` | POST, GET | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
+| `app/api/bilans/generate/route.ts` | POST, GET | no | yes | yes | no | yes | yes | P2 | pédagogique sensible |
 | `app/api/bilans/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
 | `app/api/coach/dashboard/route.ts` | GET | no | yes | yes | no | no | no | P2 | coach; guard manuel |
 | `app/api/coach/eaf-stage-printemps/students/[studentId]/report/regenerate/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
@@ -106,7 +117,7 @@ Lecture statique uniquement. La colonne `Ownership explicit` signale des indices
 | `app/api/coach/stages/route.ts` | GET | no | yes | yes | no | no | no | P2 | coach |
 | `app/api/coach/students/[studentId]/bilan-diagnostic-maths-terminale/route.ts` | GET, PATCH | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
 | `app/api/coach/students/[studentId]/documents/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | coach; documents/PII |
-| `app/api/coach/students/[studentId]/dossier/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | coach; guard manuel |
+| `app/api/coach/students/[studentId]/dossier/route.ts` | GET | yes | yes | no | no | no | yes | P2 | coach; guard manuel |
 | `app/api/coach/students/[studentId]/eaf-preparation-report/route.ts` | GET, PUT | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
 | `app/api/coach/students/[studentId]/eaf-preparation-report/validate/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
 | `app/api/coach/students/[studentId]/generated-reports/[reportId]/download/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | coach; pédagogique sensible |
@@ -115,7 +126,7 @@ Lecture statique uniquement. La colonne `Ownership explicit` signale des indices
 | `app/api/coach/students/[studentId]/generated-reports/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | coach; pédagogique sensible |
 | `app/api/coach/students/[studentId]/notes/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | coach; guard manuel |
 | `app/api/coach/students/[studentId]/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | coach |
-| `app/api/coach/students/[studentId]/survival-mode/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | coach; guard manuel |
+| `app/api/coach/students/[studentId]/survival-mode/route.ts` | POST | yes | yes | no | no | yes | yes | P2 | coach; guard manuel |
 | `app/api/coach/students/eam-summary/route.ts` | GET | no | yes | yes | no | no | yes | P2 | coach; guard manuel |
 | `app/api/coach/students/route.ts` | GET | no | yes | yes | no | no | no | P2 | coach |
 | `app/api/coach/trajectory/route.ts` | POST | no | yes | yes | no | yes | no | P2 | coach; guard manuel |
@@ -123,7 +134,8 @@ Lecture statique uniquement. La colonne `Ownership explicit` signale des indices
 | `app/api/coaches/available/route.ts` | GET | no | yes | yes | no | no | no | P2 | guard manuel |
 | `app/api/contact/route.ts` | POST | no | no | no | no | no | no | OK | - |
 | `app/api/diagnostics/definitions/route.ts` | GET | no | no | no | no | no | no | OK | - |
-| `app/api/documents/[id]/route.ts` | GET | yes | yes | yes | no | yes | yes | P2 | documents/PII; guard manuel |
+| `app/api/documents/[id]/download/route.ts` | GET | yes | yes | yes | no | yes | yes | P2 | documents/PII; guard manuel |
+| `app/api/documents/[id]/route.ts` | GET | yes | yes | no | no | yes | yes | P2 | documents/PII; guard manuel |
 | `app/api/eam/progress/route.ts` | GET, POST | no | yes | no | no | yes | no | OK | guard manuel |
 | `app/api/eleve/bilan-diagnostic-maths-terminale/route.ts` | GET, POST | no | yes | yes | no | yes | yes | P2 | pédagogique sensible |
 | `app/api/eleve/nsi-pratique-2026/progress/route.ts` | GET, PUT | no | yes | yes | no | no | yes | OK | - |
@@ -138,17 +150,16 @@ Lecture statique uniquement. La colonne `Ownership explicit` signale des indices
 | `app/api/lamis/exercises/route.ts` | - | no | no | no | no | no | no | OK | - |
 | `app/api/lamis/export/route.ts` | POST | no | no | no | no | no | no | OK | - |
 | `app/api/lamis/progress/route.ts` | POST | no | no | no | no | no | no | OK | - |
-| `app/api/lamis/teacher-report/route.ts` | POST, GET | no | yes | yes | no | yes | no | P2 | pédagogique sensible |
 | `app/api/me/next-step/route.ts` | GET | no | yes | no | no | no | no | OK | guard manuel |
 | `app/api/messages/conversations/route.ts` | GET | no | yes | no | no | no | no | OK | guard manuel |
-| `app/api/messages/send/route.ts` | POST | no | yes | yes | no | yes | no | OK | guard manuel |
+| `app/api/messages/send/route.ts` | POST | no | yes | no | no | yes | no | OK | guard manuel |
 | `app/api/newsletter/route.ts` | POST | no | no | no | no | no | no | OK | - |
 | `app/api/notifications/route.ts` | GET, PATCH | no | yes | no | no | no | yes | OK | guard manuel |
 | `app/api/notify/email/route.ts` | POST | no | no | no | no | yes | no | OK | - |
 | `app/api/npc/files/[...path]/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | guard manuel |
-| `app/api/npc/submissions/[submissionId]/documents/[documentId]/route.ts` | PATCH, DELETE | yes | yes | yes | no | yes | yes | P2 | documents/PII; pédagogique sensible; guard manuel |
-| `app/api/npc/submissions/[submissionId]/documents/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | documents/PII; pédagogique sensible; guard manuel |
-| `app/api/npc/submissions/[submissionId]/generate/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | pédagogique sensible; guard manuel |
+| `app/api/npc/submissions/[submissionId]/documents/[documentId]/route.ts` | PATCH, DELETE | yes | yes | no | no | yes | yes | P2 | documents/PII; pédagogique sensible; guard manuel |
+| `app/api/npc/submissions/[submissionId]/documents/route.ts` | GET, POST | yes | yes | no | no | yes | yes | P2 | documents/PII; pédagogique sensible; guard manuel |
+| `app/api/npc/submissions/[submissionId]/generate/route.ts` | POST | yes | yes | no | no | yes | yes | P2 | pédagogique sensible; guard manuel |
 | `app/api/npc/submissions/route.ts` | POST, GET | no | yes | yes | no | yes | yes | P2 | pédagogique sensible; guard manuel |
 | `app/api/npc/uploads/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | guard manuel |
 | `app/api/parent/bilans/[id]/pdf/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | pédagogique sensible |
@@ -160,7 +171,7 @@ Lecture statique uniquement. La colonne `Ownership explicit` signale des indices
 | `app/api/parent/subscriptions/route.ts` | GET, POST | no | yes | yes | no | yes | no | P2 | guard manuel |
 | `app/api/payments/bank-transfer/confirm/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | finance; guard manuel |
 | `app/api/payments/check-pending/route.ts` | GET | no | yes | yes | no | no | yes | P2 | finance; guard manuel |
-| `app/api/payments/clictopay/init/route.ts` | POST | no | yes | yes | no | yes | no | P2 | finance; guard manuel |
+| `app/api/payments/clictopay/init/route.ts` | POST | no | yes | yes | no | yes | no | P2 | finance |
 | `app/api/payments/clictopay/webhook/route.ts` | POST | no | no | no | no | no | no | P1 | finance |
 | `app/api/payments/pending/route.ts` | GET | no | yes | yes | no | no | no | P2 | finance; guard manuel |
 | `app/api/payments/validate/route.ts` | POST | no | yes | yes | no | yes | no | P2 | finance; guard manuel |
@@ -177,12 +188,12 @@ Lecture statique uniquement. La colonne `Ownership explicit` signale des indices
 | `app/api/sessions/cancel/route.ts` | POST | no | yes | yes | no | yes | no | P2 | - |
 | `app/api/sessions/video/route.ts` | POST | no | yes | yes | no | yes | yes | P2 | guard manuel |
 | `app/api/stages/[stageSlug]/bilans/route.ts` | GET, POST | yes | yes | yes | no | yes | yes | P2 | pédagogique sensible |
-| `app/api/stages/[stageSlug]/inscrire/route.ts` | POST | yes | no | no | no | yes | no | P1 | - |
+| `app/api/stages/[stageSlug]/inscrire/route.ts` | POST | yes | no | no | no | yes | no | PUBLIC | Formulaire public d'inscription aux stages — Zod + rate-limit |
 | `app/api/stages/[stageSlug]/reservations/[reservationId]/confirm/route.ts` | POST | yes | yes | yes | no | yes | yes | P2 | - |
 | `app/api/stages/[stageSlug]/reservations/route.ts` | GET | yes | yes | yes | no | no | no | P2 | - |
 | `app/api/stages/[stageSlug]/route.ts` | GET | yes | no | no | no | yes | no | P2 | - |
 | `app/api/stages/route.ts` | GET | no | no | no | no | yes | no | P2 | - |
-| `app/api/student/activate/route.ts` | GET, POST | no | no | no | no | yes | no | P1 | - |
+| `app/api/student/activate/route.ts` | GET, POST | no | no | no | no | yes | no | PUBLIC | Lien d'activation élève via token unique hashé — Zod + rate-limit auth |
 | `app/api/student/automatismes/attempts/[id]/route.ts` | GET | yes | yes | yes | no | no | yes | P2 | guard manuel |
 | `app/api/student/automatismes/attempts/route.ts` | POST, GET | no | yes | yes | no | yes | yes | P2 | guard manuel |
 | `app/api/student/automatismes/check-answer/route.ts` | POST | no | yes | yes | no | yes | no | P2 | guard manuel |


### PR DESCRIPTION
## Summary

- Regenerated `api-security-matrix.full.md` and `API_GUARD_INVENTORY.md` on main post-merge of G-SEC #62 + G-PAY #61
- Added `POST-MERGE-CHORES.md` tracking 5 follow-up chores and 3 G-FUNNEL heritage items
- Matrix: P0=0, P1=2, PUBLIC=3, P2=144, OK=27

## Test plan

- [x] No code changes — docs only
- [x] CI green (no tests affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerated the API security matrix and guard inventory after merging G-SEC #62 and G-PAY #61, and added `POST-MERGE-CHORES.md` to track 5 follow-ups and 3 G-FUNNEL heritage items. Matrix now reads P0=0, P1=2, PUBLIC=3, P2=144, OK=27; notable updates: `/api/bilan-gratuit`, `/api/stages/[stageSlug]/inscrire`, and `/api/student/activate` marked PUBLIC, new `/api/documents/[id]/download` captured, and several coach/NPC/document routes flagged for ownership checks.

<sup>Written for commit d2e7fd04570be71d8fb7c8ed0a96c0903cf7c734. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

