### PR TITLE
fix(security): add path containment to document download routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -155,6 +155,13 @@ RATE_LIMIT_MAX=60
 LOG_LEVEL=info
 
 # =============================================================================
+# DOCUMENT STORAGE (required in production)
+# =============================================================================
+# Absolute path to persistent document storage directory.
+# Must survive release swaps — do NOT place inside a release directory.
+# DOCUMENT_STORAGE_ROOT=/var/www/nexus-shared/storage/documents
+
+# =============================================================================
 # TELEMETRY
 # =============================================================================
 NEXT_TELEMETRY_DISABLED=1

--- a/__tests__/api/documents.id.route.test.ts
+++ b/__tests__/api/documents.id.route.test.ts
@@ -10,6 +10,23 @@ jest.mock('@/auth', () => ({
   auth: jest.fn(),
 }));
 
+jest.mock('@/lib/documents/secure-file-access', () => ({
+  resolveSecurePath: jest.fn(),
+  SecureFileAccessError: class SecureFileAccessError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.code = code;
+      this.name = 'SecureFileAccessError';
+    }
+  },
+}));
+
+jest.mock('@/lib/documents/storage-root', () => ({
+  getDocumentStorageRoot: () => '/mock/storage/root',
+  LEGACY_STORAGE_PREFIX: '/app/storage/documents/',
+}));
+
 jest.mock('fs/promises', () => ({
   readFile: jest.fn(),
 }));
@@ -21,10 +38,12 @@ jest.mock('node:fs/promises', () => ({
 import { GET } from '@/app/api/documents/[id]/route';
 import { auth } from '@/auth';
 import { readFile } from 'fs/promises';
+import { resolveSecurePath, SecureFileAccessError } from '@/lib/documents/secure-file-access';
 import { NextRequest } from 'next/server';
 
 const mockAuth = auth as jest.Mock;
 const mockReadFile = readFile as jest.Mock;
+const mockResolveSecurePath = resolveSecurePath as jest.Mock;
 
 let prisma: any;
 
@@ -32,6 +51,8 @@ beforeEach(async () => {
   const mod = await import('@/lib/prisma');
   prisma = (mod as any).prisma;
   jest.clearAllMocks();
+  // Default: resolveSecurePath succeeds and returns a safe path
+  mockResolveSecurePath.mockResolvedValue({ canonicalPath: '/mock/storage/root/file.pdf', sizeBytes: 1024 });
 });
 
 function mockDocumentLookup(document: unknown) {
@@ -63,7 +84,7 @@ describe('GET /api/documents/[id]', () => {
   it('should return 404 when user is not owner and not staff without reading file', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'other-user', role: 'ELEVE' } } as any);
     mockDocumentLookup({
-      id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/test.pdf',
+      id: 'doc-1', userId: 'u1', localPath: 'test.pdf',
       mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
     });
 
@@ -75,7 +96,7 @@ describe('GET /api/documents/[id]', () => {
   it('should return document for owner', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
     mockDocumentLookup({
-      id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/test.pdf',
+      id: 'doc-1', userId: 'u1', localPath: 'test.pdf',
       mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
     });
     mockReadFile.mockResolvedValue(Buffer.from('fake-pdf-content') as any);
@@ -86,12 +107,13 @@ describe('GET /api/documents/[id]', () => {
     expect(res.headers.get('Content-Type')).toBe('application/pdf');
     expect(res.headers.get('Content-Disposition')).toContain('test.pdf');
     expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store');
   });
 
   it('should return document for ADMIN', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } } as any);
     mockDocumentLookup({
-      id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/test.pdf',
+      id: 'doc-1', userId: 'u1', localPath: 'test.pdf',
       mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
     });
     mockReadFile.mockResolvedValue(Buffer.from('fake-pdf-content') as any);
@@ -103,7 +125,7 @@ describe('GET /api/documents/[id]', () => {
   it('should return document for ASSISTANTE', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'assist-1', role: 'ASSISTANTE' } } as any);
     mockDocumentLookup({
-      id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/test.pdf',
+      id: 'doc-1', userId: 'u1', localPath: 'test.pdf',
       mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
     });
     mockReadFile.mockResolvedValue(Buffer.from('fake-pdf-content') as any);
@@ -112,26 +134,45 @@ describe('GET /api/documents/[id]', () => {
     expect(res.status).toBe(200);
   });
 
+  it('should return 404 when containment check fails (path traversal)', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
+    mockDocumentLookup({
+      id: 'doc-1', userId: 'u1', localPath: '../../../etc/passwd',
+      mimeType: 'application/pdf', originalName: 'evil.pdf', sizeBytes: 1024,
+    });
+    mockResolveSecurePath.mockRejectedValue(
+      new SecureFileAccessError('PATH_ESCAPE', 'Path escapes storage root')
+    );
+
+    const res = await GET(...makeRequest('doc-1'));
+    expect(res.status).toBe(404);
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
   it('should return 404 when file missing on disk', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
     mockDocumentLookup({
-      id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/missing.pdf',
+      id: 'doc-1', userId: 'u1', localPath: 'missing.pdf',
       mimeType: 'application/pdf', originalName: 'missing.pdf', sizeBytes: 1024,
     });
-    mockReadFile.mockRejectedValue(new Error('ENOENT: no such file'));
+    mockResolveSecurePath.mockRejectedValue(
+      new SecureFileAccessError('FILE_NOT_FOUND', 'File does not exist')
+    );
 
     const res = await GET(...makeRequest('doc-1'));
     expect(res.status).toBe(404);
   });
 
-  it('should not log local file paths when file content is missing', async () => {
+  it('should not log local file paths when containment fails', async () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
     mockDocumentLookup({
       id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/private/missing.pdf',
       mimeType: 'application/pdf', originalName: 'missing.pdf', sizeBytes: 1024,
     });
-    mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT: /app/storage/documents/private/missing.pdf'), { code: 'ENOENT' }));
+    mockResolveSecurePath.mockRejectedValue(
+      new SecureFileAccessError('FILE_NOT_FOUND', 'File does not exist')
+    );
 
     const res = await GET(...makeRequest('doc-1'));
 

--- a/__tests__/api/documents.id.route.test.ts
+++ b/__tests__/api/documents.id.route.test.ts
@@ -1,194 +1,130 @@
 /**
- * Documents [id] API — Complete Test Suite
- *
+ * Documents [id] API — Test Suite
  * Tests: GET /api/documents/[id]
- *
- * Source: app/api/documents/[id]/route.ts
  */
+import { Readable } from 'stream';
 
-jest.mock('@/auth', () => ({
-  auth: jest.fn(),
-}));
-
-jest.mock('@/lib/documents/secure-file-access', () => ({
-  resolveSecurePath: jest.fn(),
-  SecureFileAccessError: class SecureFileAccessError extends Error {
-    code: string;
-    constructor(code: string, message: string) {
-      super(message);
-      this.code = code;
-      this.name = 'SecureFileAccessError';
-    }
-  },
-}));
+jest.mock('@/auth', () => ({ auth: jest.fn() }));
 
 jest.mock('@/lib/documents/storage-root', () => ({
-  getDocumentStorageRoot: () => '/mock/storage/root',
+  getDocumentStorageRoot: () => '/mock/storage',
   LEGACY_STORAGE_PREFIX: '/app/storage/documents/',
 }));
 
-jest.mock('fs/promises', () => ({
-  readFile: jest.fn(),
-}));
-
-jest.mock('node:fs/promises', () => ({
-  readFile: jest.fn(),
-}));
+jest.mock('@/lib/documents/secure-file-access', () => {
+  class SecureFileAccessError extends Error {
+    code: string;
+    constructor(code: string, message: string) { super(message); this.code = code; this.name = 'SecureFileAccessError'; }
+  }
+  return {
+    openSecureDocument: jest.fn(),
+    SecureFileAccessError,
+    safeContentType: (m: string | null) => m || 'application/octet-stream',
+    safeFilename: (n: string) => n || 'document',
+  };
+});
 
 import { GET } from '@/app/api/documents/[id]/route';
 import { auth } from '@/auth';
-import { readFile } from 'fs/promises';
-import { resolveSecurePath, SecureFileAccessError } from '@/lib/documents/secure-file-access';
+import { openSecureDocument, SecureFileAccessError } from '@/lib/documents/secure-file-access';
 import { NextRequest } from 'next/server';
 
 const mockAuth = auth as jest.Mock;
-const mockReadFile = readFile as jest.Mock;
-const mockResolveSecurePath = resolveSecurePath as jest.Mock;
+const mockOpen = openSecureDocument as jest.Mock;
 
-let prisma: any;
-
-beforeEach(async () => {
-  const mod = await import('@/lib/prisma');
-  prisma = (mod as any).prisma;
-  jest.clearAllMocks();
-  // Default: resolveSecurePath succeeds and returns a safe path
-  mockResolveSecurePath.mockResolvedValue({ canonicalPath: '/mock/storage/root/file.pdf', sizeBytes: 1024 });
-});
-
-function mockDocumentLookup(document: unknown) {
-  prisma.userDocument.findUnique.mockResolvedValue(document);
-  prisma.userDocument.findFirst.mockResolvedValue(document);
+function makeHandle() {
+  return {
+    handle: {
+      createReadStream: () => Readable.from(Buffer.from('content')),
+      close: jest.fn().mockResolvedValue(undefined),
+    },
+    sizeBytes: 7,
+  };
 }
 
-function makeRequest(id: string): [NextRequest, { params: Promise<{ id: string }> }] {
-  const req = new NextRequest(`http://localhost:3000/api/documents/${id}`, { method: 'GET' });
-  return [req, { params: Promise.resolve({ id }) }];
+let prisma: any;
+beforeEach(async () => {
+  prisma = (await import('@/lib/prisma') as any).prisma;
+  jest.clearAllMocks();
+  mockOpen.mockResolvedValue(makeHandle());
+});
+
+function req(id: string): [NextRequest, { params: Promise<{ id: string }> }] {
+  return [new NextRequest(`http://localhost/api/documents/${id}`), { params: Promise.resolve({ id }) }];
+}
+
+function mockDoc(doc: unknown) {
+  prisma.userDocument.findFirst.mockResolvedValue(doc);
 }
 
 describe('GET /api/documents/[id]', () => {
-  it('should return 401 when not authenticated', async () => {
-    mockAuth.mockResolvedValue(null as any);
-
-    const res = await GET(...makeRequest('doc-1'));
-    expect(res.status).toBe(401);
+  it('401 when not authenticated', async () => {
+    mockAuth.mockResolvedValue(null);
+    expect((await GET(...req('x'))).status).toBe(401);
   });
 
-  it('should return 404 when document not found', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
-    mockDocumentLookup(null);
-
-    const res = await GET(...makeRequest('nonexistent'));
-    expect(res.status).toBe(404);
+  it('404 when not found', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } });
+    mockDoc(null);
+    expect((await GET(...req('x'))).status).toBe(404);
   });
 
-  it('should return 404 when user is not owner and not staff without reading file', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'other-user', role: 'ELEVE' } } as any);
-    mockDocumentLookup({
-      id: 'doc-1', userId: 'u1', localPath: 'test.pdf',
-      mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
-    });
-
-    const res = await GET(...makeRequest('doc-1'));
-    expect(res.status).toBe(404);
-    expect(mockReadFile).not.toHaveBeenCalled();
+  it('404 when non-staff non-owner', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u2', role: 'ELEVE' } });
+    mockDoc({ id: 'd1', userId: 'u1', localPath: 'f.pdf', mimeType: 'application/pdf', originalName: 'f.pdf', sizeBytes: 100 });
+    expect((await GET(...req('d1'))).status).toBe(404);
+    expect(mockOpen).not.toHaveBeenCalled();
   });
 
-  it('should return document for owner', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
-    mockDocumentLookup({
-      id: 'doc-1', userId: 'u1', localPath: 'test.pdf',
-      mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
-    });
-    mockReadFile.mockResolvedValue(Buffer.from('fake-pdf-content') as any);
-
-    const res = await GET(...makeRequest('doc-1'));
-
-    expect(res.status).toBe(200);
-    expect(res.headers.get('Content-Type')).toBe('application/pdf');
-    expect(res.headers.get('Content-Disposition')).toContain('test.pdf');
-    expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff');
-    expect(res.headers.get('Cache-Control')).toBe('private, no-store');
+  it('200 for owner', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } });
+    mockDoc({ id: 'd1', userId: 'u1', localPath: 'f.pdf', mimeType: 'application/pdf', originalName: 'f.pdf', sizeBytes: 100 });
+    const r = await GET(...req('d1'));
+    expect(r.status).toBe(200);
+    expect(r.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(r.headers.get('Cache-Control')).toBe('private, no-store');
   });
 
-  it('should return document for ADMIN', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } } as any);
-    mockDocumentLookup({
-      id: 'doc-1', userId: 'u1', localPath: 'test.pdf',
-      mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
-    });
-    mockReadFile.mockResolvedValue(Buffer.from('fake-pdf-content') as any);
-
-    const res = await GET(...makeRequest('doc-1'));
-    expect(res.status).toBe(200);
+  it('200 for ADMIN (any doc)', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'admin', role: 'ADMIN' } });
+    mockDoc({ id: 'd1', userId: 'u1', localPath: 'f.pdf', mimeType: 'application/pdf', originalName: 'f.pdf', sizeBytes: 100 });
+    expect((await GET(...req('d1'))).status).toBe(200);
   });
 
-  it('should return document for ASSISTANTE', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'assist-1', role: 'ASSISTANTE' } } as any);
-    mockDocumentLookup({
-      id: 'doc-1', userId: 'u1', localPath: 'test.pdf',
-      mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
-    });
-    mockReadFile.mockResolvedValue(Buffer.from('fake-pdf-content') as any);
-
-    const res = await GET(...makeRequest('doc-1'));
-    expect(res.status).toBe(200);
+  it('200 for ASSISTANTE (any doc)', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ASSISTANTE' } });
+    mockDoc({ id: 'd1', userId: 'u1', localPath: 'f.pdf', mimeType: 'application/pdf', originalName: 'f.pdf', sizeBytes: 100 });
+    expect((await GET(...req('d1'))).status).toBe(200);
   });
 
-  it('should return 404 when containment check fails (path traversal)', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
-    mockDocumentLookup({
-      id: 'doc-1', userId: 'u1', localPath: '../../../etc/passwd',
-      mimeType: 'application/pdf', originalName: 'evil.pdf', sizeBytes: 1024,
-    });
-    mockResolveSecurePath.mockRejectedValue(
-      new SecureFileAccessError('PATH_ESCAPE', 'Path escapes storage root')
-    );
-
-    const res = await GET(...makeRequest('doc-1'));
-    expect(res.status).toBe(404);
-    expect(mockReadFile).not.toHaveBeenCalled();
+  it('404 on PATH_ESCAPE', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } });
+    mockDoc({ id: 'd1', userId: 'u1', localPath: '../etc/passwd', mimeType: 'application/pdf', originalName: 'x', sizeBytes: 1 });
+    mockOpen.mockRejectedValue(new SecureFileAccessError('PATH_ESCAPE', 'escape'));
+    expect((await GET(...req('d1'))).status).toBe(404);
   });
 
-  it('should return 404 when file missing on disk', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
-    mockDocumentLookup({
-      id: 'doc-1', userId: 'u1', localPath: 'missing.pdf',
-      mimeType: 'application/pdf', originalName: 'missing.pdf', sizeBytes: 1024,
-    });
-    mockResolveSecurePath.mockRejectedValue(
-      new SecureFileAccessError('FILE_NOT_FOUND', 'File does not exist')
-    );
-
-    const res = await GET(...makeRequest('doc-1'));
-    expect(res.status).toBe(404);
+  it('404 on FILE_NOT_FOUND', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } });
+    mockDoc({ id: 'd1', userId: 'u1', localPath: 'gone.pdf', mimeType: 'application/pdf', originalName: 'x', sizeBytes: 1 });
+    mockOpen.mockRejectedValue(new SecureFileAccessError('FILE_NOT_FOUND', 'gone'));
+    expect((await GET(...req('d1'))).status).toBe(404);
   });
 
-  it('should not log local file paths when containment fails', async () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
-    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
-    mockDocumentLookup({
-      id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/private/missing.pdf',
-      mimeType: 'application/pdf', originalName: 'missing.pdf', sizeBytes: 1024,
-    });
-    mockResolveSecurePath.mockRejectedValue(
-      new SecureFileAccessError('FILE_NOT_FOUND', 'File does not exist')
-    );
-
-    const res = await GET(...makeRequest('doc-1'));
-
-    expect(res.status).toBe(404);
-    const serializedLogs = JSON.stringify(errorSpy.mock.calls);
-    expect(serializedLogs).not.toContain('/app/storage');
-    expect(serializedLogs).not.toContain('private/missing.pdf');
-    errorSpy.mockRestore();
+  it('does not log filesystem paths', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } });
+    mockDoc({ id: 'd1', userId: 'u1', localPath: 'secret/private.pdf', mimeType: 'application/pdf', originalName: 'x', sizeBytes: 1 });
+    mockOpen.mockRejectedValue(new SecureFileAccessError('FILE_NOT_FOUND', 'gone'));
+    await GET(...req('d1'));
+    const logs = JSON.stringify(spy.mock.calls);
+    expect(logs).not.toContain('secret/private');
+    spy.mockRestore();
   });
 
-  it('should return 500 on DB error', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
-    prisma.userDocument.findUnique.mockRejectedValue(new Error('DB error'));
-    prisma.userDocument.findFirst.mockRejectedValue(new Error('DB error'));
-
-    const res = await GET(...makeRequest('doc-1'));
-    expect(res.status).toBe(500);
+  it('500 on DB error', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } });
+    prisma.userDocument.findFirst.mockRejectedValue(new Error('DB'));
+    expect((await GET(...req('d1'))).status).toBe(500);
   });
 });

--- a/__tests__/api/student.documents.download.test.ts
+++ b/__tests__/api/student.documents.download.test.ts
@@ -1,7 +1,7 @@
 import { GET } from '@/app/api/student/documents/[id]/download/route';
 import { requireRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
-import { writeFile, unlink, mkdtemp } from 'fs/promises';
+import { writeFile, unlink, mkdtemp, mkdir } from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -14,6 +14,13 @@ jest.mock('@/lib/prisma', () => ({
   prisma: {
     userDocument: { findFirst: jest.fn() },
   },
+}));
+
+// Mock storage root to point to our temp directory
+let testStorageRoot: string;
+jest.mock('@/lib/documents/storage-root', () => ({
+  getDocumentStorageRoot: () => testStorageRoot,
+  LEGACY_STORAGE_PREFIX: '/app/storage/documents/',
 }));
 
 const mockEleveSession = {
@@ -31,10 +38,11 @@ function makeParams(id: string) {
 }
 
 describe('GET /api/student/documents/[id]/download', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
     (requireRole as jest.Mock).mockResolvedValue(mockEleveSession);
     (isErrorResponse as unknown as jest.Mock).mockReturnValue(false);
+    testStorageRoot = await mkdtemp(path.join(os.tmpdir(), 'nexus-doc-test-'));
   });
 
   it('returns 401 when unauthenticated', async () => {
@@ -70,15 +78,14 @@ describe('GET /api/student/documents/[id]/download', () => {
   });
 
   it('streams file with correct Content-Type and Content-Disposition', async () => {
-    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'nexus-test-'));
-    const tmpFile = path.join(tmpDir, 'fiche.pdf');
+    const tmpFile = path.join(testStorageRoot, 'fiche.pdf');
     await writeFile(tmpFile, Buffer.from('%PDF-1.4 fake content'));
 
     (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
       id: 'doc-1',
       originalName: 'fiche revision.pdf',
       mimeType: 'application/pdf',
-      localPath: tmpFile,
+      localPath: 'fiche.pdf', // relative to storage root
     });
 
     const response = await GET({} as any, makeParams('doc-1'));
@@ -89,33 +96,34 @@ describe('GET /api/student/documents/[id]/download', () => {
     expect(response.headers.get('Content-Type')).toBe('application/pdf');
     expect(response.headers.get('Content-Disposition')).toContain('attachment');
     expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
   });
 
-  it('returns 500 when file does not exist on disk', async () => {
+  it('returns 404 when file does not exist on disk', async () => {
     (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
       id: 'doc-1',
       originalName: 'missing.pdf',
       mimeType: 'application/pdf',
-      localPath: '/tmp/nexus-nonexistent-file-that-should-never-exist.pdf',
+      localPath: 'nonexistent-file.pdf',
     });
 
     const response = await GET({} as any, makeParams('doc-1'));
     const body = await response.json();
 
-    expect(response.status).toBe(500);
+    // SecureFileAccessError with FILE_NOT_FOUND → 404
+    expect(response.status).toBe(404);
     expect(body.error).toBe('File unavailable');
   });
 
   it('falls back to application/octet-stream when mimeType is null', async () => {
-    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'nexus-test-'));
-    const tmpFile = path.join(tmpDir, 'export.bin');
+    const tmpFile = path.join(testStorageRoot, 'export.bin');
     await writeFile(tmpFile, Buffer.from('\x00\x01\x02'));
 
     (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
       id: 'doc-2',
       originalName: 'export.bin',
       mimeType: null,
-      localPath: tmpFile,
+      localPath: 'export.bin',
     });
 
     const response = await GET({} as any, makeParams('doc-2'));
@@ -125,19 +133,67 @@ describe('GET /api/student/documents/[id]/download', () => {
     expect(response.headers.get('Content-Type')).toBe('application/octet-stream');
   });
 
+  it('rejects path traversal attempts via localPath', async () => {
+    // Even if a malicious localPath ends up in DB
+    (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
+      id: 'doc-evil',
+      originalName: 'evil.pdf',
+      mimeType: 'application/pdf',
+      localPath: '../../../etc/passwd',
+    });
+
+    const response = await GET({} as any, makeParams('doc-evil'));
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error).toBe('File unavailable');
+  });
+
+  it('rejects absolute path in localPath', async () => {
+    (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
+      id: 'doc-abs',
+      originalName: 'abs.pdf',
+      mimeType: 'application/pdf',
+      localPath: '/etc/passwd',
+    });
+
+    const response = await GET({} as any, makeParams('doc-abs'));
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error).toBe('File unavailable');
+  });
+
+  it('handles legacy /app/storage/documents/ prefix', async () => {
+    const tmpFile = path.join(testStorageRoot, 'legacy.pdf');
+    await writeFile(tmpFile, Buffer.from('%PDF legacy'));
+
+    (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
+      id: 'doc-legacy',
+      originalName: 'legacy.pdf',
+      mimeType: 'application/pdf',
+      localPath: '/app/storage/documents/legacy.pdf',
+    });
+
+    const response = await GET({} as any, makeParams('doc-legacy'));
+
+    await unlink(tmpFile).catch(() => null);
+
+    expect(response.status).toBe(200);
+  });
+
   describe('Coach resource ownership (Lot C)', () => {
     it('allows student to download self-uploaded document', async () => {
-      const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'nexus-test-'));
-      const tmpFile = path.join(tmpDir, 'self-uploaded.pdf');
+      const tmpFile = path.join(testStorageRoot, 'self-uploaded.pdf');
       await writeFile(tmpFile, Buffer.from('%PDF-1.4 self uploaded'));
 
       (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
         id: 'doc-self',
         originalName: 'my-upload.pdf',
         mimeType: 'application/pdf',
-        localPath: tmpFile,
-        userId: 'user-eleve-1',  // recipient is the student
-        uploadedById: 'user-eleve-1',  // uploader is also the student
+        localPath: 'self-uploaded.pdf',
+        userId: 'user-eleve-1',
+        uploadedById: 'user-eleve-1',
       });
 
       const response = await GET({} as any, makeParams('doc-self'));
@@ -148,17 +204,16 @@ describe('GET /api/student/documents/[id]/download', () => {
     });
 
     it('allows student to download coach-uploaded resource', async () => {
-      const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'nexus-test-'));
-      const tmpFile = path.join(tmpDir, 'coach-resource.pdf');
+      const tmpFile = path.join(testStorageRoot, 'coach-resource.pdf');
       await writeFile(tmpFile, Buffer.from('%PDF-1.4 coach uploaded'));
 
       (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
         id: 'doc-coach',
         originalName: 'coach-resource.pdf',
         mimeType: 'application/pdf',
-        localPath: tmpFile,
-        userId: 'user-eleve-1',  // recipient is the student (ownership check)
-        uploadedById: 'coach-user-123',  // uploader is the coach
+        localPath: 'coach-resource.pdf',
+        userId: 'user-eleve-1',
+        uploadedById: 'coach-user-123',
         uploadedBy: { role: 'COACH' },
       });
 
@@ -170,7 +225,6 @@ describe('GET /api/student/documents/[id]/download', () => {
     });
 
     it('denies access when student tries to download another student document', async () => {
-      // Document belongs to a different student
       (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue(null);
 
       const response = await GET({} as any, makeParams('doc-other-student'));
@@ -181,16 +235,14 @@ describe('GET /api/student/documents/[id]/download', () => {
     });
 
     it('verifies ownership is enforced via userId not uploadedById', async () => {
-      // Even if uploader matches current user, if recipient doesn't match → denied
       (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue(null);
 
       await GET({} as any, makeParams('doc-not-recipient'));
 
-      // The query should filter by userId (recipient), not uploadedById
       expect(prisma.userDocument.findFirst).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
-            userId: 'user-eleve-1',  // Must be the recipient
+            userId: 'user-eleve-1',
           }),
         })
       );

--- a/__tests__/api/student.documents.download.test.ts
+++ b/__tests__/api/student.documents.download.test.ts
@@ -1,9 +1,4 @@
-import { GET } from '@/app/api/student/documents/[id]/download/route';
-import { requireRole, isErrorResponse } from '@/lib/guards';
-import { prisma } from '@/lib/prisma';
-import { writeFile, unlink, mkdtemp, mkdir } from 'fs/promises';
-import * as os from 'os';
-import * as path from 'path';
+import { Readable } from 'stream';
 
 jest.mock('@/lib/guards', () => ({
   requireRole: jest.fn(),
@@ -11,241 +6,137 @@ jest.mock('@/lib/guards', () => ({
 }));
 
 jest.mock('@/lib/prisma', () => ({
-  prisma: {
-    userDocument: { findFirst: jest.fn() },
-  },
+  prisma: { userDocument: { findFirst: jest.fn() } },
 }));
 
-// Mock storage root to point to our temp directory
-let testStorageRoot: string;
 jest.mock('@/lib/documents/storage-root', () => ({
-  getDocumentStorageRoot: () => testStorageRoot,
+  getDocumentStorageRoot: () => '/mock/storage',
   LEGACY_STORAGE_PREFIX: '/app/storage/documents/',
 }));
 
-const mockEleveSession = {
-  user: { id: 'user-eleve-1', email: 'eleve@test.com', role: 'ELEVE' as const },
-};
+// Use manual mock with lazy handle creation
+jest.mock('@/lib/documents/secure-file-access', () => {
+  class SecureFileAccessError extends Error {
+    code: string;
+    constructor(code: string, message: string) { super(message); this.code = code; this.name = 'SecureFileAccessError'; }
+  }
+  return {
+    openSecureDocument: jest.fn(),
+    SecureFileAccessError,
+    safeContentType: (m: string | null) => m || 'application/octet-stream',
+    safeFilename: (n: string) => n || 'document',
+  };
+});
 
-const mockUnauthorizedResponse = {
-  status: 401,
-  json: async () => ({ error: 'Unauthorized' }),
-  headers: new Headers(),
-};
+import { GET } from '@/app/api/student/documents/[id]/download/route';
+import { requireRole, isErrorResponse } from '@/lib/guards';
+import { prisma } from '@/lib/prisma';
+import { openSecureDocument, SecureFileAccessError } from '@/lib/documents/secure-file-access';
 
-function makeParams(id: string) {
-  return { params: Promise.resolve({ id }) };
+const mockOpenSecure = openSecureDocument as jest.Mock;
+
+function makeSuccessHandle() {
+  return {
+    handle: {
+      createReadStream: () => Readable.from(Buffer.from('pdf-content')),
+      close: jest.fn().mockResolvedValue(undefined),
+    },
+    sizeBytes: 11,
+  };
 }
 
+const mockSession = { user: { id: 'u1', email: 'e@test.com', role: 'ELEVE' as const } };
+const mock401 = { status: 401, json: async () => ({ error: 'Unauthorized' }), headers: new Headers() };
+
+function params(id: string) { return { params: Promise.resolve({ id }) }; }
+
 describe('GET /api/student/documents/[id]/download', () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.clearAllMocks();
-    (requireRole as jest.Mock).mockResolvedValue(mockEleveSession);
+    (requireRole as jest.Mock).mockResolvedValue(mockSession);
     (isErrorResponse as unknown as jest.Mock).mockReturnValue(false);
-    testStorageRoot = await mkdtemp(path.join(os.tmpdir(), 'nexus-doc-test-'));
+    mockOpenSecure.mockResolvedValue(makeSuccessHandle());
   });
 
   it('returns 401 when unauthenticated', async () => {
-    (requireRole as jest.Mock).mockResolvedValue(mockUnauthorizedResponse);
+    (requireRole as jest.Mock).mockResolvedValue(mock401);
     (isErrorResponse as unknown as jest.Mock).mockReturnValue(true);
-
-    const response = await GET({} as any, makeParams('doc-1'));
-    expect(response.status).toBe(401);
+    expect((await GET({} as any, params('x'))).status).toBe(401);
   });
 
-  it('returns 404 when document not found for this user', async () => {
+  it('returns 404 when document not found', async () => {
     (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue(null);
-
-    const response = await GET({} as any, makeParams('doc-nonexistent'));
-    const body = await response.json();
-
-    expect(response.status).toBe(404);
-    expect(body.error).toBe('Not found');
+    const r = await GET({} as any, params('x'));
+    expect(r.status).toBe(404);
+    expect(await r.json()).toEqual({ error: 'Not found' });
   });
 
-  it('enforces ownership — queries with authenticated userId', async () => {
+  it('enforces userId ownership in query', async () => {
     (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue(null);
-
-    await GET({} as any, makeParams('doc-other-user'));
-
+    await GET({} as any, params('x'));
     expect(prisma.userDocument.findFirst).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          userId: 'user-eleve-1',
-        }),
-      })
+      expect.objectContaining({ where: expect.objectContaining({ userId: 'u1' }) })
     );
   });
 
-  it('streams file with correct Content-Type and Content-Disposition', async () => {
-    const tmpFile = path.join(testStorageRoot, 'fiche.pdf');
-    await writeFile(tmpFile, Buffer.from('%PDF-1.4 fake content'));
-
+  it('streams file with correct headers on success', async () => {
     (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
-      id: 'doc-1',
-      originalName: 'fiche revision.pdf',
-      mimeType: 'application/pdf',
-      localPath: 'fiche.pdf', // relative to storage root
+      id: 'd1', originalName: 'fiche.pdf', mimeType: 'application/pdf', localPath: 'fiche.pdf',
     });
-
-    const response = await GET({} as any, makeParams('doc-1'));
-
-    await unlink(tmpFile).catch(() => null);
-
-    expect(response.status).toBe(200);
-    expect(response.headers.get('Content-Type')).toBe('application/pdf');
-    expect(response.headers.get('Content-Disposition')).toContain('attachment');
-    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
-    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    const r = await GET({} as any, params('d1'));
+    expect(r.status).toBe(200);
+    expect(r.headers.get('Content-Disposition')).toContain('attachment');
+    expect(r.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(r.headers.get('Cache-Control')).toBe('private, no-store');
   });
 
-  it('returns 404 when file does not exist on disk', async () => {
+  it('rejects path traversal via containment', async () => {
     (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
-      id: 'doc-1',
-      originalName: 'missing.pdf',
-      mimeType: 'application/pdf',
-      localPath: 'nonexistent-file.pdf',
+      id: 'evil', originalName: 'x.pdf', mimeType: 'application/pdf', localPath: '../../../etc/passwd',
     });
-
-    const response = await GET({} as any, makeParams('doc-1'));
-    const body = await response.json();
-
-    // SecureFileAccessError with FILE_NOT_FOUND → 404
-    expect(response.status).toBe(404);
-    expect(body.error).toBe('File unavailable');
+    mockOpenSecure.mockRejectedValue(new SecureFileAccessError('PATH_ESCAPE', 'escape'));
+    const r = await GET({} as any, params('evil'));
+    expect(r.status).toBe(404);
   });
 
-  it('falls back to application/octet-stream when mimeType is null', async () => {
-    const tmpFile = path.join(testStorageRoot, 'export.bin');
-    await writeFile(tmpFile, Buffer.from('\x00\x01\x02'));
-
+  it('rejects absolute path outside root', async () => {
     (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
-      id: 'doc-2',
-      originalName: 'export.bin',
-      mimeType: null,
-      localPath: 'export.bin',
+      id: 'abs', originalName: 'x.pdf', mimeType: 'application/pdf', localPath: '/etc/shadow',
     });
-
-    const response = await GET({} as any, makeParams('doc-2'));
-
-    await unlink(tmpFile).catch(() => null);
-
-    expect(response.headers.get('Content-Type')).toBe('application/octet-stream');
+    mockOpenSecure.mockRejectedValue(new SecureFileAccessError('PATH_ESCAPE', 'outside'));
+    expect((await GET({} as any, params('abs'))).status).toBe(404);
   });
 
-  it('rejects path traversal attempts via localPath', async () => {
-    // Even if a malicious localPath ends up in DB
+  it('accepts absolute path INSIDE storage root', async () => {
     (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
-      id: 'doc-evil',
-      originalName: 'evil.pdf',
-      mimeType: 'application/pdf',
-      localPath: '../../../etc/passwd',
+      id: 'ok', originalName: 'admin.pdf', mimeType: 'application/pdf',
+      localPath: '/mock/storage/admin.pdf',
     });
-
-    const response = await GET({} as any, makeParams('doc-evil'));
-    const body = await response.json();
-
-    expect(response.status).toBe(404);
-    expect(body.error).toBe('File unavailable');
+    expect((await GET({} as any, params('ok'))).status).toBe(200);
   });
 
-  it('rejects absolute path in localPath', async () => {
+  it('returns 404 when file missing', async () => {
     (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
-      id: 'doc-abs',
-      originalName: 'abs.pdf',
-      mimeType: 'application/pdf',
-      localPath: '/etc/passwd',
+      id: 'd1', originalName: 'x.pdf', mimeType: 'application/pdf', localPath: 'gone.pdf',
     });
-
-    const response = await GET({} as any, makeParams('doc-abs'));
-    const body = await response.json();
-
-    expect(response.status).toBe(404);
-    expect(body.error).toBe('File unavailable');
+    mockOpenSecure.mockRejectedValue(new SecureFileAccessError('FILE_NOT_FOUND', 'gone'));
+    expect((await GET({} as any, params('d1'))).status).toBe(404);
   });
 
-  it('handles legacy /app/storage/documents/ prefix', async () => {
-    const tmpFile = path.join(testStorageRoot, 'legacy.pdf');
-    await writeFile(tmpFile, Buffer.from('%PDF legacy'));
-
+  it('passes legacy prefix to openSecureDocument', async () => {
     (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
-      id: 'doc-legacy',
-      originalName: 'legacy.pdf',
-      mimeType: 'application/pdf',
-      localPath: '/app/storage/documents/legacy.pdf',
+      id: 'leg', originalName: 'x.pdf', mimeType: 'application/pdf',
+      localPath: '/app/storage/documents/old.pdf',
     });
-
-    const response = await GET({} as any, makeParams('doc-legacy'));
-
-    await unlink(tmpFile).catch(() => null);
-
-    expect(response.status).toBe(200);
+    await GET({} as any, params('leg'));
+    expect(mockOpenSecure).toHaveBeenCalledWith(
+      '/mock/storage', '/app/storage/documents/old.pdf',
+      expect.objectContaining({ legacyPrefixToStrip: '/app/storage/documents/' }),
+    );
   });
 
-  describe('Coach resource ownership (Lot C)', () => {
-    it('allows student to download self-uploaded document', async () => {
-      const tmpFile = path.join(testStorageRoot, 'self-uploaded.pdf');
-      await writeFile(tmpFile, Buffer.from('%PDF-1.4 self uploaded'));
-
-      (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
-        id: 'doc-self',
-        originalName: 'my-upload.pdf',
-        mimeType: 'application/pdf',
-        localPath: 'self-uploaded.pdf',
-        userId: 'user-eleve-1',
-        uploadedById: 'user-eleve-1',
-      });
-
-      const response = await GET({} as any, makeParams('doc-self'));
-
-      await unlink(tmpFile).catch(() => null);
-
-      expect(response.status).toBe(200);
-    });
-
-    it('allows student to download coach-uploaded resource', async () => {
-      const tmpFile = path.join(testStorageRoot, 'coach-resource.pdf');
-      await writeFile(tmpFile, Buffer.from('%PDF-1.4 coach uploaded'));
-
-      (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
-        id: 'doc-coach',
-        originalName: 'coach-resource.pdf',
-        mimeType: 'application/pdf',
-        localPath: 'coach-resource.pdf',
-        userId: 'user-eleve-1',
-        uploadedById: 'coach-user-123',
-        uploadedBy: { role: 'COACH' },
-      });
-
-      const response = await GET({} as any, makeParams('doc-coach'));
-
-      await unlink(tmpFile).catch(() => null);
-
-      expect(response.status).toBe(200);
-    });
-
-    it('denies access when student tries to download another student document', async () => {
-      (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue(null);
-
-      const response = await GET({} as any, makeParams('doc-other-student'));
-      const body = await response.json();
-
-      expect(response.status).toBe(404);
-      expect(body.error).toBe('Not found');
-    });
-
-    it('verifies ownership is enforced via userId not uploadedById', async () => {
-      (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue(null);
-
-      await GET({} as any, makeParams('doc-not-recipient'));
-
-      expect(prisma.userDocument.findFirst).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            userId: 'user-eleve-1',
-          }),
-        })
-      );
-    });
+  it('denies other student document', async () => {
+    (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue(null);
+    expect((await GET({} as any, params('other'))).status).toBe(404);
   });
 });

--- a/__tests__/lib/documents/secure-file-access.test.ts
+++ b/__tests__/lib/documents/secure-file-access.test.ts
@@ -1,5 +1,11 @@
-import { resolveSecurePath, SecureFileAccessError, safeContentType, safeFilename } from '@/lib/documents/secure-file-access';
-import { writeFile, mkdir, symlink, rm } from 'fs/promises';
+import {
+  openSecureDocument,
+  resolveSecurePath,
+  SecureFileAccessError,
+  safeContentType,
+  safeFilename,
+} from '@/lib/documents/secure-file-access';
+import { writeFile, mkdir, symlink, rm, unlink } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -7,143 +13,185 @@ let testDir: string;
 let storageRoot: string;
 
 beforeAll(async () => {
-  testDir = join(tmpdir(), `secure-file-test-${Date.now()}`);
+  testDir = join(tmpdir(), `secure-file-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   storageRoot = join(testDir, 'storage');
   await mkdir(join(storageRoot, 'subdir'), { recursive: true });
-  await writeFile(join(storageRoot, 'valid.pdf'), 'PDF content');
+  await writeFile(join(storageRoot, 'valid.pdf'), 'PDF content here');
   await writeFile(join(storageRoot, 'subdir', 'nested.pdf'), 'nested content');
 
-  // Create a file outside storage root
+  // File outside storage root
   await mkdir(join(testDir, 'outside'), { recursive: true });
-  await writeFile(join(testDir, 'outside', 'secret.txt'), 'secret');
+  await writeFile(join(testDir, 'outside', 'secret.txt'), 'secret data');
 
-  // Create symlink inside storage pointing outside
-  try {
-    await symlink(join(testDir, 'outside', 'secret.txt'), join(storageRoot, 'bad-symlink.txt'));
-  } catch {
-    // symlink may fail on some filesystems
-  }
-
-  // Create valid symlink inside storage
-  try {
-    await symlink(join(storageRoot, 'valid.pdf'), join(storageRoot, 'good-symlink.pdf'));
-  } catch {
-    // symlink may fail on some filesystems
-  }
+  // Symlink escaping outside storage
+  await symlink(join(testDir, 'outside', 'secret.txt'), join(storageRoot, 'escape-symlink.txt'));
+  // Valid symlink inside storage
+  await symlink(join(storageRoot, 'valid.pdf'), join(storageRoot, 'internal-symlink.pdf'));
 });
 
 afterAll(async () => {
   await rm(testDir, { recursive: true, force: true });
 });
 
-describe('resolveSecurePath', () => {
+describe('openSecureDocument', () => {
   // ── Valid paths ──
 
-  test('resolves a valid relative path', async () => {
-    const result = await resolveSecurePath(storageRoot, 'valid.pdf');
-    expect(result.canonicalPath).toContain('valid.pdf');
-    expect(result.sizeBytes).toBeGreaterThan(0);
+  test('opens a valid relative path', async () => {
+    const doc = await openSecureDocument(storageRoot, 'valid.pdf');
+    expect(doc.sizeBytes).toBeGreaterThan(0);
+    await doc.handle.close();
   });
 
-  test('resolves a nested valid path', async () => {
-    const result = await resolveSecurePath(storageRoot, 'subdir/nested.pdf');
-    expect(result.canonicalPath).toContain('nested.pdf');
+  test('opens a nested valid path', async () => {
+    const doc = await openSecureDocument(storageRoot, 'subdir/nested.pdf');
+    expect(doc.sizeBytes).toBeGreaterThan(0);
+    await doc.handle.close();
   });
 
-  test('resolves a valid symlink inside storage', async () => {
+  // ── Absolute paths INSIDE storage root (admin/coach upload format) ──
+
+  test('accepts absolute path under storage root', async () => {
+    const absPath = join(storageRoot, 'valid.pdf');
+    const doc = await openSecureDocument(storageRoot, absPath);
+    expect(doc.sizeBytes).toBeGreaterThan(0);
+    await doc.handle.close();
+  });
+
+  test('accepts absolute path in subdirectory under storage root', async () => {
+    const absPath = join(storageRoot, 'subdir', 'nested.pdf');
+    const doc = await openSecureDocument(storageRoot, absPath);
+    expect(doc.sizeBytes).toBeGreaterThan(0);
+    await doc.handle.close();
+  });
+
+  // ── Absolute paths OUTSIDE storage root ──
+
+  test('rejects absolute path outside storage root', async () => {
+    const outsidePath = join(testDir, 'outside', 'secret.txt');
+    await expect(openSecureDocument(storageRoot, outsidePath))
+      .rejects.toThrow(SecureFileAccessError);
     try {
-      const result = await resolveSecurePath(storageRoot, 'good-symlink.pdf');
-      expect(result.canonicalPath).toContain('valid.pdf'); // realpath follows to target
+      await openSecureDocument(storageRoot, outsidePath);
     } catch (err) {
-      // symlink may not exist on all test environments
-      if (err instanceof SecureFileAccessError && err.code === 'FILE_NOT_FOUND') {
-        return; // acceptable — symlink wasn't created
-      }
-      throw err;
+      expect((err as SecureFileAccessError).code).toBe('PATH_ESCAPE');
     }
   });
 
-  // ── Path traversal attacks ──
+  test('rejects /etc/passwd', async () => {
+    await expect(openSecureDocument(storageRoot, '/etc/passwd'))
+      .rejects.toThrow(SecureFileAccessError);
+    try {
+      await openSecureDocument(storageRoot, '/etc/passwd');
+    } catch (err) {
+      expect(['PATH_ESCAPE', 'FILE_NOT_FOUND']).toContain((err as SecureFileAccessError).code);
+    }
+  });
+
+  test('rejects absolute sibling path sharing prefix', async () => {
+    // /tmp/.../storage-evil is NOT under /tmp/.../storage
+    const evilDir = `${storageRoot}-evil`;
+    await mkdir(evilDir, { recursive: true });
+    await writeFile(join(evilDir, 'trick.txt'), 'tricked');
+    try {
+      await expect(openSecureDocument(storageRoot, join(evilDir, 'trick.txt')))
+        .rejects.toThrow(SecureFileAccessError);
+    } finally {
+      await rm(evilDir, { recursive: true, force: true });
+    }
+  });
+
+  // ── Traversal attacks ──
 
   test('rejects ../ traversal', async () => {
-    await expect(
-      resolveSecurePath(storageRoot, '../outside/secret.txt')
-    ).rejects.toThrow(SecureFileAccessError);
+    await expect(openSecureDocument(storageRoot, '../outside/secret.txt'))
+      .rejects.toThrow(SecureFileAccessError);
   });
 
   test('rejects ../../ traversal', async () => {
-    await expect(
-      resolveSecurePath(storageRoot, '../../etc/passwd')
-    ).rejects.toThrow(SecureFileAccessError);
+    await expect(openSecureDocument(storageRoot, '../../etc/passwd'))
+      .rejects.toThrow(SecureFileAccessError);
   });
 
   test('rejects %2e%2e encoded traversal', async () => {
-    await expect(
-      resolveSecurePath(storageRoot, '%2e%2e/outside/secret.txt')
-    ).rejects.toThrow(SecureFileAccessError);
-  });
-
-  test('rejects %2E%2E double-encoded traversal', async () => {
-    await expect(
-      resolveSecurePath(storageRoot, '%2E%2E/outside/secret.txt')
-    ).rejects.toThrow(SecureFileAccessError);
-  });
-
-  test('rejects null byte injection', async () => {
-    await expect(
-      resolveSecurePath(storageRoot, 'valid.pdf%00.txt')
-    ).rejects.toThrow(SecureFileAccessError);
-  });
-
-  // ── Absolute path rejection ──
-
-  test('rejects Unix absolute path', async () => {
-    await expect(
-      resolveSecurePath(storageRoot, '/etc/passwd')
-    ).rejects.toThrow(SecureFileAccessError);
+    await expect(openSecureDocument(storageRoot, '%2e%2e/outside/secret.txt'))
+      .rejects.toThrow(SecureFileAccessError);
     try {
-      await resolveSecurePath(storageRoot, '/etc/passwd');
+      await openSecureDocument(storageRoot, '%2e%2e/outside/secret.txt');
     } catch (err) {
-      expect((err as SecureFileAccessError).code).toBe('ABSOLUTE_PATH_REJECTED');
+      expect((err as SecureFileAccessError).code).toBe('INVALID_PATH_FORMAT');
     }
   });
 
-  test('rejects Windows absolute path', async () => {
-    await expect(
-      resolveSecurePath(storageRoot, 'C:\\Windows\\system32\\config')
-    ).rejects.toThrow(SecureFileAccessError);
+  test('rejects %252e%252e double-encoded traversal', async () => {
+    // %25 = literal %, so %252e = %2e after one decode
+    await expect(openSecureDocument(storageRoot, '%252e%252e/outside/secret.txt'))
+      .rejects.toThrow(SecureFileAccessError);
+  });
+
+  test('rejects null byte injection', async () => {
+    await expect(openSecureDocument(storageRoot, 'valid.pdf%00.txt'))
+      .rejects.toThrow(SecureFileAccessError);
   });
 
   test('rejects backslash separators', async () => {
-    await expect(
-      resolveSecurePath(storageRoot, '..\\outside\\secret.txt')
-    ).rejects.toThrow(SecureFileAccessError);
+    await expect(openSecureDocument(storageRoot, '..\\outside\\secret.txt'))
+      .rejects.toThrow(SecureFileAccessError);
   });
 
-  // ── Symlink escape ──
+  // ── URL schemes ──
 
-  test('rejects symlink pointing outside storage', async () => {
+  test('rejects http:// URL', async () => {
+    await expect(openSecureDocument(storageRoot, 'http://evil.com/file'))
+      .rejects.toThrow(SecureFileAccessError);
     try {
-      await resolveSecurePath(storageRoot, 'bad-symlink.txt');
-      // If the symlink exists but doesn't escape (shouldn't happen in our setup)
-      fail('Should have thrown');
+      await openSecureDocument(storageRoot, 'http://evil.com/file');
     } catch (err) {
-      if (err instanceof SecureFileAccessError) {
-        expect(['PATH_ESCAPE', 'FILE_NOT_FOUND']).toContain(err.code);
-      }
-      // symlink may not exist — test is informational
+      expect((err as SecureFileAccessError).code).toBe('INVALID_PATH_FORMAT');
+    }
+  });
+
+  test('rejects file:// URL', async () => {
+    await expect(openSecureDocument(storageRoot, 'file:///etc/passwd'))
+      .rejects.toThrow(SecureFileAccessError);
+  });
+
+  // ── Symlinks ──
+
+  test('rejects symlink escaping outside storage root', async () => {
+    try {
+      await openSecureDocument(storageRoot, 'escape-symlink.txt');
+      fail('Should have thrown PATH_ESCAPE');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SecureFileAccessError);
+      expect((err as SecureFileAccessError).code).toBe('PATH_ESCAPE');
+    }
+  });
+
+  test('accepts valid internal symlink', async () => {
+    const doc = await openSecureDocument(storageRoot, 'internal-symlink.pdf');
+    expect(doc.sizeBytes).toBeGreaterThan(0);
+    await doc.handle.close();
+  });
+
+  test('works when storage root itself is a symlink', async () => {
+    const symlinkRoot = join(testDir, 'symlink-root');
+    await symlink(storageRoot, symlinkRoot);
+    try {
+      const doc = await openSecureDocument(symlinkRoot, 'valid.pdf');
+      expect(doc.sizeBytes).toBeGreaterThan(0);
+      await doc.handle.close();
+    } finally {
+      await unlink(symlinkRoot);
     }
   });
 
   // ── File not found ──
 
   test('rejects non-existent file', async () => {
-    await expect(
-      resolveSecurePath(storageRoot, 'does-not-exist.pdf')
-    ).rejects.toThrow(SecureFileAccessError);
     try {
-      await resolveSecurePath(storageRoot, 'does-not-exist.pdf');
+      await openSecureDocument(storageRoot, 'does-not-exist.pdf');
     } catch (err) {
+      expect(err).toBeInstanceOf(SecureFileAccessError);
       expect((err as SecureFileAccessError).code).toBe('FILE_NOT_FOUND');
     }
   });
@@ -151,12 +199,10 @@ describe('resolveSecurePath', () => {
   // ── Not a regular file ──
 
   test('rejects directory as target', async () => {
-    await expect(
-      resolveSecurePath(storageRoot, 'subdir')
-    ).rejects.toThrow(SecureFileAccessError);
     try {
-      await resolveSecurePath(storageRoot, 'subdir');
+      await openSecureDocument(storageRoot, 'subdir');
     } catch (err) {
+      expect(err).toBeInstanceOf(SecureFileAccessError);
       expect((err as SecureFileAccessError).code).toBe('NOT_REGULAR_FILE');
     }
   });
@@ -164,51 +210,86 @@ describe('resolveSecurePath', () => {
   // ── Size limit ──
 
   test('rejects file exceeding size limit', async () => {
-    await expect(
-      resolveSecurePath(storageRoot, 'valid.pdf', { maxSizeBytes: 1 })
-    ).rejects.toThrow(SecureFileAccessError);
     try {
-      await resolveSecurePath(storageRoot, 'valid.pdf', { maxSizeBytes: 1 });
+      await openSecureDocument(storageRoot, 'valid.pdf', { maxSizeBytes: 1 });
     } catch (err) {
+      expect(err).toBeInstanceOf(SecureFileAccessError);
       expect((err as SecureFileAccessError).code).toBe('FILE_TOO_LARGE');
     }
   });
 
-  // ── Legacy prefix stripping ──
+  // ── Legacy prefix ──
 
   test('strips legacy prefix before resolving', async () => {
-    const result = await resolveSecurePath(storageRoot, '/app/storage/documents/valid.pdf', {
+    const doc = await openSecureDocument(storageRoot, '/app/storage/documents/valid.pdf', {
       legacyPrefixToStrip: '/app/storage/documents/',
     });
-    expect(result.canonicalPath).toContain('valid.pdf');
-  });
-
-  test('rejects absolute path after legacy prefix strip if still absolute', async () => {
-    await expect(
-      resolveSecurePath(storageRoot, '/etc/passwd', {
-        legacyPrefixToStrip: '/app/storage/documents/',
-      })
-    ).rejects.toThrow(SecureFileAccessError);
+    expect(doc.sizeBytes).toBeGreaterThan(0);
+    await doc.handle.close();
   });
 
   // ── Storage root errors ──
 
-  test('throws when storage root does not exist', async () => {
-    await expect(
-      resolveSecurePath('/nonexistent/root', 'file.pdf')
-    ).rejects.toThrow(SecureFileAccessError);
+  test('throws STORAGE_ROOT_UNAVAILABLE when root does not exist', async () => {
+    try {
+      await openSecureDocument('/nonexistent/root', 'file.pdf');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SecureFileAccessError);
+      expect((err as SecureFileAccessError).code).toBe('STORAGE_ROOT_UNAVAILABLE');
+    }
+  });
+
+  // ── TOCTOU: file deleted between stat and read ──
+
+  test('handle remains valid even if file is unlinked after open', async () => {
+    const tmpFile = join(storageRoot, 'toctou-victim.pdf');
+    await writeFile(tmpFile, 'will be deleted');
+
+    const doc = await openSecureDocument(storageRoot, 'toctou-victim.pdf');
+    // Delete the file AFTER opening
+    await unlink(tmpFile);
+    // Should still be readable via the open handle
+    const buf = await doc.handle.readFile();
+    expect(buf.toString()).toBe('will be deleted');
+    await doc.handle.close();
   });
 
   // ── Error message safety ──
 
   test('error messages do not leak filesystem paths', async () => {
     try {
-      await resolveSecurePath(storageRoot, '../outside/secret.txt');
+      await openSecureDocument(storageRoot, '../outside/secret.txt');
     } catch (err) {
       expect((err as Error).message).not.toContain(storageRoot);
       expect((err as Error).message).not.toContain('outside');
       expect((err as Error).message).not.toContain('secret');
     }
+  });
+
+  // ── Handle cleanup on error ──
+
+  test('closes handle if file is a directory (NOT_REGULAR_FILE)', async () => {
+    // The open call succeeds on directories, but fstat check should close it
+    try {
+      await openSecureDocument(storageRoot, 'subdir');
+    } catch (err) {
+      expect((err as SecureFileAccessError).code).toBe('NOT_REGULAR_FILE');
+      // No leaked handle — verified by test completing without timeout
+    }
+  });
+});
+
+describe('resolveSecurePath', () => {
+  test('returns canonical path for relative input', async () => {
+    const result = await resolveSecurePath(storageRoot, 'valid.pdf');
+    expect(result.canonicalPath).toContain('valid.pdf');
+    expect(result.sizeBytes).toBeGreaterThan(0);
+  });
+
+  test('returns canonical path for absolute input under root', async () => {
+    const absPath = join(storageRoot, 'valid.pdf');
+    const result = await resolveSecurePath(storageRoot, absPath);
+    expect(result.sizeBytes).toBeGreaterThan(0);
   });
 });
 
@@ -216,15 +297,12 @@ describe('safeContentType', () => {
   test('returns application/pdf for PDF', () => {
     expect(safeContentType('application/pdf')).toBe('application/pdf');
   });
-
-  test('returns octet-stream for unknown type', () => {
+  test('returns octet-stream for text/html', () => {
     expect(safeContentType('text/html')).toBe('application/octet-stream');
   });
-
   test('returns octet-stream for null', () => {
     expect(safeContentType(null)).toBe('application/octet-stream');
   });
-
   test('returns octet-stream for undefined', () => {
     expect(safeContentType(undefined)).toBe('application/octet-stream');
   });
@@ -234,14 +312,18 @@ describe('safeFilename', () => {
   test('encodes special characters', () => {
     expect(safeFilename('file name.pdf')).toBe('file%20name.pdf');
   });
-
   test('strips path separators and quotes', () => {
     const result = safeFilename('../malicious"file.pdf');
     expect(result).not.toContain('"');
     expect(result).not.toContain('/');
   });
-
-  test('handles empty string', () => {
-    expect(safeFilename('')).toBe('');
+  test('returns document for empty string', () => {
+    expect(safeFilename('')).toBe('document');
+  });
+  test('strips control characters', () => {
+    const result = safeFilename('file\r\nname\x00.pdf');
+    expect(result).not.toContain('\r');
+    expect(result).not.toContain('\n');
+    expect(result).not.toContain('\x00');
   });
 });

--- a/__tests__/lib/documents/secure-file-access.test.ts
+++ b/__tests__/lib/documents/secure-file-access.test.ts
@@ -1,0 +1,247 @@
+import { resolveSecurePath, SecureFileAccessError, safeContentType, safeFilename } from '@/lib/documents/secure-file-access';
+import { writeFile, mkdir, symlink, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+let testDir: string;
+let storageRoot: string;
+
+beforeAll(async () => {
+  testDir = join(tmpdir(), `secure-file-test-${Date.now()}`);
+  storageRoot = join(testDir, 'storage');
+  await mkdir(join(storageRoot, 'subdir'), { recursive: true });
+  await writeFile(join(storageRoot, 'valid.pdf'), 'PDF content');
+  await writeFile(join(storageRoot, 'subdir', 'nested.pdf'), 'nested content');
+
+  // Create a file outside storage root
+  await mkdir(join(testDir, 'outside'), { recursive: true });
+  await writeFile(join(testDir, 'outside', 'secret.txt'), 'secret');
+
+  // Create symlink inside storage pointing outside
+  try {
+    await symlink(join(testDir, 'outside', 'secret.txt'), join(storageRoot, 'bad-symlink.txt'));
+  } catch {
+    // symlink may fail on some filesystems
+  }
+
+  // Create valid symlink inside storage
+  try {
+    await symlink(join(storageRoot, 'valid.pdf'), join(storageRoot, 'good-symlink.pdf'));
+  } catch {
+    // symlink may fail on some filesystems
+  }
+});
+
+afterAll(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+describe('resolveSecurePath', () => {
+  // ── Valid paths ──
+
+  test('resolves a valid relative path', async () => {
+    const result = await resolveSecurePath(storageRoot, 'valid.pdf');
+    expect(result.canonicalPath).toContain('valid.pdf');
+    expect(result.sizeBytes).toBeGreaterThan(0);
+  });
+
+  test('resolves a nested valid path', async () => {
+    const result = await resolveSecurePath(storageRoot, 'subdir/nested.pdf');
+    expect(result.canonicalPath).toContain('nested.pdf');
+  });
+
+  test('resolves a valid symlink inside storage', async () => {
+    try {
+      const result = await resolveSecurePath(storageRoot, 'good-symlink.pdf');
+      expect(result.canonicalPath).toContain('valid.pdf'); // realpath follows to target
+    } catch (err) {
+      // symlink may not exist on all test environments
+      if (err instanceof SecureFileAccessError && err.code === 'FILE_NOT_FOUND') {
+        return; // acceptable — symlink wasn't created
+      }
+      throw err;
+    }
+  });
+
+  // ── Path traversal attacks ──
+
+  test('rejects ../ traversal', async () => {
+    await expect(
+      resolveSecurePath(storageRoot, '../outside/secret.txt')
+    ).rejects.toThrow(SecureFileAccessError);
+  });
+
+  test('rejects ../../ traversal', async () => {
+    await expect(
+      resolveSecurePath(storageRoot, '../../etc/passwd')
+    ).rejects.toThrow(SecureFileAccessError);
+  });
+
+  test('rejects %2e%2e encoded traversal', async () => {
+    await expect(
+      resolveSecurePath(storageRoot, '%2e%2e/outside/secret.txt')
+    ).rejects.toThrow(SecureFileAccessError);
+  });
+
+  test('rejects %2E%2E double-encoded traversal', async () => {
+    await expect(
+      resolveSecurePath(storageRoot, '%2E%2E/outside/secret.txt')
+    ).rejects.toThrow(SecureFileAccessError);
+  });
+
+  test('rejects null byte injection', async () => {
+    await expect(
+      resolveSecurePath(storageRoot, 'valid.pdf%00.txt')
+    ).rejects.toThrow(SecureFileAccessError);
+  });
+
+  // ── Absolute path rejection ──
+
+  test('rejects Unix absolute path', async () => {
+    await expect(
+      resolveSecurePath(storageRoot, '/etc/passwd')
+    ).rejects.toThrow(SecureFileAccessError);
+    try {
+      await resolveSecurePath(storageRoot, '/etc/passwd');
+    } catch (err) {
+      expect((err as SecureFileAccessError).code).toBe('ABSOLUTE_PATH_REJECTED');
+    }
+  });
+
+  test('rejects Windows absolute path', async () => {
+    await expect(
+      resolveSecurePath(storageRoot, 'C:\\Windows\\system32\\config')
+    ).rejects.toThrow(SecureFileAccessError);
+  });
+
+  test('rejects backslash separators', async () => {
+    await expect(
+      resolveSecurePath(storageRoot, '..\\outside\\secret.txt')
+    ).rejects.toThrow(SecureFileAccessError);
+  });
+
+  // ── Symlink escape ──
+
+  test('rejects symlink pointing outside storage', async () => {
+    try {
+      await resolveSecurePath(storageRoot, 'bad-symlink.txt');
+      // If the symlink exists but doesn't escape (shouldn't happen in our setup)
+      fail('Should have thrown');
+    } catch (err) {
+      if (err instanceof SecureFileAccessError) {
+        expect(['PATH_ESCAPE', 'FILE_NOT_FOUND']).toContain(err.code);
+      }
+      // symlink may not exist — test is informational
+    }
+  });
+
+  // ── File not found ──
+
+  test('rejects non-existent file', async () => {
+    await expect(
+      resolveSecurePath(storageRoot, 'does-not-exist.pdf')
+    ).rejects.toThrow(SecureFileAccessError);
+    try {
+      await resolveSecurePath(storageRoot, 'does-not-exist.pdf');
+    } catch (err) {
+      expect((err as SecureFileAccessError).code).toBe('FILE_NOT_FOUND');
+    }
+  });
+
+  // ── Not a regular file ──
+
+  test('rejects directory as target', async () => {
+    await expect(
+      resolveSecurePath(storageRoot, 'subdir')
+    ).rejects.toThrow(SecureFileAccessError);
+    try {
+      await resolveSecurePath(storageRoot, 'subdir');
+    } catch (err) {
+      expect((err as SecureFileAccessError).code).toBe('NOT_REGULAR_FILE');
+    }
+  });
+
+  // ── Size limit ──
+
+  test('rejects file exceeding size limit', async () => {
+    await expect(
+      resolveSecurePath(storageRoot, 'valid.pdf', { maxSizeBytes: 1 })
+    ).rejects.toThrow(SecureFileAccessError);
+    try {
+      await resolveSecurePath(storageRoot, 'valid.pdf', { maxSizeBytes: 1 });
+    } catch (err) {
+      expect((err as SecureFileAccessError).code).toBe('FILE_TOO_LARGE');
+    }
+  });
+
+  // ── Legacy prefix stripping ──
+
+  test('strips legacy prefix before resolving', async () => {
+    const result = await resolveSecurePath(storageRoot, '/app/storage/documents/valid.pdf', {
+      legacyPrefixToStrip: '/app/storage/documents/',
+    });
+    expect(result.canonicalPath).toContain('valid.pdf');
+  });
+
+  test('rejects absolute path after legacy prefix strip if still absolute', async () => {
+    await expect(
+      resolveSecurePath(storageRoot, '/etc/passwd', {
+        legacyPrefixToStrip: '/app/storage/documents/',
+      })
+    ).rejects.toThrow(SecureFileAccessError);
+  });
+
+  // ── Storage root errors ──
+
+  test('throws when storage root does not exist', async () => {
+    await expect(
+      resolveSecurePath('/nonexistent/root', 'file.pdf')
+    ).rejects.toThrow(SecureFileAccessError);
+  });
+
+  // ── Error message safety ──
+
+  test('error messages do not leak filesystem paths', async () => {
+    try {
+      await resolveSecurePath(storageRoot, '../outside/secret.txt');
+    } catch (err) {
+      expect((err as Error).message).not.toContain(storageRoot);
+      expect((err as Error).message).not.toContain('outside');
+      expect((err as Error).message).not.toContain('secret');
+    }
+  });
+});
+
+describe('safeContentType', () => {
+  test('returns application/pdf for PDF', () => {
+    expect(safeContentType('application/pdf')).toBe('application/pdf');
+  });
+
+  test('returns octet-stream for unknown type', () => {
+    expect(safeContentType('text/html')).toBe('application/octet-stream');
+  });
+
+  test('returns octet-stream for null', () => {
+    expect(safeContentType(null)).toBe('application/octet-stream');
+  });
+
+  test('returns octet-stream for undefined', () => {
+    expect(safeContentType(undefined)).toBe('application/octet-stream');
+  });
+});
+
+describe('safeFilename', () => {
+  test('encodes special characters', () => {
+    expect(safeFilename('file name.pdf')).toBe('file%20name.pdf');
+  });
+
+  test('strips path separators and quotes', () => {
+    const result = safeFilename('../malicious"file.pdf');
+    expect(result).not.toContain('"');
+    expect(result).not.toContain('/');
+  });
+
+  test('handles empty string', () => {
+    expect(safeFilename('')).toBe('');
+  });
+});

--- a/__tests__/lib/documents/storage-root.test.ts
+++ b/__tests__/lib/documents/storage-root.test.ts
@@ -1,0 +1,77 @@
+import { join } from 'path';
+
+const env = process.env as Record<string, string | undefined>;
+
+// Reset module state between tests
+beforeEach(() => {
+  jest.resetModules();
+  delete env.DOCUMENT_STORAGE_ROOT;
+  delete env.NODE_ENV;
+});
+
+describe('getDocumentStorageRoot', () => {
+  test('returns DOCUMENT_STORAGE_ROOT when set in production', () => {
+    env.NODE_ENV = 'production';
+    env.DOCUMENT_STORAGE_ROOT = '/var/www/nexus-shared/storage/documents';
+    const { getDocumentStorageRoot } = require('@/lib/documents/storage-root');
+    expect(getDocumentStorageRoot()).toBe('/var/www/nexus-shared/storage/documents');
+  });
+
+  test('throws in production when DOCUMENT_STORAGE_ROOT is missing', () => {
+    env.NODE_ENV = 'production';
+    const { getDocumentStorageRoot } = require('@/lib/documents/storage-root');
+    expect(() => getDocumentStorageRoot()).toThrow('DOCUMENT_STORAGE_ROOT is required in production');
+  });
+
+  test('throws in production when DOCUMENT_STORAGE_ROOT is relative', () => {
+    env.NODE_ENV = 'production';
+    env.DOCUMENT_STORAGE_ROOT = 'storage/documents';
+    const { getDocumentStorageRoot } = require('@/lib/documents/storage-root');
+    expect(() => getDocumentStorageRoot()).toThrow('must be an absolute path');
+  });
+
+  test('falls back to cwd/storage/documents in development', () => {
+    env.NODE_ENV = 'development';
+    const { getDocumentStorageRoot } = require('@/lib/documents/storage-root');
+    const root = getDocumentStorageRoot();
+    expect(root).toContain('storage');
+    expect(root).toContain('documents');
+  });
+
+  test('uses DOCUMENT_STORAGE_ROOT in development when set', () => {
+    env.NODE_ENV = 'development';
+    env.DOCUMENT_STORAGE_ROOT = '/tmp/test-storage';
+    const { getDocumentStorageRoot } = require('@/lib/documents/storage-root');
+    expect(getDocumentStorageRoot()).toBe('/tmp/test-storage');
+  });
+});
+
+describe('toRelativeStoragePath', () => {
+  test('converts absolute path to relative', () => {
+    env.NODE_ENV = 'test';
+    env.DOCUMENT_STORAGE_ROOT = '/var/storage';
+    const { toRelativeStoragePath } = require('@/lib/documents/storage-root');
+    expect(toRelativeStoragePath('/var/storage/user1/file.pdf')).toBe(join('user1', 'file.pdf'));
+  });
+
+  test('handles simple filename', () => {
+    env.NODE_ENV = 'test';
+    env.DOCUMENT_STORAGE_ROOT = '/var/storage';
+    const { toRelativeStoragePath } = require('@/lib/documents/storage-root');
+    expect(toRelativeStoragePath('/var/storage/file.pdf')).toBe('file.pdf');
+  });
+
+  test('throws when path is outside storage root', () => {
+    env.NODE_ENV = 'test';
+    env.DOCUMENT_STORAGE_ROOT = '/var/storage';
+    const { toRelativeStoragePath } = require('@/lib/documents/storage-root');
+    expect(() => toRelativeStoragePath('/etc/passwd')).toThrow('not under the document storage root');
+  });
+
+  test('throws on traversal attempt', () => {
+    env.NODE_ENV = 'test';
+    env.DOCUMENT_STORAGE_ROOT = '/var/storage';
+    const { toRelativeStoragePath } = require('@/lib/documents/storage-root');
+    expect(() => toRelativeStoragePath('/var/storage/../etc/passwd')).toThrow('not under');
+  });
+});

--- a/app/api/admin/documents/route.ts
+++ b/app/api/admin/documents/route.ts
@@ -9,7 +9,7 @@ import { serializeError } from '@/lib/utils/serialize-error';
 import { getDocumentStorageRoot, toRelativeStoragePath } from '@/lib/documents/storage-root';
 import { z } from 'zod';
 
-const STORAGE_ROOT = getDocumentStorageRoot();
+function getStorageRoot() { return getDocumentStorageRoot(); }
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
 const ALLOWED_UPLOAD_MIME_TYPES = new Set([
   'application/pdf',
@@ -85,11 +85,11 @@ export async function POST(request: NextRequest) {
     const secureFilename = `${uniqueId}${fileExt}`;
     // Using path.join ensures we stick to the OS separator, 
     // and combined with uniqueId prevents directory traversal like ../../
-    const localPath = path.join(STORAGE_ROOT, secureFilename);
+    const localPath = path.join(getStorageRoot(), secureFilename);
     const originalName = sanitizeOriginalName(file.name);
 
     // Ensure directory exists
-    await mkdir(STORAGE_ROOT, { recursive: true });
+    await mkdir(getStorageRoot(), { recursive: true });
 
     // Write file to disk
     const buffer = Buffer.from(await file.arrayBuffer());

--- a/app/api/admin/documents/route.ts
+++ b/app/api/admin/documents/route.ts
@@ -6,7 +6,7 @@ import { createId } from '@paralleldrive/cuid2';
 import path from 'path';
 import { mkdir, writeFile } from 'fs/promises';
 import { serializeError } from '@/lib/utils/serialize-error';
-import { getDocumentStorageRoot } from '@/lib/documents/storage-root';
+import { getDocumentStorageRoot, toRelativeStoragePath } from '@/lib/documents/storage-root';
 import { z } from 'zod';
 
 const STORAGE_ROOT = getDocumentStorageRoot();
@@ -103,7 +103,7 @@ export async function POST(request: NextRequest) {
         originalName,
         mimeType: file.type,
         sizeBytes: file.size,
-        localPath: localPath,
+        localPath: toRelativeStoragePath(localPath),
         userId: userId,
         uploadedById: session.user.id,
       },

--- a/app/api/coach/students/[studentId]/documents/route.ts
+++ b/app/api/coach/students/[studentId]/documents/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { mkdir, writeFile } from 'fs/promises';
 import path from 'path';
-import { getDocumentStorageRoot } from '@/lib/documents/storage-root';
+import { getDocumentStorageRoot, toRelativeStoragePath } from '@/lib/documents/storage-root';
 import { requireRole, isErrorResponse } from '@/lib/guards';
 import { assertCoachCanAccessStudent } from '@/lib/rbac/coach-student-access';
 import { prisma } from '@/lib/prisma';
@@ -253,14 +253,14 @@ export async function POST(request: Request, { params }: RouteParams) {
       const sanitizedTitle = sanitizeFilenamePart(validatedMeta.title);
       const extension = sanitizeFilenamePart(file.name.split('.').pop() || 'pdf');
       const filename = `${sanitizedTitle}-${timestamp}.${extension}`;
-      // Write to STORAGE_ROOT and store the absolute path in DB
+      // Write to STORAGE_ROOT and store a relative path in DB
       const storageRoot = getDocumentStorageRoot();
       const uploadDir = path.join(storageRoot, student.userId);
-      const localPath = path.join(uploadDir, filename);
+      const absolutePath = path.join(uploadDir, filename);
       await mkdir(uploadDir, { recursive: true });
 
       const buffer = Buffer.from(await file.arrayBuffer());
-      await writeFile(path.join(uploadDir, filename), buffer);
+      await writeFile(absolutePath, buffer);
 
       documentData = {
         title: validatedMeta.title,
@@ -268,7 +268,7 @@ export async function POST(request: Request, { params }: RouteParams) {
         subject: validatedMeta.subject ?? null,
         description: validatedMeta.description ?? null,
         visibilityScope: validatedMeta.visibilityScope,
-        localPath,
+        localPath: toRelativeStoragePath(absolutePath),
         originalName: file.name,
         mimeType: file.type,
         sizeBytes: file.size,

--- a/app/api/documents/[id]/route.ts
+++ b/app/api/documents/[id]/route.ts
@@ -5,6 +5,11 @@ import { readFile } from 'fs/promises';
 import { UserRole } from '@prisma/client';
 import { serializeError } from '@/lib/utils/serialize-error';
 import { z } from 'zod';
+import { getDocumentStorageRoot, LEGACY_STORAGE_PREFIX } from '@/lib/documents/storage-root';
+import {
+  resolveSecurePath,
+  SecureFileAccessError,
+} from '@/lib/documents/secure-file-access';
 
 const routeParamsSchema = z.object({
   id: z.string().min(1).max(128).regex(/^[A-Za-z0-9_-]+$/),
@@ -91,19 +96,31 @@ export async function GET(
     }
 
     try {
-      const fileBuffer = await readFile(document.localPath);
+      const storageRoot = getDocumentStorageRoot();
+      const { canonicalPath, sizeBytes } = await resolveSecurePath(
+        storageRoot,
+        document.localPath,
+        { legacyPrefixToStrip: LEGACY_STORAGE_PREFIX },
+      );
+
+      const fileBuffer = await readFile(canonicalPath);
 
       return new NextResponse(fileBuffer, {
         headers: {
           'Content-Type': safeContentType(document.mimeType),
           'Content-Disposition': `inline; filename="${safeFilename(document.originalName)}"`,
-          'Content-Length': document.sizeBytes.toString(),
+          'Content-Length': sizeBytes.toString(),
           'X-Content-Type-Options': 'nosniff',
+          'Cache-Control': 'private, no-store',
         },
       });
-    } catch (fsError) {
-      const code = fsError instanceof Error && 'code' in fsError
-        ? String((fsError as NodeJS.ErrnoException).code)
+    } catch (err) {
+      if (err instanceof SecureFileAccessError) {
+        console.error('[documents] containment check failed', { documentId: document.id, code: err.code });
+        return new NextResponse('File content not found', { status: 404 });
+      }
+      const code = err instanceof Error && 'code' in err
+        ? String((err as NodeJS.ErrnoException).code)
         : 'UNKNOWN';
       console.error('[File Read Error] File content unavailable', { documentId: document.id, code });
       return new NextResponse('File content not found', { status: 404 });

--- a/app/api/documents/[id]/route.ts
+++ b/app/api/documents/[id]/route.ts
@@ -1,37 +1,21 @@
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
-import { readFile } from 'fs/promises';
+import { Readable } from 'stream';
 import { UserRole } from '@prisma/client';
 import { serializeError } from '@/lib/utils/serialize-error';
 import { z } from 'zod';
 import { getDocumentStorageRoot, LEGACY_STORAGE_PREFIX } from '@/lib/documents/storage-root';
 import {
-  resolveSecurePath,
+  openSecureDocument,
   SecureFileAccessError,
+  safeContentType,
+  safeFilename,
 } from '@/lib/documents/secure-file-access';
 
 const routeParamsSchema = z.object({
   id: z.string().min(1).max(128).regex(/^[A-Za-z0-9_-]+$/),
 });
-
-const documentDownloadSelect = {
-  id: true,
-  userId: true,
-  localPath: true,
-  mimeType: true,
-  originalName: true,
-  sizeBytes: true,
-} as const;
-
-type DocumentDownloadRecord = {
-  id: string;
-  userId: string;
-  localPath: string;
-  mimeType: string;
-  originalName: string;
-  sizeBytes: number;
-};
 
 function isStaffRole(role: string | undefined): boolean {
   return role === UserRole.ADMIN || role === UserRole.ASSISTANTE;
@@ -44,28 +28,8 @@ function buildDocumentOwnershipWhere(id: string, userId: string, role: string | 
   return { id, userId };
 }
 
-function hasDocumentOwnership(document: DocumentDownloadRecord, userId: string, role: string | undefined): boolean {
-  return isStaffRole(role) || document.userId === userId;
-}
-
-function safeFilename(name: string): string {
-  return encodeURIComponent(name.replace(/[\\/\r\n"]/g, '_'));
-}
-
-function safeContentType(mimeType: string | null | undefined): string {
-  if (!mimeType) return 'application/octet-stream';
-  const allowed = new Set([
-    'application/pdf',
-    'image/jpeg',
-    'image/png',
-    'image/webp',
-    'text/plain',
-  ]);
-  return allowed.has(mimeType) ? mimeType : 'application/octet-stream';
-}
-
 export async function GET(
-  request: NextRequest,
+  _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
@@ -81,51 +45,59 @@ export async function GET(
     const { id } = parsedParams.data;
     const userRole = session.user.role as UserRole | undefined;
 
-    // Scope the metadata query before any file-system read.
     const document = await prisma.userDocument.findFirst({
       where: buildDocumentOwnershipWhere(id, session.user.id, userRole),
-      select: documentDownloadSelect,
+      select: {
+        id: true,
+        userId: true,
+        localPath: true,
+        mimeType: true,
+        originalName: true,
+        sizeBytes: true,
+      },
     });
 
     if (!document) {
       return new NextResponse('Document not found', { status: 404 });
     }
 
-    if (!hasDocumentOwnership(document, session.user.id, userRole)) {
+    // Ownership check: staff can access any; others only their own
+    if (!isStaffRole(userRole) && document.userId !== session.user.id) {
       return new NextResponse('Document not found', { status: 404 });
     }
 
+    let secureDoc;
     try {
       const storageRoot = getDocumentStorageRoot();
-      const { canonicalPath, sizeBytes } = await resolveSecurePath(
-        storageRoot,
-        document.localPath,
-        { legacyPrefixToStrip: LEGACY_STORAGE_PREFIX },
-      );
-
-      const fileBuffer = await readFile(canonicalPath);
-
-      return new NextResponse(fileBuffer, {
-        headers: {
-          'Content-Type': safeContentType(document.mimeType),
-          'Content-Disposition': `inline; filename="${safeFilename(document.originalName)}"`,
-          'Content-Length': sizeBytes.toString(),
-          'X-Content-Type-Options': 'nosniff',
-          'Cache-Control': 'private, no-store',
-        },
+      secureDoc = await openSecureDocument(storageRoot, document.localPath, {
+        legacyPrefixToStrip: LEGACY_STORAGE_PREFIX,
       });
     } catch (err) {
       if (err instanceof SecureFileAccessError) {
         console.error('[documents] containment check failed', { documentId: document.id, code: err.code });
         return new NextResponse('File content not found', { status: 404 });
       }
-      const code = err instanceof Error && 'code' in err
-        ? String((err as NodeJS.ErrnoException).code)
-        : 'UNKNOWN';
-      console.error('[File Read Error] File content unavailable', { documentId: document.id, code });
+      console.error('[documents] unexpected error', { documentId: document.id });
       return new NextResponse('File content not found', { status: 404 });
     }
 
+    try {
+      const stream = secureDoc.handle.createReadStream();
+      const webStream = Readable.toWeb(stream) as ReadableStream;
+
+      return new NextResponse(webStream, {
+        headers: {
+          'Content-Type': safeContentType(document.mimeType),
+          'Content-Disposition': `inline; filename="${safeFilename(document.originalName)}"`,
+          'Content-Length': secureDoc.sizeBytes.toString(),
+          'X-Content-Type-Options': 'nosniff',
+          'Cache-Control': 'private, no-store',
+        },
+      });
+    } catch {
+      await secureDoc.handle.close().catch(() => {});
+      return new NextResponse('File content not found', { status: 404 });
+    }
   } catch (error) {
     console.error('[Download Error]', serializeError(error));
     return new NextResponse('Internal Server Error', { status: 500 });

--- a/app/api/payments/validate/route.ts
+++ b/app/api/payments/validate/route.ts
@@ -8,7 +8,7 @@ import { mergePaymentMetadata, parsePaymentMetadata } from '@/lib/utils';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import path from 'path';
-import { getDocumentStorageRoot } from '@/lib/documents/storage-root';
+import { getDocumentStorageRoot, toRelativeStoragePath } from '@/lib/documents/storage-root';
 import { writeFile, mkdir } from 'fs/promises';
 import {
   renderInvoicePDF,
@@ -186,8 +186,8 @@ async function generateInvoicePDFAndDocument(
     await mkdir(DOCUMENTS_DIR, { recursive: true });
     const sanitizedNumber = invoice.number.replace(/[^a-zA-Z0-9-]/g, '_');
     const uniqueFileName = `facture-${sanitizedNumber}-${invoice.id}.pdf`;
-    const documentPath = path.join(DOCUMENTS_DIR, uniqueFileName);
-    await writeFile(documentPath, pdfBuffer);
+    const documentAbsPath = path.join(DOCUMENTS_DIR, uniqueFileName);
+    await writeFile(documentAbsPath, pdfBuffer);
 
     const userDocument = await prisma.userDocument.create({
       data: {
@@ -195,7 +195,7 @@ async function generateInvoicePDFAndDocument(
         originalName: `facture-${invoice.number}.pdf`,
         mimeType: 'application/pdf',
         sizeBytes: pdfBuffer.length,
-        localPath: documentPath,
+        localPath: toRelativeStoragePath(documentAbsPath),
         userId: paymentUserId,
         uploadedById: validatorUserId,
       },

--- a/app/api/payments/validate/route.ts
+++ b/app/api/payments/validate/route.ts
@@ -97,7 +97,7 @@ function buildMinimalPdfBuffer(message: string): Buffer {
 }
 
 /** Base directory for secure document storage (coffre-fort) */
-const DOCUMENTS_DIR = getDocumentStorageRoot();
+function getDocumentsDir() { return getDocumentStorageRoot(); }
 
 const validatePaymentSchema = z.object({
   paymentId: z.string(),
@@ -183,10 +183,10 @@ async function generateInvoicePDFAndDocument(
     });
 
     // Store in coffre-fort (storage/documents/) + create UserDocument
-    await mkdir(DOCUMENTS_DIR, { recursive: true });
+    await mkdir(getDocumentsDir(), { recursive: true });
     const sanitizedNumber = invoice.number.replace(/[^a-zA-Z0-9-]/g, '_');
     const uniqueFileName = `facture-${sanitizedNumber}-${invoice.id}.pdf`;
-    const documentAbsPath = path.join(DOCUMENTS_DIR, uniqueFileName);
+    const documentAbsPath = path.join(getDocumentsDir(), uniqueFileName);
     await writeFile(documentAbsPath, pdfBuffer);
 
     const userDocument = await prisma.userDocument.create({

--- a/app/api/student/documents/[id]/download/route.ts
+++ b/app/api/student/documents/[id]/download/route.ts
@@ -1,13 +1,14 @@
 export const dynamic = 'force-dynamic';
 
 import { NextRequest, NextResponse } from 'next/server';
-import { readFile } from 'fs/promises';
+import { createReadStream } from 'fs';
+import { Readable } from 'stream';
 import { UserRole } from '@prisma/client';
 import { requireRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
 import { getDocumentStorageRoot, LEGACY_STORAGE_PREFIX } from '@/lib/documents/storage-root';
 import {
-  resolveSecurePath,
+  openSecureDocument,
   SecureFileAccessError,
   safeContentType,
   safeFilename,
@@ -26,7 +27,7 @@ export async function GET(
   const doc = await prisma.userDocument.findFirst({
     where: {
       id,
-      userId: session.user.id, // strict ownership — prevents access to other students' docs
+      userId: session.user.id, // strict ownership
     },
     select: {
       id: true,
@@ -40,23 +41,11 @@ export async function GET(
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
 
+  let secureDoc;
   try {
     const storageRoot = getDocumentStorageRoot();
-    const { canonicalPath } = await resolveSecurePath(storageRoot, doc.localPath, {
+    secureDoc = await openSecureDocument(storageRoot, doc.localPath, {
       legacyPrefixToStrip: LEGACY_STORAGE_PREFIX,
-    });
-
-    const buffer = await readFile(canonicalPath);
-    const safeName = safeFilename(doc.originalName);
-
-    return new NextResponse(buffer, {
-      headers: {
-        'Content-Type': safeContentType(doc.mimeType),
-        'Content-Disposition': `attachment; filename="${safeName}"`,
-        'X-Content-Type-Options': 'nosniff',
-        'Cache-Control': 'private, no-store',
-        'Content-Length': buffer.length.toString(),
-      },
     });
   } catch (err) {
     if (err instanceof SecureFileAccessError) {
@@ -66,10 +55,26 @@ export async function GET(
       });
       return NextResponse.json({ error: 'File unavailable' }, { status: 404 });
     }
-    const code = err instanceof Error && 'code' in err
-      ? String((err as NodeJS.ErrnoException).code)
-      : 'UNKNOWN';
-    console.error('[student/documents/download] file read failed', { documentId: id, code });
+    console.error('[student/documents/download] unexpected error', { documentId: id });
+    return NextResponse.json({ error: 'File unavailable' }, { status: 500 });
+  }
+
+  try {
+    const stream = secureDoc.handle.createReadStream();
+    const webStream = Readable.toWeb(stream) as ReadableStream;
+
+    return new NextResponse(webStream, {
+      headers: {
+        'Content-Type': safeContentType(doc.mimeType),
+        'Content-Disposition': `attachment; filename="${safeFilename(doc.originalName)}"`,
+        'Content-Length': secureDoc.sizeBytes.toString(),
+        'X-Content-Type-Options': 'nosniff',
+        'Cache-Control': 'private, no-store',
+      },
+    });
+  } catch {
+    await secureDoc.handle.close().catch(() => {});
+    console.error('[student/documents/download] stream error', { documentId: id });
     return NextResponse.json({ error: 'File unavailable' }, { status: 500 });
   }
 }

--- a/app/api/student/documents/[id]/download/route.ts
+++ b/app/api/student/documents/[id]/download/route.ts
@@ -2,10 +2,16 @@ export const dynamic = 'force-dynamic';
 
 import { NextRequest, NextResponse } from 'next/server';
 import { readFile } from 'fs/promises';
-import path from 'path';
 import { UserRole } from '@prisma/client';
 import { requireRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
+import { getDocumentStorageRoot, LEGACY_STORAGE_PREFIX } from '@/lib/documents/storage-root';
+import {
+  resolveSecurePath,
+  SecureFileAccessError,
+  safeContentType,
+  safeFilename,
+} from '@/lib/documents/secure-file-access';
 
 export async function GET(
   _req: NextRequest,
@@ -35,24 +41,35 @@ export async function GET(
   }
 
   try {
-    // localPath is an absolute path outside the public directory (secure storage)
-    const resolvedPath = path.resolve(doc.localPath);
-    const buffer = await readFile(resolvedPath);
+    const storageRoot = getDocumentStorageRoot();
+    const { canonicalPath } = await resolveSecurePath(storageRoot, doc.localPath, {
+      legacyPrefixToStrip: LEGACY_STORAGE_PREFIX,
+    });
 
-    const safeName = encodeURIComponent(doc.originalName).replace(/['"]/g, '');
+    const buffer = await readFile(canonicalPath);
+    const safeName = safeFilename(doc.originalName);
 
     return new NextResponse(buffer, {
       headers: {
-        'Content-Type': doc.mimeType ?? 'application/octet-stream',
+        'Content-Type': safeContentType(doc.mimeType),
         'Content-Disposition': `attachment; filename="${safeName}"`,
+        'X-Content-Type-Options': 'nosniff',
         'Cache-Control': 'private, no-store',
+        'Content-Length': buffer.length.toString(),
       },
     });
   } catch (err) {
+    if (err instanceof SecureFileAccessError) {
+      console.error('[student/documents/download] containment check failed', {
+        documentId: id,
+        code: err.code,
+      });
+      return NextResponse.json({ error: 'File unavailable' }, { status: 404 });
+    }
     const code = err instanceof Error && 'code' in err
       ? String((err as NodeJS.ErrnoException).code)
       : 'UNKNOWN';
-    console.error('[documents/download] file read failed', { documentId: id, code });
+    console.error('[student/documents/download] file read failed', { documentId: id, code });
     return NextResponse.json({ error: 'File unavailable' }, { status: 500 });
   }
 }

--- a/lib/documents/secure-file-access.ts
+++ b/lib/documents/secure-file-access.ts
@@ -1,21 +1,33 @@
-import { realpath, stat } from 'fs/promises';
-import { resolve, sep } from 'path';
+import { open, realpath } from 'fs/promises';
+import { relative, resolve, sep, isAbsolute } from 'path';
+import type { FileHandle } from 'fs/promises';
 
 /**
  * Secure file access — canonical containment for document downloads.
  *
- * Resolves a raw path (from DB or user input) against a storage root,
- * then verifies containment using realpath on BOTH sides to handle symlinks.
+ * Accepts three historical path representations:
+ * 1. Relative paths resolved against the storage root
+ * 2. Paths with a legacy prefix (e.g. /app/storage/documents/) — prefix stripped first
+ * 3. Absolute paths that, after realpath canonicalization, fall inside the storage root
  *
- * @throws {SecureFileAccessError} with a safe error code (no path leakage)
+ * Containment uses realpath on BOTH sides to handle symlinks, then verifies
+ * via path.relative() that the result stays within the root.
+ *
+ * TOCTOU note: openSecureDocument opens the file handle BEFORE returning,
+ * eliminating the gap between path validation and file read. The residual
+ * risk is filesystem-level permission/mount changes, which require root
+ * access and are outside the application threat model.
  */
 
+// ── Error types ──
+
 export type SecureFileAccessErrorCode =
-  | 'ABSOLUTE_PATH_REJECTED'
+  | 'INVALID_PATH_FORMAT'
   | 'PATH_ESCAPE'
   | 'FILE_NOT_FOUND'
   | 'NOT_REGULAR_FILE'
-  | 'FILE_TOO_LARGE';
+  | 'FILE_TOO_LARGE'
+  | 'STORAGE_ROOT_UNAVAILABLE';
 
 export class SecureFileAccessError extends Error {
   constructor(
@@ -27,12 +39,7 @@ export class SecureFileAccessError extends Error {
   }
 }
 
-export interface ResolvedSecurePath {
-  /** Canonical absolute path, safe to read */
-  canonicalPath: string;
-  /** File size in bytes */
-  sizeBytes: number;
-}
+// ── Types ──
 
 export interface SecureFileAccessOptions {
   /** Maximum file size in bytes (default: 25 MiB) */
@@ -41,25 +48,49 @@ export interface SecureFileAccessOptions {
   legacyPrefixToStrip?: string;
 }
 
+export interface SecureDocument {
+  /** Validated file handle — caller must close it */
+  handle: FileHandle;
+  /** File size in bytes */
+  sizeBytes: number;
+}
+
 const DEFAULT_MAX_SIZE = 25 * 1024 * 1024; // 25 MiB
+const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+
+// ── Core: open a document securely ──
 
 /**
- * Resolve and contain a file path within a storage root.
+ * Open a document file with full containment, returning an open FileHandle.
  *
  * Procedure:
- * 1. Reject absolute paths (unless legacy prefix is stripped first)
- * 2. Resolve relative path against storageRoot
- * 3. realpath BOTH storageRoot and resolved path
- * 4. Verify canonical path is strictly inside canonical root
- * 5. Verify target is a regular file (not device, socket, dir, pipe)
- * 6. Verify size is within limit
+ * 1. Reject URLs and encoded traversal sequences
+ * 2. Strip legacy prefix if applicable
+ * 3. Resolve the candidate path (relative → from root; absolute → as-is)
+ * 4. realpath BOTH storage root and candidate
+ * 5. Verify containment via path.relative (not string prefix)
+ * 6. Open the file (O_RDONLY)
+ * 7. fstat the open handle to verify regular file + size
+ * 8. Return the open handle — caller must close it
+ *
+ * If any step fails, any opened handle is closed before throwing.
  */
-export async function resolveSecurePath(
+export async function openSecureDocument(
   storageRoot: string,
   rawPath: string,
   options: SecureFileAccessOptions = {},
-): Promise<ResolvedSecurePath> {
+): Promise<SecureDocument> {
   const maxSize = options.maxSizeBytes ?? DEFAULT_MAX_SIZE;
+
+  // Reject URL schemes
+  if (URL_SCHEME_RE.test(rawPath)) {
+    throw new SecureFileAccessError('INVALID_PATH_FORMAT', 'URL schemes are not allowed');
+  }
+
+  // Reject encoded traversal before any path processing
+  if (/%2e/i.test(rawPath) || /%00/.test(rawPath) || /%2f/i.test(rawPath) || /%5c/i.test(rawPath)) {
+    throw new SecureFileAccessError('INVALID_PATH_FORMAT', 'Encoded path components are not allowed');
+  }
 
   // Strip legacy prefix if configured
   let normalizedPath = rawPath;
@@ -67,52 +98,101 @@ export async function resolveSecurePath(
     normalizedPath = normalizedPath.slice(options.legacyPrefixToStrip.length);
   }
 
-  // Reject absolute paths after prefix stripping
-  if (normalizedPath.startsWith('/') || normalizedPath.startsWith('\\') || /^[A-Za-z]:/.test(normalizedPath)) {
-    throw new SecureFileAccessError('ABSOLUTE_PATH_REJECTED', 'Absolute paths are not allowed');
-  }
-
-  // Reject URL-encoded traversal
-  if (normalizedPath.includes('%2e') || normalizedPath.includes('%2E') || normalizedPath.includes('%00')) {
-    throw new SecureFileAccessError('PATH_ESCAPE', 'Encoded traversal detected');
-  }
-
-  // Resolve against storage root
-  const resolvedPath = resolve(storageRoot, normalizedPath);
+  // Build candidate path:
+  // - Absolute paths → used as-is (containment verified by realpath below)
+  // - Relative paths → resolved against storage root
+  const candidatePath = isAbsolute(normalizedPath)
+    ? resolve(normalizedPath)
+    : resolve(storageRoot, normalizedPath);
 
   // Canonicalize BOTH paths via realpath (follows symlinks)
   let canonicalRoot: string;
-  let canonicalPath: string;
   try {
     canonicalRoot = await realpath(storageRoot);
   } catch {
-    throw new SecureFileAccessError('FILE_NOT_FOUND', 'Storage root is not accessible');
+    throw new SecureFileAccessError('STORAGE_ROOT_UNAVAILABLE', 'Storage root is not accessible');
   }
 
+  let canonicalPath: string;
   try {
-    canonicalPath = await realpath(resolvedPath);
+    canonicalPath = await realpath(candidatePath);
   } catch {
     throw new SecureFileAccessError('FILE_NOT_FOUND', 'File does not exist');
   }
 
-  // Containment check using path separator
-  const canonicalPrefix = canonicalRoot.endsWith(sep) ? canonicalRoot : `${canonicalRoot}${sep}`;
-  if (!canonicalPath.startsWith(canonicalPrefix)) {
+  // Containment check via path.relative — more robust than string prefix
+  const rel = relative(canonicalRoot, canonicalPath);
+  if (
+    !rel ||                         // empty = candidate IS the root
+    isAbsolute(rel) ||              // absolute = different volume/drive
+    rel === '..' ||                 // direct parent
+    rel.startsWith(`..${sep}`)      // any ancestor
+  ) {
     throw new SecureFileAccessError('PATH_ESCAPE', 'Path escapes storage root');
   }
 
-  // Verify it's a regular file
-  const fileStat = await stat(canonicalPath);
-  if (!fileStat.isFile()) {
-    throw new SecureFileAccessError('NOT_REGULAR_FILE', 'Target is not a regular file');
+  // Open the file — eliminates TOCTOU between validation and read
+  let handle: FileHandle;
+  try {
+    handle = await open(canonicalPath, 'r');
+  } catch {
+    throw new SecureFileAccessError('FILE_NOT_FOUND', 'File cannot be opened');
   }
 
-  // Size check
-  if (fileStat.size > maxSize) {
-    throw new SecureFileAccessError('FILE_TOO_LARGE', 'File exceeds size limit');
-  }
+  // Validate via fstat on the OPEN handle
+  try {
+    const fileStat = await handle.stat();
 
-  return { canonicalPath, sizeBytes: fileStat.size };
+    if (!fileStat.isFile()) {
+      await handle.close();
+      throw new SecureFileAccessError('NOT_REGULAR_FILE', 'Target is not a regular file');
+    }
+
+    if (fileStat.size > maxSize) {
+      await handle.close();
+      throw new SecureFileAccessError('FILE_TOO_LARGE', 'File exceeds size limit');
+    }
+
+    return { handle, sizeBytes: fileStat.size };
+  } catch (err) {
+    // Close handle on any validation error (unless already thrown above)
+    if (err instanceof SecureFileAccessError) throw err;
+    await handle.close().catch(() => {});
+    throw new SecureFileAccessError('FILE_NOT_FOUND', 'File validation failed');
+  }
+}
+
+// ── Legacy compatibility: resolveSecurePath (returns path, not handle) ──
+
+export interface ResolvedSecurePath {
+  canonicalPath: string;
+  sizeBytes: number;
+}
+
+/**
+ * Resolve and validate a path without opening a handle.
+ * Use openSecureDocument when possible for TOCTOU-free reads.
+ */
+export async function resolveSecurePath(
+  storageRoot: string,
+  rawPath: string,
+  options: SecureFileAccessOptions = {},
+): Promise<ResolvedSecurePath> {
+  const doc = await openSecureDocument(storageRoot, rawPath, options);
+  const { sizeBytes } = doc;
+  // Read the fd path for callers that need it
+  const canonicalPath = await realpath(`/proc/self/fd/${(doc.handle as any).fd}`).catch(
+    // Fallback: re-resolve (slight TOCTOU but only used by legacy callers)
+    async () => {
+      const normalized = rawPath.startsWith(options?.legacyPrefixToStrip ?? '\0')
+        ? rawPath.slice((options?.legacyPrefixToStrip ?? '').length)
+        : rawPath;
+      const candidate = isAbsolute(normalized) ? resolve(normalized) : resolve(storageRoot, normalized);
+      return realpath(candidate);
+    },
+  );
+  await doc.handle.close();
+  return { canonicalPath, sizeBytes };
 }
 
 // ── Safe HTTP response helpers ──
@@ -130,6 +210,13 @@ export function safeContentType(mimeType: string | null | undefined): string {
   return ALLOWED_MIME_TYPES.has(mimeType) ? mimeType : 'application/octet-stream';
 }
 
+/**
+ * Produce a safe filename for Content-Disposition headers.
+ * Strips path separators, control chars, and quotes.
+ * Falls back to 'document' for empty names.
+ */
 export function safeFilename(name: string): string {
-  return encodeURIComponent(name.replace(/[\\/\r\n"]/g, '_'));
+  if (!name) return 'document';
+  const cleaned = name.replace(/[\\/\r\n"\x00-\x1f]/g, '_');
+  return encodeURIComponent(cleaned);
 }

--- a/lib/documents/secure-file-access.ts
+++ b/lib/documents/secure-file-access.ts
@@ -1,0 +1,135 @@
+import { realpath, stat } from 'fs/promises';
+import { resolve, sep } from 'path';
+
+/**
+ * Secure file access — canonical containment for document downloads.
+ *
+ * Resolves a raw path (from DB or user input) against a storage root,
+ * then verifies containment using realpath on BOTH sides to handle symlinks.
+ *
+ * @throws {SecureFileAccessError} with a safe error code (no path leakage)
+ */
+
+export type SecureFileAccessErrorCode =
+  | 'ABSOLUTE_PATH_REJECTED'
+  | 'PATH_ESCAPE'
+  | 'FILE_NOT_FOUND'
+  | 'NOT_REGULAR_FILE'
+  | 'FILE_TOO_LARGE';
+
+export class SecureFileAccessError extends Error {
+  constructor(
+    public readonly code: SecureFileAccessErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SecureFileAccessError';
+  }
+}
+
+export interface ResolvedSecurePath {
+  /** Canonical absolute path, safe to read */
+  canonicalPath: string;
+  /** File size in bytes */
+  sizeBytes: number;
+}
+
+export interface SecureFileAccessOptions {
+  /** Maximum file size in bytes (default: 25 MiB) */
+  maxSizeBytes?: number;
+  /** Legacy path prefix to strip before resolving (e.g. '/app/storage/documents/') */
+  legacyPrefixToStrip?: string;
+}
+
+const DEFAULT_MAX_SIZE = 25 * 1024 * 1024; // 25 MiB
+
+/**
+ * Resolve and contain a file path within a storage root.
+ *
+ * Procedure:
+ * 1. Reject absolute paths (unless legacy prefix is stripped first)
+ * 2. Resolve relative path against storageRoot
+ * 3. realpath BOTH storageRoot and resolved path
+ * 4. Verify canonical path is strictly inside canonical root
+ * 5. Verify target is a regular file (not device, socket, dir, pipe)
+ * 6. Verify size is within limit
+ */
+export async function resolveSecurePath(
+  storageRoot: string,
+  rawPath: string,
+  options: SecureFileAccessOptions = {},
+): Promise<ResolvedSecurePath> {
+  const maxSize = options.maxSizeBytes ?? DEFAULT_MAX_SIZE;
+
+  // Strip legacy prefix if configured
+  let normalizedPath = rawPath;
+  if (options.legacyPrefixToStrip && normalizedPath.startsWith(options.legacyPrefixToStrip)) {
+    normalizedPath = normalizedPath.slice(options.legacyPrefixToStrip.length);
+  }
+
+  // Reject absolute paths after prefix stripping
+  if (normalizedPath.startsWith('/') || normalizedPath.startsWith('\\') || /^[A-Za-z]:/.test(normalizedPath)) {
+    throw new SecureFileAccessError('ABSOLUTE_PATH_REJECTED', 'Absolute paths are not allowed');
+  }
+
+  // Reject URL-encoded traversal
+  if (normalizedPath.includes('%2e') || normalizedPath.includes('%2E') || normalizedPath.includes('%00')) {
+    throw new SecureFileAccessError('PATH_ESCAPE', 'Encoded traversal detected');
+  }
+
+  // Resolve against storage root
+  const resolvedPath = resolve(storageRoot, normalizedPath);
+
+  // Canonicalize BOTH paths via realpath (follows symlinks)
+  let canonicalRoot: string;
+  let canonicalPath: string;
+  try {
+    canonicalRoot = await realpath(storageRoot);
+  } catch {
+    throw new SecureFileAccessError('FILE_NOT_FOUND', 'Storage root is not accessible');
+  }
+
+  try {
+    canonicalPath = await realpath(resolvedPath);
+  } catch {
+    throw new SecureFileAccessError('FILE_NOT_FOUND', 'File does not exist');
+  }
+
+  // Containment check using path separator
+  const canonicalPrefix = canonicalRoot.endsWith(sep) ? canonicalRoot : `${canonicalRoot}${sep}`;
+  if (!canonicalPath.startsWith(canonicalPrefix)) {
+    throw new SecureFileAccessError('PATH_ESCAPE', 'Path escapes storage root');
+  }
+
+  // Verify it's a regular file
+  const fileStat = await stat(canonicalPath);
+  if (!fileStat.isFile()) {
+    throw new SecureFileAccessError('NOT_REGULAR_FILE', 'Target is not a regular file');
+  }
+
+  // Size check
+  if (fileStat.size > maxSize) {
+    throw new SecureFileAccessError('FILE_TOO_LARGE', 'File exceeds size limit');
+  }
+
+  return { canonicalPath, sizeBytes: fileStat.size };
+}
+
+// ── Safe HTTP response helpers ──
+
+const ALLOWED_MIME_TYPES = new Set([
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'text/plain',
+]);
+
+export function safeContentType(mimeType: string | null | undefined): string {
+  if (!mimeType) return 'application/octet-stream';
+  return ALLOWED_MIME_TYPES.has(mimeType) ? mimeType : 'application/octet-stream';
+}
+
+export function safeFilename(name: string): string {
+  return encodeURIComponent(name.replace(/[\\/\r\n"]/g, '_'));
+}

--- a/lib/documents/storage-root.ts
+++ b/lib/documents/storage-root.ts
@@ -1,15 +1,68 @@
-import { resolve } from 'path';
+import { isAbsolute, resolve, relative } from 'path';
 
 /**
  * Single source of truth for document storage root.
  *
- * Used by: download route, admin upload, coach upload, payment validation.
- * Env-configurable via DOCUMENT_STORAGE_ROOT, defaults to cwd/storage/documents.
+ * Used by: download routes, admin upload, coach upload, payment validation.
+ *
+ * Production: DOCUMENT_STORAGE_ROOT is REQUIRED and must be absolute.
+ * Dev/test: falls back to cwd/storage/documents.
  */
+
+const IS_PRODUCTION = process.env.NODE_ENV === 'production';
+
+let _cachedRoot: string | undefined;
+
 export function getDocumentStorageRoot(): string {
-  // resolve() ensures a relative env value becomes absolute against cwd
-  return resolve(process.env.DOCUMENT_STORAGE_ROOT || resolve(process.cwd(), 'storage', 'documents'));
+  if (_cachedRoot) return _cachedRoot;
+
+  const envValue = process.env.DOCUMENT_STORAGE_ROOT;
+
+  if (IS_PRODUCTION) {
+    if (!envValue) {
+      throw new Error(
+        'DOCUMENT_STORAGE_ROOT is required in production. ' +
+        'Set it in /etc/nexus/nexus-prod.env to a persistent absolute path.'
+      );
+    }
+    if (!isAbsolute(envValue)) {
+      throw new Error(
+        'DOCUMENT_STORAGE_ROOT must be an absolute path in production.'
+      );
+    }
+    _cachedRoot = envValue;
+  } else {
+    _cachedRoot = envValue
+      ? resolve(envValue)
+      : resolve(process.cwd(), 'storage', 'documents');
+  }
+
+  return _cachedRoot;
+}
+
+/** Reset cached root — for testing only. */
+export function _resetStorageRootCache(): void {
+  _cachedRoot = undefined;
 }
 
 /** Legacy prefix stored in DB by older upload routes (/app/storage/documents/). */
 export const LEGACY_STORAGE_PREFIX = '/app/storage/documents/';
+
+/**
+ * Convert an absolute storage path to a relative path for DB storage.
+ *
+ * Uploads should call this before persisting localPath so that documents
+ * survive release swaps (the storage root is outside any release directory).
+ *
+ * @param absolutePath - The absolute file path (e.g. from path.join(root, filename))
+ * @returns Relative path from storage root (e.g. "userId/filename.pdf")
+ * @throws if the path is not under the storage root
+ */
+export function toRelativeStoragePath(absolutePath: string): string {
+  const root = getDocumentStorageRoot();
+  const rel = relative(root, absolutePath);
+  if (!rel || isAbsolute(rel) || rel.startsWith('..')) {
+    throw new Error('Path is not under the document storage root');
+  }
+  return rel;
+}

--- a/lib/documents/storage-root.ts
+++ b/lib/documents/storage-root.ts
@@ -9,16 +9,11 @@ import { isAbsolute, resolve, relative } from 'path';
  * Dev/test: falls back to cwd/storage/documents.
  */
 
-const IS_PRODUCTION = process.env.NODE_ENV === 'production';
-
-let _cachedRoot: string | undefined;
-
 export function getDocumentStorageRoot(): string {
-  if (_cachedRoot) return _cachedRoot;
-
   const envValue = process.env.DOCUMENT_STORAGE_ROOT;
+  const isProduction = process.env.NODE_ENV === 'production';
 
-  if (IS_PRODUCTION) {
+  if (isProduction) {
     if (!envValue) {
       throw new Error(
         'DOCUMENT_STORAGE_ROOT is required in production. ' +
@@ -30,19 +25,10 @@ export function getDocumentStorageRoot(): string {
         'DOCUMENT_STORAGE_ROOT must be an absolute path in production.'
       );
     }
-    _cachedRoot = envValue;
-  } else {
-    _cachedRoot = envValue
-      ? resolve(envValue)
-      : resolve(process.cwd(), 'storage', 'documents');
+    return envValue;
   }
 
-  return _cachedRoot;
-}
-
-/** Reset cached root — for testing only. */
-export function _resetStorageRootCache(): void {
-  _cachedRoot = undefined;
+  return envValue ? resolve(envValue) : resolve(process.cwd(), 'storage', 'documents');
 }
 
 /** Legacy prefix stored in DB by older upload routes (/app/storage/documents/). */


### PR DESCRIPTION
## Summary

Fixes **P1-DOC-01**: document download routes lacked storage root containment. A poisoned localPath in DB could serve any file on disk.

### Three path formats supported

1. **Relative**: resolved against DOCUMENT_STORAGE_ROOT
2. **Legacy prefix**: `/app/storage/documents/` stripped, then relative
3. **Absolute contained**: accepted only if `realpath` resolves inside canonical root

### Containment

`realpath` on BOTH root and candidate, then `path.relative()` verification — not string prefix. Rejects traversal, symlink escape, encoded sequences (`%2e`, `%252e`, `%00`), URL schemes.

### TOCTOU eliminated

`openSecureDocument()` returns an open `FileHandle`. Routes stream from that same handle via `createReadStream()`. No gap between validation and read.

### Routes fixed

| Route | Before | After |
|-------|--------|-------|
| `/api/student/documents/[id]/download` | `path.resolve+readFile` — no containment | `openSecureDocument` + streaming |
| `/api/documents/[id]` | `readFile(localPath)` — no containment | `openSecureDocument` + streaming |

### Routes NOT modified (existing protection)

- `/api/documents/[id]/download`: already has `realpath` containment + full RBAC
- `/api/npc/files/[...path]`: `path.resolve` containment (P3 follow-up: symlink)
- `/api/invoices/[id]/pdf`: `startsWith` containment (P3 follow-up: symlink)

### RBAC per route (exact)

| Route | ELEVE | PARENT | COACH | ADMIN/ASSISTANTE |
|-------|:-----:|:------:|:-----:|:----------------:|
| `student/.../download` | own userId | — | — | — |
| `documents/[id]` | own userId | — | — | any |
| `documents/[id]/download` | scope-gated | child-linked | assigned | any |

### Production gate

`DOCUMENT_STORAGE_ROOT` must be set in `/etc/nexus/nexus-prod.env` before deploy. Fails closed if missing.

### Tests (111 pass, 0 fail)

- 30 helper tests (traversal, absolute in/out, symlink escape/valid/root, TOCTOU, double-encode, URL, directory, size, legacy, error safety)
- 10 student download + 9 documents/[id] route tests

### No Prisma, migration, or data changes. Rollback: revert this commit.