### PR TITLE
fix(public-funnel): close account-enumeration oracle on /api/bilan-gratuit

### DIFF
--- a/__tests__/api/bilan-gratuit.test.ts
+++ b/__tests__/api/bilan-gratuit.test.ts
@@ -1,7 +1,8 @@
 import { NextRequest } from 'next/server';
 import { POST } from '../../app/api/bilan-gratuit/route';
 import { prisma } from '../../lib/prisma';
-import { sendWelcomeParentEmail } from '../../lib/email';
+import { sendWelcomeParentEmail, sendExistingAccountBilanEmail } from '../../lib/email';
+import { captureContactLead } from '../../lib/crm/contact-leads';
 
 jest.mock('bcryptjs');
 
@@ -21,9 +22,17 @@ jest.mock('@paralleldrive/cuid2', () => ({
 
 jest.mock('../../lib/email', () => ({
   sendWelcomeParentEmail: jest.fn().mockResolvedValue(undefined),
+  sendExistingAccountBilanEmail: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../lib/crm/contact-leads', () => ({
+  captureContactLead: jest.fn().mockResolvedValue({ id: 'lead-existing-123' }),
+  ContactLeadValidationError: class ContactLeadValidationError extends Error {},
 }));
 
 const mockSendWelcomeParentEmail = sendWelcomeParentEmail as jest.Mock;
+const mockSendExistingAccountBilanEmail = sendExistingAccountBilanEmail as jest.Mock;
+const mockCaptureContactLead = captureContactLead as jest.Mock;
 
 describe('/api/bilan-gratuit', () => {
   const validRequestData = {
@@ -97,7 +106,7 @@ describe('/api/bilan-gratuit', () => {
 
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
-    expect(body.message).toBe('Votre demande a bien été enregistrée. Un lien d’activation a été envoyé.');
+    expect(body.message).toBe('Votre demande a bien été enregistrée. Vous allez recevoir un e-mail avec la marche à suivre.');
     expect(body.parentId).toBe('parent-123');
     expect(body.studentId).toBe('student-profile-123');
 
@@ -241,18 +250,70 @@ describe('/api/bilan-gratuit', () => {
     );
   });
 
-  it('returns 400 when parent email already exists', async () => {
-    jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({
-      id: 'existing-user',
-      email: 'jean.dupont@test.com',
-    } as never);
+  describe('when the parent email already belongs to an existing account (H1-H4 hotfix)', () => {
+    function mockExistingParent() {
+      jest.spyOn(prisma.user, 'findUnique').mockResolvedValue({
+        id: 'existing-user-123',
+        email: 'jean.dupont@test.com',
+      } as never);
+      jest.spyOn(prisma.parentProfile, 'findUnique').mockResolvedValue({
+        id: 'existing-parent-profile-123',
+        children: [{ id: 'existing-student-123' }],
+      } as never);
+    }
 
-    const response = await POST(buildRequest(validRequestData));
-    const body = await response.json();
+    it('returns a response indistinguishable from the account-creation success response', async () => {
+      mockExistingParent();
 
-    expect(response.status).toBe(400);
-    expect(body.error).toBe('Un compte existe déjà avec cet email');
-    expect(prisma.$transaction).not.toHaveBeenCalled();
+      const response = await POST(buildRequest(validRequestData));
+      const body = await response.json();
+
+      // Same status, same shape, same message as the "new account" success path —
+      // an attacker probing this public endpoint must not be able to tell the two apart.
+      expect(response.status).toBe(200);
+      expect(body).toEqual({
+        success: true,
+        message: 'Votre demande a bien été enregistrée. Vous allez recevoir un e-mail avec la marche à suivre.',
+        parentId: expect.any(String),
+        studentId: expect.any(String),
+      });
+      expect(body.error).toBeUndefined();
+
+      // No second account is ever created for an email that already exists.
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('fires an internal notification without any minor PII', async () => {
+      mockExistingParent();
+
+      await POST(buildRequest(validRequestData));
+
+      expect(mockCaptureContactLead).toHaveBeenCalledTimes(1);
+      const leadPayload = mockCaptureContactLead.mock.calls[0][0];
+
+      // Parent identity/contact channel: allowed.
+      expect(leadPayload.email).toBe(validRequestData.parentEmail);
+      expect(leadPayload.phone).toBe(validRequestData.parentPhone);
+      expect(leadPayload.source).toBe('bilan-gratuit-existing-account');
+
+      // No minor PII anywhere in the payload: no student first name, no grade, no school.
+      const serializedPayload = JSON.stringify(leadPayload);
+      expect(serializedPayload).not.toContain(validRequestData.studentFirstName);
+      expect(serializedPayload).not.toContain(validRequestData.studentGrade);
+      expect(serializedPayload).not.toContain(validRequestData.studentSchool);
+    });
+
+    it('sends the existing parent a coherent access email, not an error and not a duplicate-account invite', async () => {
+      mockExistingParent();
+
+      await POST(buildRequest(validRequestData));
+
+      expect(mockSendExistingAccountBilanEmail).toHaveBeenCalledWith(
+        'jean.dupont@test.com',
+        'Jean Dupont',
+      );
+      expect(mockSendWelcomeParentEmail).not.toHaveBeenCalled();
+    });
   });
 
   it('returns 400 when validation fails (invalid email)', async () => {

--- a/__tests__/api/bilan-gratuit.test.ts
+++ b/__tests__/api/bilan-gratuit.test.ts
@@ -349,6 +349,79 @@ describe('/api/bilan-gratuit', () => {
     expect(body.error).toBe('Erreur interne du serveur');
   });
 
+  // Décision 3 (2026-07-29): staff must be notified of every genuine bilan
+  // submission — success, existing-account, or technical failure — via the
+  // same captureContactLead mechanism, with no minor PII.
+  describe('staff notification on every genuine submission (Décision 3)', () => {
+    it('notifies staff when a new account is created successfully', async () => {
+      const userCreate = jest.fn()
+        .mockResolvedValueOnce({
+          id: 'parent-123',
+          email: 'jean.dupont@test.com',
+          firstName: 'Jean',
+          lastName: 'Dupont',
+        })
+        .mockResolvedValueOnce({
+          id: 'student-123',
+          email: 'marie.dupont.test@nexus-student.local',
+          firstName: 'Marie',
+          lastName: 'Dupont',
+        });
+      jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(null as never);
+      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => callback({
+        user: { create: userCreate },
+        parentProfile: { create: jest.fn().mockResolvedValue({ id: 'parent-profile-123' }) },
+        student: { create: jest.fn().mockResolvedValue({ id: 'student-profile-123' }) },
+      } as any));
+
+      const response = await POST(buildRequest(validRequestData));
+      expect(response.status).toBe(200);
+
+      expect(mockCaptureContactLead).toHaveBeenCalledTimes(1);
+      const leadPayload = mockCaptureContactLead.mock.calls[0][0];
+      expect(leadPayload.source).toBe('bilan-gratuit-new-account');
+      expect(leadPayload.email).toBe(validRequestData.parentEmail);
+      const serializedPayload = JSON.stringify(leadPayload);
+      expect(serializedPayload).not.toContain(validRequestData.studentFirstName);
+      expect(serializedPayload).not.toContain(validRequestData.studentGrade);
+      expect(serializedPayload).not.toContain(validRequestData.studentSchool);
+    });
+
+    it('notifies staff when account creation fails technically, without PII, and still returns 500', async () => {
+      jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(null as never);
+      jest.spyOn(prisma, '$transaction').mockRejectedValue(new Error('Database connection failed'));
+
+      const response = await POST(buildRequest(validRequestData));
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toBe('Erreur interne du serveur');
+
+      expect(mockCaptureContactLead).toHaveBeenCalledTimes(1);
+      const leadPayload = mockCaptureContactLead.mock.calls[0][0];
+      expect(leadPayload.source).toBe('bilan-gratuit-error');
+      expect(leadPayload.email).toBe(validRequestData.parentEmail);
+      const serializedPayload = JSON.stringify(leadPayload);
+      expect(serializedPayload).not.toContain(validRequestData.studentFirstName);
+      expect(serializedPayload).not.toContain(validRequestData.studentGrade);
+      expect(serializedPayload).not.toContain(validRequestData.studentSchool);
+    });
+
+    it('does not notify staff for a request that never validates (Zod error)', async () => {
+      const response = await POST(buildRequest({ ...validRequestData, parentEmail: 'invalid-email' }));
+
+      expect(response.status).toBe(400);
+      expect(mockCaptureContactLead).not.toHaveBeenCalled();
+    });
+
+    it('does not notify staff for a silently-rejected bot submission', async () => {
+      const response = await POST(buildRequest({ ...validRequestData, website: 'http://spam.example' }));
+
+      expect(response.status).toBe(200);
+      expect(mockCaptureContactLead).not.toHaveBeenCalled();
+    });
+  });
+
   it('continues even if email sending fails', async () => {
     mockSendWelcomeParentEmail.mockRejectedValueOnce(new Error('Email service unavailable'));
 

--- a/app/api/bilan-gratuit/route.ts
+++ b/app/api/bilan-gratuit/route.ts
@@ -1,7 +1,7 @@
 export const dynamic = 'force-dynamic';
 
 import { prisma } from '@/lib/prisma';
-import { bilanGratuitSchema } from '@/lib/validations';
+import { bilanGratuitSchema, type BilanGratuitData } from '@/lib/validations';
 import { normalizeStudentLevelAndTrack } from '@/lib/utils/grade-utils';
 import { UserRole } from '@/types/enums';
 import { guardRateLimitAsync } from '@/lib/rate-limit';
@@ -19,9 +19,47 @@ import { NextRequest, NextResponse } from 'next/server';
 const GENERIC_SUCCESS_MESSAGE =
   'Votre demande a bien été enregistrée. Vous allez recevoir un e-mail avec la marche à suivre.';
 
-export async function POST(request: NextRequest) {
+/**
+ * Notifie l'équipe qu'une demande de bilan gratuit vient d'arriver — quel
+ * que soit son issue (nouveau compte, compte existant, échec technique).
+ * Aucune donnée personnelle du mineur (pas de prénom élève, pas de niveau,
+ * pas d'établissement) : seulement l'identité du parent et le canal
+ * technique de la demande. Même mécanisme que les autres canaux
+ * (`captureContactLead`), pas un second système de notification.
+ */
+async function notifyStaffOfBilanSubmission(
+  validatedData: { parentFirstName: string; parentLastName: string; parentEmail: string; parentPhone: string; acceptTerms: boolean },
+  source: 'bilan-gratuit-new-account' | 'bilan-gratuit-existing-account' | 'bilan-gratuit-error',
+  interest: string,
+  isTestEnv: boolean,
+) {
   try {
-    const isTestEnv = process.env.NODE_ENV === 'test';
+    await captureContactLead({
+      name: `${validatedData.parentFirstName} ${validatedData.parentLastName}`.trim(),
+      email: validatedData.parentEmail,
+      phone: validatedData.parentPhone,
+      profile: source === 'bilan-gratuit-existing-account' ? 'Parent (compte existant)' : 'Parent',
+      interest,
+      source,
+      type: source.replace(/-/g, '_'),
+      consent: validatedData.acceptTerms,
+    });
+  } catch (leadError) {
+    if (!isTestEnv) {
+      console.error(`Erreur notification interne (${source}):`, serializeError(leadError));
+    }
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const isTestEnv = process.env.NODE_ENV === 'test';
+  // Hoisted above the try/catch so the failure path (Décision 3) can notify
+  // staff for a genuine, validated submission that failed technically —
+  // without needing to notify for a request that never even parsed (Zod
+  // validation failure, honeypot rejection): those aren't real submissions.
+  let validatedData: BilanGratuitData | undefined;
+
+  try {
 
     // CSRF protection — verify same-origin
     const csrfResponse = checkCsrf(request);
@@ -44,7 +82,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Validation des données
-    const validatedData = bilanGratuitSchema.parse(body);
+    validatedData = bilanGratuitSchema.parse(body);
     const campaignContext = synchronizePreRentreeCampaignContext({
       campaignContext: validatedData.campaignContext ?? undefined,
       studentGrade: validatedData.studentGrade,
@@ -81,25 +119,12 @@ export async function POST(request: NextRequest) {
         }
       }
 
-      // Notification interne — aucune donnée personnelle du mineur (pas de prénom
-      // élève, pas de niveau, pas d'établissement), seulement l'identité du parent
-      // et le canal technique de la demande.
-      try {
-        await captureContactLead({
-          name: `${validatedData.parentFirstName} ${validatedData.parentLastName}`.trim(),
-          email: validatedData.parentEmail,
-          phone: validatedData.parentPhone,
-          profile: 'Parent (compte existant)',
-          interest: 'Bilan gratuit - nouvelle demande sur compte existant',
-          source: 'bilan-gratuit-existing-account',
-          type: 'bilan_gratuit_existing_account',
-          consent: validatedData.acceptTerms,
-        });
-      } catch (leadError) {
-        if (!isTestEnv) {
-          console.error('Erreur notification interne (compte existant):', serializeError(leadError));
-        }
-      }
+      await notifyStaffOfBilanSubmission(
+        validatedData,
+        'bilan-gratuit-existing-account',
+        'Bilan gratuit - nouvelle demande sur compte existant',
+        isTestEnv,
+      );
 
       // Email cohérent pour le parent : ni une erreur, ni une invitation à créer un doublon.
       try {
@@ -122,17 +147,21 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    const resolvedStudentLastName = validatedData.studentLastName ?? validatedData.parentLastName;
+    // Rebind to a const: TypeScript can't carry the "defined past this point"
+    // narrowing of the outer `let validatedData` into the async closures below
+    // (prisma.$transaction's callback).
+    const data = validatedData;
+    const resolvedStudentLastName = data.studentLastName ?? data.parentLastName;
     const rawActivationToken = `act_${createId()}_${crypto.randomBytes(16).toString('hex')}`;
     const hashedActivationToken = crypto.createHash('sha256').update(rawActivationToken).digest('hex');
     const activationExpiry = new Date(Date.now() + 72 * 60 * 60 * 1000);
 
     // Normaliser le niveau scolaire AVANT la transaction
-    const gTrack = normalizeStudentLevelAndTrack(validatedData.studentGrade);
+    const gTrack = normalizeStudentLevelAndTrack(data.studentGrade);
     
     if (!gTrack) {
       return NextResponse.json(
-        { error: `Niveau scolaire non reconnu : ${validatedData.studentGrade}` },
+        { error: `Niveau scolaire non reconnu : ${data.studentGrade}` },
         { status: 400 }
       );
     }
@@ -142,12 +171,12 @@ export async function POST(request: NextRequest) {
       // Créer le compte parent
       const parentUser = await tx.user.create({
         data: {
-          email: validatedData.parentEmail,
+          email: data.parentEmail,
           password: null,
           role: UserRole.PARENT,
-          firstName: validatedData.parentFirstName,
-          lastName: validatedData.parentLastName,
-          phone: validatedData.parentPhone,
+          firstName: data.parentFirstName,
+          lastName: data.parentLastName,
+          phone: data.parentPhone,
           activatedAt: null,
           activationToken: hashedActivationToken,
           activationExpiry,
@@ -163,13 +192,13 @@ export async function POST(request: NextRequest) {
 
       // Créer le compte élève sans accès direct.
       // Email format: prenom.nom.random@nexus-student.local to ensure uniqueness
-      const studentEmailSlug = `${validatedData.studentFirstName.toLowerCase()}.${resolvedStudentLastName.toLowerCase()}.${createId().slice(0, 4)}@nexus-student.local`;
+      const studentEmailSlug = `${data.studentFirstName.toLowerCase()}.${resolvedStudentLastName.toLowerCase()}.${createId().slice(0, 4)}@nexus-student.local`;
       
       const studentUser = await tx.user.create({
         data: {
           email: studentEmailSlug,
           role: UserRole.ELEVE,
-          firstName: validatedData.studentFirstName,
+          firstName: data.studentFirstName,
           lastName: resolvedStudentLastName,
           password: null,
           activatedAt: null,
@@ -180,20 +209,20 @@ export async function POST(request: NextRequest) {
         data: {
           parentId: parentProfile.id,
           userId: studentUser.id,
-          grade: validatedData.studentGrade,
+          grade: data.studentGrade,
           gradeLevel: gTrack.level,
           academicTrack: gTrack.track,
-          school: validatedData.studentSchool,
-          birthDate: validatedData.studentBirthDate ? new Date(validatedData.studentBirthDate) : null
+          school: data.studentSchool,
+          birthDate: data.studentBirthDate ? new Date(data.studentBirthDate) : null
         }
       });
 
       const campaignLead = campaignContext
         ? await tx.contactLead.create({
             data: {
-              name: `${validatedData.parentFirstName} ${validatedData.parentLastName}`,
-              email: validatedData.parentEmail,
-              phone: validatedData.parentPhone,
+              name: `${data.parentFirstName} ${data.parentLastName}`,
+              email: data.parentEmail,
+              phone: data.parentPhone,
               profile: JSON.stringify(campaignContext.profile),
               interest: `${campaignContext.packCode} · ${campaignContext.level} · ${campaignContext.subjectIds.join(', ')}`,
               source: campaignContext.programme,
@@ -203,6 +232,13 @@ export async function POST(request: NextRequest) {
 
       return { parentUser, studentUser, student, campaignLead };
     });
+
+    await notifyStaffOfBilanSubmission(
+      validatedData,
+      'bilan-gratuit-new-account',
+      'Bilan gratuit - nouvelle demande, nouveau compte créé',
+      isTestEnv,
+    );
 
     // Envoyer email de bienvenue
     try {
@@ -233,9 +269,24 @@ export async function POST(request: NextRequest) {
       console.error('Erreur inscription bilan gratuit:', serializeError(error));
     }
 
-    if (error instanceof Error && error.name === 'ZodError') {
+    const isZodError = error instanceof Error && error.name === 'ZodError';
+
+    // Notify staff for a genuine, validated submission that failed
+    // technically (e.g. a transaction error during account creation) — not
+    // for a request that never validated (Zod error) or was silently
+    // rejected as a bot (no validatedData in either case).
+    if (validatedData && !isZodError) {
+      await notifyStaffOfBilanSubmission(
+        validatedData,
+        'bilan-gratuit-error',
+        'Bilan gratuit - nouvelle demande, échec technique de création de compte',
+        isTestEnv,
+      );
+    }
+
+    if (isZodError) {
       return NextResponse.json(
-        { error: 'Données invalides', details: error.message },
+        { error: 'Données invalides', details: (error as Error).message },
         { status: 400 }
       );
     }

--- a/app/api/bilan-gratuit/route.ts
+++ b/app/api/bilan-gratuit/route.ts
@@ -8,9 +8,16 @@ import { guardRateLimitAsync } from '@/lib/rate-limit';
 import { checkCsrf, checkBodySize } from '@/lib/csrf';
 import { serializeError } from '@/lib/utils/serialize-error';
 import { synchronizePreRentreeCampaignContext } from '@/lib/campaigns/pre-rentree-2026/bilan-prefill';
+import { captureContactLead } from '@/lib/crm/contact-leads';
 import { createId } from '@paralleldrive/cuid2';
 import crypto from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
+
+// Réponse générique : ne doit jamais permettre de distinguer, depuis l'extérieur,
+// une création de compte d'une demande reçue sur un email de parent déjà client
+// (énumération de comptes sur un endpoint public non authentifié).
+const GENERIC_SUCCESS_MESSAGE =
+  'Votre demande a bien été enregistrée. Vous allez recevoir un e-mail avec la marche à suivre.';
 
 export async function POST(request: NextRequest) {
   try {
@@ -55,10 +62,64 @@ export async function POST(request: NextRequest) {
     }
 
     if (existingUser) {
-      return NextResponse.json(
-        { error: 'Un compte existe déjà avec cet email' },
-        { status: 400 }
-      );
+      // Ne jamais révéler qu'un compte existe déjà (énumération de comptes) :
+      // même statut, même forme de réponse, même ordre de grandeur de travail
+      // que le chemin de création — voir docs/audits/2026-07-28-bilan-gratuit-cemetery-and-account-creation-bug.md.
+      let existingParentId = existingUser.id;
+      let existingStudentId = existingUser.id;
+      try {
+        const parentProfile = await prisma.parentProfile.findUnique({
+          where: { userId: existingUser.id },
+          include: { children: { take: 1, select: { id: true } } },
+        });
+        if (parentProfile?.children?.[0]?.id) {
+          existingStudentId = parentProfile.children[0].id;
+        }
+      } catch (lookupErr) {
+        if (!isTestEnv) {
+          console.error('Erreur résolution profil parent existant:', serializeError(lookupErr));
+        }
+      }
+
+      // Notification interne — aucune donnée personnelle du mineur (pas de prénom
+      // élève, pas de niveau, pas d'établissement), seulement l'identité du parent
+      // et le canal technique de la demande.
+      try {
+        await captureContactLead({
+          name: `${validatedData.parentFirstName} ${validatedData.parentLastName}`.trim(),
+          email: validatedData.parentEmail,
+          phone: validatedData.parentPhone,
+          profile: 'Parent (compte existant)',
+          interest: 'Bilan gratuit - nouvelle demande sur compte existant',
+          source: 'bilan-gratuit-existing-account',
+          type: 'bilan_gratuit_existing_account',
+          consent: validatedData.acceptTerms,
+        });
+      } catch (leadError) {
+        if (!isTestEnv) {
+          console.error('Erreur notification interne (compte existant):', serializeError(leadError));
+        }
+      }
+
+      // Email cohérent pour le parent : ni une erreur, ni une invitation à créer un doublon.
+      try {
+        const { sendExistingAccountBilanEmail } = await import('@/lib/email');
+        await sendExistingAccountBilanEmail(
+          existingUser.email,
+          `${validatedData.parentFirstName} ${validatedData.parentLastName}`
+        );
+      } catch (emailError) {
+        if (!isTestEnv) {
+          console.error('Erreur envoi email (compte existant):', serializeError(emailError));
+        }
+      }
+
+      return NextResponse.json({
+        success: true,
+        message: GENERIC_SUCCESS_MESSAGE,
+        parentId: existingParentId,
+        studentId: existingStudentId,
+      });
     }
 
     const resolvedStudentLastName = validatedData.studentLastName ?? validatedData.parentLastName;
@@ -162,7 +223,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       success: true,
-      message: 'Votre demande a bien été enregistrée. Un lien d’activation a été envoyé.',
+      message: GENERIC_SUCCESS_MESSAGE,
       parentId: result.parentUser.id,
       studentId: result.student.id
     });

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -105,6 +105,62 @@ export async function sendWelcomeParentEmail(
   }
 }
 
+// Email envoyé lorsqu'une demande de bilan gratuit arrive sur un email de parent déjà client.
+// Ne doit jamais ressembler à une erreur ni inviter à créer un second compte.
+export async function sendExistingAccountBilanEmail(
+  parentEmail: string,
+  parentName: string
+) {
+  const baseUrl = process.env.NEXTAUTH_URL || 'https://nexusreussite.academy';
+  const signInUrl = `${baseUrl}/auth/signin`;
+  const forgotPasswordUrl = `${baseUrl}/auth/mot-de-passe-oublie`;
+
+  const mailOptions = {
+    from: process.env.SMTP_FROM || `Nexus Réussite <${LEGAL.contact.email}>`,
+    to: parentEmail,
+    subject: 'Votre demande de bilan a été enregistrée',
+    html: `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        <div style="background: linear-gradient(135deg, #0f172a, #2563EB); padding: 30px; text-align: center;">
+          <h1 style="color: white; margin: 0;">Votre demande de bilan a bien été enregistrée</h1>
+        </div>
+
+        <div style="padding: 30px; background: #f9f9f9;">
+          <h2>Bonjour ${parentName},</h2>
+
+          <p>Nous avons bien reçu votre nouvelle demande de bilan stratégique gratuit.</p>
+          <p>Vous disposez déjà d'un espace Nexus Réussite avec cette adresse email. Notre équipe pédagogique va également examiner cette nouvelle demande et vous recontacter.</p>
+
+          <div style="background: white; padding: 20px; border-radius: 8px; margin: 20px 0;">
+            <h3>🔑 Accéder à votre espace :</h3>
+            <p><a href="${signInUrl}" style="color:#2563EB;">Me connecter</a></p>
+            <p>Mot de passe oublié ? <a href="${forgotPasswordUrl}" style="color:#2563EB;">Réinitialiser mon mot de passe</a></p>
+          </div>
+
+          <p>Une question ? Contactez-nous :</p>
+          <ul>
+            <li>📞 ${LEGAL.contact.phone}</li>
+            <li>📧 ${LEGAL.contact.email}</li>
+          </ul>
+
+          <p>À très bientôt,<br><strong>L'équipe Nexus Réussite</strong></p>
+        </div>
+      </div>
+    `
+  };
+
+  try {
+    const transporter = createTransporter();
+    await transporter.sendMail(mailOptions);
+  } catch (error) {
+    console.error('Erreur envoi email:', serializeError(error));
+    if ((process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test')) {
+      return;
+    }
+    throw error;
+  }
+}
+
 // Email de rappel d'expiration des crédits
 export async function sendCreditExpirationReminder(
   parentEmail: string,


### PR DESCRIPTION
## Summary

`POST /api/bilan-gratuit` (unauthenticated, public) has returned a distinguishable `400 { error: 'Un compte existe déjà avec cet email' }` since 2026-07-06 whenever the submitted parent email already has an account — an account-enumeration oracle on a database of families with minors. A correct fix existed the same day (`798f712ae`) but never merged; see `docs/audits/2026-07-28-bilan-gratuit-cemetery-and-account-creation-bug.md` on `feat/bilan-gratuit-audit` for the full history of how it was lost.

This PR is a **narrow, standalone hotfix** — not the broader lead-capture architecture change (that stays in the separate `Lot A1` workstream, which will still add ContactLead schema fields, migrations, etc.). Scope here is strictly:

- Same status (200), same body shape, same generic message whether the parent email is new or already registered. No second account is ever created for an existing email.
- An internal staff notification fires via the existing `captureContactLead()` — carrying only the parent's own contact identity and the request channel (`source: 'bilan-gratuit-existing-account'`). No minor PII: no student first name, grade, or school.
- The existing parent receives a coherent email acknowledging the new request and explaining how to reach their existing space (sign-in / forgot-password) — never an error, never an invitation to create a duplicate account.

Explicitly out of scope (left for Lot A1): no ContactLead schema/migration change, no removal of account creation for genuinely new users.

## Test plan

- [x] `__tests__/api/bilan-gratuit.test.ts` — 10/10 pass, including 3 new tests:
  - response is byte-for-byte the same shape/message as the account-creation success path
  - `captureContactLead` payload contains no student first name / grade / school
  - existing parent gets `sendExistingAccountBilanEmail`, never `sendWelcomeParentEmail`
- [x] `scripts/check-work-delivered.sh` run against this branch pre-push (confirmed NOT DELIVERED until pushed, as expected)
- [ ] No deployment performed — review/merge only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes account enumeration on the public `POST /api/bilan-gratuit` by returning the same 200 response for new and existing emails, and adds staff notifications for every genuine submission without minor PII.

- **Bug Fixes**
  - Always return 200 with the same body and generic message: "Votre demande a bien été enregistrée. Vous allez recevoir un e-mail avec la marche à suivre." Never create a duplicate account.
  - Send `sendExistingAccountBilanEmail` for existing emails to guide sign-in/forgot-password instead of showing an error or sending a new-account welcome.
  - Tests cover indistinguishable response, PII-free notification payloads, and correct email dispatch.

- **New Features**
  - Notify staff via `captureContactLead` on all genuine submissions using `notifyStaffOfBilanSubmission`: new account (`source: 'bilan-gratuit-new-account'`), existing account (`'bilan-gratuit-existing-account'`), and technical failures (`'bilan-gratuit-error'`).
  - Never include minor PII; do not notify for Zod-invalid inputs or honeypot (bot) requests.

<sup>Written for commit bbe65d3f6718e200d671fd44dd964c8a7bc19ac5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

