### PR TITLE
feat(bilans): compléter les exemples pédagogiques des prompts

### DIFF
--- a/content/bilans/prompts/EXEMPLES-PROMPTS-TOUS-NIVEAUX.md
+++ b/content/bilans/prompts/EXEMPLES-PROMPTS-TOUS-NIVEAUX.md
@@ -1,0 +1,1797 @@
+# EXEMPLES PÉDAGOGIQUES — tous niveaux hors Seconde
+
+Proposition rédigée pour relecture par le responsable pédagogique.
+Amendez librement : ce sont vos formulations qui feront foi.
+
+Chaque bloc remplace la ligne « À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE »
+sous les titres « Bonne formulation » et « Mauvaise formulation ».
+
+**Packs couverts — 15 packs, 75 prompts, 150 blocs d'exemples**
+4e Maths · 4e Français · 3e Maths · 3e Français · 1re Maths · 1re Français ·
+1re SVT · 1re NSI · 1re Physique-Chimie · Tle Maths · Tle Maths expertes ·
+Tle NSI · Tle SVT · Tle Physique-Chimie · Tle Philosophie
+
+Avec les deux packs Seconde déjà traités, les **17 packs** du dispositif sont
+couverts.
+
+Les règles sont les mêmes partout, et ce sont elles que les exemples illustrent :
+aucun chiffre chez l'élève et les parents, singulier tenu, priorités formulées
+comme contenu de séance, aucun programme annoncé avant les diagnostics du groupe,
+chiffres autorisés et attendus dans l'audience Nexus.
+
+═══════════════════════════════════════════════════════════════════════════════
+PACK 1 — entree-quatrieme-maths-v1
+═══════════════════════════════════════════════════════════════════════════════
+
+───────────────────────────────────────────────────────────────────────────────
+1.1 · pre-analysis.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Réponse libre : « je m'embrouille avec les moins et j'ai eu 8 de moyenne ».
+
+  synthese       : « L'élève identifie les nombres relatifs comme une source
+                     d'erreurs et mentionne une moyenne annuelle faible. »
+  forces_percues : []
+  craintes       : ["nombres relatifs"]
+
+La moyenne déclarée est enregistrée comme un élément du discours, jamais
+reprise comme une mesure ni convertie en niveau.
+
+### Mauvaise formulation
+
+« Avec 8 de moyenne, l'élève est en difficulté générale en mathématiques et son
+problème avec les signes en est le symptôme. »
+
+Une moyenne déclarée devient un diagnostic, une difficulté ponctuelle devient
+générale, et un lien de cause est inventé entre les deux.
+
+───────────────────────────────────────────────────────────────────────────────
+1.2 · eleve.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Force : « Tu calcules l'aire d'un rectangle et d'un triangle sans hésiter sur la
+formule. »
+
+Priorité, nœud en erreur confiante : « L'ordre des opérations quand un produit
+suit une addition. Ce point a l'air acquis mais il ne l'est pas encore — c'est
+exactement le type d'écart qui coûte cher en devoir surveillé. »
+
+Micro-plan : « Refaire huit calculs mêlant addition et multiplication en
+entourant d'abord le produit — 10 minutes. »
+
+### Mauvaise formulation
+
+« Tu as 8 bonnes réponses sur 18, c'est faible. Tu confonds tout avec les signes
+et tu étais sûr de toi. Sans ça la 4e sera compliquée. »
+
+Un score, un jugement, la formulation interdite sur la confiance, une menace.
+
+───────────────────────────────────────────────────────────────────────────────
+1.3 · parents.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Point d'appui : « Les formules d'aire et de périmètre sont mobilisées avec
+sûreté, y compris lorsque la figure est présentée autrement qu'en position
+habituelle. »
+
+Priorité : « Nous reprendrons les priorités opératoires et le calcul avec les
+nombres relatifs, par des exercices courts et répétés plutôt que par un
+réapprentissage de la règle. »
+
+Cadre : « Le contenu des cinq séances de deux heures sera arrêté après
+croisement des diagnostics du groupe. »
+
+### Mauvaise formulation
+
+« Votre enfant a 8/18 et un niveau très insuffisant. Le stage couvrira les
+relatifs, les fractions et la proportionnalité, et lui permettra de reprendre
+confiance pour réussir son année. »
+
+Un score, un jugement de niveau, un programme annoncé avant les diagnostics,
+une promesse de résultat.
+
+───────────────────────────────────────────────────────────────────────────────
+1.4 · nexus.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Deux nœuds en erreur confiante : relatifs.somme-difference-priorites, score
+de nœud 25,0, et calcul-litteral.distributivite-simple, score 33,3. Indice de
+calibration 38,9 — l'élève tranche avec assurance sur le calcul, moins ailleurs.
+
+Statistiques et aires en maîtrise, score 100,0 : rappel actif suffisant, vingt
+minutes.
+
+Vigilance : trois items non traités en fin de questionnaire, tous sur la
+symétrie centrale. Fatigue ou manque de temps, à vérifier oralement. »
+
+### Mauvaise formulation
+
+« Élève en grande difficulté, sans doute peu suivi à la maison. Groupe faible
+recommandé. »
+
+Jugement sur la personne, hypothèse sur le milieu familial, aucune mesure.
+
+───────────────────────────────────────────────────────────────────────────────
+1.5 · verifier.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Violation détectée. Bilan PARENTS, champ pointsAppui : la phrase contient
+« 8/18 ». Règle V2, aucun chiffre autorisé.
+
+Violation détectée. Bilan PARENTS, champ priorites, premier élément : le texte
+annonce un contenu de stage. Le prompt interdit d'anticiper l'ordre, le temps
+et la profondeur du travail.
+
+Aucune autre violation. Les cinq domaines évalués figurent bien dans les
+sorties ELEVE et PARENTS. »
+
+### Mauvaise formulation
+
+« Le bilan me paraît un peu dur pour un élève de cet âge. Je propose d'adoucir
+la formulation des priorités. »
+
+Le vérificateur contrôle des faits et des règles. Il ne juge ni le ton ni
+l'opportunité.
+
+═══════════════════════════════════════════════════════════════════════════════
+PACK 2 — entree-quatrieme-francais-v1
+═══════════════════════════════════════════════════════════════════════════════
+
+───────────────────────────────────────────────────────────────────────────────
+2.1 · pre-analysis.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Réponse libre : « je fais beaucoup de fautes mais j'aime bien lire ».
+
+  synthese       : « L'élève déclare des difficultés orthographiques et un goût
+                     affirmé pour la lecture. »
+  forces_percues : ["lecture"]
+  craintes       : ["orthographe"]
+
+### Mauvaise formulation
+
+« L'élève aime lire, ce qui devrait compenser ses lacunes en orthographe. »
+
+Une compensation est supposée entre deux compétences distinctes. La
+pré-analyse rapporte, elle ne pronostique pas.
+
+───────────────────────────────────────────────────────────────────────────────
+2.2 · eleve.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Force : « Tu reconnais la nature d'un mot même lorsqu'il change de place dans
+la phrase. »
+
+Priorité : « L'accord du participe passé employé avec l'auxiliaire être. Ce
+point a l'air acquis mais il ne l'est pas encore — c'est exactement le type
+d'écart qui coûte cher en dictée. »
+
+Micro-plan : « Écrire cinq phrases au passé composé avec être, en entourant le
+sujet avant d'accorder — 10 minutes. »
+
+### Mauvaise formulation
+
+« Tu fais trop de fautes. Tu crois savoir accorder mais tu te trompes tout le
+temps. Il faut travailler l'orthographe cet été. »
+
+Un jugement global, la formulation interdite, une injonction sans contenu.
+
+───────────────────────────────────────────────────────────────────────────────
+2.3 · parents.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Point d'appui : « L'identification des classes de mots est stable, y compris
+sur des constructions déplacées. »
+
+Priorité : « Nous travaillerons l'accord du participe passé, d'abord par
+repérage guidé du sujet, puis en production écrite. »
+
+Étape suivante : « Être conseillé »
+
+### Mauvaise formulation
+
+« Votre enfant a un niveau d'orthographe préoccupant pour un entrant en 4e.
+Nous garantissons une remise à niveau en cinq séances. »
+
+Un jugement de niveau, un ressort anxiogène, une promesse garantie.
+
+───────────────────────────────────────────────────────────────────────────────
+2.4 · nexus.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Nœud orthographe.accords en erreur confiante : score 0,0, confiance moyenne
+3,5. L'élève accorde systématiquement avec le mot le plus proche et n'en
+doute pas — priorité 1.
+
+Figures de style en maîtrise fragile : réussite 75,0, confiance 2. Traitement
+par répétition, la définition est connue.
+
+Homophones en maîtrise, score 100,0. Rappel actif seulement.
+
+Indice de calibration 50,0. »
+
+### Mauvaise formulation
+
+« Élève négligent, écrit trop vite. À recadrer sur la méthode. »
+
+Jugement de caractère, aucune mesure, aucune indication exploitable.
+
+───────────────────────────────────────────────────────────────────────────────
+2.5 · verifier.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Violation détectée. Bilan ELEVE, champ priorites, premier élément : la
+formulation « tu crois savoir et tu te trompes » est interdite. Le prompt
+impose la formulation par l'écart non perçu.
+
+Contrôle des domaines : les quatre domaines évalués sont représentés dans les
+sorties ELEVE et PARENTS. Aucun omis. »
+
+### Mauvaise formulation
+
+« Rien à signaler. »
+
+Une vérification qui ne cite ni champ, ni règle, ni valeur n'atteste de rien.
+
+═══════════════════════════════════════════════════════════════════════════════
+PACK 3 — entree-troisieme-maths-v1
+═══════════════════════════════════════════════════════════════════════════════
+
+───────────────────────────────────────────────────────────────────────────────
+3.1 · pre-analysis.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Réponse libre : « le brevet me stresse et je n'ai jamais compris Thalès ».
+
+  synthese       : « L'élève exprime une appréhension liée au brevet et
+                     identifie le théorème de Thalès comme non compris. »
+  forces_percues : []
+  craintes       : ["brevet", "théorème de Thalès"]
+
+### Mauvaise formulation
+
+« L'élève est anxieux, ce qui l'empêche de comprendre la géométrie. Le stress
+explique probablement ses difficultés sur Thalès. »
+
+Un état émotionnel est transformé en cause de difficulté cognitive.
+
+───────────────────────────────────────────────────────────────────────────────
+3.2 · eleve.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Force : « Tu résous une équation du premier degré et tu vérifies ton résultat
+en le remplaçant dans l'équation de départ. »
+
+Priorité : « La conversion d'une durée en heures décimales : une heure trente
+vaut 1,5 heure et non 1,30. Ce point a l'air acquis mais il ne l'est pas
+encore, et il fausse tout un calcul de vitesse. »
+
+Micro-plan : « Convertir dix durées en heures décimales, puis calculer une
+vitesse moyenne — 15 minutes. »
+
+### Mauvaise formulation
+
+« Tu as raté la moitié des questions. Tu confonds les durées et tu étais sûr de
+toi. Le brevet va être difficile si tu ne travailles pas. »
+
+Un score déguisé, la formulation interdite, un pronostic anxiogène.
+
+───────────────────────────────────────────────────────────────────────────────
+3.3 · parents.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Point d'appui : « La résolution d'équations est solide, et l'habitude de
+vérifier le résultat est installée. »
+
+Priorité : « Nous reprendrons les grandeurs composées, en particulier la
+conversion des durées, par des calculs courts en situation. »
+
+Cadre : « Ce bilan est un positionnement. Il ne préjuge pas des résultats au
+brevet. »
+
+### Mauvaise formulation
+
+« Votre enfant risque d'échouer au brevet s'il ne comble pas ses lacunes. Notre
+stage couvrira Pythagore, Thalès et les statistiques, et sécurisera son
+examen. »
+
+Un ressort anxiogène, un pronostic, un programme annoncé, une promesse.
+
+───────────────────────────────────────────────────────────────────────────────
+3.4 · nexus.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Nœud proportionnalite.grandeurs-composees en erreur confiante : score 0,0,
+confiance 4. L'élève convertit une heure trente en 1,30 sans hésiter.
+
+Pythagore en maîtrise, score 100,0, y compris la réciproque : temps rendu.
+Triangles semblables en lacune consciente, score 25,0, confiance 1 :
+enseignement direct nécessaire, l'élève sait qu'il ne sait pas.
+
+Indice de calibration 55,6. »
+
+### Mauvaise formulation
+
+« Niveau brevet non atteint. Redoublement à envisager. »
+
+Un pronostic d'orientation qu'un positionnement de dix-huit items ne peut pas
+fonder.
+
+───────────────────────────────────────────────────────────────────────────────
+3.5 · verifier.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Violation détectée. Bilan PARENTS, champ cadre : la phrase « risque d'échouer
+au brevet » constitue un pronostic et un ressort anxiogène. Deux règles
+enfreintes.
+
+Violation détectée. Bilan ELEVE, champ accroche : contient « la moitié des
+questions ». Règle V2.
+
+Aucune autre violation. »
+
+### Mauvaise formulation
+
+« Deux problèmes détectés, à corriger. »
+
+Aucun champ, aucune règle, aucune citation. Inexploitable.
+
+═══════════════════════════════════════════════════════════════════════════════
+PACK 4 — entree-troisieme-francais-v1
+═══════════════════════════════════════════════════════════════════════════════
+
+───────────────────────────────────────────────────────────────────────────────
+4.1 · pre-analysis.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Réponse libre : « j'ai du mal à comprendre les textes anciens ».
+
+  synthese       : « L'élève déclare une difficulté de compréhension sur les
+                     textes anciens. »
+  forces_percues : []
+  craintes       : ["textes anciens"]
+
+Aucune extension à la compréhension en général : l'élève a nommé un type de
+texte, pas une compétence.
+
+### Mauvaise formulation
+
+« L'élève a des difficultés de compréhension écrite, sans doute liées à un
+vocabulaire insuffisant. »
+
+Une difficulté ciblée devient générale, et une cause lexicale est inventée.
+
+───────────────────────────────────────────────────────────────────────────────
+4.2 · eleve.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Force : « Tu distingues le narrateur du personnage, même quand le récit est à
+la première personne. »
+
+Priorité : « L'accord du participe passé avec le complément d'objet placé avant
+le verbe. Ce point a l'air acquis mais il ne l'est pas encore, et il est évalué
+directement en dictée et en réécriture. »
+
+Micro-plan : « Réécrire cinq phrases en déplaçant le complément d'objet avant
+le verbe, puis accorder — 15 minutes. »
+
+### Mauvaise formulation
+
+« Tu as 9/18. Tu es sûr de toi mais tu te trompes sur les accords. Attention au
+brevet. »
+
+Un score, la formulation interdite, une menace.
+
+───────────────────────────────────────────────────────────────────────────────
+4.3 · parents.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Point d'appui : « L'analyse du point de vue narratif est maîtrisée, y compris
+sur des récits à la première personne. »
+
+Priorité : « Nous travaillerons l'accord du participe passé avec le complément
+d'objet antéposé, exercice directement évalué à l'épreuve de réécriture. »
+
+Étape suivante : « Voir les offres et tarifs »
+
+### Mauvaise formulation
+
+« Votre enfant ne maîtrise pas les accords, ce qui lui coûtera des points au
+brevet. Notre stage garantit une progression mesurable. »
+
+Une priorité formulée comme un manque, un pronostic chiffré implicite, une
+promesse de résultat.
+
+───────────────────────────────────────────────────────────────────────────────
+4.4 · nexus.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Nœud orthographe.accords en erreur confiante : score 0,0, confiance 4.
+Accord systématique avec le sujet, jamais avec le complément antéposé.
+
+Discours rapporté en lacune consciente : score 25,0, confiance 1. La
+transposition n'est pas installée et l'élève le sait.
+
+Narrateur et points de vue en maîtrise, score 100,0.
+
+Indice de calibration 44,4 : surestimation nette sur l'orthographe. »
+
+### Mauvaise formulation
+
+« Bon élève dans l'ensemble, quelques fautes d'inattention. »
+
+« Inattention » est un jugement, pas un diagnostic. Une erreur systématique
+avec confiance élevée n'est jamais de l'inattention.
+
+───────────────────────────────────────────────────────────────────────────────
+4.5 · verifier.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Violation détectée. Bilan PARENTS, champ priorites, premier élément : « ne
+maîtrise pas les accords » formule une priorité comme un manque de l'élève. Le
+prompt impose une formulation en contenu de séance.
+
+Contrôle des domaines : trois domaines évalués, trois représentés. »
+
+### Mauvaise formulation
+
+« La formulation pourrait être plus positive. »
+
+Un avis de style, non une vérification.
+
+═══════════════════════════════════════════════════════════════════════════════
+PACK 5 — entree-premiere-maths-v1
+═══════════════════════════════════════════════════════════════════════════════
+
+───────────────────────────────────────────────────────────────────────────────
+5.1 · pre-analysis.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Réponse libre : « j'ai choisi spé maths mais je ne sais pas si j'ai le niveau ».
+
+  synthese       : « L'élève a choisi la spécialité mathématiques et exprime un
+                     doute sur sa capacité à y réussir. »
+  forces_percues : []
+  craintes       : ["capacité à suivre la spécialité"]
+
+Le doute est rapporté comme un doute. Il n'est ni confirmé, ni infirmé, ni
+transformé en évaluation.
+
+### Mauvaise formulation
+
+« L'élève doute de son niveau, et ce doute est probablement fondé au vu de ses
+résultats. »
+
+La pré-analyse traite le déclaratif seul. Elle n'a pas accès aux résultats et
+ne doit jamais les invoquer.
+
+───────────────────────────────────────────────────────────────────────────────
+5.2 · eleve.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Force : « Tu développes une identité remarquable sans oublier le double
+produit, y compris quand le coefficient devant x n'est pas 1. »
+
+Priorité : « Les variations de la fonction inverse : elle décroît sur chacun
+des deux intervalles, mais pas sur leur réunion. Ce point a l'air acquis mais
+il ne l'est pas encore — c'est lui qui reviendra à chaque étude de fonction. »
+
+Micro-plan : « Tracer la fonction inverse et écrire les deux intervalles de
+décroissance séparément — 10 minutes. »
+
+### Mauvaise formulation
+
+« Tu as 12/18, ce qui est juste correct pour une spé maths. Tu croyais savoir
+les variations et tu t'es trompé. »
+
+Un score, un jugement d'adéquation à la spécialité, la formulation interdite.
+
+───────────────────────────────────────────────────────────────────────────────
+5.3 · parents.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Point d'appui : « Le calcul littéral et les identités remarquables sont des
+automatismes installés, mobilisés sans hésitation. »
+
+Priorité : « Nous reprendrons les fonctions de référence et leurs variations,
+en insistant sur les cas où une fonction décroît sur plusieurs intervalles sans
+décroître sur leur réunion. »
+
+Cadre : « Ce bilan est un positionnement conduit avant le stage. Il ne
+constitue ni une évaluation notée, ni un avis sur le choix de spécialité. »
+
+### Mauvaise formulation
+
+« Votre enfant a un niveau limite pour la spécialité mathématiques. Avec notre
+accompagnement, il tiendra le rythme et pourra viser une mention. »
+
+Un jugement d'orientation, une promesse de résultat, une projection de mention.
+
+───────────────────────────────────────────────────────────────────────────────
+5.4 · nexus.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Nœud fonctions-reference.variations en erreur confiante : score 0,0,
+confiance 4. L'élève affirme la décroissance sur R entier.
+
+Nœud inequations.resolution-premier-degre en erreur confiante : score 50,0.
+N'inverse pas le sens lors d'une division par un négatif — deux erreurs
+confiantes sur le même geste, celui du signe.
+
+Calcul littéral en maîtrise, score 100,0 : temps rendu, rappel actif.
+
+Indice de calibration 44,4. Drapeau ERREURS_CONFIANTES_MULTIPLES levé. »
+
+### Mauvaise formulation
+
+« Profil à risque pour la spécialité. Réorientation à envisager si les
+résultats ne remontent pas. »
+
+Une recommandation d'orientation, hors du champ d'un positionnement d'entrée.
+
+───────────────────────────────────────────────────────────────────────────────
+5.5 · verifier.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Violation détectée. Bilan PARENTS, champ etapeSuivante : le texte évoque une
+mention au baccalauréat. Projection de résultat interdite.
+
+Violation détectée. Bilan ELEVE, champ accroche : contient « 12/18 ». Règle V2.
+
+Contrôle des domaines : quatre domaines évalués, quatre représentés. »
+
+### Mauvaise formulation
+
+« Le bilan est bon mais manque d'encouragement pour un élève qui doute. »
+
+Le vérificateur ne compense pas un état émotionnel. Il contrôle des règles.
+
+═══════════════════════════════════════════════════════════════════════════════
+PACK 6 — entree-premiere-francais-v1
+═══════════════════════════════════════════════════════════════════════════════
+
+───────────────────────────────────────────────────────────────────────────────
+6.1 · pre-analysis.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Réponse libre : « l'oral du bac de français me fait peur, je n'arrive pas à
+analyser un texte ».
+
+  synthese       : « L'élève exprime une appréhension de l'épreuve orale
+                     anticipée et déclare une difficulté à analyser un texte. »
+  forces_percues : []
+  craintes       : ["oral des épreuves anticipées", "analyse de texte"]
+
+### Mauvaise formulation
+
+« L'élève ne sait pas analyser un texte, ce qui compromet ses chances à l'oral
+des épreuves anticipées. »
+
+Une difficulté déclarée devient un constat établi, puis un pronostic d'examen.
+
+───────────────────────────────────────────────────────────────────────────────
+6.2 · eleve.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Force : « Tu nommes précisément une figure de style et tu distingues métaphore
+et métonymie sans les confondre. »
+
+Priorité : « Passer du relevé à l'interprétation. Relever un procédé sans dire
+ce qu'il produit reste un catalogue, pas un commentaire — c'est ce qui fait la
+différence à l'écrit comme à l'oral. »
+
+Micro-plan : « Reprendre trois procédés relevés dans un texte et écrire, pour
+chacun, une phrase disant l'effet produit — 20 minutes. »
+
+### Mauvaise formulation
+
+« Tu as la moitié des points. Tu crois analyser mais tu ne fais que relever.
+L'oral risque d'être compliqué. »
+
+Un score, la formulation interdite, un pronostic.
+
+───────────────────────────────────────────────────────────────────────────────
+6.3 · parents.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Point d'appui : « L'identification des procédés d'écriture est précise, y
+compris sur les figures voisines souvent confondues. »
+
+Priorité : « Nous travaillerons le passage du relevé à l'interprétation, geste
+central du commentaire et de l'explication linéaire. »
+
+Cadre : « Le contenu des cinq séances sera arrêté après croisement des
+diagnostics du groupe constitué. »
+
+### Mauvaise formulation
+
+« Votre enfant relève sans analyser, ce qui lui vaudra une note faible à
+l'écrit. Le stage traitera le commentaire, la dissertation et l'oral. »
+
+Une priorité formulée comme un manque, un pronostic de note, un programme
+annoncé avant les diagnostics.
+
+───────────────────────────────────────────────────────────────────────────────
+6.4 · nexus.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Nœud methode.commentaire en erreur confiante : score 0,0, confiance 4.
+L'élève identifie le paragraphe de commentaire à un relevé de figures.
+
+Nœud grammaire.interrogation-negation en lacune consciente : score 0,0,
+confiance 1. Prérequis directement évalué à l'oral des épreuves anticipées —
+priorité opérationnelle malgré une confiance basse.
+
+Figures de style en maîtrise, score 100,0.
+
+Indice de calibration 50,0. »
+
+### Mauvaise formulation
+
+« Élève scolaire, applique sans comprendre. Manque de finesse littéraire. »
+
+Un jugement de qualité personnelle, sans mesure et sans usage.
+
+───────────────────────────────────────────────────────────────────────────────
+6.5 · verifier.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Violation détectée. Bilan PARENTS, champ priorites : le texte annonce le
+contenu du stage. Le prompt interdit d'anticiper l'ordre et la profondeur du
+travail avant croisement des diagnostics.
+
+Violation détectée. Bilan PARENTS, champ cadre : « note faible à l'écrit »
+constitue une projection de note.
+
+Aucune autre violation. »
+
+### Mauvaise formulation
+
+« Deux formulations à revoir dans le bilan parents. »
+
+Sans champ ni règle citée, la vérification n'est pas reproductible.
+
+═══════════════════════════════════════════════════════════════════════════════
+PACK 7 — entree-premiere-svt-v1
+═══════════════════════════════════════════════════════════════════════════════
+
+───────────────────────────────────────────────────────────────────────────────
+7.1 · pre-analysis.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Réponse libre : « j'aime la SVT mais je n'arrive pas à rédiger les réponses aux
+documents ».
+
+  synthese       : « L'élève déclare un intérêt pour la discipline et une
+                     difficulté à rédiger l'exploitation de documents. »
+  forces_percues : ["intérêt pour la discipline"]
+  craintes       : ["rédaction de l'exploitation de documents"]
+
+### Mauvaise formulation
+
+« L'élève est motivé mais manque de méthode rédactionnelle, ce qui explique ses
+notes moyennes. »
+
+Une méthode est diagnostiquée, des notes sont invoquées sans donnée.
+
+───────────────────────────────────────────────────────────────────────────────
+7.2 · eleve.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Force : « Tu situes correctement les niveaux d'organisation du vivant, de la
+cellule à l'organisme. »
+
+Priorité : « Toutes les cellules d'un individu portent le même ADN : ce qui
+change d'un organe à l'autre, ce sont les gènes exprimés. Ce point a l'air
+acquis mais il ne l'est pas encore, et il conditionne tout le premier
+chapitre. »
+
+Micro-plan : « Écrire en trois lignes pourquoi une cellule de peau et une
+cellule de foie diffèrent malgré un ADN identique — 10 minutes. »
+
+### Mauvaise formulation
+
+« Tu as 10/18. Tu pensais que l'ADN changeait selon l'organe et tu en étais
+sûr. Sans cette base, l'année sera dure. »
+
+Un score, la formulation interdite, une menace.
+
+───────────────────────────────────────────────────────────────────────────────
+7.3 · parents.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Point d'appui : « Le raisonnement par changement d'échelle, de la molécule à
+l'organisme, est en place. »
+
+Priorité : « Nous reprendrons la distinction entre patrimoine génétique et
+expression des gènes, notion qui fonde le premier thème de l'année. »
+
+Étape suivante : « Être conseillé »
+
+### Mauvaise formulation
+
+« Votre enfant a de grosses lacunes en génétique, ce qui compromet le premier
+trimestre. Nous garantissons une mise à niveau. »
+
+Un jugement, un pronostic, une promesse garantie.
+
+───────────────────────────────────────────────────────────────────────────────
+7.4 · nexus.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Nœud genetique.adn-gene-information en erreur confiante : score 0,0,
+confiance 4. L'élève soutient qu'une cellule de foie et une cellule de peau
+portent un ADN différent — obstacle au thème 1 entier.
+
+Nœud evolution.mecanismes en erreur confiante : score 33,3. Conception
+lamarckienne persistante sur les caractères acquis.
+
+Démarche et exploitation de données en maîtrise fragile : réussite 75,0,
+confiance 2. Automatisation, pas ré-explication.
+
+Indice de calibration 38,9. Drapeau ERREURS_CONFIANTES_MULTIPLES. »
+
+### Mauvaise formulation
+
+« Élève qui apprend par cœur sans comprendre. Typique des profils
+scientifiques faibles. »
+
+Un jugement, une catégorisation, aucune mesure.
+
+───────────────────────────────────────────────────────────────────────────────
+7.5 · verifier.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Violation détectée. Bilan ELEVE, champ priorites, premier élément : la
+formulation « tu en étais sûr » est interdite.
+
+Violation détectée. Bilan PARENTS, champ pointsAppui : contient « 10/18 ».
+Règle V2.
+
+Contrôle des domaines : cinq domaines évalués, cinq représentés dans les deux
+audiences. »
+
+### Mauvaise formulation
+
+« Correct dans l'ensemble. »
+
+Aucune trace de ce qui a été contrôlé.
+
+═══════════════════════════════════════════════════════════════════════════════
+PACK 8 — entree-premiere-nsi-v1
+═══════════════════════════════════════════════════════════════════════════════
+
+───────────────────────────────────────────────────────────────────────────────
+8.1 · pre-analysis.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Réponse libre : « je code un peu chez moi mais je n'ai jamais fait de réseaux ».
+
+  synthese       : « L'élève déclare une pratique personnelle de la
+                     programmation et aucune expérience des réseaux. »
+  forces_percues : ["programmation"]
+  craintes       : ["réseaux"]
+
+### Mauvaise formulation
+
+« L'élève code en autodidacte, ce qui lui donne de bonnes bases mais sans
+doute de mauvaises habitudes. »
+
+Une compétence est évaluée et un défaut est supposé, à partir d'une simple
+déclaration de pratique.
+
+───────────────────────────────────────────────────────────────────────────────
+8.2 · eleve.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Force : « Tu suis l'exécution d'une boucle et tu sais combien de fois son corps
+s'exécute, sans te tromper sur les bornes. »
+
+Priorité : « L'affectation n'est pas une égalité mathématique : dans x = x + 1,
+on calcule d'abord la valeur de droite, puis on la range dans x. Ce point a
+l'air acquis mais il ne l'est pas encore, et il bloque toute lecture de
+programme. »
+
+Micro-plan : « Dérouler à la main un programme de six lignes en notant la
+valeur de chaque variable après chaque instruction — 15 minutes. »
+
+### Mauvaise formulation
+
+« Tu as 11/18. Tu confonds l'affectation et l'égalité, alors que tu codes déjà.
+Ça va poser problème toute l'année. »
+
+Un score, un reproche implicite, un pronostic.
+
+───────────────────────────────────────────────────────────────────────────────
+8.3 · parents.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Point d'appui : « La lecture d'une boucle et le décompte de ses itérations sont
+maîtrisés, y compris sur les bornes. »
+
+Priorité : « Nous reprendrons la notion d'affectation, distincte de l'égalité
+mathématique, qui conditionne la lecture et la mise au point de tout
+programme. »
+
+Cadre : « Ce bilan porte sur les prérequis issus de l'enseignement de sciences
+numériques et technologie, non sur le programme de la spécialité. »
+
+### Mauvaise formulation
+
+« Votre enfant a des bases autodidactes à corriger. Le stage couvrira Python,
+les réseaux et le Web, et le mettra à niveau pour la spécialité. »
+
+Un jugement sur l'origine des acquis, un programme annoncé, une promesse de
+mise à niveau.
+
+───────────────────────────────────────────────────────────────────────────────
+8.4 · nexus.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Nœud programmation.variables-affectation en erreur confiante : score 0,0,
+confiance 4. Lit le signe égal comme une égalité mathématique — obstacle
+fondateur, priorité absolue.
+
+Nœud programmation.listes en maîtrise fragile : réussite 75,0, confiance 2.
+L'indexation à partir de zéro est connue mais pas automatisée : répétition.
+
+Réseaux en lacune consciente : score 0,0, confiance 1. Cohérent avec le
+déclaratif.
+
+Indice de calibration 44,4. »
+
+### Mauvaise formulation
+
+« Élève qui bricole. Devra désapprendre avant d'apprendre. »
+
+Un jugement sur la pratique de l'élève, sans mesure et sans action possible.
+
+───────────────────────────────────────────────────────────────────────────────
+8.5 · verifier.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Violation détectée. Bilan PARENTS, champ priorites : le texte énumère un
+contenu de stage. Anticipation interdite.
+
+Violation détectée. Bilan ELEVE, champ motDeFin : contient « 11/18 ». Règle V2.
+
+Contrôle des domaines : trois domaines évalués, trois représentés. »
+
+### Mauvaise formulation
+
+« Le ton est un peu technique pour des parents non informaticiens. »
+
+Une remarque de lisibilité, non une vérification de règle.
+
+═══════════════════════════════════════════════════════════════════════════════
+PACK 9 — entree-premiere-physique-chimie-v1
+═══════════════════════════════════════════════════════════════════════════════
+
+───────────────────────────────────────────────────────────────────────────────
+9.1 · pre-analysis.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Réponse libre : « la chimie ça va, mais la mécanique je n'ai jamais compris ».
+
+  synthese       : « L'élève se déclare à l'aise en chimie et en difficulté en
+                     mécanique. »
+  forces_percues : ["chimie"]
+  craintes       : ["mécanique"]
+
+### Mauvaise formulation
+
+« L'élève est meilleur en chimie qu'en mécanique, ce que confirment ses
+résultats. »
+
+Une hiérarchie déclarée devient un constat, et des résultats sont invoqués
+alors que la pré-analyse n'y a pas accès.
+
+───────────────────────────────────────────────────────────────────────────────
+9.2 · eleve.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Force : « Tu passes d'une masse à une quantité de matière sans hésiter sur le
+sens de la division. »
+
+Priorité : « Un objet qui avance à vitesse constante en ligne droite n'est pas
+poussé par une force : les forces qui s'exercent sur lui se compensent. Ce
+point a l'air acquis mais il ne l'est pas encore, et il bloque toute la
+mécanique. »
+
+Micro-plan : « Faire le bilan des forces sur trois objets en mouvement
+rectiligne uniforme, sans en ajouter aucune vers l'avant — 15 minutes. »
+
+### Mauvaise formulation
+
+« Tu as 9/18, surtout en mécanique. Tu croyais qu'une force pousse un objet et
+tu en étais certain. Il va falloir tout reprendre. »
+
+Un score, une répartition chiffrée, la formulation interdite, une exagération.
+
+───────────────────────────────────────────────────────────────────────────────
+9.3 · parents.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Point d'appui : « Les conversions entre masse et quantité de matière sont
+sûres, dans les deux sens. »
+
+Priorité : « Nous reprendrons le principe d'inertie, en particulier l'idée
+qu'un mouvement uniforme ne nécessite aucune force motrice — représentation
+tenace qui conditionne toute la mécanique de l'année. »
+
+Étape suivante : « Écrire sur WhatsApp »
+
+### Mauvaise formulation
+
+« Votre enfant a des lacunes graves en mécanique qui compromettent la
+spécialité. Cinq séances suffiront à combler l'essentiel. »
+
+Un jugement de gravité, un pronostic, une promesse chiffrée sur le résultat du
+stage.
+
+───────────────────────────────────────────────────────────────────────────────
+9.4 · nexus.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Nœud mecanique.forces-inertie en erreur confiante : score 0,0, confiance 4.
+Conception aristotélicienne du mouvement — obstacle épistémologique le plus
+tenace de la discipline, priorité 1.
+
+Nœud mesure.grandeurs-unites en erreur confiante : score 50,0. Chiffres
+significatifs non maîtrisés : fausse des réponses dont le raisonnement est
+juste.
+
+Mole et concentration en maîtrise, score 100,0 : cohérent avec le déclaratif,
+temps rendu.
+
+Indice de calibration 38,9. Drapeau ERREURS_CONFIANTES_MULTIPLES. »
+
+### Mauvaise formulation
+
+« Profil de chimiste, pas de physicien. À orienter en conséquence. »
+
+Une catégorisation d'aptitude, hors du champ d'un positionnement d'entrée.
+
+───────────────────────────────────────────────────────────────────────────────
+9.5 · verifier.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Violation détectée. Bilan PARENTS, champ etapeSuivante : « cinq séances
+suffiront » constitue une promesse de résultat.
+
+Violation détectée. Bilan ELEVE, champ forces : contient « 9/18 ». Règle V2.
+
+Contrôle des domaines : quatre domaines évalués, quatre représentés. »
+
+### Mauvaise formulation
+
+« Deux points à corriger, sinon rien à signaler. »
+
+Les deux points ne sont ni localisés ni rattachés à une règle.
+
+═══════════════════════════════════════════════════════════════════════════════
+PACK 10 — entree-terminale-maths-v1
+═══════════════════════════════════════════════════════════════════════════════
+
+───────────────────────────────────────────────────────────────────────────────
+10.1 · pre-analysis.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Réponse libre : « je vise une prépa, je veux être sûr de mes bases ».
+
+  synthese       : « L'élève déclare un projet de classe préparatoire et une
+                     volonté de consolider ses bases. »
+  forces_percues : []
+  craintes       : []
+  Le champ craintes reste vide : aucune difficulté n'est exprimée. Une exigence
+  n'est pas une crainte.
+
+### Mauvaise formulation
+
+« L'élève ambitieux souhaite intégrer une prépa, ce qui suppose un niveau
+solide qu'il faudra vérifier. »
+
+Un commentaire sur l'ambition et une condition ajoutée que l'élève n'a pas
+formulée.
+
+───────────────────────────────────────────────────────────────────────────────
+10.2 · eleve.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Force : « Tu établis l'équation d'une tangente en évaluant correctement le
+nombre dérivé au point demandé. »
+
+Priorité : « Le signe de la dérivée donne le sens de variation de la fonction,
+pas le signe de la fonction elle-même. Ce point a l'air acquis mais il ne l'est
+pas encore — c'est le raisonnement le plus réinvesti de toute la Terminale. »
+
+Micro-plan : « Sur trois tableaux de variations, écrire à côté de chaque signe
+de f prime la phrase correspondante sur f — 15 minutes. »
+
+### Mauvaise formulation
+
+« Tu as 14/18, c'est bien mais insuffisant pour une prépa. Tu confondais f et f
+prime en étant sûr de toi. »
+
+Un score, un jugement d'adéquation à un projet d'orientation, la formulation
+interdite.
+
+───────────────────────────────────────────────────────────────────────────────
+10.3 · parents.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Point d'appui : « La dérivation et l'équation de tangente sont des automatismes
+en place, appliqués sans erreur de calcul. »
+
+Priorité : « Nous reprendrons le lien entre le signe de la dérivée et le sens
+de variation, distinction qui commande l'étude de fonctions de toute l'année. »
+
+Cadre : « Ce bilan ne constitue ni une évaluation notée, ni un avis sur un
+projet d'orientation. »
+
+### Mauvaise formulation
+
+« Votre enfant vise une prépa mais son niveau actuel ne le permet pas encore.
+Notre accompagnement lui donnera les moyens d'y prétendre. »
+
+Un avis d'orientation, une promesse de résultat, un ressort de doute.
+
+───────────────────────────────────────────────────────────────────────────────
+10.4 · nexus.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Nœud derivation.signe-derivee-variations en erreur confiante : score 50,0,
+confiance 4. Confond le signe de f prime et celui de f — erreur la plus
+coûteuse du programme, priorité 1.
+
+Nœud exponentielle.proprietes-algebriques en maîtrise fragile : réussite 75,0,
+confiance 2. Les règles sont sues, l'automatisation manque : répétition.
+
+Second degré et produit scalaire en maîtrise, score 100,0 : rappel actif,
+vingt minutes chacun.
+
+Indice de calibration 61,1 : correcte hors dérivation. »
+
+### Mauvaise formulation
+
+« Bon élève, prépa jouable. À suivre. »
+
+Un pronostic d'orientation et une appréciation globale, sans usage pour la
+préparation d'une séance.
+
+───────────────────────────────────────────────────────────────────────────────
+10.5 · verifier.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Violation détectée. Bilan PARENTS, champ cadre : le texte porte un avis sur
+un projet d'orientation, hors du champ du positionnement.
+
+Violation détectée. Bilan ELEVE, champ accroche : contient « 14/18 ». Règle V2.
+
+Contrôle des domaines : quatre domaines évalués, quatre représentés. »
+
+### Mauvaise formulation
+
+« Le bilan pourrait mieux valoriser un élève de ce niveau. »
+
+Un avis éditorial. Le vérificateur ne module pas le propos selon le niveau.
+
+═══════════════════════════════════════════════════════════════════════════════
+PACK 11 — entree-terminale-svt-v1
+═══════════════════════════════════════════════════════════════════════════════
+
+───────────────────────────────────────────────────────────────────────────────
+11.1 · pre-analysis.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Réponse libre : « je veux faire médecine, la génétique m'intéresse mais la
+géologie m'ennuie ».
+
+  synthese       : « L'élève déclare un projet en études de santé, un intérêt
+                     pour la génétique et un désintérêt pour la géologie. »
+  forces_percues : ["génétique"]
+  craintes       : []
+
+Un désintérêt n'est pas une crainte et ne figure pas dans ce champ. Il est
+rapporté dans la synthèse, où il éclaire l'engagement, pas la maîtrise.
+
+### Mauvaise formulation
+
+« L'élève se désintéresse de la géologie, ce qui explique ses résultats plus
+faibles dans ce domaine et pourrait lui coûter des points au baccalauréat. »
+
+Un désintérêt devient une cause, puis un pronostic d'examen.
+
+───────────────────────────────────────────────────────────────────────────────
+11.2 · eleve.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Force : « Tu distingues transcription et traduction et tu sais où chacune se
+déroule dans la cellule. »
+
+Priorité : « Les mutations surviennent au hasard : aucune n'apparaît parce que
+l'organisme en aurait besoin. Ce point a l'air acquis mais il ne l'est pas
+encore, et il fausse tout raisonnement sur l'évolution des populations. »
+
+Micro-plan : « Reformuler en trois lignes pourquoi une bactérie résistante
+n'est pas devenue résistante à cause de l'antibiotique — 15 minutes. »
+
+### Mauvaise formulation
+
+« Tu as 12/18, avec la géologie en dessous. Tu croyais que les mutations
+s'adaptent au besoin et tu en étais sûr. En médecine ça ne pardonne pas. »
+
+Un score, une répartition chiffrée, la formulation interdite, une projection
+sur un projet d'orientation.
+
+───────────────────────────────────────────────────────────────────────────────
+11.3 · parents.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Point d'appui : « Les mécanismes de l'expression du génome sont maîtrisés, avec
+une localisation correcte de chaque étape. »
+
+Priorité : « Nous reprendrons le caractère aléatoire des mutations,
+représentation dont dépend tout le raisonnement sur l'évolution, puis la
+distinction mécanique entre lithosphère et asthénosphère. »
+
+Étape suivante : « Être conseillé »
+
+### Mauvaise formulation
+
+« Votre enfant néglige la géologie et vise médecine : ce déséquilibre lui
+coûtera cher. Notre stage rééquilibrera son niveau. »
+
+Un jugement de comportement, un pronostic, une promesse de rééquilibrage.
+
+───────────────────────────────────────────────────────────────────────────────
+11.4 · nexus.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Nœud genetique.mutations en erreur confiante : score 0,0, confiance 4.
+Finalisme persistant, obstacle direct au thème 1 — priorité 1.
+
+Nœud geologie.tectonique-des-plaques en lacune consciente : score 25,0,
+confiance 1. Distinction lithosphère et asthénosphère non installée, mais
+l'élève le sait : enseignement direct, pas déconstruction.
+
+Expression du génome et immunité en maîtrise, score 100,0 : temps rendu.
+
+Indice de calibration 50,0. Déclaratif cohérent avec les mesures. »
+
+### Mauvaise formulation
+
+« Profil médecine classique : fort en bio, faible en géol. Rien d'alarmant. »
+
+Une catégorisation, une appréciation rassurante sans mesure, aucune indication
+de traitement.
+
+───────────────────────────────────────────────────────────────────────────────
+11.5 · verifier.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Violation détectée. Bilan ELEVE, champ priorites, premier élément :
+formulation « tu en étais sûr » interdite.
+
+Violation détectée. Bilan PARENTS, champ cadre : mention d'un projet
+d'orientation et de son coût, hors du champ du positionnement.
+
+Contrôle des domaines : quatre domaines évalués, quatre représentés. »
+
+### Mauvaise formulation
+
+« Bilan conforme. »
+
+Aucune trace du contrôle effectué.
+
+═══════════════════════════════════════════════════════════════════════════════
+PACK 12 — entree-terminale-physique-chimie-v1
+═══════════════════════════════════════════════════════════════════════════════
+
+───────────────────────────────────────────────────────────────────────────────
+12.1 · pre-analysis.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Réponse libre : « les exercices de chimie organique me bloquent toujours ».
+
+  synthese       : « L'élève identifie la chimie organique comme un point de
+                     blocage récurrent. »
+  forces_percues : []
+  craintes       : ["chimie organique"]
+
+### Mauvaise formulation
+
+« L'élève bloque en chimie organique, probablement par manque d'apprentissage
+des groupes caractéristiques. »
+
+Une cause est attribuée à un blocage que l'élève n'a pas expliqué.
+
+───────────────────────────────────────────────────────────────────────────────
+12.2 · eleve.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Force : « Tu identifies le réactif limitant en comparant les quantités divisées
+par les coefficients, et non les masses. »
+
+Priorité : « Une force perpendiculaire au déplacement ne travaille pas, même si
+elle s'exerce en permanence. Ce point a l'air acquis mais il ne l'est pas
+encore, et il fausse tous les bilans d'énergie. »
+
+Micro-plan : « Calculer le travail du poids sur trois trajets — horizontal,
+vertical, incliné — en écrivant l'angle à chaque fois — 15 minutes. »
+
+### Mauvaise formulation
+
+« Tu as 13/18 mais tu t'es planté sur l'énergie en étant sûr de toi. C'est
+inquiétant pour une Terminale spé. »
+
+Un score, un registre familier, la formulation interdite, un ressort anxiogène.
+
+───────────────────────────────────────────────────────────────────────────────
+12.3 · parents.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Point d'appui : « La détermination du réactif limitant est conduite sur les
+quantités de matière rapportées aux coefficients, méthode juste et stable. »
+
+Priorité : « Nous reprendrons la notion de travail d'une force, en particulier
+le cas où une force s'exerce sans travailler, préalable à tous les bilans
+d'énergie de l'année. »
+
+Cadre : « Le contenu des cinq séances de deux heures sera arrêté après
+croisement des diagnostics du groupe. »
+
+### Mauvaise formulation
+
+« Votre enfant a des fragilités inquiétantes en énergie. Le stage traitera la
+cinétique, la mécanique et les ondes, et sécurisera son année. »
+
+Un ressort anxiogène, un programme annoncé, une promesse.
+
+───────────────────────────────────────────────────────────────────────────────
+12.4 · nexus.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Nœud energie.travail-energie-mecanique en erreur confiante : score 50,0,
+confiance 4. Considère qu'une force permanente travaille toujours — priorité 1,
+préalable au premier principe.
+
+Nœud chimie-organique.familles-fonctionnelles en lacune consciente : score
+0,0, confiance 1. Cohérent avec le déclaratif : enseignement direct.
+
+Avancement et oxydo-réduction en maîtrise, score 100,0.
+
+Indice de calibration 55,6. »
+
+### Mauvaise formulation
+
+« Élève inégal, dépend de sa motivation selon les chapitres. »
+
+Une hypothèse sur la motivation, sans mesure et sans action possible.
+
+───────────────────────────────────────────────────────────────────────────────
+12.5 · verifier.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Violation détectée. Bilan ELEVE, champ priorites : registre familier
+inadapté, et formulation « en étant sûr de toi » interdite. Deux règles.
+
+Violation détectée. Bilan PARENTS, champ priorites : le texte énumère un
+contenu de stage. Anticipation interdite.
+
+Contrôle des domaines : quatre domaines évalués, quatre représentés. »
+
+### Mauvaise formulation
+
+« Le vocabulaire est parfois trop familier, à revoir. »
+
+Le constat est juste mais ni localisé, ni rattaché à une règle, ni exhaustif.
+
+═══════════════════════════════════════════════════════════════════════════════
+PACK 13 — entree-terminale-philosophie-v1
+═══════════════════════════════════════════════════════════════════════════════
+
+Rappel : cette banque n'évalue aucune notion de philosophie. Un élève entrant en
+Terminale n'en a jamais fait. Les prérequis évalués relèvent du français de
+Première : argumentation, définition, cohérence, analyse d'une question. Les
+exemples ci-dessous en tiennent compte.
+
+───────────────────────────────────────────────────────────────────────────────
+13.1 · pre-analysis.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Réponse libre : « je n'ai jamais fait de philo, je ne sais pas à quoi
+m'attendre ».
+
+  synthese       : « L'élève n'a jamais suivi d'enseignement de philosophie et
+                     exprime une incertitude sur ce qui l'attend. »
+  forces_percues : []
+  craintes       : ["nouveauté de la discipline"]
+
+L'absence d'expérience préalable est un fait attendu de tous, jamais une
+lacune.
+
+### Mauvaise formulation
+
+« L'élève part de zéro en philosophie et devra fournir un effort important pour
+combler ce retard. »
+
+Une situation universelle est présentée comme un retard individuel.
+
+───────────────────────────────────────────────────────────────────────────────
+13.2 · eleve.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Force : « Tu repères la thèse d'un texte et tu la distingues des arguments qui
+la soutiennent. »
+
+Priorité : « Un raisonnement peut être valide et partir de prémisses fausses :
+la validité concerne l'enchaînement, pas la vérité de la conclusion. Ce point a
+l'air acquis mais il ne l'est pas encore, et c'est lui qui permet de discuter
+un texte au lieu d'y adhérer ou de le rejeter. »
+
+Micro-plan : « Construire un raisonnement valide dont la conclusion est fausse,
+et dire pourquoi il reste valide — 20 minutes. »
+
+### Mauvaise formulation
+
+« Tu as 11/18 en logique. Tu crois qu'un raisonnement valide donne toujours une
+conclusion vraie, et tu en es persuadé. La philo va être rude. »
+
+Un score, la formulation interdite, un pronostic sur la discipline.
+
+───────────────────────────────────────────────────────────────────────────────
+13.3 · parents.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Cadre : « Ce positionnement n'évalue aucune notion de philosophie, discipline
+que votre enfant n'a pas encore étudiée. Il porte sur les compétences
+d'analyse et d'argumentation acquises en français, qui conditionnent l'entrée
+dans la discipline. »
+
+Point d'appui : « La distinction entre thèse, argument et exemple est en
+place, y compris sur un texte court non préparé. »
+
+Priorité : « Nous travaillerons la distinction entre validité d'un raisonnement
+et vérité de sa conclusion, préalable à toute discussion de texte. »
+
+### Mauvaise formulation
+
+« Votre enfant a un niveau faible en philosophie, ce qui est préoccupant à
+l'entrée en Terminale. Notre stage lui donnera les bases qui lui manquent. »
+
+Un niveau est attribué dans une discipline jamais étudiée, un ressort
+anxiogène, une promesse.
+
+───────────────────────────────────────────────────────────────────────────────
+13.4 · nexus.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Nœud argumentation.coherence-du-raisonnement en erreur confiante : score 0,0,
+confiance 4. Identifie la validité à la vérité de la conclusion — prérequis
+logique minimal, priorité 1.
+
+Nœud lexique.vocabulaire-abstrait en lacune consciente : score 0,0, confiance
+1. Les sens stricts de « nécessaire » et « distinct » ne sont pas installés,
+et l'élève le sait.
+
+Thèse, argument et exemple en maîtrise, score 100,0 : temps rendu.
+
+Indice de calibration 50,0. Rappel : les nœuds de cette banque relèvent du
+français de Première, non de la philosophie. »
+
+### Mauvaise formulation
+
+« Élève peu réflexif, aura du mal en dissertation. Profil scientifique. »
+
+Un jugement d'aptitude, une catégorisation, un pronostic sur une épreuve.
+
+───────────────────────────────────────────────────────────────────────────────
+13.5 · verifier.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Violation détectée. Bilan PARENTS, champ pointsAppui : le texte attribue un
+niveau en philosophie. Cette banque n'évalue aucune notion de la discipline.
+
+Violation détectée. Bilan ELEVE, champ accroche : contient « 11/18 ». Règle V2.
+
+Contrôle des domaines : trois domaines évalués, trois représentés. »
+
+### Mauvaise formulation
+
+« Attention, le bilan parle de philosophie alors que ce n'est pas testé. »
+
+Le constat est juste mais ni localisé par champ, ni rattaché à une règle, et
+la seconde violation n'est pas relevée.
+
+═══════════════════════════════════════════════════════════════════════════════
+PACK 14 — entree-terminale-maths-expertes-v1
+═══════════════════════════════════════════════════════════════════════════════
+
+Rappel : les mathématiques expertes sont réservées aux élèves qui suivent aussi
+la spécialité mathématiques. Cette banque évalue les prérequis d'arithmétique,
+de logique et de dénombrement, dont une partie remonte au collège — c'est
+normal, l'arithmétique n'est plus travaillée depuis la Troisième.
+
+───────────────────────────────────────────────────────────────────────────────
+14.1 · pre-analysis.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Réponse libre : « je prends maths expertes pour les écoles d'ingénieurs, mais
+l'arithmétique remonte à la 3e ».
+
+  synthese       : « L'élève choisit l'option en vue d'études d'ingénieur et
+                     signale que ses derniers travaux d'arithmétique datent de
+                     la Troisième. »
+  forces_percues : []
+  craintes       : ["arithmétique"]
+
+Le constat de l'élève est exact et vaut pour tous : il est rapporté comme une
+information de contexte, jamais comme une lacune personnelle.
+
+### Mauvaise formulation
+
+« L'élève a oublié l'arithmétique du collège, ce qui constitue un handicap pour
+une option aussi exigeante. »
+
+Une situation commune à tous devient un handicap individuel, et l'exigence de
+l'option est invoquée comme un jugement.
+
+───────────────────────────────────────────────────────────────────────────────
+14.2 · eleve.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Force : « Tu résous un système de deux équations linéaires en choisissant la
+méthode la plus économique selon les coefficients. »
+
+Priorité : « La contraposée d'une implication : si A implique B, alors non-B
+implique non-A, et non l'inverse. Ce point a l'air acquis mais il ne l'est pas
+encore — c'est lui qui commande tous les raisonnements de l'option. »
+
+Micro-plan : « Écrire la réciproque et la contraposée de trois implications,
+puis dire laquelle est équivalente à l'énoncé de départ — 15 minutes. »
+
+### Mauvaise formulation
+
+« Tu as 12/18, ce qui est léger pour des maths expertes. Tu confondais
+réciproque et contraposée en étant sûr de toi. »
+
+Un score, un jugement d'adéquation à l'option, la formulation interdite.
+
+───────────────────────────────────────────────────────────────────────────────
+14.3 · parents.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Cadre : « Cette option s'appuie sur des notions d'arithmétique travaillées au
+collège et peu revues depuis. Ce positionnement les réactive : il ne mesure pas
+un niveau, il situe un point de départ. »
+
+Point d'appui : « La résolution de systèmes linéaires est sûre, avec un choix
+pertinent de la méthode. »
+
+Priorité : « Nous reprendrons les règles de la logique, en particulier la
+distinction entre réciproque et contraposée, qui structure les démonstrations
+de l'option. »
+
+### Mauvaise formulation
+
+« Votre enfant a d'importantes lacunes en arithmétique, ce qui rend le suivi de
+l'option incertain. Nous garantissons une remise à niveau complète. »
+
+Un jugement de lacune sur des notions non travaillées depuis trois ans, un
+doute sur la poursuite de l'option, une promesse garantie.
+
+───────────────────────────────────────────────────────────────────────────────
+14.4 · nexus.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Nœud 1re.maths.logique.implication-contraposee en erreur confiante : score
+0,0, confiance 4. Confond contraposée et réciproque — obstacle direct aux
+démonstrations de l'option, priorité 1.
+
+Nœud college.maths.arithmetique.pgcd en lacune consciente : score 25,0,
+confiance 1. Algorithme d'Euclide non disponible, l'élève le sait :
+enseignement direct, pas déconstruction.
+
+Systèmes linéaires et factorisation en maîtrise, score 100,0 : rappel actif,
+vingt minutes chacun.
+
+Indice de calibration 50,0. Quatre des neuf nœuds relèvent du collège : la
+réactivation domine, le rattrapage est secondaire. »
+
+### Mauvaise formulation
+
+« Élève qui a choisi expertes par ambition plus que par goût. Suivi rapproché
+recommandé. »
+
+Une hypothèse sur les motivations, sans mesure, et une recommandation qui
+n'aide à préparer aucune séance.
+
+───────────────────────────────────────────────────────────────────────────────
+14.5 · verifier.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Violation détectée. Bilan PARENTS, champ cadre : le texte met en doute la
+poursuite de l'option, ce qui constitue un avis d'orientation hors du champ du
+positionnement.
+
+Violation détectée. Bilan ELEVE, champ accroche : contient « 12/18 ». Règle V2.
+
+Contrôle des domaines : les domaines évalués sont tous représentés dans les
+sorties ELEVE et PARENTS. »
+
+### Mauvaise formulation
+
+« Le bilan est correct pour un élève de ce niveau d'exigence. »
+
+Le vérificateur ne module pas son contrôle selon le niveau supposé de l'élève.
+
+═══════════════════════════════════════════════════════════════════════════════
+PACK 15 — entree-terminale-nsi-v1
+═══════════════════════════════════════════════════════════════════════════════
+
+───────────────────────────────────────────────────────────────────────────────
+15.1 · pre-analysis.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Réponse libre : « je programme bien mais les tris et la complexité, je récite
+sans comprendre ».
+
+  synthese       : « L'élève déclare une aisance en programmation et une
+                     maîtrise seulement mémorisée des algorithmes de tri. »
+  forces_percues : ["programmation"]
+  craintes       : ["algorithmes de tri"]
+
+La distinction que l'élève établit entre réciter et comprendre est conservée
+telle quelle : c'est une information précieuse, pas une formule à lisser.
+
+### Mauvaise formulation
+
+« L'élève programme bien mais son apprentissage par cœur des tris révèle un
+manque de fond en algorithmique. »
+
+Une déclaration lucide devient un verdict sur le fond, et une compétence
+déclarée est retournée contre l'élève.
+
+───────────────────────────────────────────────────────────────────────────────
+15.2 · eleve.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Force : « Tu manipules un dictionnaire en distinguant clairement ce qui relève
+de la clé et ce qui relève de la valeur. »
+
+Priorité : « Une recherche dichotomique exige un tableau trié : sans cette
+condition, l'algorithme peut renvoyer que l'élément est absent alors qu'il y
+est. Ce point a l'air acquis mais il ne l'est pas encore, et il revient dans
+toute l'étude de la complexité. »
+
+Micro-plan : « Dérouler une recherche dichotomique sur un tableau non trié et
+noter l'étape exacte où le raisonnement se rompt — 15 minutes. »
+
+### Mauvaise formulation
+
+« Tu as 13/18. Tu récites les tris sans les comprendre et tu ne t'en rends même
+pas compte. La Terminale NSI est exigeante. »
+
+Un score, un reproche formulé à partir de ce que l'élève a lui-même déclaré,
+un pronostic.
+
+───────────────────────────────────────────────────────────────────────────────
+15.3 · parents.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+Point d'appui : « La manipulation des types construits, listes et
+dictionnaires, est sûre et raisonnée. »
+
+Priorité : « Nous reprendrons les conditions de validité des algorithmes de
+recherche, notamment le prérequis de tri, avant d'aborder l'étude du coût. »
+
+Cadre : « Ce bilan est un positionnement conduit avant le stage. Le contenu des
+cinq séances de deux heures sera arrêté après croisement des diagnostics du
+groupe constitué. »
+
+### Mauvaise formulation
+
+« Votre enfant apprend par cœur sans comprendre, ce qui l'empêchera de suivre.
+Le stage traitera les tris, la complexité et les bases de données, et corrigera
+cette méthode de travail. »
+
+Un jugement sur la méthode de travail, un pronostic d'échec, un programme
+annoncé avant les diagnostics.
+
+───────────────────────────────────────────────────────────────────────────────
+15.4 · nexus.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Nœud 1re.nsi.algorithmique.recherche-tris en erreur confiante : score 0,0,
+confiance 4. Applique la recherche dichotomique sans vérifier que le tableau
+est trié — obstacle direct à l'étude de la complexité.
+
+Nœud 1re.nsi.architecture.von-neumann-os en lacune consciente : score 25,0,
+confiance 1. Rôles du processeur et de la mémoire non stabilisés, l'élève le
+sait.
+
+Types construits et fonctions en maîtrise, score 100,0 : cohérent avec le
+déclaratif, temps rendu.
+
+Indice de calibration 55,6 : l'élève se juge lucidement, sauf sur les tris —
+seul point où il se croit sûr et se trompe. »
+
+### Mauvaise formulation
+
+« Élève scolaire qui applique des recettes. Manque de recul algorithmique. »
+
+Un jugement de posture intellectuelle, sans mesure, et sans indication de
+traitement pour une séance.
+
+───────────────────────────────────────────────────────────────────────────────
+15.5 · verifier.md
+───────────────────────────────────────────────────────────────────────────────
+
+### Bonne formulation
+
+« Violation détectée. Bilan PARENTS, champ pointsAppui : le texte porte un
+jugement sur la méthode de travail de l'élève, formulé comme un manque et non
+comme un contenu de séance.
+
+Violation détectée. Bilan PARENTS, champ priorites : énumération d'un contenu
+de stage. Anticipation interdite.
+
+Violation détectée. Bilan ELEVE, champ accroche : contient « 13/18 ». Règle V2.
+
+Contrôle des domaines : tous les domaines évalués sont représentés. »
+
+### Mauvaise formulation
+
+« Plusieurs problèmes de ton dans le bilan parents. »
+
+Trois violations distinctes sont réduites à une impression de ton, sans
+localisation ni règle citée.

--- a/content/bilans/prompts/entree-premiere-francais-v1/eleve.md
+++ b/content/bilans/prompts/entree-premiere-francais-v1/eleve.md
@@ -34,8 +34,19 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `accroc
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Force : « Tu nommes précisément une figure de style et tu distingues métaphore
+et métonymie sans les confondre. »
+
+Priorité : « Passer du relevé à l'interprétation. Relever un procédé sans dire
+ce qu'il produit reste un catalogue, pas un commentaire — c'est ce qui fait la
+différence à l'écrit comme à l'oral. »
+
+Micro-plan : « Reprendre trois procédés relevés dans un texte et écrire, pour
+chacun, une phrase disant l'effet produit — 20 minutes. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Tu as la moitié des points. Tu crois analyser mais tu ne fais que relever.
+L'oral risque d'être compliqué. »
+
+Un score, la formulation interdite, un pronostic.

--- a/content/bilans/prompts/entree-premiere-francais-v1/nexus.md
+++ b/content/bilans/prompts/entree-premiere-francais-v1/nexus.md
@@ -33,8 +33,19 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Nœud methode.commentaire en erreur confiante : score 0,0, confiance 4.
+L'élève identifie le paragraphe de commentaire à un relevé de figures.
+
+Nœud grammaire.interrogation-negation en lacune consciente : score 0,0,
+confiance 1. Prérequis directement évalué à l'oral des épreuves anticipées —
+priorité opérationnelle malgré une confiance basse.
+
+Figures de style en maîtrise, score 100,0.
+
+Indice de calibration 50,0. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Élève scolaire, applique sans comprendre. Manque de finesse littéraire. »
+
+Un jugement de qualité personnelle, sans mesure et sans usage.

--- a/content/bilans/prompts/entree-premiere-francais-v1/parents.md
+++ b/content/bilans/prompts/entree-premiere-francais-v1/parents.md
@@ -41,8 +41,19 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `cadre`
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Point d'appui : « L'identification des procédés d'écriture est précise, y
+compris sur les figures voisines souvent confondues. »
+
+Priorité : « Nous travaillerons le passage du relevé à l'interprétation, geste
+central du commentaire et de l'explication linéaire. »
+
+Cadre : « Le contenu des cinq séances sera arrêté après croisement des
+diagnostics du groupe constitué. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Votre enfant relève sans analyser, ce qui lui vaudra une note faible à
+l'écrit. Le stage traitera le commentaire, la dissertation et l'oral. »
+
+Une priorité formulée comme un manque, un pronostic de note, un programme
+annoncé avant les diagnostics.

--- a/content/bilans/prompts/entree-premiere-francais-v1/pre-analysis.md
+++ b/content/bilans/prompts/entree-premiere-francais-v1/pre-analysis.md
@@ -29,8 +29,17 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack :
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Réponse libre : « l'oral du bac de français me fait peur, je n'arrive pas à
+analyser un texte ».
+
+  synthese       : « L'élève exprime une appréhension de l'épreuve orale
+                     anticipée et déclare une difficulté à analyser un texte. »
+  forces_percues : []
+  craintes       : ["oral des épreuves anticipées", "analyse de texte"]
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« L'élève ne sait pas analyser un texte, ce qui compromet ses chances à l'oral
+des épreuves anticipées. »
+
+Une difficulté déclarée devient un constat établi, puis un pronostic d'examen.

--- a/content/bilans/prompts/entree-premiere-francais-v1/verifier.md
+++ b/content/bilans/prompts/entree-premiere-francais-v1/verifier.md
@@ -35,8 +35,17 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Violation détectée. Bilan PARENTS, champ priorites : le texte annonce le
+contenu du stage. Le prompt interdit d'anticiper l'ordre et la profondeur du
+travail avant croisement des diagnostics.
+
+Violation détectée. Bilan PARENTS, champ cadre : « note faible à l'écrit »
+constitue une projection de note.
+
+Aucune autre violation. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Deux formulations à revoir dans le bilan parents. »
+
+Sans champ ni règle citée, la vérification n'est pas reproductible.

--- a/content/bilans/prompts/entree-premiere-maths-v1/eleve.md
+++ b/content/bilans/prompts/entree-premiere-maths-v1/eleve.md
@@ -34,8 +34,19 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `accroc
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Force : « Tu développes une identité remarquable sans oublier le double
+produit, y compris quand le coefficient devant x n'est pas 1. »
+
+Priorité : « Les variations de la fonction inverse : elle décroît sur chacun
+des deux intervalles, mais pas sur leur réunion. Ce point a l'air acquis mais
+il ne l'est pas encore — c'est lui qui reviendra à chaque étude de fonction. »
+
+Micro-plan : « Tracer la fonction inverse et écrire les deux intervalles de
+décroissance séparément — 10 minutes. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Tu as 12/18, ce qui est juste correct pour une spé maths. Tu croyais savoir
+les variations et tu t'es trompé. »
+
+Un score, un jugement d'adéquation à la spécialité, la formulation interdite.

--- a/content/bilans/prompts/entree-premiere-maths-v1/nexus.md
+++ b/content/bilans/prompts/entree-premiere-maths-v1/nexus.md
@@ -33,8 +33,20 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Nœud fonctions-reference.variations en erreur confiante : score 0,0,
+confiance 4. L'élève affirme la décroissance sur R entier.
+
+Nœud inequations.resolution-premier-degre en erreur confiante : score 50,0.
+N'inverse pas le sens lors d'une division par un négatif — deux erreurs
+confiantes sur le même geste, celui du signe.
+
+Calcul littéral en maîtrise, score 100,0 : temps rendu, rappel actif.
+
+Indice de calibration 44,4. Drapeau ERREURS_CONFIANTES_MULTIPLES levé. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Profil à risque pour la spécialité. Réorientation à envisager si les
+résultats ne remontent pas. »
+
+Une recommandation d'orientation, hors du champ d'un positionnement d'entrée.

--- a/content/bilans/prompts/entree-premiere-maths-v1/parents.md
+++ b/content/bilans/prompts/entree-premiere-maths-v1/parents.md
@@ -41,8 +41,19 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `cadre`
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Point d'appui : « Le calcul littéral et les identités remarquables sont des
+automatismes installés, mobilisés sans hésitation. »
+
+Priorité : « Nous reprendrons les fonctions de référence et leurs variations,
+en insistant sur les cas où une fonction décroît sur plusieurs intervalles sans
+décroître sur leur réunion. »
+
+Cadre : « Ce bilan est un positionnement conduit avant le stage. Il ne
+constitue ni une évaluation notée, ni un avis sur le choix de spécialité. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Votre enfant a un niveau limite pour la spécialité mathématiques. Avec notre
+accompagnement, il tiendra le rythme et pourra viser une mention. »
+
+Un jugement d'orientation, une promesse de résultat, une projection de mention.

--- a/content/bilans/prompts/entree-premiere-maths-v1/pre-analysis.md
+++ b/content/bilans/prompts/entree-premiere-maths-v1/pre-analysis.md
@@ -29,8 +29,20 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack :
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Réponse libre : « j'ai choisi spé maths mais je ne sais pas si j'ai le niveau ».
+
+  synthese       : « L'élève a choisi la spécialité mathématiques et exprime un
+                     doute sur sa capacité à y réussir. »
+  forces_percues : []
+  craintes       : ["capacité à suivre la spécialité"]
+
+Le doute est rapporté comme un doute. Il n'est ni confirmé, ni infirmé, ni
+transformé en évaluation.
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« L'élève doute de son niveau, et ce doute est probablement fondé au vu de ses
+résultats. »
+
+La pré-analyse traite le déclaratif seul. Elle n'a pas accès aux résultats et
+ne doit jamais les invoquer.

--- a/content/bilans/prompts/entree-premiere-maths-v1/verifier.md
+++ b/content/bilans/prompts/entree-premiere-maths-v1/verifier.md
@@ -35,8 +35,15 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Violation détectée. Bilan PARENTS, champ etapeSuivante : le texte évoque une
+mention au baccalauréat. Projection de résultat interdite.
+
+Violation détectée. Bilan ELEVE, champ accroche : contient « 12/18 ». Règle V2.
+
+Contrôle des domaines : quatre domaines évalués, quatre représentés. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Le bilan est bon mais manque d'encouragement pour un élève qui doute. »
+
+Le vérificateur ne compense pas un état émotionnel. Il contrôle des règles.

--- a/content/bilans/prompts/entree-premiere-nsi-v1/eleve.md
+++ b/content/bilans/prompts/entree-premiere-nsi-v1/eleve.md
@@ -34,8 +34,20 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `accroc
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Force : « Tu suis l'exécution d'une boucle et tu sais combien de fois son corps
+s'exécute, sans te tromper sur les bornes. »
+
+Priorité : « L'affectation n'est pas une égalité mathématique : dans x = x + 1,
+on calcule d'abord la valeur de droite, puis on la range dans x. Ce point a
+l'air acquis mais il ne l'est pas encore, et il bloque toute lecture de
+programme. »
+
+Micro-plan : « Dérouler à la main un programme de six lignes en notant la
+valeur de chaque variable après chaque instruction — 15 minutes. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Tu as 11/18. Tu confonds l'affectation et l'égalité, alors que tu codes déjà.
+Ça va poser problème toute l'année. »
+
+Un score, un reproche implicite, un pronostic.

--- a/content/bilans/prompts/entree-premiere-nsi-v1/nexus.md
+++ b/content/bilans/prompts/entree-premiere-nsi-v1/nexus.md
@@ -33,8 +33,20 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Nœud programmation.variables-affectation en erreur confiante : score 0,0,
+confiance 4. Lit le signe égal comme une égalité mathématique — obstacle
+fondateur, priorité absolue.
+
+Nœud programmation.listes en maîtrise fragile : réussite 75,0, confiance 2.
+L'indexation à partir de zéro est connue mais pas automatisée : répétition.
+
+Réseaux en lacune consciente : score 0,0, confiance 1. Cohérent avec le
+déclaratif.
+
+Indice de calibration 44,4. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Élève qui bricole. Devra désapprendre avant d'apprendre. »
+
+Un jugement sur la pratique de l'élève, sans mesure et sans action possible.

--- a/content/bilans/prompts/entree-premiere-nsi-v1/parents.md
+++ b/content/bilans/prompts/entree-premiere-nsi-v1/parents.md
@@ -41,8 +41,20 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `cadre`
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Point d'appui : « La lecture d'une boucle et le décompte de ses itérations sont
+maîtrisés, y compris sur les bornes. »
+
+Priorité : « Nous reprendrons la notion d'affectation, distincte de l'égalité
+mathématique, qui conditionne la lecture et la mise au point de tout
+programme. »
+
+Cadre : « Ce bilan porte sur les prérequis issus de l'enseignement de sciences
+numériques et technologie, non sur le programme de la spécialité. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Votre enfant a des bases autodidactes à corriger. Le stage couvrira Python,
+les réseaux et le Web, et le mettra à niveau pour la spécialité. »
+
+Un jugement sur l'origine des acquis, un programme annoncé, une promesse de
+mise à niveau.

--- a/content/bilans/prompts/entree-premiere-nsi-v1/pre-analysis.md
+++ b/content/bilans/prompts/entree-premiere-nsi-v1/pre-analysis.md
@@ -29,8 +29,17 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack :
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Réponse libre : « je code un peu chez moi mais je n'ai jamais fait de réseaux ».
+
+  synthese       : « L'élève déclare une pratique personnelle de la
+                     programmation et aucune expérience des réseaux. »
+  forces_percues : ["programmation"]
+  craintes       : ["réseaux"]
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« L'élève code en autodidacte, ce qui lui donne de bonnes bases mais sans
+doute de mauvaises habitudes. »
+
+Une compétence est évaluée et un défaut est supposé, à partir d'une simple
+déclaration de pratique.

--- a/content/bilans/prompts/entree-premiere-nsi-v1/verifier.md
+++ b/content/bilans/prompts/entree-premiere-nsi-v1/verifier.md
@@ -35,8 +35,15 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Violation détectée. Bilan PARENTS, champ priorites : le texte énumère un
+contenu de stage. Anticipation interdite.
+
+Violation détectée. Bilan ELEVE, champ motDeFin : contient « 11/18 ». Règle V2.
+
+Contrôle des domaines : trois domaines évalués, trois représentés. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Le ton est un peu technique pour des parents non informaticiens. »
+
+Une remarque de lisibilité, non une vérification de règle.

--- a/content/bilans/prompts/entree-premiere-physique-chimie-v1/eleve.md
+++ b/content/bilans/prompts/entree-premiere-physique-chimie-v1/eleve.md
@@ -34,8 +34,20 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `accroc
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Force : « Tu passes d'une masse à une quantité de matière sans hésiter sur le
+sens de la division. »
+
+Priorité : « Un objet qui avance à vitesse constante en ligne droite n'est pas
+poussé par une force : les forces qui s'exercent sur lui se compensent. Ce
+point a l'air acquis mais il ne l'est pas encore, et il bloque toute la
+mécanique. »
+
+Micro-plan : « Faire le bilan des forces sur trois objets en mouvement
+rectiligne uniforme, sans en ajouter aucune vers l'avant — 15 minutes. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Tu as 9/18, surtout en mécanique. Tu croyais qu'une force pousse un objet et
+tu en étais certain. Il va falloir tout reprendre. »
+
+Un score, une répartition chiffrée, la formulation interdite, une exagération.

--- a/content/bilans/prompts/entree-premiere-physique-chimie-v1/nexus.md
+++ b/content/bilans/prompts/entree-premiere-physique-chimie-v1/nexus.md
@@ -33,8 +33,21 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Nœud mecanique.forces-inertie en erreur confiante : score 0,0, confiance 4.
+Conception aristotélicienne du mouvement — obstacle épistémologique le plus
+tenace de la discipline, priorité 1.
+
+Nœud mesure.grandeurs-unites en erreur confiante : score 50,0. Chiffres
+significatifs non maîtrisés : fausse des réponses dont le raisonnement est
+juste.
+
+Mole et concentration en maîtrise, score 100,0 : cohérent avec le déclaratif,
+temps rendu.
+
+Indice de calibration 38,9. Drapeau ERREURS_CONFIANTES_MULTIPLES. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Profil de chimiste, pas de physicien. À orienter en conséquence. »
+
+Une catégorisation d'aptitude, hors du champ d'un positionnement d'entrée.

--- a/content/bilans/prompts/entree-premiere-physique-chimie-v1/parents.md
+++ b/content/bilans/prompts/entree-premiere-physique-chimie-v1/parents.md
@@ -41,8 +41,19 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `cadre`
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Point d'appui : « Les conversions entre masse et quantité de matière sont
+sûres, dans les deux sens. »
+
+Priorité : « Nous reprendrons le principe d'inertie, en particulier l'idée
+qu'un mouvement uniforme ne nécessite aucune force motrice — représentation
+tenace qui conditionne toute la mécanique de l'année. »
+
+Étape suivante : « Écrire sur WhatsApp »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Votre enfant a des lacunes graves en mécanique qui compromettent la
+spécialité. Cinq séances suffiront à combler l'essentiel. »
+
+Un jugement de gravité, un pronostic, une promesse chiffrée sur le résultat du
+stage.

--- a/content/bilans/prompts/entree-premiere-physique-chimie-v1/pre-analysis.md
+++ b/content/bilans/prompts/entree-premiere-physique-chimie-v1/pre-analysis.md
@@ -29,8 +29,17 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack :
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Réponse libre : « la chimie ça va, mais la mécanique je n'ai jamais compris ».
+
+  synthese       : « L'élève se déclare à l'aise en chimie et en difficulté en
+                     mécanique. »
+  forces_percues : ["chimie"]
+  craintes       : ["mécanique"]
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« L'élève est meilleur en chimie qu'en mécanique, ce que confirment ses
+résultats. »
+
+Une hiérarchie déclarée devient un constat, et des résultats sont invoqués
+alors que la pré-analyse n'y a pas accès.

--- a/content/bilans/prompts/entree-premiere-physique-chimie-v1/verifier.md
+++ b/content/bilans/prompts/entree-premiere-physique-chimie-v1/verifier.md
@@ -35,8 +35,15 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Violation détectée. Bilan PARENTS, champ etapeSuivante : « cinq séances
+suffiront » constitue une promesse de résultat.
+
+Violation détectée. Bilan ELEVE, champ forces : contient « 9/18 ». Règle V2.
+
+Contrôle des domaines : quatre domaines évalués, quatre représentés. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Deux points à corriger, sinon rien à signaler. »
+
+Les deux points ne sont ni localisés ni rattachés à une règle.

--- a/content/bilans/prompts/entree-premiere-svt-v1/eleve.md
+++ b/content/bilans/prompts/entree-premiere-svt-v1/eleve.md
@@ -34,8 +34,20 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `accroc
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Force : « Tu situes correctement les niveaux d'organisation du vivant, de la
+cellule à l'organisme. »
+
+Priorité : « Toutes les cellules d'un individu portent le même ADN : ce qui
+change d'un organe à l'autre, ce sont les gènes exprimés. Ce point a l'air
+acquis mais il ne l'est pas encore, et il conditionne tout le premier
+chapitre. »
+
+Micro-plan : « Écrire en trois lignes pourquoi une cellule de peau et une
+cellule de foie diffèrent malgré un ADN identique — 10 minutes. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Tu as 10/18. Tu pensais que l'ADN changeait selon l'organe et tu en étais
+sûr. Sans cette base, l'année sera dure. »
+
+Un score, la formulation interdite, une menace.

--- a/content/bilans/prompts/entree-premiere-svt-v1/nexus.md
+++ b/content/bilans/prompts/entree-premiere-svt-v1/nexus.md
@@ -33,8 +33,21 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Nœud genetique.adn-gene-information en erreur confiante : score 0,0,
+confiance 4. L'élève soutient qu'une cellule de foie et une cellule de peau
+portent un ADN différent — obstacle au thème 1 entier.
+
+Nœud evolution.mecanismes en erreur confiante : score 33,3. Conception
+lamarckienne persistante sur les caractères acquis.
+
+Démarche et exploitation de données en maîtrise fragile : réussite 75,0,
+confiance 2. Automatisation, pas ré-explication.
+
+Indice de calibration 38,9. Drapeau ERREURS_CONFIANTES_MULTIPLES. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Élève qui apprend par cœur sans comprendre. Typique des profils
+scientifiques faibles. »
+
+Un jugement, une catégorisation, aucune mesure.

--- a/content/bilans/prompts/entree-premiere-svt-v1/parents.md
+++ b/content/bilans/prompts/entree-premiere-svt-v1/parents.md
@@ -41,8 +41,17 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `cadre`
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Point d'appui : « Le raisonnement par changement d'échelle, de la molécule à
+l'organisme, est en place. »
+
+Priorité : « Nous reprendrons la distinction entre patrimoine génétique et
+expression des gènes, notion qui fonde le premier thème de l'année. »
+
+Étape suivante : « Être conseillé »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Votre enfant a de grosses lacunes en génétique, ce qui compromet le premier
+trimestre. Nous garantissons une mise à niveau. »
+
+Un jugement, un pronostic, une promesse garantie.

--- a/content/bilans/prompts/entree-premiere-svt-v1/pre-analysis.md
+++ b/content/bilans/prompts/entree-premiere-svt-v1/pre-analysis.md
@@ -29,8 +29,17 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack :
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Réponse libre : « j'aime la SVT mais je n'arrive pas à rédiger les réponses aux
+documents ».
+
+  synthese       : « L'élève déclare un intérêt pour la discipline et une
+                     difficulté à rédiger l'exploitation de documents. »
+  forces_percues : ["intérêt pour la discipline"]
+  craintes       : ["rédaction de l'exploitation de documents"]
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« L'élève est motivé mais manque de méthode rédactionnelle, ce qui explique ses
+notes moyennes. »
+
+Une méthode est diagnostiquée, des notes sont invoquées sans donnée.

--- a/content/bilans/prompts/entree-premiere-svt-v1/verifier.md
+++ b/content/bilans/prompts/entree-premiere-svt-v1/verifier.md
@@ -35,8 +35,17 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Violation détectée. Bilan ELEVE, champ priorites, premier élément : la
+formulation « tu en étais sûr » est interdite.
+
+Violation détectée. Bilan PARENTS, champ pointsAppui : contient « 10/18 ».
+Règle V2.
+
+Contrôle des domaines : cinq domaines évalués, cinq représentés dans les deux
+audiences. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Correct dans l'ensemble. »
+
+Aucune trace de ce qui a été contrôlé.

--- a/content/bilans/prompts/entree-quatrieme-francais-v1/eleve.md
+++ b/content/bilans/prompts/entree-quatrieme-francais-v1/eleve.md
@@ -34,8 +34,19 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `accroc
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Force : « Tu reconnais la nature d'un mot même lorsqu'il change de place dans
+la phrase. »
+
+Priorité : « L'accord du participe passé employé avec l'auxiliaire être. Ce
+point a l'air acquis mais il ne l'est pas encore — c'est exactement le type
+d'écart qui coûte cher en dictée. »
+
+Micro-plan : « Écrire cinq phrases au passé composé avec être, en entourant le
+sujet avant d'accorder — 10 minutes. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Tu fais trop de fautes. Tu crois savoir accorder mais tu te trompes tout le
+temps. Il faut travailler l'orthographe cet été. »
+
+Un jugement global, la formulation interdite, une injonction sans contenu.

--- a/content/bilans/prompts/entree-quatrieme-francais-v1/nexus.md
+++ b/content/bilans/prompts/entree-quatrieme-francais-v1/nexus.md
@@ -33,8 +33,19 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Nœud orthographe.accords en erreur confiante : score 0,0, confiance moyenne
+3,5. L'élève accorde systématiquement avec le mot le plus proche et n'en
+doute pas — priorité 1.
+
+Figures de style en maîtrise fragile : réussite 75,0, confiance 2. Traitement
+par répétition, la définition est connue.
+
+Homophones en maîtrise, score 100,0. Rappel actif seulement.
+
+Indice de calibration 50,0. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Élève négligent, écrit trop vite. À recadrer sur la méthode. »
+
+Jugement de caractère, aucune mesure, aucune indication exploitable.

--- a/content/bilans/prompts/entree-quatrieme-francais-v1/parents.md
+++ b/content/bilans/prompts/entree-quatrieme-francais-v1/parents.md
@@ -41,8 +41,17 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `cadre`
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Point d'appui : « L'identification des classes de mots est stable, y compris
+sur des constructions déplacées. »
+
+Priorité : « Nous travaillerons l'accord du participe passé, d'abord par
+repérage guidé du sujet, puis en production écrite. »
+
+Étape suivante : « Être conseillé »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Votre enfant a un niveau d'orthographe préoccupant pour un entrant en 4e.
+Nous garantissons une remise à niveau en cinq séances. »
+
+Un jugement de niveau, un ressort anxiogène, une promesse garantie.

--- a/content/bilans/prompts/entree-quatrieme-francais-v1/pre-analysis.md
+++ b/content/bilans/prompts/entree-quatrieme-francais-v1/pre-analysis.md
@@ -29,8 +29,16 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack :
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Réponse libre : « je fais beaucoup de fautes mais j'aime bien lire ».
+
+  synthese       : « L'élève déclare des difficultés orthographiques et un goût
+                     affirmé pour la lecture. »
+  forces_percues : ["lecture"]
+  craintes       : ["orthographe"]
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« L'élève aime lire, ce qui devrait compenser ses lacunes en orthographe. »
+
+Une compensation est supposée entre deux compétences distinctes. La
+pré-analyse rapporte, elle ne pronostique pas.

--- a/content/bilans/prompts/entree-quatrieme-francais-v1/verifier.md
+++ b/content/bilans/prompts/entree-quatrieme-francais-v1/verifier.md
@@ -35,8 +35,15 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Violation détectée. Bilan ELEVE, champ priorites, premier élément : la
+formulation « tu crois savoir et tu te trompes » est interdite. Le prompt
+impose la formulation par l'écart non perçu.
+
+Contrôle des domaines : les quatre domaines évalués sont représentés dans les
+sorties ELEVE et PARENTS. Aucun omis. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Rien à signaler. »
+
+Une vérification qui ne cite ni champ, ni règle, ni valeur n'atteste de rien.

--- a/content/bilans/prompts/entree-quatrieme-maths-v1/eleve.md
+++ b/content/bilans/prompts/entree-quatrieme-maths-v1/eleve.md
@@ -34,8 +34,19 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `accroc
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Force : « Tu calcules l'aire d'un rectangle et d'un triangle sans hésiter sur la
+formule. »
+
+Priorité, nœud en erreur confiante : « L'ordre des opérations quand un produit
+suit une addition. Ce point a l'air acquis mais il ne l'est pas encore — c'est
+exactement le type d'écart qui coûte cher en devoir surveillé. »
+
+Micro-plan : « Refaire huit calculs mêlant addition et multiplication en
+entourant d'abord le produit — 10 minutes. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Tu as 8 bonnes réponses sur 18, c'est faible. Tu confonds tout avec les signes
+et tu étais sûr de toi. Sans ça la 4e sera compliquée. »
+
+Un score, un jugement, la formulation interdite sur la confiance, une menace.

--- a/content/bilans/prompts/entree-quatrieme-maths-v1/nexus.md
+++ b/content/bilans/prompts/entree-quatrieme-maths-v1/nexus.md
@@ -33,8 +33,19 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Deux nœuds en erreur confiante : relatifs.somme-difference-priorites, score
+de nœud 25,0, et calcul-litteral.distributivite-simple, score 33,3. Indice de
+calibration 38,9 — l'élève tranche avec assurance sur le calcul, moins ailleurs.
+
+Statistiques et aires en maîtrise, score 100,0 : rappel actif suffisant, vingt
+minutes.
+
+Vigilance : trois items non traités en fin de questionnaire, tous sur la
+symétrie centrale. Fatigue ou manque de temps, à vérifier oralement. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Élève en grande difficulté, sans doute peu suivi à la maison. Groupe faible
+recommandé. »
+
+Jugement sur la personne, hypothèse sur le milieu familial, aucune mesure.

--- a/content/bilans/prompts/entree-quatrieme-maths-v1/parents.md
+++ b/content/bilans/prompts/entree-quatrieme-maths-v1/parents.md
@@ -41,8 +41,22 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `cadre`
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Point d'appui : « Les formules d'aire et de périmètre sont mobilisées avec
+sûreté, y compris lorsque la figure est présentée autrement qu'en position
+habituelle. »
+
+Priorité : « Nous reprendrons les priorités opératoires et le calcul avec les
+nombres relatifs, par des exercices courts et répétés plutôt que par un
+réapprentissage de la règle. »
+
+Cadre : « Le contenu des cinq séances de deux heures sera arrêté après
+croisement des diagnostics du groupe. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Votre enfant a 8/18 et un niveau très insuffisant. Le stage couvrira les
+relatifs, les fractions et la proportionnalité, et lui permettra de reprendre
+confiance pour réussir son année. »
+
+Un score, un jugement de niveau, un programme annoncé avant les diagnostics,
+une promesse de résultat.

--- a/content/bilans/prompts/entree-quatrieme-maths-v1/pre-analysis.md
+++ b/content/bilans/prompts/entree-quatrieme-maths-v1/pre-analysis.md
@@ -29,8 +29,20 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack :
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Réponse libre : « je m'embrouille avec les moins et j'ai eu 8 de moyenne ».
+
+  synthese       : « L'élève identifie les nombres relatifs comme une source
+                     d'erreurs et mentionne une moyenne annuelle faible. »
+  forces_percues : []
+  craintes       : ["nombres relatifs"]
+
+La moyenne déclarée est enregistrée comme un élément du discours, jamais
+reprise comme une mesure ni convertie en niveau.
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Avec 8 de moyenne, l'élève est en difficulté générale en mathématiques et son
+problème avec les signes en est le symptôme. »
+
+Une moyenne déclarée devient un diagnostic, une difficulté ponctuelle devient
+générale, et un lien de cause est inventé entre les deux.

--- a/content/bilans/prompts/entree-quatrieme-maths-v1/verifier.md
+++ b/content/bilans/prompts/entree-quatrieme-maths-v1/verifier.md
@@ -35,8 +35,20 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Violation détectée. Bilan PARENTS, champ pointsAppui : la phrase contient
+« 8/18 ». Règle V2, aucun chiffre autorisé.
+
+Violation détectée. Bilan PARENTS, champ priorites, premier élément : le texte
+annonce un contenu de stage. Le prompt interdit d'anticiper l'ordre, le temps
+et la profondeur du travail.
+
+Aucune autre violation. Les cinq domaines évalués figurent bien dans les
+sorties ELEVE et PARENTS. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Le bilan me paraît un peu dur pour un élève de cet âge. Je propose d'adoucir
+la formulation des priorités. »
+
+Le vérificateur contrôle des faits et des règles. Il ne juge ni le ton ni
+l'opportunité.

--- a/content/bilans/prompts/entree-terminale-maths-expertes-v1/eleve.md
+++ b/content/bilans/prompts/entree-terminale-maths-expertes-v1/eleve.md
@@ -34,8 +34,19 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `accroc
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Force : « Tu résous un système de deux équations linéaires en choisissant la
+méthode la plus économique selon les coefficients. »
+
+Priorité : « La contraposée d'une implication : si A implique B, alors non-B
+implique non-A, et non l'inverse. Ce point a l'air acquis mais il ne l'est pas
+encore — c'est lui qui commande tous les raisonnements de l'option. »
+
+Micro-plan : « Écrire la réciproque et la contraposée de trois implications,
+puis dire laquelle est équivalente à l'énoncé de départ — 15 minutes. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Tu as 12/18, ce qui est léger pour des maths expertes. Tu confondais
+réciproque et contraposée en étant sûr de toi. »
+
+Un score, un jugement d'adéquation à l'option, la formulation interdite.

--- a/content/bilans/prompts/entree-terminale-maths-expertes-v1/nexus.md
+++ b/content/bilans/prompts/entree-terminale-maths-expertes-v1/nexus.md
@@ -33,8 +33,24 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Nœud 1re.maths.logique.implication-contraposee en erreur confiante : score
+0,0, confiance 4. Confond contraposée et réciproque — obstacle direct aux
+démonstrations de l'option, priorité 1.
+
+Nœud college.maths.arithmetique.pgcd en lacune consciente : score 25,0,
+confiance 1. Algorithme d'Euclide non disponible, l'élève le sait :
+enseignement direct, pas déconstruction.
+
+Systèmes linéaires et factorisation en maîtrise, score 100,0 : rappel actif,
+vingt minutes chacun.
+
+Indice de calibration 50,0. Quatre des neuf nœuds relèvent du collège : la
+réactivation domine, le rattrapage est secondaire. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Élève qui a choisi expertes par ambition plus que par goût. Suivi rapproché
+recommandé. »
+
+Une hypothèse sur les motivations, sans mesure, et une recommandation qui
+n'aide à préparer aucune séance.

--- a/content/bilans/prompts/entree-terminale-maths-expertes-v1/parents.md
+++ b/content/bilans/prompts/entree-terminale-maths-expertes-v1/parents.md
@@ -41,8 +41,21 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `cadre`
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Cadre : « Cette option s'appuie sur des notions d'arithmétique travaillées au
+collège et peu revues depuis. Ce positionnement les réactive : il ne mesure pas
+un niveau, il situe un point de départ. »
+
+Point d'appui : « La résolution de systèmes linéaires est sûre, avec un choix
+pertinent de la méthode. »
+
+Priorité : « Nous reprendrons les règles de la logique, en particulier la
+distinction entre réciproque et contraposée, qui structure les démonstrations
+de l'option. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Votre enfant a d'importantes lacunes en arithmétique, ce qui rend le suivi de
+l'option incertain. Nous garantissons une remise à niveau complète. »
+
+Un jugement de lacune sur des notions non travaillées depuis trois ans, un
+doute sur la poursuite de l'option, une promesse garantie.

--- a/content/bilans/prompts/entree-terminale-maths-expertes-v1/pre-analysis.md
+++ b/content/bilans/prompts/entree-terminale-maths-expertes-v1/pre-analysis.md
@@ -29,8 +29,22 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack :
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Réponse libre : « je prends maths expertes pour les écoles d'ingénieurs, mais
+l'arithmétique remonte à la 3e ».
+
+  synthese       : « L'élève choisit l'option en vue d'études d'ingénieur et
+                     signale que ses derniers travaux d'arithmétique datent de
+                     la Troisième. »
+  forces_percues : []
+  craintes       : ["arithmétique"]
+
+Le constat de l'élève est exact et vaut pour tous : il est rapporté comme une
+information de contexte, jamais comme une lacune personnelle.
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« L'élève a oublié l'arithmétique du collège, ce qui constitue un handicap pour
+une option aussi exigeante. »
+
+Une situation commune à tous devient un handicap individuel, et l'exigence de
+l'option est invoquée comme un jugement.

--- a/content/bilans/prompts/entree-terminale-maths-expertes-v1/verifier.md
+++ b/content/bilans/prompts/entree-terminale-maths-expertes-v1/verifier.md
@@ -35,8 +35,17 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Violation détectée. Bilan PARENTS, champ cadre : le texte met en doute la
+poursuite de l'option, ce qui constitue un avis d'orientation hors du champ du
+positionnement.
+
+Violation détectée. Bilan ELEVE, champ accroche : contient « 12/18 ». Règle V2.
+
+Contrôle des domaines : les domaines évalués sont tous représentés dans les
+sorties ELEVE et PARENTS. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Le bilan est correct pour un élève de ce niveau d'exigence. »
+
+Le vérificateur ne module pas son contrôle selon le niveau supposé de l'élève.

--- a/content/bilans/prompts/entree-terminale-maths-v1/eleve.md
+++ b/content/bilans/prompts/entree-terminale-maths-v1/eleve.md
@@ -34,8 +34,20 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `accroc
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Force : « Tu établis l'équation d'une tangente en évaluant correctement le
+nombre dérivé au point demandé. »
+
+Priorité : « Le signe de la dérivée donne le sens de variation de la fonction,
+pas le signe de la fonction elle-même. Ce point a l'air acquis mais il ne l'est
+pas encore — c'est le raisonnement le plus réinvesti de toute la Terminale. »
+
+Micro-plan : « Sur trois tableaux de variations, écrire à côté de chaque signe
+de f prime la phrase correspondante sur f — 15 minutes. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Tu as 14/18, c'est bien mais insuffisant pour une prépa. Tu confondais f et f
+prime en étant sûr de toi. »
+
+Un score, un jugement d'adéquation à un projet d'orientation, la formulation
+interdite.

--- a/content/bilans/prompts/entree-terminale-maths-v1/nexus.md
+++ b/content/bilans/prompts/entree-terminale-maths-v1/nexus.md
@@ -33,8 +33,21 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Nœud derivation.signe-derivee-variations en erreur confiante : score 50,0,
+confiance 4. Confond le signe de f prime et celui de f — erreur la plus
+coûteuse du programme, priorité 1.
+
+Nœud exponentielle.proprietes-algebriques en maîtrise fragile : réussite 75,0,
+confiance 2. Les règles sont sues, l'automatisation manque : répétition.
+
+Second degré et produit scalaire en maîtrise, score 100,0 : rappel actif,
+vingt minutes chacun.
+
+Indice de calibration 61,1 : correcte hors dérivation. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Bon élève, prépa jouable. À suivre. »
+
+Un pronostic d'orientation et une appréciation globale, sans usage pour la
+préparation d'une séance.

--- a/content/bilans/prompts/entree-terminale-maths-v1/parents.md
+++ b/content/bilans/prompts/entree-terminale-maths-v1/parents.md
@@ -41,8 +41,18 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `cadre`
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Point d'appui : « La dérivation et l'équation de tangente sont des automatismes
+en place, appliqués sans erreur de calcul. »
+
+Priorité : « Nous reprendrons le lien entre le signe de la dérivée et le sens
+de variation, distinction qui commande l'étude de fonctions de toute l'année. »
+
+Cadre : « Ce bilan ne constitue ni une évaluation notée, ni un avis sur un
+projet d'orientation. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Votre enfant vise une prépa mais son niveau actuel ne le permet pas encore.
+Notre accompagnement lui donnera les moyens d'y prétendre. »
+
+Un avis d'orientation, une promesse de résultat, un ressort de doute.

--- a/content/bilans/prompts/entree-terminale-maths-v1/pre-analysis.md
+++ b/content/bilans/prompts/entree-terminale-maths-v1/pre-analysis.md
@@ -29,8 +29,19 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack :
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Réponse libre : « je vise une prépa, je veux être sûr de mes bases ».
+
+  synthese       : « L'élève déclare un projet de classe préparatoire et une
+                     volonté de consolider ses bases. »
+  forces_percues : []
+  craintes       : []
+  Le champ craintes reste vide : aucune difficulté n'est exprimée. Une exigence
+  n'est pas une crainte.
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« L'élève ambitieux souhaite intégrer une prépa, ce qui suppose un niveau
+solide qu'il faudra vérifier. »
+
+Un commentaire sur l'ambition et une condition ajoutée que l'élève n'a pas
+formulée.

--- a/content/bilans/prompts/entree-terminale-maths-v1/verifier.md
+++ b/content/bilans/prompts/entree-terminale-maths-v1/verifier.md
@@ -35,8 +35,15 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Violation détectée. Bilan PARENTS, champ cadre : le texte porte un avis sur
+un projet d'orientation, hors du champ du positionnement.
+
+Violation détectée. Bilan ELEVE, champ accroche : contient « 14/18 ». Règle V2.
+
+Contrôle des domaines : quatre domaines évalués, quatre représentés. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Le bilan pourrait mieux valoriser un élève de ce niveau. »
+
+Un avis éditorial. Le vérificateur ne module pas le propos selon le niveau.

--- a/content/bilans/prompts/entree-terminale-nsi-v1/eleve.md
+++ b/content/bilans/prompts/entree-terminale-nsi-v1/eleve.md
@@ -34,8 +34,21 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `accroc
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Force : « Tu manipules un dictionnaire en distinguant clairement ce qui relève
+de la clé et ce qui relève de la valeur. »
+
+Priorité : « Une recherche dichotomique exige un tableau trié : sans cette
+condition, l'algorithme peut renvoyer que l'élément est absent alors qu'il y
+est. Ce point a l'air acquis mais il ne l'est pas encore, et il revient dans
+toute l'étude de la complexité. »
+
+Micro-plan : « Dérouler une recherche dichotomique sur un tableau non trié et
+noter l'étape exacte où le raisonnement se rompt — 15 minutes. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Tu as 13/18. Tu récites les tris sans les comprendre et tu ne t'en rends même
+pas compte. La Terminale NSI est exigeante. »
+
+Un score, un reproche formulé à partir de ce que l'élève a lui-même déclaré,
+un pronostic.

--- a/content/bilans/prompts/entree-terminale-nsi-v1/nexus.md
+++ b/content/bilans/prompts/entree-terminale-nsi-v1/nexus.md
@@ -33,8 +33,23 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Nœud 1re.nsi.algorithmique.recherche-tris en erreur confiante : score 0,0,
+confiance 4. Applique la recherche dichotomique sans vérifier que le tableau
+est trié — obstacle direct à l'étude de la complexité.
+
+Nœud 1re.nsi.architecture.von-neumann-os en lacune consciente : score 25,0,
+confiance 1. Rôles du processeur et de la mémoire non stabilisés, l'élève le
+sait.
+
+Types construits et fonctions en maîtrise, score 100,0 : cohérent avec le
+déclaratif, temps rendu.
+
+Indice de calibration 55,6 : l'élève se juge lucidement, sauf sur les tris —
+seul point où il se croit sûr et se trompe. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Élève scolaire qui applique des recettes. Manque de recul algorithmique. »
+
+Un jugement de posture intellectuelle, sans mesure, et sans indication de
+traitement pour une séance.

--- a/content/bilans/prompts/entree-terminale-nsi-v1/parents.md
+++ b/content/bilans/prompts/entree-terminale-nsi-v1/parents.md
@@ -41,8 +41,21 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `cadre`
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Point d'appui : « La manipulation des types construits, listes et
+dictionnaires, est sûre et raisonnée. »
+
+Priorité : « Nous reprendrons les conditions de validité des algorithmes de
+recherche, notamment le prérequis de tri, avant d'aborder l'étude du coût. »
+
+Cadre : « Ce bilan est un positionnement conduit avant le stage. Le contenu des
+cinq séances de deux heures sera arrêté après croisement des diagnostics du
+groupe constitué. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Votre enfant apprend par cœur sans comprendre, ce qui l'empêchera de suivre.
+Le stage traitera les tris, la complexité et les bases de données, et corrigera
+cette méthode de travail. »
+
+Un jugement sur la méthode de travail, un pronostic d'échec, un programme
+annoncé avant les diagnostics.

--- a/content/bilans/prompts/entree-terminale-nsi-v1/pre-analysis.md
+++ b/content/bilans/prompts/entree-terminale-nsi-v1/pre-analysis.md
@@ -29,8 +29,21 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack :
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Réponse libre : « je programme bien mais les tris et la complexité, je récite
+sans comprendre ».
+
+  synthese       : « L'élève déclare une aisance en programmation et une
+                     maîtrise seulement mémorisée des algorithmes de tri. »
+  forces_percues : ["programmation"]
+  craintes       : ["algorithmes de tri"]
+
+La distinction que l'élève établit entre réciter et comprendre est conservée
+telle quelle : c'est une information précieuse, pas une formule à lisser.
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« L'élève programme bien mais son apprentissage par cœur des tris révèle un
+manque de fond en algorithmique. »
+
+Une déclaration lucide devient un verdict sur le fond, et une compétence
+déclarée est retournée contre l'élève.

--- a/content/bilans/prompts/entree-terminale-nsi-v1/verifier.md
+++ b/content/bilans/prompts/entree-terminale-nsi-v1/verifier.md
@@ -35,8 +35,20 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Violation détectée. Bilan PARENTS, champ pointsAppui : le texte porte un
+jugement sur la méthode de travail de l'élève, formulé comme un manque et non
+comme un contenu de séance.
+
+Violation détectée. Bilan PARENTS, champ priorites : énumération d'un contenu
+de stage. Anticipation interdite.
+
+Violation détectée. Bilan ELEVE, champ accroche : contient « 13/18 ». Règle V2.
+
+Contrôle des domaines : tous les domaines évalués sont représentés. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Plusieurs problèmes de ton dans le bilan parents. »
+
+Trois violations distinctes sont réduites à une impression de ton, sans
+localisation ni règle citée.

--- a/content/bilans/prompts/entree-terminale-philosophie-v1/eleve.md
+++ b/content/bilans/prompts/entree-terminale-philosophie-v1/eleve.md
@@ -34,8 +34,20 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `accroc
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Force : « Tu repères la thèse d'un texte et tu la distingues des arguments qui
+la soutiennent. »
+
+Priorité : « Un raisonnement peut être valide et partir de prémisses fausses :
+la validité concerne l'enchaînement, pas la vérité de la conclusion. Ce point a
+l'air acquis mais il ne l'est pas encore, et c'est lui qui permet de discuter
+un texte au lieu d'y adhérer ou de le rejeter. »
+
+Micro-plan : « Construire un raisonnement valide dont la conclusion est fausse,
+et dire pourquoi il reste valide — 20 minutes. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Tu as 11/18 en logique. Tu crois qu'un raisonnement valide donne toujours une
+conclusion vraie, et tu en es persuadé. La philo va être rude. »
+
+Un score, la formulation interdite, un pronostic sur la discipline.

--- a/content/bilans/prompts/entree-terminale-philosophie-v1/nexus.md
+++ b/content/bilans/prompts/entree-terminale-philosophie-v1/nexus.md
@@ -33,8 +33,21 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Nœud argumentation.coherence-du-raisonnement en erreur confiante : score 0,0,
+confiance 4. Identifie la validité à la vérité de la conclusion — prérequis
+logique minimal, priorité 1.
+
+Nœud lexique.vocabulaire-abstrait en lacune consciente : score 0,0, confiance
+1. Les sens stricts de « nécessaire » et « distinct » ne sont pas installés,
+et l'élève le sait.
+
+Thèse, argument et exemple en maîtrise, score 100,0 : temps rendu.
+
+Indice de calibration 50,0. Rappel : les nœuds de cette banque relèvent du
+français de Première, non de la philosophie. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Élève peu réflexif, aura du mal en dissertation. Profil scientifique. »
+
+Un jugement d'aptitude, une catégorisation, un pronostic sur une épreuve.

--- a/content/bilans/prompts/entree-terminale-philosophie-v1/parents.md
+++ b/content/bilans/prompts/entree-terminale-philosophie-v1/parents.md
@@ -41,8 +41,21 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `cadre`
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Cadre : « Ce positionnement n'évalue aucune notion de philosophie, discipline
+que votre enfant n'a pas encore étudiée. Il porte sur les compétences
+d'analyse et d'argumentation acquises en français, qui conditionnent l'entrée
+dans la discipline. »
+
+Point d'appui : « La distinction entre thèse, argument et exemple est en
+place, y compris sur un texte court non préparé. »
+
+Priorité : « Nous travaillerons la distinction entre validité d'un raisonnement
+et vérité de sa conclusion, préalable à toute discussion de texte. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Votre enfant a un niveau faible en philosophie, ce qui est préoccupant à
+l'entrée en Terminale. Notre stage lui donnera les bases qui lui manquent. »
+
+Un niveau est attribué dans une discipline jamais étudiée, un ressort
+anxiogène, une promesse.

--- a/content/bilans/prompts/entree-terminale-philosophie-v1/pre-analysis.md
+++ b/content/bilans/prompts/entree-terminale-philosophie-v1/pre-analysis.md
@@ -29,8 +29,20 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack :
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Réponse libre : « je n'ai jamais fait de philo, je ne sais pas à quoi
+m'attendre ».
+
+  synthese       : « L'élève n'a jamais suivi d'enseignement de philosophie et
+                     exprime une incertitude sur ce qui l'attend. »
+  forces_percues : []
+  craintes       : ["nouveauté de la discipline"]
+
+L'absence d'expérience préalable est un fait attendu de tous, jamais une
+lacune.
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« L'élève part de zéro en philosophie et devra fournir un effort important pour
+combler ce retard. »
+
+Une situation universelle est présentée comme un retard individuel.

--- a/content/bilans/prompts/entree-terminale-philosophie-v1/verifier.md
+++ b/content/bilans/prompts/entree-terminale-philosophie-v1/verifier.md
@@ -35,8 +35,16 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Violation détectée. Bilan PARENTS, champ pointsAppui : le texte attribue un
+niveau en philosophie. Cette banque n'évalue aucune notion de la discipline.
+
+Violation détectée. Bilan ELEVE, champ accroche : contient « 11/18 ». Règle V2.
+
+Contrôle des domaines : trois domaines évalués, trois représentés. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Attention, le bilan parle de philosophie alors que ce n'est pas testé. »
+
+Le constat est juste mais ni localisé par champ, ni rattaché à une règle, et
+la seconde violation n'est pas relevée.

--- a/content/bilans/prompts/entree-terminale-physique-chimie-v1/eleve.md
+++ b/content/bilans/prompts/entree-terminale-physique-chimie-v1/eleve.md
@@ -34,8 +34,19 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `accroc
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Force : « Tu identifies le réactif limitant en comparant les quantités divisées
+par les coefficients, et non les masses. »
+
+Priorité : « Une force perpendiculaire au déplacement ne travaille pas, même si
+elle s'exerce en permanence. Ce point a l'air acquis mais il ne l'est pas
+encore, et il fausse tous les bilans d'énergie. »
+
+Micro-plan : « Calculer le travail du poids sur trois trajets — horizontal,
+vertical, incliné — en écrivant l'angle à chaque fois — 15 minutes. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Tu as 13/18 mais tu t'es planté sur l'énergie en étant sûr de toi. C'est
+inquiétant pour une Terminale spé. »
+
+Un score, un registre familier, la formulation interdite, un ressort anxiogène.

--- a/content/bilans/prompts/entree-terminale-physique-chimie-v1/nexus.md
+++ b/content/bilans/prompts/entree-terminale-physique-chimie-v1/nexus.md
@@ -33,8 +33,19 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Nœud energie.travail-energie-mecanique en erreur confiante : score 50,0,
+confiance 4. Considère qu'une force permanente travaille toujours — priorité 1,
+préalable au premier principe.
+
+Nœud chimie-organique.familles-fonctionnelles en lacune consciente : score
+0,0, confiance 1. Cohérent avec le déclaratif : enseignement direct.
+
+Avancement et oxydo-réduction en maîtrise, score 100,0.
+
+Indice de calibration 55,6. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Élève inégal, dépend de sa motivation selon les chapitres. »
+
+Une hypothèse sur la motivation, sans mesure et sans action possible.

--- a/content/bilans/prompts/entree-terminale-physique-chimie-v1/parents.md
+++ b/content/bilans/prompts/entree-terminale-physique-chimie-v1/parents.md
@@ -41,8 +41,19 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `cadre`
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Point d'appui : « La détermination du réactif limitant est conduite sur les
+quantités de matière rapportées aux coefficients, méthode juste et stable. »
+
+Priorité : « Nous reprendrons la notion de travail d'une force, en particulier
+le cas où une force s'exerce sans travailler, préalable à tous les bilans
+d'énergie de l'année. »
+
+Cadre : « Le contenu des cinq séances de deux heures sera arrêté après
+croisement des diagnostics du groupe. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Votre enfant a des fragilités inquiétantes en énergie. Le stage traitera la
+cinétique, la mécanique et les ondes, et sécurisera son année. »
+
+Un ressort anxiogène, un programme annoncé, une promesse.

--- a/content/bilans/prompts/entree-terminale-physique-chimie-v1/pre-analysis.md
+++ b/content/bilans/prompts/entree-terminale-physique-chimie-v1/pre-analysis.md
@@ -29,8 +29,16 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack :
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Réponse libre : « les exercices de chimie organique me bloquent toujours ».
+
+  synthese       : « L'élève identifie la chimie organique comme un point de
+                     blocage récurrent. »
+  forces_percues : []
+  craintes       : ["chimie organique"]
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« L'élève bloque en chimie organique, probablement par manque d'apprentissage
+des groupes caractéristiques. »
+
+Une cause est attribuée à un blocage que l'élève n'a pas expliqué.

--- a/content/bilans/prompts/entree-terminale-physique-chimie-v1/verifier.md
+++ b/content/bilans/prompts/entree-terminale-physique-chimie-v1/verifier.md
@@ -35,8 +35,16 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Violation détectée. Bilan ELEVE, champ priorites : registre familier
+inadapté, et formulation « en étant sûr de toi » interdite. Deux règles.
+
+Violation détectée. Bilan PARENTS, champ priorites : le texte énumère un
+contenu de stage. Anticipation interdite.
+
+Contrôle des domaines : quatre domaines évalués, quatre représentés. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Le vocabulaire est parfois trop familier, à revoir. »
+
+Le constat est juste mais ni localisé, ni rattaché à une règle, ni exhaustif.

--- a/content/bilans/prompts/entree-terminale-svt-v1/eleve.md
+++ b/content/bilans/prompts/entree-terminale-svt-v1/eleve.md
@@ -34,8 +34,20 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `accroc
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Force : « Tu distingues transcription et traduction et tu sais où chacune se
+déroule dans la cellule. »
+
+Priorité : « Les mutations surviennent au hasard : aucune n'apparaît parce que
+l'organisme en aurait besoin. Ce point a l'air acquis mais il ne l'est pas
+encore, et il fausse tout raisonnement sur l'évolution des populations. »
+
+Micro-plan : « Reformuler en trois lignes pourquoi une bactérie résistante
+n'est pas devenue résistante à cause de l'antibiotique — 15 minutes. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Tu as 12/18, avec la géologie en dessous. Tu croyais que les mutations
+s'adaptent au besoin et tu en étais sûr. En médecine ça ne pardonne pas. »
+
+Un score, une répartition chiffrée, la formulation interdite, une projection
+sur un projet d'orientation.

--- a/content/bilans/prompts/entree-terminale-svt-v1/nexus.md
+++ b/content/bilans/prompts/entree-terminale-svt-v1/nexus.md
@@ -33,8 +33,20 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Nœud genetique.mutations en erreur confiante : score 0,0, confiance 4.
+Finalisme persistant, obstacle direct au thème 1 — priorité 1.
+
+Nœud geologie.tectonique-des-plaques en lacune consciente : score 25,0,
+confiance 1. Distinction lithosphère et asthénosphère non installée, mais
+l'élève le sait : enseignement direct, pas déconstruction.
+
+Expression du génome et immunité en maîtrise, score 100,0 : temps rendu.
+
+Indice de calibration 50,0. Déclaratif cohérent avec les mesures. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Profil médecine classique : fort en bio, faible en géol. Rien d'alarmant. »
+
+Une catégorisation, une appréciation rassurante sans mesure, aucune indication
+de traitement.

--- a/content/bilans/prompts/entree-terminale-svt-v1/parents.md
+++ b/content/bilans/prompts/entree-terminale-svt-v1/parents.md
@@ -41,8 +41,18 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `cadre`
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Point d'appui : « Les mécanismes de l'expression du génome sont maîtrisés, avec
+une localisation correcte de chaque étape. »
+
+Priorité : « Nous reprendrons le caractère aléatoire des mutations,
+représentation dont dépend tout le raisonnement sur l'évolution, puis la
+distinction mécanique entre lithosphère et asthénosphère. »
+
+Étape suivante : « Être conseillé »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Votre enfant néglige la géologie et vise médecine : ce déséquilibre lui
+coûtera cher. Notre stage rééquilibrera son niveau. »
+
+Un jugement de comportement, un pronostic, une promesse de rééquilibrage.

--- a/content/bilans/prompts/entree-terminale-svt-v1/pre-analysis.md
+++ b/content/bilans/prompts/entree-terminale-svt-v1/pre-analysis.md
@@ -29,8 +29,20 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack :
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Réponse libre : « je veux faire médecine, la génétique m'intéresse mais la
+géologie m'ennuie ».
+
+  synthese       : « L'élève déclare un projet en études de santé, un intérêt
+                     pour la génétique et un désintérêt pour la géologie. »
+  forces_percues : ["génétique"]
+  craintes       : []
+
+Un désintérêt n'est pas une crainte et ne figure pas dans ce champ. Il est
+rapporté dans la synthèse, où il éclaire l'engagement, pas la maîtrise.
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« L'élève se désintéresse de la géologie, ce qui explique ses résultats plus
+faibles dans ce domaine et pourrait lui coûter des points au baccalauréat. »
+
+Un désintérêt devient une cause, puis un pronostic d'examen.

--- a/content/bilans/prompts/entree-terminale-svt-v1/verifier.md
+++ b/content/bilans/prompts/entree-terminale-svt-v1/verifier.md
@@ -35,8 +35,16 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Violation détectée. Bilan ELEVE, champ priorites, premier élément :
+formulation « tu en étais sûr » interdite.
+
+Violation détectée. Bilan PARENTS, champ cadre : mention d'un projet
+d'orientation et de son coût, hors du champ du positionnement.
+
+Contrôle des domaines : quatre domaines évalués, quatre représentés. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Bilan conforme. »
+
+Aucune trace du contrôle effectué.

--- a/content/bilans/prompts/entree-troisieme-francais-v1/eleve.md
+++ b/content/bilans/prompts/entree-troisieme-francais-v1/eleve.md
@@ -34,8 +34,19 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `accroc
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Force : « Tu distingues le narrateur du personnage, même quand le récit est à
+la première personne. »
+
+Priorité : « L'accord du participe passé avec le complément d'objet placé avant
+le verbe. Ce point a l'air acquis mais il ne l'est pas encore, et il est évalué
+directement en dictée et en réécriture. »
+
+Micro-plan : « Réécrire cinq phrases en déplaçant le complément d'objet avant
+le verbe, puis accorder — 15 minutes. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Tu as 9/18. Tu es sûr de toi mais tu te trompes sur les accords. Attention au
+brevet. »
+
+Un score, la formulation interdite, une menace.

--- a/content/bilans/prompts/entree-troisieme-francais-v1/nexus.md
+++ b/content/bilans/prompts/entree-troisieme-francais-v1/nexus.md
@@ -33,8 +33,19 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Nœud orthographe.accords en erreur confiante : score 0,0, confiance 4.
+Accord systématique avec le sujet, jamais avec le complément antéposé.
+
+Discours rapporté en lacune consciente : score 25,0, confiance 1. La
+transposition n'est pas installée et l'élève le sait.
+
+Narrateur et points de vue en maîtrise, score 100,0.
+
+Indice de calibration 44,4 : surestimation nette sur l'orthographe. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Bon élève dans l'ensemble, quelques fautes d'inattention. »
+
+« Inattention » est un jugement, pas un diagnostic. Une erreur systématique
+avec confiance élevée n'est jamais de l'inattention.

--- a/content/bilans/prompts/entree-troisieme-francais-v1/parents.md
+++ b/content/bilans/prompts/entree-troisieme-francais-v1/parents.md
@@ -41,8 +41,18 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `cadre`
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Point d'appui : « L'analyse du point de vue narratif est maîtrisée, y compris
+sur des récits à la première personne. »
+
+Priorité : « Nous travaillerons l'accord du participe passé avec le complément
+d'objet antéposé, exercice directement évalué à l'épreuve de réécriture. »
+
+Étape suivante : « Voir les offres et tarifs »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Votre enfant ne maîtrise pas les accords, ce qui lui coûtera des points au
+brevet. Notre stage garantit une progression mesurable. »
+
+Une priorité formulée comme un manque, un pronostic chiffré implicite, une
+promesse de résultat.

--- a/content/bilans/prompts/entree-troisieme-francais-v1/pre-analysis.md
+++ b/content/bilans/prompts/entree-troisieme-francais-v1/pre-analysis.md
@@ -29,8 +29,19 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack :
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Réponse libre : « j'ai du mal à comprendre les textes anciens ».
+
+  synthese       : « L'élève déclare une difficulté de compréhension sur les
+                     textes anciens. »
+  forces_percues : []
+  craintes       : ["textes anciens"]
+
+Aucune extension à la compréhension en général : l'élève a nommé un type de
+texte, pas une compétence.
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« L'élève a des difficultés de compréhension écrite, sans doute liées à un
+vocabulaire insuffisant. »
+
+Une difficulté ciblée devient générale, et une cause lexicale est inventée.

--- a/content/bilans/prompts/entree-troisieme-francais-v1/verifier.md
+++ b/content/bilans/prompts/entree-troisieme-francais-v1/verifier.md
@@ -35,8 +35,14 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Violation détectée. Bilan PARENTS, champ priorites, premier élément : « ne
+maîtrise pas les accords » formule une priorité comme un manque de l'élève. Le
+prompt impose une formulation en contenu de séance.
+
+Contrôle des domaines : trois domaines évalués, trois représentés. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« La formulation pourrait être plus positive. »
+
+Un avis de style, non une vérification.

--- a/content/bilans/prompts/entree-troisieme-maths-v1/eleve.md
+++ b/content/bilans/prompts/entree-troisieme-maths-v1/eleve.md
@@ -34,8 +34,19 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `accroc
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Force : « Tu résous une équation du premier degré et tu vérifies ton résultat
+en le remplaçant dans l'équation de départ. »
+
+Priorité : « La conversion d'une durée en heures décimales : une heure trente
+vaut 1,5 heure et non 1,30. Ce point a l'air acquis mais il ne l'est pas
+encore, et il fausse tout un calcul de vitesse. »
+
+Micro-plan : « Convertir dix durées en heures décimales, puis calculer une
+vitesse moyenne — 15 minutes. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Tu as raté la moitié des questions. Tu confonds les durées et tu étais sûr de
+toi. Le brevet va être difficile si tu ne travailles pas. »
+
+Un score déguisé, la formulation interdite, un pronostic anxiogène.

--- a/content/bilans/prompts/entree-troisieme-maths-v1/nexus.md
+++ b/content/bilans/prompts/entree-troisieme-maths-v1/nexus.md
@@ -33,8 +33,18 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Nœud proportionnalite.grandeurs-composees en erreur confiante : score 0,0,
+confiance 4. L'élève convertit une heure trente en 1,30 sans hésiter.
+
+Pythagore en maîtrise, score 100,0, y compris la réciproque : temps rendu.
+Triangles semblables en lacune consciente, score 25,0, confiance 1 :
+enseignement direct nécessaire, l'élève sait qu'il ne sait pas.
+
+Indice de calibration 55,6. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Niveau brevet non atteint. Redoublement à envisager. »
+
+Un pronostic d'orientation qu'un positionnement de dix-huit items ne peut pas
+fonder.

--- a/content/bilans/prompts/entree-troisieme-maths-v1/parents.md
+++ b/content/bilans/prompts/entree-troisieme-maths-v1/parents.md
@@ -41,8 +41,19 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack : `cadre`
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Point d'appui : « La résolution d'équations est solide, et l'habitude de
+vérifier le résultat est installée. »
+
+Priorité : « Nous reprendrons les grandeurs composées, en particulier la
+conversion des durées, par des calculs courts en situation. »
+
+Cadre : « Ce bilan est un positionnement. Il ne préjuge pas des résultats au
+brevet. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Votre enfant risque d'échouer au brevet s'il ne comble pas ses lacunes. Notre
+stage couvrira Pythagore, Thalès et les statistiques, et sécurisera son
+examen. »
+
+Un ressort anxiogène, un pronostic, un programme annoncé, une promesse.

--- a/content/bilans/prompts/entree-troisieme-maths-v1/pre-analysis.md
+++ b/content/bilans/prompts/entree-troisieme-maths-v1/pre-analysis.md
@@ -29,8 +29,16 @@ Tu produis uniquement un objet JSON strict conforme au schéma du pack :
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+Réponse libre : « le brevet me stresse et je n'ai jamais compris Thalès ».
+
+  synthese       : « L'élève exprime une appréhension liée au brevet et
+                     identifie le théorème de Thalès comme non compris. »
+  forces_percues : []
+  craintes       : ["brevet", "théorème de Thalès"]
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« L'élève est anxieux, ce qui l'empêche de comprendre la géométrie. Le stress
+explique probablement ses difficultés sur Thalès. »
+
+Un état émotionnel est transformé en cause de difficulté cognitive.

--- a/content/bilans/prompts/entree-troisieme-maths-v1/verifier.md
+++ b/content/bilans/prompts/entree-troisieme-maths-v1/verifier.md
@@ -35,8 +35,17 @@ Aucune clé supplémentaire et aucun texte autour.
 
 ### Bonne formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Violation détectée. Bilan PARENTS, champ cadre : la phrase « risque d'échouer
+au brevet » constitue un pronostic et un ressort anxiogène. Deux règles
+enfreintes.
+
+Violation détectée. Bilan ELEVE, champ accroche : contient « la moitié des
+questions ». Règle V2.
+
+Aucune autre violation. »
 
 ### Mauvaise formulation
 
-À COMPLÉTER PAR LE RESPONSABLE PÉDAGOGIQUE
+« Deux problèmes détectés, à corriger. »
+
+Aucun champ, aucune règle, aucune citation. Inexploitable.

--- a/content/bilans/prompts/remplacer_exemples_prompts.py
+++ b/content/bilans/prompts/remplacer_exemples_prompts.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Remplace les exemples terminaux des prompts Markdown à partir du catalogue.
+
+Le fichier EXEMPLES-PROMPTS-TOUS-NIVEAUX.md est l'unique source de vérité.
+Seuls les packs et fichiers explicitement décrits dans ce catalogue sont
+traités. Sans option, le script effectue une simulation. Utiliser --apply pour
+écrire les modifications.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import stat
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NoReturn
+
+
+SOURCE_DEFAULT = "EXEMPLES-PROMPTS-TOUS-NIVEAUX.md"
+TARGET_HEADING = "## Exemples à compléter par le responsable pédagogique"
+EXPECTED_PROMPTS = (
+    "pre-analysis.md",
+    "eleve.md",
+    "parents.md",
+    "nexus.md",
+    "verifier.md",
+)
+
+PACK_RE = re.compile(
+    r"^PACK\s+(?P<number>\d+)\s+[—-]\s+"
+    r"(?P<pack>[A-Za-z0-9][A-Za-z0-9._-]*)\s*$"
+)
+PROMPT_RE = re.compile(
+    r"^\d+\.\d+\s+[·•]\s+"
+    r"(?P<filename>pre-analysis|eleve|parents|nexus|verifier)\.md\s*$"
+)
+SEPARATOR_RE = re.compile(r"^[─═]{10,}$")
+H2_RE = re.compile(r"(?m)^##\s+")
+
+
+class ValidationError(Exception):
+    """Erreur de structure détectée avant toute écriture."""
+
+
+@dataclass(frozen=True)
+class TextDocument:
+    """Texte normalisé et informations nécessaires à sa restitution fidèle."""
+
+    text: str
+    newline: str
+    has_bom: bool
+
+
+@dataclass(frozen=True)
+class PlannedChange:
+    path: Path
+    original: bytes
+    updated: bytes
+    changed: bool
+
+
+def fail(message: str) -> NoReturn:
+    raise ValidationError(message)
+
+
+def decode_document(path: Path) -> TextDocument:
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        fail(f"lecture impossible de {path}: {exc}")
+
+    has_bom = raw.startswith(b"\xef\xbb\xbf")
+    payload = raw[3:] if has_bom else raw
+    try:
+        text = payload.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        fail(f"{path} n'est pas un fichier UTF-8 valide: {exc}")
+
+    crlf_count = text.count("\r\n")
+    without_crlf = text.replace("\r\n", "")
+    lf_count = without_crlf.count("\n")
+    cr_count = without_crlf.count("\r")
+    styles = sum(count > 0 for count in (crlf_count, lf_count, cr_count))
+    if styles > 1:
+        fail(f"fins de ligne mixtes dans {path}; correction manuelle requise")
+
+    newline = "\r\n" if crlf_count else ("\r" if cr_count else "\n")
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    return TextDocument(normalized, newline, has_bom)
+
+
+def encode_document(document: TextDocument, normalized_text: str) -> bytes:
+    text = normalized_text.replace("\n", document.newline)
+    payload = text.encode("utf-8")
+    return (b"\xef\xbb\xbf" + payload) if document.has_bom else payload
+
+
+def trim_catalogue_tail(lines: list[str]) -> list[str]:
+    """Retire uniquement les séparateurs placés entre deux entrées du catalogue."""
+
+    end = len(lines)
+    while end > 0 and (not lines[end - 1].strip() or SEPARATOR_RE.fullmatch(lines[end - 1])):
+        end -= 1
+    return lines[:end]
+
+
+def parse_catalogue(source: Path) -> dict[tuple[str, str], str]:
+    document = decode_document(source)
+    lines = document.text.splitlines()
+    pack_positions = [index for index, line in enumerate(lines) if PACK_RE.fullmatch(line)]
+    if not pack_positions:
+        fail(f"aucun en-tête PACK reconnu dans {source}")
+
+    mappings: dict[tuple[str, str], str] = {}
+    seen_packs: set[str] = set()
+
+    for pack_order, pack_start in enumerate(pack_positions):
+        pack_match = PACK_RE.fullmatch(lines[pack_start])
+        assert pack_match is not None
+        pack_name = pack_match.group("pack")
+        if pack_name in seen_packs:
+            fail(f"pack dupliqué dans le catalogue: {pack_name}")
+        seen_packs.add(pack_name)
+
+        pack_end = (
+            pack_positions[pack_order + 1]
+            if pack_order + 1 < len(pack_positions)
+            else len(lines)
+        )
+        prompt_positions = [
+            index
+            for index in range(pack_start + 1, pack_end)
+            if PROMPT_RE.fullmatch(lines[index])
+        ]
+        prompt_names = []
+
+        for prompt_order, prompt_start in enumerate(prompt_positions):
+            prompt_match = PROMPT_RE.fullmatch(lines[prompt_start])
+            assert prompt_match is not None
+            filename = prompt_match.group("filename") + ".md"
+            prompt_names.append(filename)
+
+            prompt_end = (
+                prompt_positions[prompt_order + 1]
+                if prompt_order + 1 < len(prompt_positions)
+                else pack_end
+            )
+            section = trim_catalogue_tail(lines[prompt_start + 1 : prompt_end])
+
+            good_positions = [
+                index for index, line in enumerate(section)
+                if line == "### Bonne formulation"
+            ]
+            bad_positions = [
+                index for index, line in enumerate(section)
+                if line == "### Mauvaise formulation"
+            ]
+            if len(good_positions) != 1 or len(bad_positions) != 1:
+                fail(
+                    f"{pack_name}/{filename}: exactement un titre Bonne et un titre "
+                    "Mauvaise sont requis"
+                )
+            if good_positions[0] >= bad_positions[0]:
+                fail(f"{pack_name}/{filename}: ordre Bonne/Mauvaise invalide")
+
+            block_lines = section[good_positions[0] :]
+            block = "\n".join(block_lines).strip("\n")
+            good_body = section[good_positions[0] + 1 : bad_positions[0]]
+            bad_body = section[bad_positions[0] + 1 :]
+            if not any(line.strip() for line in good_body):
+                fail(f"{pack_name}/{filename}: exemple Bonne vide")
+            if not any(line.strip() for line in bad_body):
+                fail(f"{pack_name}/{filename}: exemple Mauvaise vide")
+
+            key = (pack_name, filename)
+            if key in mappings:
+                fail(f"entrée dupliquée dans le catalogue: {pack_name}/{filename}")
+            mappings[key] = block
+
+        if tuple(prompt_names) != EXPECTED_PROMPTS:
+            fail(
+                f"{pack_name}: fichiers attendus dans cet ordre: "
+                f"{', '.join(EXPECTED_PROMPTS)}; trouvés: "
+                f"{', '.join(prompt_names) or 'aucun'}"
+            )
+
+    expected_count = len(seen_packs) * len(EXPECTED_PROMPTS)
+    if len(mappings) != expected_count:
+        fail(
+            f"catalogue incohérent: {len(mappings)} blocs trouvés, "
+            f"{expected_count} attendus"
+        )
+    return mappings
+
+
+def replace_terminal_section(path: Path, block: str) -> PlannedChange:
+    document = decode_document(path)
+    heading_pattern = re.compile(
+        rf"(?m)^{re.escape(TARGET_HEADING)}[ \t]*\n"
+    )
+    matches = list(heading_pattern.finditer(document.text))
+    if len(matches) != 1:
+        fail(
+            f"{path}: exactement une section « {TARGET_HEADING} » est requise "
+            f"({len(matches)} trouvée(s))"
+        )
+
+    match = matches[0]
+    current_suffix = document.text[match.end() :]
+    if H2_RE.search(current_suffix):
+        fail(f"{path}: la section d'exemples n'est pas la dernière section de niveau 2")
+
+    if current_suffix.count("### Bonne formulation") != 1:
+        fail(f"{path}: titre « Bonne formulation » absent ou dupliqué")
+    if current_suffix.count("### Mauvaise formulation") != 1:
+        fail(f"{path}: titre « Mauvaise formulation » absent ou dupliqué")
+
+    updated_text = document.text[: match.end()] + "\n" + block.rstrip() + "\n"
+    original_bytes = path.read_bytes()
+    updated_bytes = encode_document(document, updated_text)
+    return PlannedChange(path, original_bytes, updated_bytes, original_bytes != updated_bytes)
+
+
+def validate_target_path(root: Path, pack_name: str, filename: str) -> Path:
+    target = root / pack_name / filename
+    if not target.exists():
+        fail(f"fichier cible manquant: {target}")
+    if not target.is_file():
+        fail(f"la cible n'est pas un fichier ordinaire: {target}")
+    try:
+        target.resolve(strict=True).relative_to(root.resolve(strict=True))
+    except ValueError:
+        fail(f"la cible sort du dossier racine via un lien symbolique: {target}")
+    return target
+
+
+def find_uncovered_pack_directories(root: Path, covered: set[str]) -> list[str]:
+    uncovered = []
+    try:
+        children = sorted(root.iterdir(), key=lambda path: path.name)
+    except OSError as exc:
+        fail(f"lecture impossible du dossier {root}: {exc}")
+
+    for child in children:
+        if not child.is_dir() or child.name in covered:
+            continue
+        if all((child / filename).is_file() for filename in EXPECTED_PROMPTS):
+            uncovered.append(child.name)
+    return uncovered
+
+
+def atomic_write(path: Path, content: bytes) -> None:
+    mode = stat.S_IMODE(path.stat().st_mode)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            temporary.unlink(missing_ok=True)
+        finally:
+            raise
+
+
+def apply_with_rollback(changes: list[PlannedChange]) -> None:
+    written: list[PlannedChange] = []
+    try:
+        for change in changes:
+            atomic_write(change.path, change.updated)
+            written.append(change)
+    except Exception as exc:
+        rollback_errors = []
+        for change in reversed(written):
+            try:
+                atomic_write(change.path, change.original)
+            except Exception as rollback_exc:  # situation exceptionnelle à signaler
+                rollback_errors.append(f"{change.path}: {rollback_exc}")
+        detail = f"écriture interrompue; retour arrière effectué: {exc}"
+        if rollback_errors:
+            detail += "; échec partiel du retour arrière: " + " | ".join(rollback_errors)
+        fail(detail)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Injecte dans les prompts Markdown les exemples définis dans "
+            f"{SOURCE_DEFAULT}."
+        )
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="dossier prompts (défaut: dossier courant)",
+    )
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=Path(SOURCE_DEFAULT),
+        help=(
+            "catalogue source; un chemin relatif est résolu depuis --root "
+            f"(défaut: {SOURCE_DEFAULT})"
+        ),
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--apply",
+        action="store_true",
+        help="écrit réellement les fichiers (sinon: simulation)",
+    )
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help="n'écrit rien et renvoie le code 1 si des fichiers diffèrent",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="affiche le chemin de chaque fichier qui serait ou a été modifié",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    root = args.root.expanduser().resolve()
+    source_argument = args.source.expanduser()
+    source = source_argument if source_argument.is_absolute() else root / source_argument
+
+    if not root.is_dir():
+        fail(f"dossier racine introuvable: {root}")
+    if not source.is_file():
+        fail(f"catalogue source introuvable: {source}")
+
+    mappings = parse_catalogue(source)
+    covered_packs = {pack for pack, _ in mappings}
+    uncovered = find_uncovered_pack_directories(root, covered_packs)
+
+    plan = []
+    for (pack_name, filename), block in mappings.items():
+        target = validate_target_path(root, pack_name, filename)
+        plan.append(replace_terminal_section(target, block))
+
+    changed = [change for change in plan if change.changed]
+
+    print(
+        f"Catalogue validé : {len(covered_packs)} pack(s), "
+        f"{len(mappings)} bloc(s) d'exemples."
+    )
+    print(f"Fichiers déjà conformes : {len(plan) - len(changed)}.")
+    print(f"Fichiers à modifier : {len(changed)}.")
+    if uncovered:
+        print(
+            "Répertoires de prompts non couverts par le catalogue et ignorés : "
+            + ", ".join(uncovered)
+            + "."
+        )
+
+    if args.list:
+        for change in changed:
+            print(f"  - {change.path.relative_to(root)}")
+
+    if args.check:
+        if changed:
+            print("Contrôle négatif : certains fichiers ne correspondent pas au catalogue.")
+            return 1
+        print("Contrôle positif : tous les fichiers couverts sont conformes.")
+        return 0
+
+    if not args.apply:
+        print("Simulation uniquement. Relancez avec --apply pour écrire les changements.")
+        return 0
+
+    apply_with_rollback(changed)
+    print(f"Mise à jour terminée : {len(changed)} fichier(s) modifié(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ValidationError as exc:
+        print(f"ERREUR : {exc}", file=sys.stderr)
+        raise SystemExit(2)


### PR DESCRIPTION
## Objet

Compléter les exemples pédagogiques des prompts de bilan pour les 15 packs
couverts par le catalogue.

## Modifications

- remplacement des 150 marqueurs pédagogiques dans 75 prompts ;
- ajout du catalogue source `EXEMPLES-PROMPTS-TOUS-NIVEAUX.md` ;
- ajout du script reproductible `remplacer_exemples_prompts.py` ;
- conservation hors périmètre des deux packs Seconde et du pack historique
  `maths-terminale-bilan-v1`.

## Vérifications

- 15 packs et 75 blocs validés ;
- 75 fichiers conformes après application ;
- `git diff --check` sans erreur ;
- analyse des secrets réussie.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ajoute des exemples pédagogiques complets aux prompts de bilans sur 15 packs (75 prompts) pour uniformiser les formulations et éviter les interdits. Introduit un catalogue source unique et un script pour appliquer ces exemples de façon reproductible.

- **New Features**
  - Remplacement des marqueurs pédagogiques dans tous les prompts concernés.
  - Ajout de `EXEMPLES-PROMPTS-TOUS-NIVEAUX.md` comme source de vérité.
  - Ajout de `remplacer_exemples_prompts.py` (simulation par défaut, `--apply` pour écrire ; traite uniquement les packs/fichiers listés).
  - Hors périmètre : packs Seconde et `maths-terminale-bilan-v1`.

- **Migration**
  - Mettre à jour le catalogue puis lancer `python3 content/bilans/prompts/remplacer_exemples_prompts.py` pour une simulation.
  - Utiliser `--apply` pour écrire les modifications.

<sup>Written for commit 8d24a44bc7ddf32cafdb604a4ad12b14956f52e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

