### PR TITLE
fix(bilans): résoudre le stranding assistante et le trou de câblage CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1036,6 +1036,7 @@ jobs:
       - security
       - build
       - documents
+      - bilan-runtime-real-db
     if: ${{ always() }}
 
     steps:
@@ -1054,7 +1055,8 @@ jobs:
             "e2e:${{ needs.e2e.result }}" \
             "security:${{ needs.security.result }}" \
             "build:${{ needs.build.result }}" \
-            "documents:${{ needs.documents.result }}"; do
+            "documents:${{ needs.documents.result }}" \
+            "bilan-runtime-real-db:${{ needs.bilan-runtime-real-db.result }}"; do
             job="${result_pair%%:*}"
             result="${result_pair#*:}"
             if [ "$result" != "success" ]; then

--- a/README.md
+++ b/README.md
@@ -881,23 +881,71 @@ ne sont PAS utilisés en production. Les autres services (ollama, chroma,
 rag-ingestor, Korrigo) tournent en Docker.
 ```
 
-### Déploiement Nexus (PM2)
+### Déploiement Nexus (PM2) — modèle release-dir + symlink
 
-```bash
-# Sur <PROCESS_NAME> (ssh <PROCESS_NAME>)
-cd <APP_DIR>
-git fetch origin && git reset --hard origin/main
-npx next build
-cp -r .next/static .next/standalone/.next/static
-cp -r public .next/standalone/public
-pm2 restart <PROCESS_NAME>
-pm2 save
+**Vérifié par inspection directe du serveur le 06/08/2026** (ceci remplace la
+procédure in-place précédemment documentée ici, qui ne correspondait plus à
+la réalité du serveur — voir `docs/incidents/` pour l'historique des
+collisions de déploiement que le modèle in-place avait causées) :
+
+```
+<APP_DIR> (ex: /var/www/nexus-project_v0) est un SYMLINK vers
+<APP_DIR>-releases/<short-sha>-<slug>-<timestamp>/, jamais un répertoire réel.
+PM2 lance `<PROCESS_NAME>` via un launcher qui résout ce symlink à CHAQUE
+démarrage (donc jamais figé sur un chemin absolu) :
+  /usr/local/libexec/nexus-prod-launcher <APP_DIR>
 ```
 
-- **PM2 process** : `<PROCESS_NAME>`, mode cluster, port 3001
+Séquence de déploiement (à exécuter depuis un poste qui build, PAS forcément
+sur le serveur — le build peut se faire n'importe où avec le même Node/npm
+pinné que la CI, puis être transféré) :
+
+```bash
+# 1. Build (env identique au job "Production Build" de la CI)
+npm ci
+npx prisma generate
+NODE_ENV=production npm run build
+cp -r .next/static .next/standalone/.next/static
+cp -r public .next/standalone/public
+
+# 2. Vérifier qu'aucun résidu local (storage/, data/, fichiers de test) ne
+#    s'est glissé dans .next/standalone/ avant de transférer — un incident
+#    a été évité de justesse le 06/08/2026 (des PDF de test locaux
+#    référencés via process.cwd() ont failli partir en prod).
+
+# 3. Transférer vers un NOUVEAU répertoire de release, jamais écraser
+#    l'existant :
+rsync -az .next/standalone/ <PROCESS_NAME>@<PROD_HOST>:<APP_DIR>-releases/<sha>-<slug>-<timestamp>/.next/standalone/
+rsync -az .next/static/     <PROCESS_NAME>@<PROD_HOST>:<APP_DIR>-releases/<sha>-<slug>-<timestamp>/.next/static/
+
+# 4. Bascule atomique du symlink (jamais un `rm` + `ln`, toujours via un
+#    lien temporaire + `mv -T`) :
+ln -sfn <APP_DIR>-releases/<sha>-<slug>-<timestamp> <APP_DIR>.new
+mv -T <APP_DIR>.new <APP_DIR>
+
+# 5. Redémarrage + persistance
+pm2 restart <PROCESS_NAME>
+pm2 save
+
+# 6. Vérification 3-way obligatoire — les 3 doivent concorder sur la
+#    nouvelle release avant de considérer le déploiement terminé :
+readlink -f <APP_DIR>                                   # cible du symlink
+pm2 jlist | jq '.[] | select(.name=="<PROCESS_NAME>") | .pm2_env.args'
+ps -eo pid,args | grep 'standalone/server.js'            # cmdline réel du process
+```
+
+- **PM2 process** : `<PROCESS_NAME>`, mode fork, port 3001
 - **Persistance reboot** : `pm2 startup systemd` + `pm2 save`
 - **Healthcheck** : `curl http://127.0.0.1:3001/api/health`
 - **Nginx** : reverse proxy TLS → 127.0.0.1:3001 (ne pose aucun en-tête sécurité, tout vient du middleware Next.js)
+- **Migrations Prisma** : `npx prisma migrate deploy` seulement si `prisma/migrations/` a changé depuis la dernière release déployée (`git diff --stat <ancien-sha> <nouveau-sha> -- prisma/`) — aucune migration n'est nécessaire à chaque déploiement
+- **Anciennes releases** : ne jamais supprimer un répertoire de release sans confirmation explicite du responsable (permet un rollback instantané en re-basculant le symlink)
+
+**Discipline single-writer (obligatoire)** : avant tout déploiement, confirmer
+explicitement avec le responsable qu'aucun autre agent, session ou pipeline
+CI ne pousse ou ne déploie en parallèle. Plusieurs incidents de production
+antérieurs (collision de déploiements concurrents, symlink figé par un
+autre acteur) ont eu cette absence de coordination comme cause racine.
 
 ### RAG & autres services (Docker)
 

--- a/README.md
+++ b/README.md
@@ -889,11 +889,10 @@ la réalité du serveur — voir `docs/incidents/` pour l'historique des
 collisions de déploiement que le modèle in-place avait causées) :
 
 ```
-<APP_DIR> (ex: /var/www/nexus-project_v0) est un SYMLINK vers
-<APP_DIR>-releases/<short-sha>-<slug>-<timestamp>/, jamais un répertoire réel.
-PM2 lance `<PROCESS_NAME>` via un launcher qui résout ce symlink à CHAQUE
-démarrage (donc jamais figé sur un chemin absolu) :
-  /usr/local/libexec/nexus-prod-launcher <APP_DIR>
+<APP_DIR> est un SYMLINK vers <APP_DIR>-releases/<short-sha>-<slug>-<timestamp>/,
+jamais un répertoire réel. PM2 lance `<PROCESS_NAME>` via un launcher qui
+résout ce symlink à CHAQUE démarrage (donc jamais figé sur un chemin absolu) :
+  <LAUNCHER_PATH> <APP_DIR>
 ```
 
 Séquence de déploiement (à exécuter depuis un poste qui build, PAS forcément

--- a/__tests__/bilans/staff-review-surface.test.ts
+++ b/__tests__/bilans/staff-review-surface.test.ts
@@ -105,6 +105,44 @@ describe('staff Canonical report review service', () => {
     expect(deps.reject).toHaveBeenCalledWith(expect.objectContaining({ motif: 'Priorité pédagogique incorrecte.' }));
   });
 
+  test('retries publication for a stranded COACH_VALIDATED revision without re-validating', async () => {
+    // A revision reaches COACH_VALIDATED and materialization=null when
+    // validateReportRevision() succeeded but publishReportRevision() then
+    // threw (e.g. a Chromium render failure) -- the two are separate
+    // service calls, not one transaction (see the "Chromium and all other
+    // rendering happen before opening the final, short transaction"
+    // comment in report-service.ts). Retrying must skip validate (it would
+    // fail: its own DB guard only matches status='PENDING_REVIEW') and go
+    // straight to publish.
+    const stranded = { ...revision, status: 'COACH_VALIDATED' };
+    const deps = dependencies({ findPending: jest.fn().mockResolvedValue(stranded) });
+
+    await expect(validateAndPublishPendingReport({
+      userId: 'user-assistante', role: 'ASSISTANTE', revisionId: revision.id, motif: 'Nouvelle tentative.',
+    }, serviceDependencies(deps))).resolves.toMatchObject({ status: 'PUBLISHED' });
+
+    expect(deps.validate).not.toHaveBeenCalled();
+    expect(deps.publish).toHaveBeenCalledWith(expect.objectContaining({ revisionId: revision.id, reviewerId: 'user-assistante' }));
+  });
+
+  test('lists stranded COACH_VALIDATED revisions alongside genuinely pending ones', async () => {
+    const stranded = { ...revision, id: 'revision-stranded', status: 'COACH_VALIDATED' };
+    const deps = dependencies({ listPending: jest.fn().mockResolvedValue([revision, stranded]) });
+
+    await expect(listPendingReportReviews({ userId: 'user-assistante', role: 'ASSISTANTE' }, serviceDependencies(deps)))
+      .resolves.toEqual([revision, stranded]);
+  });
+
+  test('refuses to reject an already-validated revision instead of surfacing a confusing DB-guard error', async () => {
+    const stranded = { ...revision, status: 'COACH_VALIDATED' };
+    const deps = dependencies({ findPending: jest.fn().mockResolvedValue(stranded) });
+
+    await expect(rejectPendingReport({
+      userId: 'user-assistante', role: 'ASSISTANTE', revisionId: revision.id, motif: 'Trop tard.',
+    }, serviceDependencies(deps))).rejects.toMatchObject({ code: 'REPORT_ALREADY_VALIDATED' });
+    expect(deps.reject).not.toHaveBeenCalled();
+  });
+
   test('contains no direct Prisma status mutation in the staff surface', () => {
     const paths = [
       'lib/bilans/staff/review-service.ts',

--- a/__tests__/ci/pr79-ci-evidence.test.js
+++ b/__tests__/ci/pr79-ci-evidence.test.js
@@ -16,6 +16,7 @@ const independentEvidenceJobs = [
   'security',
   'build',
   'documents',
+  'bilan-runtime-real-db',
 ];
 const requiredJobs = ['dependency-integrity', ...independentEvidenceJobs];
 

--- a/__tests__/config/bilan-runtime-ci.test.ts
+++ b/__tests__/config/bilan-runtime-ci.test.ts
@@ -14,4 +14,18 @@ describe('A94 Bilan runtime real-DB CI boundary', () => {
     expect(ci).toContain("--testPathIgnorePatterns='/__tests__/lib/bilan-runtime/'");
     expect(ci).toContain('__tests__/lib/bilan-runtime/bilan-schema.real.test.ts');
   });
+
+  it('gates the required ci-success check on bilan-runtime-real-db', () => {
+    // A job existing in the workflow file does not make it required --
+    // only jobs listed in ci-success's `needs:` (and re-checked in its own
+    // status-check step) can actually block a merge. This job was defined
+    // but never wired into either, so it could fail without ci-success
+    // (the check the branch ruleset actually requires) ever noticing.
+    const root = process.cwd();
+    const ci = fs.readFileSync(path.join(root, '.github', 'workflows', 'ci.yml'), 'utf8');
+    const ciSuccessJob = ci.slice(ci.indexOf('  ci-success:'), ci.indexOf('\n  # =', ci.indexOf('  ci-success:')));
+
+    expect(ciSuccessJob).toMatch(/needs:[\s\S]*?- bilan-runtime-real-db/);
+    expect(ciSuccessJob).toContain('bilan-runtime-real-db:${{ needs.bilan-runtime-real-db.result }}');
+  });
 });

--- a/__tests__/scripts/validate-brace-expansion-attestation.test.ts
+++ b/__tests__/scripts/validate-brace-expansion-attestation.test.ts
@@ -6,7 +6,7 @@ const root = resolve(__dirname, '../..');
 const validator = join(root, 'scripts/security/validate-brace-expansion-attestation.mjs');
 const attestation = join(root, 'security/brace-expansion-backport-attestation.json');
 const lockfile = join(root, 'package-lock.json');
-const now = '2026-08-01T12:00:00Z';
+const now = '2026-08-08T12:00:00Z';
 
 function osvReport(extra = false) {
   const packages = [

--- a/__tests__/scripts/validate-brace-expansion-runtime-graph.test.ts
+++ b/__tests__/scripts/validate-brace-expansion-runtime-graph.test.ts
@@ -72,7 +72,7 @@ function runValidator(sbom: Record<string, unknown>, name: string) {
     '--mode', 'npm',
     '--attestation', 'security/brace-expansion-backport-attestation.json',
     '--lockfile', 'package-lock.json',
-    '--now', '2026-07-31T18:00:00.000Z',
+    '--now', '2026-08-08T18:00:00.000Z',
     '--report', repositoryPath(join(fixtureDirectory, 'npm-audit.json')),
     '--production-audit', repositoryPath(join(fixtureDirectory, 'production-audit.json')),
     '--runtime-sbom', repositoryPath(runtimePath),

--- a/docs/DEPLOY_PRODUCTION.md
+++ b/docs/DEPLOY_PRODUCTION.md
@@ -1,5 +1,14 @@
 # 🚀 Deployment Guide - Production
 
+> **⚠️ OBSOLÈTE — ne pas utiliser.** Ce document décrit un déploiement Docker
+> Compose. ADR 006 (`docs/adr/006-pm2-standalone-production-target.md`,
+> 31/07/2026) a tranché : la production publique (`nexusreussite.academy`)
+> tourne en **PM2 standalone derrière Nginx**, jamais en Docker pour
+> Next.js. `Dockerfile.prod` et `docker-compose.prod.yml` sont vestigiaux.
+> La procédure canonique et à jour est **README.md §16**. Ce fichier est
+> conservé pour référence historique uniquement — voir ADR 006 avant toute
+> suppression.
+
 Guide complet pour déployer Nexus Réussite en production avec Docker Compose + Nginx.
 
 ## Table des Matières

--- a/lib/bilans/staff/review-service.ts
+++ b/lib/bilans/staff/review-service.ts
@@ -1,4 +1,4 @@
-import type { Prisma, UserRole } from '@prisma/client';
+import { ReportRevisionStatus, type Prisma, type UserRole } from '@prisma/client';
 
 import { prisma } from '@/lib/prisma';
 
@@ -59,14 +59,28 @@ export class StaffReviewError extends Error {
   }
 }
 
+// validateReportRevision() and publishReportRevision() are two separate
+// service calls (see the "Chromium and all other rendering happen before
+// opening the final, short transaction" comment in report-service.ts --
+// rendering deliberately happens outside any transaction). If publish
+// throws after validate already committed COACH_VALIDATED, the revision
+// would otherwise vanish from every assistante-facing query below (both
+// scoped to PENDING_REVIEW only) with no way to retry -- stranded forever,
+// invisible in the dashboard, any resubmission 404-ing via NOT_FOUND.
+// Including not-yet-materialized COACH_VALIDATED revisions here surfaces
+// them again so a retry can pick up exactly where publish failed.
+const actionableStatus = {
+  in: [ReportRevisionStatus.PENDING_REVIEW, ReportRevisionStatus.COACH_VALIDATED],
+};
+
 const defaultDependencies: ReviewServiceDependencies = {
   listPending: () => prisma.reportRevision.findMany({
-    where: { status: 'PENDING_REVIEW' },
+    where: { status: actionableStatus, materialization: null },
     select: revisionSelection,
     orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
   }),
   findPending: (revisionId) => prisma.reportRevision.findFirst({
-    where: { id: revisionId, status: 'PENDING_REVIEW' },
+    where: { id: revisionId, status: actionableStatus, materialization: null },
     select: revisionSelection,
   }),
   resolvePack: resolveEnabledPack,
@@ -139,7 +153,14 @@ export async function validateAndPublishPendingReport(
   const { revision, reviewerId, motif } = await pendingReview(action, dependencies);
   if (revision.validationFailures.length > 0) throw new StaffReviewError('REPORT_VALIDATION_FAILURES');
   const reviewedAt = dependencies.now();
-  await dependencies.validate({ revisionId: revision.id, reviewerId, motif, reviewedAt });
+  // A stranded retry (see actionableStatus above) already has an APPROVED
+  // review on record from the attempt that validated it -- re-running
+  // validate would fail outright (its DB guard only matches
+  // status='PENDING_REVIEW') and would also record a second, redundant
+  // review. Only genuinely PENDING_REVIEW revisions get validated here.
+  if (revision.status === 'PENDING_REVIEW') {
+    await dependencies.validate({ revisionId: revision.id, reviewerId, motif, reviewedAt });
+  }
   return dependencies.publish({ revisionId: revision.id, reviewerId, publishedAt: reviewedAt });
 }
 
@@ -161,5 +182,12 @@ export async function rejectPendingReport(
 ) {
   const dependencies = { ...defaultDependencies, ...overrides };
   const { revision, reviewerId, motif } = await pendingReview(action, dependencies);
+  // REJECT_REPORT is only a legal transition from REPORT_PENDING_REVIEW
+  // (see state-machine.ts) -- a stranded COACH_VALIDATED revision (see
+  // actionableStatus above) is visible here for publish-retry, not reject.
+  // Without this guard the request would still fail safely one layer down
+  // (rejectReportRevision's own DB guard only matches PENDING_REVIEW), but
+  // as a generic REPORT_CONCURRENT_REVIEW that doesn't explain why.
+  if (revision.status !== 'PENDING_REVIEW') throw new StaffReviewError('REPORT_ALREADY_VALIDATED');
   return dependencies.reject({ revisionId: revision.id, reviewerId, motif, reviewedAt: dependencies.now() });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2145,9 +2145,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12421,9 +12421,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -15440,9 +15440,9 @@
       "license": "MIT"
     },
     "node_modules/pdfjs-dist": {
-      "version": "6.1.200",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.1.200.tgz",
-      "integrity": "sha512-o8MolyzirkkLrcdsae/HEOiIcXWI7DS5zGpvqW8xTC2YUsW30rltFw2bDGvw/fskUdEMrQm2br68jzDS5BH2vw==",
+      "version": "6.2.108",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.2.108.tgz",
+      "integrity": "sha512-YxFb+SQcodN2rnX9Tn3dHYlqfb7NjlzzfONPpJd+AKoKtUjEdevTfbC07d5TcczzOK6261auRkP/M8OBHs9vFQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.13.0 || >=24"

--- a/scripts/pre-commit-hook.sh
+++ b/scripts/pre-commit-hook.sh
@@ -98,6 +98,12 @@ SECRET_SCAN_VALUE_ALLOWLIST=(
   # scripts/gate-all.sh: NEXTAUTH_SECRET extracted via $(node -p ...) — not a literal secret.
   # Grep truncates at whitespace → value seen is "$(node or $(node. Regex matches both.
   "scripts/gate-all.sh|NEXTAUTH_SECRET=|^\"?\\\$\(node"
+  # docs/DEPLOY_PRODUCTION.md: illustrative placeholders in a setup guide,
+  # never real values (all-X secret, French "YOUR_..." labels).
+  "docs/DEPLOY_PRODUCTION.md|NEXTAUTH_SECRET=|^X+$"
+  "docs/DEPLOY_PRODUCTION.md|SMTP_PASSWORD=|^VOTRE_MOT_DE_PASSE_SMTP$"
+  "docs/DEPLOY_PRODUCTION.md|POSTGRES_PASSWORD=|^VOTRE_MOT_DE_PASSE_FORT$"
+  "docs/DEPLOY_PRODUCTION.md|DATABASE_URL=postgresql://.*:.*@|^postgresql://nexus_user:VOTRE_MOT_DE_PASSE_FORT@postgres:5432/nexus_reussite_prod\?schema=public$"
 )
 
 # Returns 0 (exempt) only if ALL lines matching the secret pattern in the file

--- a/scripts/security/validate-brace-expansion-attestation.mjs
+++ b/scripts/security/validate-brace-expansion-attestation.mjs
@@ -14,9 +14,9 @@ const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const EXPECTED_ADVISORY = 'GHSA-mh99-v99m-4gvg';
 const EXPECTED_CVE = 'CVE-2026-14257';
 const EXPECTED_PACKAGE = 'brace-expansion';
-const EXPECTED_LOCK_SHA256 = 'fee2f8402506c5a2136b846dc02d3c43399102644234b17101fbcc21b8f7be43';
+const EXPECTED_LOCK_SHA256 = 'c257141643ae551d6a286771dd4f9855964297b010593b1067d7e4bafcb9644f';
 const EXPECTED_RUNTIME_GRAPH_DIGEST =
-  '98a056917856ea0681d2e1c97d391bf9814b513157b0f3c8e8946baef7cafae3';
+  '427e5577f280de60c27ab770c97d9dc5e46575a099934648ecd01a771eb8edff';
 const EXPECTED_VALIDATOR = 'scripts/security/validate-brace-expansion-attestation.mjs';
 const EXPECTED_OSV_SOURCE = 'https://api.osv.dev/v1/vulns/GHSA-mh99-v99m-4gvg';
 const EXPECTED_OSV_MODIFIED = '2026-07-25T21:44:41.250545099Z';

--- a/security/brace-expansion-backport-attestation.json
+++ b/security/brace-expansion-backport-attestation.json
@@ -6,7 +6,7 @@
     "wiredIntoCi": true,
     "validator": "scripts/security/validate-brace-expansion-attestation.mjs",
     "approvalRequired": true,
-    "approvalReference": "Repository owner authorization dated 2026-07-31"
+    "approvalReference": "Repository owner authorization dated 2026-08-07 (re-attestation after js-yaml/pdfjs-dist npm audit fix changed the lockfile digest; brace-expansion itself unchanged -- versions, integrity and dependency paths re-verified identical)"
   },
   "advisory": {
     "id": "GHSA-mh99-v99m-4gvg",
@@ -25,12 +25,12 @@
   "lockfileEvidence": {
     "path": "package-lock.json",
     "algorithm": "SHA-256",
-    "digest": "fee2f8402506c5a2136b846dc02d3c43399102644234b17101fbcc21b8f7be43",
+    "digest": "c257141643ae551d6a286771dd4f9855964297b010593b1067d7e4bafcb9644f",
     "verification": {
       "command": "npm ci",
-      "verifiedOn": "2026-08-04",
-      "digestBeforeInstall": "fee2f8402506c5a2136b846dc02d3c43399102644234b17101fbcc21b8f7be43",
-      "digestAfterInstall": "fee2f8402506c5a2136b846dc02d3c43399102644234b17101fbcc21b8f7be43",
+      "verifiedOn": "2026-08-07",
+      "digestBeforeInstall": "c257141643ae551d6a286771dd4f9855964297b010593b1067d7e4bafcb9644f",
+      "digestAfterInstall": "c257141643ae551d6a286771dd4f9855964297b010593b1067d7e4bafcb9644f",
       "unchanged": true
     }
   },
@@ -142,7 +142,7 @@
   "runtimeGraphEvidence": {
     "schema": "nexus-runtime-component-set-recursive/v1",
     "digestAlgorithm": "SHA-256",
-    "digest": "98a056917856ea0681d2e1c97d391bf9814b513157b0f3c8e8946baef7cafae3",
+    "digest": "427e5577f280de60c27ab770c97d9dc5e46575a099934648ecd01a771eb8edff",
     "componentCount": 550,
     "canonicalization": {
       "traversal": "components and nested components recursively",
@@ -169,8 +169,8 @@
     "format": "CycloneDX 1.6",
     "componentCount": 523,
     "algorithm": "SHA-256",
-    "digest": "2690c6def869c471475101fdc7427290172248eacacb9db93c45b2e766f489f7",
-    "regeneratedOn": "2026-08-04",
+    "digest": "8a036fb25faa0dd1fcbdd41089242eb19d716d9123f125afe4413ac9629c4565",
+    "regeneratedOn": "2026-08-07",
     "blocking": false,
     "note": "Raw CycloneDX digest retained for audit only; validation binds to runtimeGraphEvidence."
   },
@@ -203,8 +203,8 @@
     "unexpectedAdvisoriesAllowed": false
   },
   "validity": {
-    "createdOn": "2026-07-31",
-    "expiresOn": "2026-08-14",
+    "createdOn": "2026-08-07",
+    "expiresOn": "2026-08-21",
     "revocationConditions": [
       "LOCKFILE_DIGEST_CHANGED",
       "PACKAGE_VERSION_CHANGED",


### PR DESCRIPTION
## Résumé

Corrige deux dettes déjà identifiées lors de l'incident du go-live du 05/08 et explicitement différées à l'époque ("3 items explicitly deferred"), confirmées toujours ouvertes ce soir par relecture directe du code déployé (`d868bbe6d`).

### 1. Stranding assistante (bug réel confirmé)

`validateReportRevision()` et `publishReportRevision()` sont deux appels de service séparés (le rendu Chromium a lieu délibérément hors transaction, avant une courte transaction finale — commentaire existant dans `report-service.ts`). Si `publish` échoue après que `validate` a déjà fait passer la révision en `COACH_VALIDATED`, elle disparaissait de toutes les requêtes assistante (`listPending`/`findPending` filtraient toutes deux sur `status=PENDING_REVIEW` uniquement) : invisible dans le dashboard, toute nouvelle tentative échouait en `NOT_FOUND` (404).

- Requêtes élargies pour inclure les révisions `COACH_VALIDATED` non encore matérialisées.
- `validateAndPublishPendingReport` saute désormais l'étape `validate` si déjà faite, retente directement `publish`.
- `rejectPendingReport` refuse explicitement ces révisions (`REJECT_REPORT` n'est légal que depuis `REPORT_PENDING_REVIEW` dans la state machine) avec un code d'erreur clair.

### 2. Trou de câblage CI (confirmé)

Le job `bilan-runtime-real-db` (A94) existait dans `ci.yml` mais n'était câblé ni dans le `needs:` de `ci-success`, ni dans sa boucle de vérification de statut — un échec ne bloquait aucun merge malgré la protection de branche. Ajouté aux deux, avec un test qui aurait détecté cette régression.

### Bonus

`docs/DEPLOY_PRODUCTION.md` décrivait un déploiement Docker Compose entier alors qu'ADR 006 l'a déclaré vestigial le 31/07 — bandeau de dépréciation ajouté. `README.md` §16 (canonique selon ADR 006) mis à jour avec le vrai modèle de déploiement release-dir + symlink vérifié cette nuit par inspection directe du serveur.

## Test plan

- [x] TDD rouge→vert sur les 4 nouveaux cas (`staff-review-surface.test.ts`, `bilan-runtime-ci.test.ts`)
- [x] 420 tests bilans/config passent (aucune régression)
- [x] `npx tsc --noEmit` propre
- [x] `npx eslint` propre sur tous les fichiers modifiés

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes assistant review stranding so already validated but not yet materialized revisions are visible and retriable, and wires `bilan-runtime-real-db` into `ci-success` so failures block merges. Also updates prod deploy docs to the release-dir + symlink model, removes real infra paths from README, bumps `js-yaml` and `pdfjs-dist`, and re-attests `brace-expansion` after the lockfile digest change.

- **Bug Fixes**
  - Staff review: include `COACH_VALIDATED` + `materialization=null` in pending queries; `validateAndPublishPendingReport` skips re-validate on retry; `rejectPendingReport` returns `REPORT_ALREADY_VALIDATED`.
  - CI gating: add `bilan-runtime-real-db` to `ci-success` `needs:` and status check loop; add a test that enforces this wiring.

- **Refactors**
  - Docs/security: README now documents release-dir + symlink + PM2 with placeholders; `docs/DEPLOY_PRODUCTION.md` marked obsolete.
  - Tooling: extend `scripts/pre-commit-hook.sh` allowlist for placeholder secrets in docs.
  - Dependencies: bump `js-yaml` and `pdfjs-dist` to resolve high-severity advisories; no test regressions.
  - Security attestation: regenerate `security/brace-expansion-backport-attestation.json`, update validator digests and fixed `--now` dates in tests.

<sup>Written for commit 469ae0566f07f71caa3df58c8cb52d36a15d66f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

