### PR TITLE
Diagnostic candidat libre 2027 — intégration (flag OFF, non déployé)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -620,6 +620,13 @@ jobs:
           AUTH_TRUST_HOST: 'true'
           OPENAI_API_KEY: sk-test-mock-key-for-ci-build-only
           NODE_ENV: production
+          # "next build"'s own type-check pass (not the separate, fast
+          # `tsc --noEmit` typecheck job) OOMs on the runner's default V8
+          # heap ceiling (~2GB) once the type surface grows past a point --
+          # confirmed via the OOM log itself ("Scavenge 2042.9 (2084.5)").
+          # This is a memory ceiling, not a type error: raising the ceiling
+          # is correct here, disabling type-checking would not be.
+          NODE_OPTIONS: --max-old-space-size=4096
         run: npm run build:e2e
 
       - name: Start Next.js server in background
@@ -925,6 +932,9 @@ jobs:
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET || 'test-secret-min-32-chars-long-for-ci-environment' }}
           OPENAI_API_KEY: sk-test-mock-key-for-ci-build-only
           NODE_ENV: production
+          # See the matching comment on the E2E job's "Build Next.js for
+          # E2E" step -- same OOM, same fix, same reasoning.
+          NODE_OPTIONS: --max-old-space-size=4096
         run: npm run build
 
       - name: Validate Next.js traces

--- a/STATUT-candidat-libre.md
+++ b/STATUT-candidat-libre.md
@@ -1,0 +1,84 @@
+# Statut — Diagnostic candidat libre 2027
+
+Dernière mise à jour : 2026-08-07. Branche `feat/candidat-libre-diagnostic`, PR #100 (ouverte, non mergée).
+Flag produit `CANDIDATE_DIAGNOSTIC_ENABLED` : **OFF partout, y compris en prod**. Aucun compte réel
+provisionné. `main` intact.
+
+## Fait
+
+- **Intégration** du lot livré (16 modules, 266 items) dans `nexus-project_v0` : modèles Prisma isolés
+  `CandidateDiagnostic*`, 8 routes API, composants élève/parent, banque de questions et moteur de scoring
+  `server-only`.
+- **Guard IDOR coach** (`lib/guards.ts`, `requireCoachAssignedToStudent`) : comparait un `User.id` à
+  `CoachStudentAssignment.coachId`, qui référence en réalité `CoachProfile.id` — espaces d'id distincts.
+  Corrigé via la relation (`coach: { userId }`), 3 tests de régression.
+- **Migration validée sur clone schéma seul** (Postgres jetable `pgvector/pgvector:pg16`, aucune donnée
+  réelle) : 60 migrations existantes rejouées, la nôtre appliquée seule par-dessus, idempotente, `migrate
+  status` clean, `migrate diff` sans écart, zéro instruction destructive. Un nom d'index à 64 caractères
+  (limite Postgres 63) trouvé et corrigé (`map:` explicite, 48 caractères).
+- **Fuite cross-audience scores/avis** : le GET diagnostic partagé élève/parent renvoyait `autoScore`/
+  `reviewSummary` de tous les modules à tout viewer. Corrigé dans `serializeCandidateDiagnostic` —
+  statut/progression restent visibles (UX « en attente du parent »), score/avis masqués hors audience.
+- **Fuite documents (productions du mineur)** — gap plus sévère, trouvé lors de l'audit exhaustif : un
+  parent pouvait lister ET télécharger les copies écrites (`WRITTEN_COPY`) et l'enregistrement du Grand
+  oral (`ORAL_RECORDING`) de l'enfant, sans aucun filtre. Corrigé aux 3 points d'exposition
+  (`isDocumentVisibleToViewer`, sérialiseur + liste + téléchargement direct par id).
+- **Audit cross-audience exhaustif verrouillé par tests** : matrice champ × audience complète
+  (`docs/DIAGNOSTIC_CANDIDAT_LIBRE_CROSS_AUDIENCE_AUDIT.md`), tests qui assertent l'ensemble exact des
+  clés retournées par audience et la matrice catégorie × audience des 9 catégories de documents — une
+  régression future casse un test, pas seulement les cas déjà connus.
+- **Grilles de relecture pédagogique tronc commun** (Q6, partiel) : 218 items extraits (14 modules
+  communs à tout profil), 7 grilles CSV staff/offline + index (`docs/relecture-pedagogique/tronc-commun/`).
+- **Flag OFF prouvé, pas seulement déclaré** : `lib/diagnostics/candidat-libre/feature-flag.ts`, câblé
+  sur les 16 points d'entrée (8 fichiers de routes API + 2 pages). Test
+  `__tests__/api/diagnostics/candidat-libre/feature-flag-dark.test.ts` : chaque route renvoie 404 sans
+  toucher auth/RBAC/rate-limit/DB, y compris pour une session qui serait normalement admise (ADMIN) —
+  le flag court-circuite avant toute résolution de rôle, donc la protection ne dépend d'aucun rôle.
+
+## Gaté (et sur qui)
+
+### 1. Merge — séquencement avec l'instance A
+- Attendre le merge de **PR #98** (instance A) dans `main`.
+- Rebaser #100 sur le nouveau `main`.
+- **Re-tester la migration sur un clone du nouveau baseline** (répéter la procédure Postgres jetable +
+  schéma seul, pas maintenant — le baseline va changer avec #98).
+- Approbation du responsable → merge #100.
+- Jamais deux migrations/déploiements prod concurrents.
+
+### 2. Ops / légal (hors code, prérequis dur avant tout dossier réel — mineur concerné)
+- Notice d'information RGPD (finalités, destinataires, durée de conservation, droits) élève + parent.
+- Politique de rétention et purge automatique des documents et réponses.
+- Sauvegarde chiffrée du stockage documentaire privé, restauration testée.
+- CSP / limites de requête au reverse proxy, alerting sur échecs de dépôt/saturation/base.
+- Antivirus (`DIAGNOSTIC_AV_MODE=clamdscan`) configuré et testé en conditions réelles.
+
+### 3. Relecture pédagogique (Q6)
+- **Prêt** : grilles tronc commun (218 items, 7 fichiers), voir `docs/relecture-pedagogique/tronc-commun/README.md`.
+- **Non couvert** :
+  - anglais / histoire-géo / LVB / méthodologie du tronc commun — 17 items, aucun relecteur du vivier nommé.
+  - Grand oral — 12 items, sujet dépendant des spécialités réelles, assignation différée.
+  - 126 items transversaux (accueil, profil, autonomie, potentiel d'apprentissage, documents, validation,
+    questionnaire parent) — proposés au responsable comme coordinateur pédagogique, **à confirmer**.
+  - NSI (26 items) et SES (22 items) — non extraits, en attente de confirmation formelle des spécialités.
+
+### 4. Provisionnement (Phase P)
+- 2 comptes réels (père PARENT, fils ELEVE_CANDIDAT_LIBRE) par le chemin canonique sûr, liés, coachs
+  affectés (Maths + NSI selon l'échange précédent, à reconfirmer formellement — voir décisions attendues).
+- Activation réelle, consentement élève + parent.
+- En toute fin, une fois 1 → 3 verts.
+
+## Décisions attendues du responsable
+
+- (a) **Les 2 spécialités de l'élève** — confirmation formelle (Maths + NSI évoqué précédemment, à
+  reconfirmer pour engager la relecture pédagogique de ces modules).
+- (b) **Qui relit les 126 items transversaux** et si le rôle de « coordination pédagogique » proposé au
+  responsable est le bon découpage.
+- (c) **Relecteurs pour les 17 items non couverts** (anglais, histoire-géo, LVB, méthodologie).
+- (d) **Confirmer le choix produit** « le parent ne voit pas les productions académiques de l'enfant
+  (copies écrites, Grand oral) » — c'est le défaut sûr implémenté, mais c'est un choix produit qui mérite
+  une validation explicite, pas seulement une décision technique unilatérale.
+
+## Ce qui ne doit PAS se produire avant que ces gates soient levées
+
+Merge dans `main` sans séquencement avec #98, déploiement, flip du flag, provisionnement d'un compte réel,
+ou ouverture d'un dossier réel sans RGPD + relecture + consentement.

--- a/STATUT-candidat-libre.md
+++ b/STATUT-candidat-libre.md
@@ -13,10 +13,15 @@ Dernière mise à jour : 2026-08-07. Branche `feat/candidat-libre-diagnostic`, P
 - **Guard IDOR coach** (`lib/guards.ts`, `requireCoachAssignedToStudent`) : comparait un `User.id` à
   `CoachStudentAssignment.coachId`, qui référence en réalité `CoachProfile.id` — espaces d'id distincts.
   Corrigé via la relation (`coach: { userId }`), 3 tests de régression.
-- **Migration validée sur clone schéma seul** (Postgres jetable `pgvector/pgvector:pg16`, aucune donnée
-  réelle) : 60 migrations existantes rejouées, la nôtre appliquée seule par-dessus, idempotente, `migrate
-  status` clean, `migrate diff` sans écart, zéro instruction destructive. Un nom d'index à 64 caractères
-  (limite Postgres 63) trouvé et corrigé (`map:` explicite, 48 caractères).
+- **Migration validée sur clone schéma seul** — redo du 2026-08-07 sur `pgvector/pgvector:pg15` (version
+  réelle de prod, pas pg16 comme le premier dry-run l'avait fait par erreur — voir
+  `docs/audits/2026-08-07-gate2-migration-dryrun-pg15.md`) : 61 migrations existantes + la nôtre
+  rejouées, succès, `migrate status` clean, additivité confirmée (aucun `ALTER` sur table préexistante),
+  nature des locks vérifiée empiriquement (`ShareRowExclusiveLock` sur `users`/`students`, borné par la
+  taille des nouvelles tables donc indépendant du volume de données réel), aucun `CREATE INDEX` non
+  concurrent sur table peuplée. Un écart `migrate diff` trouvé sur `eam_progress` : préexistant sur
+  `main`, sans rapport avec ce lot, signalé et non traité ici. Un nom d'index à 64 caractères (limite
+  Postgres 63) trouvé et corrigé (`map:` explicite, 48 caractères) lors du premier passage.
 - **Fuite cross-audience scores/avis** : le GET diagnostic partagé élève/parent renvoyait `autoScore`/
   `reviewSummary` de tous les modules à tout viewer. Corrigé dans `serializeCandidateDiagnostic` —
   statut/progression restent visibles (UX « en attente du parent »), score/avis masqués hors audience.
@@ -28,8 +33,12 @@ Dernière mise à jour : 2026-08-07. Branche `feat/candidat-libre-diagnostic`, P
   (`docs/DIAGNOSTIC_CANDIDAT_LIBRE_CROSS_AUDIENCE_AUDIT.md`), tests qui assertent l'ensemble exact des
   clés retournées par audience et la matrice catégorie × audience des 9 catégories de documents — une
   régression future casse un test, pas seulement les cas déjà connus.
-- **Grilles de relecture pédagogique tronc commun** (Q6, partiel) : 218 items extraits (14 modules
-  communs à tout profil), 7 grilles CSV staff/offline + index (`docs/relecture-pedagogique/tronc-commun/`).
+- **Grilles de relecture pédagogique tronc commun (Q6)** : **retirées de git le 2026-08-07** — commises
+  en clair (clé de correction + noms de 3 relecteurs) dans ce dépôt alors public. Dépôt repassé en privé,
+  historique purgé (rebase + force-push), demande de garbage collection envoyée à GitHub Support. Les 218
+  items sont considérés compromis et seront rebattus avant tout usage réel. Distribution future prévue
+  hors git (Drive restreint, dossier nominatif par relecteur) une fois les nouveaux items produits — pas
+  avant.
 - **Flag OFF prouvé, pas seulement déclaré** : `lib/diagnostics/candidat-libre/feature-flag.ts`, câblé
   sur les 16 points d'entrée (8 fichiers de routes API + 2 pages). Test
   `__tests__/api/diagnostics/candidat-libre/feature-flag-dark.test.ts` : chaque route renvoie 404 sans

--- a/STATUT-candidat-libre.md
+++ b/STATUT-candidat-libre.md
@@ -1,8 +1,9 @@
 # Statut — Diagnostic candidat libre 2027
 
-Dernière mise à jour : 2026-08-07. Branche `feat/candidat-libre-diagnostic`, PR #100 (ouverte, non mergée).
-Flag produit `CANDIDATE_DIAGNOSTIC_ENABLED` : **OFF partout, y compris en prod**. Aucun compte réel
-provisionné. `main` intact.
+Dernière mise à jour : 2026-08-07. Branche `feat/candidat-libre-diagnostic`, PR #100 (ouverte, non mergée),
+**rebasée sur `origin/main` post-PR #98** (commit `cf52146e`). Flag produit
+`CANDIDATE_DIAGNOSTIC_ENABLED` : **OFF partout, y compris en prod**. Aucun compte réel provisionné.
+`main` intact — PR #100 prête à merger, en attente de la seule approbation du responsable.
 
 ## Fait
 
@@ -34,15 +35,23 @@ provisionné. `main` intact.
   `__tests__/api/diagnostics/candidat-libre/feature-flag-dark.test.ts` : chaque route renvoie 404 sans
   toucher auth/RBAC/rate-limit/DB, y compris pour une session qui serait normalement admise (ADMIN) —
   le flag court-circuite avant toute résolution de rôle, donc la protection ne dépend d'aucun rôle.
+- **Rebasé sur `origin/main` post-#98** (`cf52146e`) : `git rebase origin/main` sans conflit — #98
+  (bilans staff, README, CI, `package-lock.json`) ne touche aucun fichier de notre périmètre. Migration
+  candidat libre **re-testée sur un Postgres jetable neuf reflétant le nouveau baseline** (61 migrations
+  existantes + la nôtre par-dessus) : applique proprement, idempotente, `migrate status` clean,
+  `migrate diff` sans écart, aucune instruction destructive, le fix d'index à 63 caractères tient
+  toujours. `build` + `typecheck` + `lint` + 116 tests verts sur la branche rebasée. Force-push effectué
+  — l'approbation devra être redonnée après ce push (attendu, normal après un rebase).
 
 ## Gaté (et sur qui)
 
 ### 1. Merge — séquencement avec l'instance A
-- Attendre le merge de **PR #98** (instance A) dans `main`.
-- Rebaser #100 sur le nouveau `main`.
-- **Re-tester la migration sur un clone du nouveau baseline** (répéter la procédure Postgres jetable +
-  schéma seul, pas maintenant — le baseline va changer avec #98).
-- Approbation du responsable → merge #100.
+- ✅ PR #98 mergée dans `main` (`cf52146e`).
+- ✅ #100 rebasée sur le nouveau `main`, sans conflit.
+- ✅ Migration re-testée sur clone du nouveau baseline (voir ci-dessus).
+- **Reste à faire** : approbation du responsable (réinitialisée par le force-push du rebase) → merge #100.
+- La migration ne touchera la prod qu'au déploiement délibéré ultérieur, jamais au merge lui-même —
+  précédé d'un nouveau clone-test sur l'état prod exact au moment du déploiement.
 - Jamais deux migrations/déploiements prod concurrents.
 
 ### 2. Ops / légal (hors code, prérequis dur avant tout dossier réel — mineur concerné)

--- a/__tests__/api/diagnostics/candidat-libre/feature-flag-dark.test.ts
+++ b/__tests__/api/diagnostics/candidat-libre/feature-flag-dark.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Proves the candidate-libre diagnostic is entirely dark when
+ * CANDIDATE_DIAGNOSTIC_ENABLED is not set to 'true'.
+ *
+ * Every route handler must return 404 *before* touching auth, RBAC, rate
+ * limiting or the database — not merely return 404 as a coincidental
+ * downstream result. So this suite asserts both the response status AND
+ * that requireAnyRole/requireRole/guardRateLimitAsync were never called.
+ * That's a role-independent proof: since the flag check is the first line
+ * and short-circuits before any role is even resolved, no role — ELEVE,
+ * PARENT, COACH, ASSISTANTE, ADMIN, or unauthenticated — can reach further.
+ * The ADMIN-bypass test below makes that explicit: even a mock session an
+ * auth layer would normally grant access to still gets 404 when the flag
+ * is off, because the guard never lets the session resolution run at all.
+ *
+ * Source: lib/diagnostics/candidat-libre/feature-flag.ts
+ */
+
+import { NextResponse } from 'next/server';
+
+const mockRequireAnyRole = jest.fn();
+const mockRequireRole = jest.fn();
+const mockIsErrorResponse = jest.fn((...args: unknown[]) => args[0] instanceof NextResponse);
+const mockRequireParentOwnsStudent = jest.fn();
+const mockRequireCoachAssignedToStudent = jest.fn();
+
+jest.mock('@/lib/guards', () => ({
+  requireAnyRole: (...args: unknown[]) => mockRequireAnyRole(...args),
+  requireRole: (...args: unknown[]) => mockRequireRole(...args),
+  isErrorResponse: (...args: unknown[]) => mockIsErrorResponse(...args),
+  requireParentOwnsStudent: (...args: unknown[]) => mockRequireParentOwnsStudent(...args),
+  requireCoachAssignedToStudent: (...args: unknown[]) => mockRequireCoachAssignedToStudent(...args),
+}));
+
+const mockGuardRateLimit = jest.fn();
+jest.mock('@/lib/rate-limit', () => ({
+  guardRateLimitAsync: (...args: unknown[]) => mockGuardRateLimit(...args),
+}));
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: new Proxy(
+    {},
+    {
+      get() {
+        throw new Error('prisma must never be touched while the diagnostic feature flag is off');
+      },
+    },
+  ),
+}));
+
+import { GET as diagnosticsGet, POST as diagnosticsPost } from '@/app/api/diagnostics/candidat-libre/route';
+import { GET as byIdGet, PATCH as byIdPatch } from '@/app/api/diagnostics/candidat-libre/[diagnosticId]/route';
+import { GET as moduleGet, PUT as modulePut, POST as modulePost } from '@/app/api/diagnostics/candidat-libre/[diagnosticId]/modules/[moduleKey]/route';
+import { GET as documentsGet, POST as documentsPost } from '@/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/route';
+import { GET as documentGet, DELETE as documentDelete } from '@/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/[documentId]/route';
+import { GET as parentGet, PUT as parentPut, POST as parentPost } from '@/app/api/diagnostics/candidat-libre/[diagnosticId]/parent/route';
+import { POST as submitPost } from '@/app/api/diagnostics/candidat-libre/[diagnosticId]/submit/route';
+import { GET as staffExportGet } from '@/app/api/diagnostics/candidat-libre/[diagnosticId]/staff-export/route';
+
+const req = (method = 'GET') => new Request('http://localhost/api/diagnostics/candidat-libre', { method });
+const diagnosticParams = () => ({ params: Promise.resolve({ diagnosticId: 'diag-1' }) });
+const moduleParams = () => ({ params: Promise.resolve({ diagnosticId: 'diag-1', moduleKey: 'mathematiques' }) });
+const documentParams = () => ({ params: Promise.resolve({ diagnosticId: 'diag-1', documentId: 'doc-1' }) });
+
+type Handler = () => Promise<Response>;
+
+const ROUTES: Array<[string, Handler]> = [
+  ['POST /api/diagnostics/candidat-libre', () => diagnosticsPost(req('POST'))],
+  ['GET /api/diagnostics/candidat-libre/{id}', () => byIdGet(req(), diagnosticParams())],
+  ['PATCH /api/diagnostics/candidat-libre/{id}', () => byIdPatch(req('PATCH'), diagnosticParams())],
+  ['GET /modules/{moduleKey}', () => moduleGet(req(), moduleParams())],
+  ['PUT /modules/{moduleKey}', () => modulePut(req('PUT'), moduleParams())],
+  ['POST /modules/{moduleKey}', () => modulePost(req('POST'), moduleParams())],
+  ['GET /documents', () => documentsGet(req(), diagnosticParams())],
+  ['POST /documents', () => documentsPost(req('POST'), diagnosticParams())],
+  ['GET /documents/{documentId}', () => documentGet(req(), documentParams())],
+  ['DELETE /documents/{documentId}', () => documentDelete(req('DELETE'), documentParams())],
+  ['GET /parent', () => parentGet(req(), diagnosticParams())],
+  ['PUT /parent', () => parentPut(req('PUT'), diagnosticParams())],
+  ['POST /parent', () => parentPost(req('POST'), diagnosticParams())],
+  ['POST /submit', () => submitPost(req('POST'), diagnosticParams())],
+  ['GET /staff-export', () => staffExportGet(req(), diagnosticParams())],
+];
+
+// GET /api/diagnostics/candidat-libre reads a query string, tested separately below.
+const diagnosticsGetHandler: [string, Handler] = [
+  'GET /api/diagnostics/candidat-libre',
+  () => diagnosticsGet(new Request('http://localhost/api/diagnostics/candidat-libre?targetSession=2027')),
+];
+
+describe('candidate-libre diagnostic — flag OFF ⇒ every route is dark', () => {
+  const originalEnv = process.env.CANDIDATE_DIAGNOSTIC_ENABLED;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.CANDIDATE_DIAGNOSTIC_ENABLED;
+  });
+
+  afterAll(() => {
+    if (originalEnv === undefined) delete process.env.CANDIDATE_DIAGNOSTIC_ENABLED;
+    else process.env.CANDIDATE_DIAGNOSTIC_ENABLED = originalEnv;
+  });
+
+  it.each([...ROUTES, diagnosticsGetHandler])('%s returns 404 with the flag unset, touching nothing downstream', async (_name, handler) => {
+    const response = await handler();
+    expect(response.status).toBe(404);
+    expect(mockRequireAnyRole).not.toHaveBeenCalled();
+    expect(mockRequireRole).not.toHaveBeenCalled();
+    expect(mockGuardRateLimit).not.toHaveBeenCalled();
+  });
+
+  it.each(['false', '', '1', 'TRUE', 'yes', 'enabled'])('stays dark for a falsy/garbage flag value %j (only the exact string "true" opens it)', async (value) => {
+    process.env.CANDIDATE_DIAGNOSTIC_ENABLED = value;
+    const response = await submitPost(req('POST'), diagnosticParams());
+    expect(response.status).toBe(404);
+    expect(mockRequireRole).not.toHaveBeenCalled();
+  });
+
+  it('even a session an auth layer would grant ADMIN access to never reaches the route logic while the flag is off', async () => {
+    // Configure the mocks as if auth would succeed for ADMIN — proves the
+    // flag check runs unconditionally, before any role is resolved, not
+    // just for the roles this suite happens to simulate.
+    mockRequireAnyRole.mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } });
+    mockRequireRole.mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } });
+
+    const response = await staffExportGet(req(), diagnosticParams());
+    expect(response.status).toBe(404);
+    expect(mockRequireAnyRole).not.toHaveBeenCalled();
+  });
+});
+
+describe('candidate-libre diagnostic — flag ON opens the gate', () => {
+  afterEach(() => {
+    delete process.env.CANDIDATE_DIAGNOSTIC_ENABLED;
+  });
+
+  it('with the flag set to "true", the route proceeds past the feature guard (and fails downstream on the unmocked-prisma trap, proving it got that far)', async () => {
+    process.env.CANDIDATE_DIAGNOSTIC_ENABLED = 'true';
+    mockRequireRole.mockResolvedValue({ user: { id: 'eleve-1', role: 'ELEVE' } });
+    mockIsErrorResponse.mockReturnValue(false);
+
+    // getDiagnosticForActor (unmocked, real) will touch the prisma proxy and throw —
+    // proof the guard let the request through instead of short-circuiting.
+    await expect(submitPost(req('POST'), diagnosticParams())).rejects.toThrow(
+      'prisma must never be touched while the diagnostic feature flag is off',
+    );
+  });
+});

--- a/__tests__/api/diagnostics/candidat-libre/module-detail-visibility.test.ts
+++ b/__tests__/api/diagnostics/candidat-libre/module-detail-visibility.test.ts
@@ -1,0 +1,94 @@
+/**
+ * GET .../modules/[moduleKey] previously conflated canEditAudience (WRITE
+ * permission) with READ visibility of `answers` — a COACH who can never
+ * edit was wrongly assumed to never read either, even on the student's own
+ * ELEVE-audience modules (their actual working material). Arbitrated
+ * 2026-08-07: `answers` visibility now uses canViewModuleDetail, the same
+ * single source of truth as staff-export and the root serializer.
+ */
+
+import { NextResponse } from 'next/server';
+
+process.env.CANDIDATE_DIAGNOSTIC_ENABLED = 'true';
+
+const mockRequireDiagnosticActor = jest.fn();
+const mockGetDiagnosticForActor = jest.fn();
+
+jest.mock('@/lib/diagnostics/candidat-libre/access.server', () => ({
+  requireDiagnosticActor: (...args: unknown[]) => mockRequireDiagnosticActor(...args),
+  getDiagnosticForActor: (...args: unknown[]) => mockGetDiagnosticForActor(...args),
+  canViewModuleDetail: jest.requireActual('@/lib/diagnostics/candidat-libre/access.server').canViewModuleDetail,
+}));
+
+jest.mock('@/lib/guards', () => ({
+  isErrorResponse: (value: unknown) => value instanceof NextResponse,
+}));
+
+import { GET as moduleGet } from '@/app/api/diagnostics/candidat-libre/[diagnosticId]/modules/[moduleKey]/route';
+
+const paramsFor = (moduleKey: string) => ({ params: Promise.resolve({ diagnosticId: 'diag-1', moduleKey }) });
+const req = () => new Request('http://localhost/api/diagnostics/candidat-libre/diag-1/modules/mathematiques');
+
+const moduleRecord = (moduleKey: string, answers: Record<string, unknown>) => ({
+  moduleKey,
+  status: 'AUTO_SCORED',
+  answers,
+  currentQuestionIndex: 5,
+  elapsedMs: 100,
+  integrity: {},
+  submittedAt: null,
+  availableAt: null,
+});
+
+function diagnosticFixture() {
+  return {
+    modules: [
+      moduleRecord('mathematiques', { q1: 'réponse élève' }),
+      moduleRecord('questionnaire-parent', { q1: 'réponse confidentielle du parent' }),
+    ],
+  };
+}
+
+async function getModuleAs(role: string, moduleKey: string) {
+  mockRequireDiagnosticActor.mockResolvedValue({ user: { id: `${role}-1`, role } });
+  mockGetDiagnosticForActor.mockResolvedValue(diagnosticFixture());
+  const response = await moduleGet(req(), paramsFor(moduleKey));
+  return { response, body: await response.json() };
+}
+
+describe('GET modules/[moduleKey] — answers visibility uses canViewModuleDetail, not canEditAudience', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('COACH reads answers on the ELEVE-audience module (mathematiques) despite never being able to edit it', async () => {
+    const { response, body } = await getModuleAs('COACH', 'mathematiques');
+    expect(response.status).toBe(200);
+    expect(body.module.answers).toEqual({ q1: 'réponse élève' });
+  });
+
+  it('COACH does not read answers on questionnaire-parent', async () => {
+    const { response, body } = await getModuleAs('COACH', 'questionnaire-parent');
+    expect(response.status).toBe(200);
+    expect(body.module.answers).toBeUndefined();
+  });
+
+  it('ASSISTANTE does not read answers even though she can still edit (canEditAudience unchanged — flagged inconsistency, not fixed here)', async () => {
+    const { response, body } = await getModuleAs('ASSISTANTE', 'mathematiques');
+    expect(response.status).toBe(200);
+    expect(body.module.answers).toBeUndefined();
+  });
+
+  it('ADMIN reads answers on both audiences', async () => {
+    expect((await getModuleAs('ADMIN', 'mathematiques')).body.module.answers).toEqual({ q1: 'réponse élève' });
+    expect((await getModuleAs('ADMIN', 'questionnaire-parent')).body.module.answers).toEqual({ q1: 'réponse confidentielle du parent' });
+  });
+
+  it('ELEVE reads their own module, not questionnaire-parent (403, unchanged cross-audience block)', async () => {
+    expect((await getModuleAs('ELEVE', 'mathematiques')).body.module.answers).toEqual({ q1: 'réponse élève' });
+    expect((await getModuleAs('ELEVE', 'questionnaire-parent')).response.status).toBe(403);
+  });
+
+  it('PARENT reads questionnaire-parent, not mathematiques (403, unchanged cross-audience block)', async () => {
+    expect((await getModuleAs('PARENT', 'questionnaire-parent')).body.module.answers).toEqual({ q1: 'réponse confidentielle du parent' });
+    expect((await getModuleAs('PARENT', 'mathematiques')).response.status).toBe(403);
+  });
+});

--- a/__tests__/api/diagnostics/candidat-libre/staff-export-content-visibility.test.ts
+++ b/__tests__/api/diagnostics/candidat-libre/staff-export-content-visibility.test.ts
@@ -1,13 +1,16 @@
 /**
- * A COACH is not the audience of the parent questionnaire (or of any
- * module's raw answers) — same rule GET .../modules/[moduleKey] already
- * enforces via canEditAudience. staff-export previously bypassed that rule
- * by treating COACH/ADMIN/ASSISTANTE as an undifferentiated "staff" block,
- * exposing every module's answers/autoScore/manualScore/reviewSummary
- * (including questionnaire-parent) to any assigned coach. This suite locks
- * the aligned behavior: ADMIN/ASSISTANTE keep full content, COACH gets
- * structure/status only, never content — for every module regardless of
- * audience.
+ * Read-visibility matrix for staff-export, arbitrated 2026-08-07: COACH is
+ * not the audience of questionnaire-parent (a confidential family
+ * instrument) but IS the audience of the student's own ELEVE-audience
+ * modules (their working material for coaching) — canEditAudience
+ * (modules/[moduleKey]) governs WRITE only and was previously
+ * mis-generalized to READ, producing a false parallel. ASSISTANTE gets no
+ * academic detail anywhere (logistics role, least privilege on a minor's
+ * data) — a stricter default than the original "staff sees everything"
+ * this route shipped with. ADMIN keeps full access, including
+ * questionnaire-parent (pedagogical direction, where the confidential
+ * family instrument is meant to land) and gets the full synthesis;
+ * ASSISTANTE gets none.
  */
 
 import { NextResponse } from 'next/server';
@@ -21,7 +24,7 @@ jest.mock('@/lib/diagnostics/candidat-libre/access.server', () => ({
   requireDiagnosticActor: (...args: unknown[]) => mockRequireDiagnosticActor(...args),
   getDiagnosticForActor: (...args: unknown[]) => mockGetDiagnosticForActor(...args),
   isDocumentVisibleToViewer: jest.requireActual('@/lib/diagnostics/candidat-libre/access.server').isDocumentVisibleToViewer,
-  actorRole: jest.requireActual('@/lib/diagnostics/candidat-libre/access.server').actorRole,
+  canViewModuleDetail: jest.requireActual('@/lib/diagnostics/candidat-libre/access.server').canViewModuleDetail,
 }));
 
 jest.mock('@/lib/guards', () => ({
@@ -33,7 +36,21 @@ import { GET as staffExportGet } from '@/app/api/diagnostics/candidat-libre/[dia
 const params = () => ({ params: Promise.resolve({ diagnosticId: 'diag-1' }) });
 const req = () => new Request('http://localhost/api/diagnostics/candidat-libre/diag-1/staff-export');
 
-const MODULE = {
+const ELEVE_MODULE = {
+  moduleKey: 'mathematiques',
+  audience: 'ELEVE',
+  status: 'REVIEWED',
+  answers: { q1: 'réponse élève' },
+  autoScore: { percentage: 70 },
+  manualScore: null,
+  integrity: {},
+  elapsedMs: 500,
+  submittedAt: new Date('2026-08-01'),
+  reviewSummary: { note: 'bon niveau' },
+  definitionSnapshot: { questions: [] },
+};
+
+const PARENT_MODULE = {
   moduleKey: 'questionnaire-parent',
   audience: 'PARENT',
   status: 'REVIEWED',
@@ -45,6 +62,19 @@ const MODULE = {
   submittedAt: new Date('2026-08-01'),
   reviewSummary: { note: 'commentaire de relecture' },
   definitionSnapshot: { questions: [] },
+};
+
+const WRITTEN_COPY_DOC = {
+  id: 'doc-1',
+  category: 'WRITTEN_COPY',
+  title: 'Copie maths',
+  originalName: 'copie.pdf',
+  mimeType: 'application/pdf',
+  sizeBytes: 1000,
+  sha256: 'abc',
+  status: 'ACCEPTED',
+  reviewNote: null,
+  createdAt: new Date('2026-08-01'),
 };
 
 const diagnosticFixture = () => ({
@@ -59,45 +89,71 @@ const diagnosticFixture = () => ({
     school: 'X',
     gradeLevel: 'TERMINALE',
   },
-  modules: [{ ...MODULE }],
-  documents: [],
+  modules: [{ ...ELEVE_MODULE }, { ...PARENT_MODULE }],
+  documents: [{ ...WRITTEN_COPY_DOC }],
   studentConsentAt: null,
   parentConsentAt: null,
   parentSubmittedAt: new Date('2026-08-01'),
   submittedAt: null,
 });
 
-describe('GET staff-export — content visibility aligned with modules/[moduleKey]', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockGetDiagnosticForActor.mockResolvedValue(diagnosticFixture());
-  });
+async function getAs(role: string) {
+  mockRequireDiagnosticActor.mockResolvedValue({ user: { id: `${role}-1`, role } });
+  mockGetDiagnosticForActor.mockResolvedValue(diagnosticFixture());
+  const response = await staffExportGet(req(), params());
+  return { response, body: await response.json() };
+}
 
-  it('withholds answers/autoScore/manualScore/reviewSummary from COACH on every module, including questionnaire-parent', async () => {
-    mockRequireDiagnosticActor.mockResolvedValue({ user: { id: 'coach-1', role: 'COACH' } });
+function moduleByKey(body: any, key: string) {
+  return body.diagnostic.modules.find((m: any) => m.moduleKey === key);
+}
 
-    const response = await staffExportGet(req(), params());
-    const body = await response.json();
+describe('GET staff-export — read-visibility matrix (arbitrated 2026-08-07)', () => {
+  beforeEach(() => jest.clearAllMocks());
 
+  it('COACH sees content on the ELEVE-audience module but not on questionnaire-parent', async () => {
+    const { response, body } = await getAs('COACH');
     expect(response.status).toBe(200);
-    const moduleView = body.diagnostic.modules[0];
-    expect(moduleView.moduleKey).toBe('questionnaire-parent');
-    expect(moduleView.status).toBe('REVIEWED');
-    expect(moduleView.answers).toBeUndefined();
-    expect(moduleView.autoScore).toBeUndefined();
-    expect(moduleView.manualScore).toBeUndefined();
-    expect(moduleView.reviewSummary).toBeUndefined();
+
+    const eleveModule = moduleByKey(body, 'mathematiques');
+    expect(eleveModule.answers).toEqual(ELEVE_MODULE.answers);
+    expect(eleveModule.autoScore).toEqual(ELEVE_MODULE.autoScore);
+    expect(eleveModule.reviewSummary).toEqual(ELEVE_MODULE.reviewSummary);
+
+    const parentModule = moduleByKey(body, 'questionnaire-parent');
+    expect(parentModule.status).toBe('REVIEWED');
+    expect(parentModule.answers).toBeUndefined();
+    expect(parentModule.autoScore).toBeUndefined();
+    expect(parentModule.manualScore).toBeUndefined();
+    expect(parentModule.reviewSummary).toBeUndefined();
+
+    expect(body.diagnostic.documents).toHaveLength(1);
+    expect(body.synthesis).not.toBeNull();
   });
 
-  it.each(['ADMIN', 'ASSISTANTE'])('keeps full content for %s', async (role) => {
-    mockRequireDiagnosticActor.mockResolvedValue({ user: { id: 'staff-1', role } });
+  it('ADMIN sees full content on both modules, including questionnaire-parent', async () => {
+    const { body } = await getAs('ADMIN');
+    expect(moduleByKey(body, 'mathematiques').answers).toEqual(ELEVE_MODULE.answers);
+    expect(moduleByKey(body, 'questionnaire-parent').answers).toEqual(PARENT_MODULE.answers);
+    expect(body.diagnostic.documents).toHaveLength(1);
+    expect(body.synthesis).not.toBeNull();
+  });
 
-    const response = await staffExportGet(req(), params());
-    const body = await response.json();
+  it('ASSISTANTE sees no academic detail on any module, no student productions, and no synthesis', async () => {
+    const { response, body } = await getAs('ASSISTANTE');
+    expect(response.status).toBe(200);
 
-    const moduleView = body.diagnostic.modules[0];
-    expect(moduleView.answers).toEqual(MODULE.answers);
-    expect(moduleView.autoScore).toEqual(MODULE.autoScore);
-    expect(moduleView.reviewSummary).toEqual(MODULE.reviewSummary);
+    const eleveModule = moduleByKey(body, 'mathematiques');
+    expect(eleveModule.answers).toBeUndefined();
+    expect(eleveModule.autoScore).toBeUndefined();
+    expect(eleveModule.reviewSummary).toBeUndefined();
+
+    const parentModule = moduleByKey(body, 'questionnaire-parent');
+    expect(parentModule.answers).toBeUndefined();
+    expect(parentModule.autoScore).toBeUndefined();
+    expect(parentModule.reviewSummary).toBeUndefined();
+
+    expect(body.diagnostic.documents).toHaveLength(0);
+    expect(body.synthesis).toBeNull();
   });
 });

--- a/__tests__/api/diagnostics/candidat-libre/staff-export-content-visibility.test.ts
+++ b/__tests__/api/diagnostics/candidat-libre/staff-export-content-visibility.test.ts
@@ -1,0 +1,103 @@
+/**
+ * A COACH is not the audience of the parent questionnaire (or of any
+ * module's raw answers) — same rule GET .../modules/[moduleKey] already
+ * enforces via canEditAudience. staff-export previously bypassed that rule
+ * by treating COACH/ADMIN/ASSISTANTE as an undifferentiated "staff" block,
+ * exposing every module's answers/autoScore/manualScore/reviewSummary
+ * (including questionnaire-parent) to any assigned coach. This suite locks
+ * the aligned behavior: ADMIN/ASSISTANTE keep full content, COACH gets
+ * structure/status only, never content — for every module regardless of
+ * audience.
+ */
+
+import { NextResponse } from 'next/server';
+
+process.env.CANDIDATE_DIAGNOSTIC_ENABLED = 'true';
+
+const mockRequireDiagnosticActor = jest.fn();
+const mockGetDiagnosticForActor = jest.fn();
+
+jest.mock('@/lib/diagnostics/candidat-libre/access.server', () => ({
+  requireDiagnosticActor: (...args: unknown[]) => mockRequireDiagnosticActor(...args),
+  getDiagnosticForActor: (...args: unknown[]) => mockGetDiagnosticForActor(...args),
+  isDocumentVisibleToViewer: jest.requireActual('@/lib/diagnostics/candidat-libre/access.server').isDocumentVisibleToViewer,
+  actorRole: jest.requireActual('@/lib/diagnostics/candidat-libre/access.server').actorRole,
+}));
+
+jest.mock('@/lib/guards', () => ({
+  isErrorResponse: (value: unknown) => value instanceof NextResponse,
+}));
+
+import { GET as staffExportGet } from '@/app/api/diagnostics/candidat-libre/[diagnosticId]/staff-export/route';
+
+const params = () => ({ params: Promise.resolve({ diagnosticId: 'diag-1' }) });
+const req = () => new Request('http://localhost/api/diagnostics/candidat-libre/diag-1/staff-export');
+
+const MODULE = {
+  moduleKey: 'questionnaire-parent',
+  audience: 'PARENT',
+  status: 'REVIEWED',
+  answers: { q1: 'réponse confidentielle du parent' },
+  autoScore: { percentage: 80 },
+  manualScore: null,
+  integrity: {},
+  elapsedMs: 1000,
+  submittedAt: new Date('2026-08-01'),
+  reviewSummary: { note: 'commentaire de relecture' },
+  definitionSnapshot: { questions: [] },
+};
+
+const diagnosticFixture = () => ({
+  id: 'diag-1',
+  diagnosticKey: 'candidat-libre-2027',
+  definitionVersion: 1,
+  targetSession: 2027,
+  status: 'IN_PROGRESS',
+  student: {
+    id: 'student-1',
+    user: { firstName: 'A', lastName: 'B', email: 'a@b.test' },
+    school: 'X',
+    gradeLevel: 'TERMINALE',
+  },
+  modules: [{ ...MODULE }],
+  documents: [],
+  studentConsentAt: null,
+  parentConsentAt: null,
+  parentSubmittedAt: new Date('2026-08-01'),
+  submittedAt: null,
+});
+
+describe('GET staff-export — content visibility aligned with modules/[moduleKey]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetDiagnosticForActor.mockResolvedValue(diagnosticFixture());
+  });
+
+  it('withholds answers/autoScore/manualScore/reviewSummary from COACH on every module, including questionnaire-parent', async () => {
+    mockRequireDiagnosticActor.mockResolvedValue({ user: { id: 'coach-1', role: 'COACH' } });
+
+    const response = await staffExportGet(req(), params());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    const module = body.diagnostic.modules[0];
+    expect(module.moduleKey).toBe('questionnaire-parent');
+    expect(module.status).toBe('REVIEWED');
+    expect(module.answers).toBeUndefined();
+    expect(module.autoScore).toBeUndefined();
+    expect(module.manualScore).toBeUndefined();
+    expect(module.reviewSummary).toBeUndefined();
+  });
+
+  it.each(['ADMIN', 'ASSISTANTE'])('keeps full content for %s', async (role) => {
+    mockRequireDiagnosticActor.mockResolvedValue({ user: { id: 'staff-1', role } });
+
+    const response = await staffExportGet(req(), params());
+    const body = await response.json();
+
+    const module = body.diagnostic.modules[0];
+    expect(module.answers).toEqual(MODULE.answers);
+    expect(module.autoScore).toEqual(MODULE.autoScore);
+    expect(module.reviewSummary).toEqual(MODULE.reviewSummary);
+  });
+});

--- a/__tests__/api/diagnostics/candidat-libre/staff-export-content-visibility.test.ts
+++ b/__tests__/api/diagnostics/candidat-libre/staff-export-content-visibility.test.ts
@@ -80,13 +80,13 @@ describe('GET staff-export — content visibility aligned with modules/[moduleKe
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    const module = body.diagnostic.modules[0];
-    expect(module.moduleKey).toBe('questionnaire-parent');
-    expect(module.status).toBe('REVIEWED');
-    expect(module.answers).toBeUndefined();
-    expect(module.autoScore).toBeUndefined();
-    expect(module.manualScore).toBeUndefined();
-    expect(module.reviewSummary).toBeUndefined();
+    const moduleView = body.diagnostic.modules[0];
+    expect(moduleView.moduleKey).toBe('questionnaire-parent');
+    expect(moduleView.status).toBe('REVIEWED');
+    expect(moduleView.answers).toBeUndefined();
+    expect(moduleView.autoScore).toBeUndefined();
+    expect(moduleView.manualScore).toBeUndefined();
+    expect(moduleView.reviewSummary).toBeUndefined();
   });
 
   it.each(['ADMIN', 'ASSISTANTE'])('keeps full content for %s', async (role) => {
@@ -95,9 +95,9 @@ describe('GET staff-export — content visibility aligned with modules/[moduleKe
     const response = await staffExportGet(req(), params());
     const body = await response.json();
 
-    const module = body.diagnostic.modules[0];
-    expect(module.answers).toEqual(MODULE.answers);
-    expect(module.autoScore).toEqual(MODULE.autoScore);
-    expect(module.reviewSummary).toEqual(MODULE.reviewSummary);
+    const moduleView = body.diagnostic.modules[0];
+    expect(moduleView.answers).toEqual(MODULE.answers);
+    expect(moduleView.autoScore).toEqual(MODULE.autoScore);
+    expect(moduleView.reviewSummary).toEqual(MODULE.reviewSummary);
   });
 });

--- a/__tests__/app/dashboard/candidat-libre-pages-dark.test.tsx
+++ b/__tests__/app/dashboard/candidat-libre-pages-dark.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Proves the 2 candidate-libre dashboard pages (élève, parent) are dark
+ * when CANDIDATE_DIAGNOSTIC_ENABLED is not set to 'true' -- the API route
+ * handlers already have this proof in feature-flag-dark.test.ts, but the
+ * 2 page components were previously unverified: the code gates correctly
+ * (`if (!isCandidateDiagnosticFeatureEnabled()) notFound();` as the first
+ * statement, before any portal component renders or params resolve), but
+ * nothing caught a regression if that ever silently broke.
+ */
+
+const mockNotFound = jest.fn(() => {
+  throw new Error('NEXT_NOT_FOUND');
+});
+jest.mock('next/navigation', () => ({
+  notFound: () => mockNotFound(),
+}));
+
+const mockDiagnosticPortal = jest.fn((_props?: unknown) => null);
+jest.mock('@/components/diagnostics/candidat-libre/DiagnosticPortal', () => ({
+  DiagnosticPortal: (props: unknown) => mockDiagnosticPortal(props),
+}));
+
+const mockParentDiagnosticPortal = jest.fn((_props?: unknown) => null);
+jest.mock('@/components/diagnostics/candidat-libre/ParentDiagnosticPortal', () => ({
+  ParentDiagnosticPortal: (props: unknown) => mockParentDiagnosticPortal(props),
+}));
+
+import { render } from '@testing-library/react';
+
+import StudentCandidateDiagnosticPage from '@/app/dashboard/eleve/diagnostic-candidat-libre/page';
+import ParentCandidateDiagnosticPage from '@/app/dashboard/parent/children/[studentId]/diagnostic-candidat-libre/page';
+
+const originalEnv = process.env.CANDIDATE_DIAGNOSTIC_ENABLED;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.CANDIDATE_DIAGNOSTIC_ENABLED;
+});
+
+afterAll(() => {
+  if (originalEnv === undefined) delete process.env.CANDIDATE_DIAGNOSTIC_ENABLED;
+  else process.env.CANDIDATE_DIAGNOSTIC_ENABLED = originalEnv;
+});
+
+describe('candidate-libre diagnostic dashboard pages — flag OFF ⇒ dark', () => {
+
+  it('student page calls notFound() and never renders DiagnosticPortal', () => {
+    expect(() => StudentCandidateDiagnosticPage()).toThrow('NEXT_NOT_FOUND');
+    expect(mockDiagnosticPortal).not.toHaveBeenCalled();
+  });
+
+  it('parent page calls notFound() before resolving params or rendering ParentDiagnosticPortal', async () => {
+    const params = jest.fn().mockResolvedValue({ studentId: 'student-1' });
+    await expect(ParentCandidateDiagnosticPage({ params: params() })).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(mockParentDiagnosticPortal).not.toHaveBeenCalled();
+  });
+
+  it.each(['false', '', '1', 'TRUE', 'yes'])('student page stays dark for a falsy/garbage flag value %j', (value) => {
+    process.env.CANDIDATE_DIAGNOSTIC_ENABLED = value;
+    expect(() => StudentCandidateDiagnosticPage()).toThrow('NEXT_NOT_FOUND');
+  });
+});
+
+describe('candidate-libre diagnostic dashboard pages — flag ON opens the gate', () => {
+  afterEach(() => {
+    delete process.env.CANDIDATE_DIAGNOSTIC_ENABLED;
+  });
+
+  it('student page renders DiagnosticPortal once the flag is "true"', () => {
+    process.env.CANDIDATE_DIAGNOSTIC_ENABLED = 'true';
+    render(StudentCandidateDiagnosticPage());
+    expect(mockNotFound).not.toHaveBeenCalled();
+    expect(mockDiagnosticPortal).toHaveBeenCalledTimes(1);
+  });
+
+  it('parent page renders ParentDiagnosticPortal once the flag is "true"', async () => {
+    process.env.CANDIDATE_DIAGNOSTIC_ENABLED = 'true';
+    const params = Promise.resolve({ studentId: 'student-1' });
+    const element = await ParentCandidateDiagnosticPage({ params });
+    render(element);
+    expect(mockNotFound).not.toHaveBeenCalled();
+    expect(mockParentDiagnosticPortal.mock.calls[0]?.[0]).toEqual({ studentId: 'student-1' });
+  });
+});

--- a/__tests__/lib/diagnostics/candidat-libre/progression.test.ts
+++ b/__tests__/lib/diagnostics/candidat-libre/progression.test.ts
@@ -1,0 +1,30 @@
+import { computeCompletionPercentage, resolveModuleAvailability } from '@/lib/diagnostics/candidat-libre/progression';
+import type { DiagnosticModuleView } from '@/lib/diagnostics/candidat-libre/types';
+
+function view(key: string, status: DiagnosticModuleView['status'], submittedAt?: string): DiagnosticModuleView {
+  return { key, status, progress: status === 'REVIEWED' ? 100 : 0, submittedAt };
+}
+
+describe('candidate diagnostic progression', () => {
+  it('locks a module until prerequisites are complete', () => {
+    const result = resolveModuleAvailability('profil-parcours', [view('accueil-integrite', 'IN_PROGRESS')]);
+    expect(result.available).toBe(false);
+  });
+
+  it('opens profile after integrity module submission', () => {
+    const result = resolveModuleAvailability('profil-parcours', [view('accueil-integrite', 'AUTO_SCORED', new Date().toISOString())]);
+    expect(result.available).toBe(true);
+  });
+
+  it('sets a delayed availability for the retention module', () => {
+    const now = new Date('2026-08-05T10:00:00.000Z');
+    const result = resolveModuleAvailability('retention-transfert', [view('potentiel-t1', 'AUTO_SCORED', now.toISOString())], now);
+    expect(result.available).toBe(false);
+    expect(result.availableAt?.toISOString()).toBe('2026-08-08T10:00:00.000Z');
+  });
+
+  it('computes progress over all required audiences', () => {
+    expect(computeCompletionPercentage([view('accueil-integrite', 'AUTO_SCORED')])).toBeGreaterThan(0);
+    expect(computeCompletionPercentage([])).toBe(0);
+  });
+});

--- a/__tests__/lib/diagnostics/candidat-libre/scoring.test.ts
+++ b/__tests__/lib/diagnostics/candidat-libre/scoring.test.ts
@@ -1,0 +1,28 @@
+jest.mock('server-only', () => ({}));
+
+import { scoreDiagnosticModule } from '@/lib/diagnostics/candidat-libre/scoring.server';
+import type { DiagnosticAnswer } from '@/lib/diagnostics/candidat-libre/types';
+
+describe('candidate diagnostic scoring', () => {
+  it('scores exact answers and excludes NOT_STUDIED from mastery denominator', () => {
+    const answers: Record<string, DiagnosticAnswer> = {
+      'math-01': { questionId: 'math-01', value: 'a', status: 'ANSWERED', confidence: 3 },
+      'math-02': { questionId: 'math-02', value: 'a', status: 'ANSWERED', confidence: 3 },
+      'math-03': { questionId: 'math-03', value: 'NOT_STUDIED', status: 'NOT_STUDIED', confidence: 0 },
+    };
+    const result = scoreDiagnosticModule('mathematiques', answers);
+    expect(result.evidence.find((item) => item.questionId === 'math-01')?.status).toBe('CORRECT');
+    expect(result.evidence.find((item) => item.questionId === 'math-02')?.status).toBe('INCORRECT');
+    expect(result.evidence.find((item) => item.questionId === 'math-03')?.status).toBe('NOT_STUDIED');
+    expect(result.coveragePercentage).toBeLessThan(100);
+    expect(result.confidenceCalibration.overconfidenceCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('never exposes manual items as automatically correct', () => {
+    const result = scoreDiagnosticModule('mathematiques', {
+      'math-25': { questionId: 'math-25', value: 'Une démonstration rédigée.', status: 'ANSWERED', confidence: 3 },
+    });
+    expect(result.manualReviewQuestionIds).toContain('math-25');
+    expect(result.evidence.find((item) => item.questionId === 'math-25')?.status).toBe('MANUAL_REVIEW');
+  });
+});

--- a/__tests__/lib/diagnostics/candidat-libre/serialize.test.ts
+++ b/__tests__/lib/diagnostics/candidat-libre/serialize.test.ts
@@ -1,6 +1,18 @@
 jest.mock('server-only', () => ({}));
 
 import { serializeCandidateDiagnostic } from '@/lib/diagnostics/candidat-libre/serialize.server';
+import { isDocumentVisibleToViewer } from '@/lib/diagnostics/candidat-libre/access.server';
+
+/**
+ * Exhaustive cross-audience field matrix for the shared diagnostic view.
+ *
+ * `serializeCandidateDiagnostic` backs GET/PATCH routes reachable by both the
+ * ELEVE and PARENT portals for the same diagnostic (a minor's record). This
+ * suite asserts the *exact* key set and *exact* values returned per audience,
+ * not just presence/absence of the two fields known to have leaked — a new
+ * field added later without updating the allow-list here fails the test,
+ * even if it forgets to redact.
+ */
 
 function buildDiagnostic() {
   return {
@@ -43,7 +55,38 @@ function buildDiagnostic() {
         reviewSummary: 'Contexte familial favorable.',
       },
     ],
-    documents: [],
+    documents: [
+      {
+        id: 'doc-identity',
+        category: 'IDENTITY',
+        originalName: 'cni.pdf',
+        mimeType: 'application/pdf',
+        sizeBytes: 1000,
+        status: 'ACCEPTED',
+        reviewNote: null,
+        createdAt: new Date('2026-08-06T08:30:00Z'),
+      },
+      {
+        id: 'doc-written-copy',
+        category: 'WRITTEN_COPY',
+        originalName: 'dissertation.pdf',
+        mimeType: 'application/pdf',
+        sizeBytes: 2000,
+        status: 'ACCEPTED',
+        reviewNote: null,
+        createdAt: new Date('2026-08-06T08:45:00Z'),
+      },
+      {
+        id: 'doc-oral',
+        category: 'ORAL_RECORDING',
+        originalName: 'grand-oral.mp3',
+        mimeType: 'audio/mpeg',
+        sizeBytes: 3000,
+        status: 'ACCEPTED',
+        reviewNote: null,
+        createdAt: new Date('2026-08-06T08:50:00Z'),
+      },
+    ],
     studentConsentAt: null,
     parentConsentAt: null,
     submittedAt: null,
@@ -53,39 +96,90 @@ function buildDiagnostic() {
   };
 }
 
-describe('serializeCandidateDiagnostic — audience redaction', () => {
-  it('hides the parent module score/review from an ELEVE viewer but keeps status visible', () => {
+// Every field on a module view, and whether it's allowed to carry real
+// content when the module's audience differs from the viewer's own.
+// `true` = must survive redaction (status/progress-shaped, never content).
+// `false` = must be nulled out when the module isn't the viewer's own audience.
+const MODULE_FIELD_KEYS = ['key', 'status', 'progress', 'startedAt', 'submittedAt', 'availableAt', 'elapsedMs', 'autoScore', 'reviewSummary'] as const;
+const MODULE_CROSS_AUDIENCE_SAFE_FIELDS = new Set(['key', 'status', 'progress', 'startedAt', 'submittedAt', 'availableAt', 'elapsedMs']);
+const MODULE_CROSS_AUDIENCE_REDACTED_FIELDS = new Set(['autoScore', 'reviewSummary']);
+
+describe('serializeCandidateDiagnostic — exhaustive audience matrix', () => {
+  it('module view exposes exactly the documented field set (no undocumented field can slip through)', () => {
     const view = serializeCandidateDiagnostic(buildDiagnostic(), 'ELEVE');
-    const parentModule = view.modules.find((m) => m.key === 'questionnaire-parent')!;
-    const ownModule = view.modules.find((m) => m.key === 'mathematiques')!;
+    for (const module of view.modules) {
+      expect(Object.keys(module).sort()).toEqual([...MODULE_FIELD_KEYS].sort());
+    }
+    // every field is classified as either safe-to-cross or must-be-redacted — none left unclassified
+    expect(new Set([...MODULE_CROSS_AUDIENCE_SAFE_FIELDS, ...MODULE_CROSS_AUDIENCE_REDACTED_FIELDS])).toEqual(new Set(MODULE_FIELD_KEYS));
+  });
 
-    expect(parentModule.autoScore).toBeNull();
-    expect(parentModule.reviewSummary).toBeNull();
-    expect(parentModule.status).toBe('AUTO_SCORED');
-    expect(parentModule.submittedAt).not.toBeNull();
+  it.each(['ELEVE', 'PARENT'] as const)('%s viewer: cross-audience module keeps only status-shaped fields, redacts content', (viewer) => {
+    const view = serializeCandidateDiagnostic(buildDiagnostic(), viewer);
+    const otherAudience = viewer === 'ELEVE' ? 'questionnaire-parent' : 'mathematiques';
+    const crossModule = view.modules.find((m) => m.key === otherAudience)!;
+
+    for (const field of MODULE_CROSS_AUDIENCE_REDACTED_FIELDS) {
+      expect((crossModule as any)[field]).toBeNull();
+    }
+    for (const field of MODULE_CROSS_AUDIENCE_SAFE_FIELDS) {
+      expect((crossModule as any)[field]).not.toBeUndefined();
+    }
+  });
+
+  it.each(['ELEVE', 'PARENT'] as const)('%s viewer: own-audience module keeps full detail', (viewer) => {
+    const view = serializeCandidateDiagnostic(buildDiagnostic(), viewer);
+    const ownKey = viewer === 'ELEVE' ? 'mathematiques' : 'questionnaire-parent';
+    const ownModule = view.modules.find((m) => m.key === ownKey)!;
 
     expect(ownModule.autoScore).not.toBeNull();
     expect(ownModule.reviewSummary).not.toBeNull();
   });
 
-  it('hides the student module score/review from a PARENT viewer but keeps status visible', () => {
+  it('staff viewers (COACH/ADMIN) and internal callers with no role see full detail on every module', () => {
+    for (const viewer of ['COACH', 'ADMIN', undefined] as const) {
+      const view = serializeCandidateDiagnostic(buildDiagnostic(), viewer);
+      expect(view.modules.every((m) => m.autoScore !== null && m.reviewSummary !== null)).toBe(true);
+    }
+  });
+
+  it('PARENT viewer never receives the student academic production documents (written copy, oral recording)', () => {
     const view = serializeCandidateDiagnostic(buildDiagnostic(), 'PARENT');
-    const studentModule = view.modules.find((m) => m.key === 'mathematiques')!;
-    const ownModule = view.modules.find((m) => m.key === 'questionnaire-parent')!;
-
-    expect(studentModule.autoScore).toBeNull();
-    expect(studentModule.reviewSummary).toBeNull();
-    expect(studentModule.status).toBe('AUTO_SCORED');
-
-    expect(ownModule.autoScore).not.toBeNull();
-    expect(ownModule.reviewSummary).not.toBeNull();
+    const categories = view.documents.map((d) => d.category).sort();
+    expect(categories).toEqual(['IDENTITY']);
   });
 
-  it('keeps full detail for staff viewers (COACH/ADMIN) and when no role is passed', () => {
-    const staffView = serializeCandidateDiagnostic(buildDiagnostic(), 'COACH');
-    expect(staffView.modules.every((m) => m.autoScore !== null)).toBe(true);
+  it('ELEVE viewer receives both their own productions and shared administrative documents', () => {
+    const view = serializeCandidateDiagnostic(buildDiagnostic(), 'ELEVE');
+    const categories = view.documents.map((d) => d.category).sort();
+    expect(categories).toEqual(['IDENTITY', 'ORAL_RECORDING', 'WRITTEN_COPY']);
+  });
 
-    const internalView = serializeCandidateDiagnostic(buildDiagnostic());
-    expect(internalView.modules.every((m) => m.autoScore !== null)).toBe(true);
+  it('staff viewers and internal callers see every document regardless of category', () => {
+    for (const viewer of ['COACH', 'ADMIN', undefined] as const) {
+      const view = serializeCandidateDiagnostic(buildDiagnostic(), viewer);
+      expect(view.documents).toHaveLength(3);
+    }
+  });
+});
+
+describe('isDocumentVisibleToViewer — category × audience matrix', () => {
+  const ALL_CATEGORIES = [
+    'IDENTITY', 'CYCLADES', 'FRENCH_BAC_TRANSCRIPT', 'TUNISIAN_BAC_TRANSCRIPT',
+    'SCHOOL_REPORT', 'EXAM_ACCOMMODATION', 'WRITTEN_COPY', 'ORAL_RECORDING', 'OTHER',
+  ] as const;
+  const STUDENT_ACADEMIC_CATEGORIES = new Set(['WRITTEN_COPY', 'ORAL_RECORDING']);
+
+  it.each(ALL_CATEGORIES)('ELEVE always sees category %s', (category) => {
+    expect(isDocumentVisibleToViewer(category, 'ELEVE')).toBe(true);
+  });
+
+  it.each(ALL_CATEGORIES)('staff (COACH/ADMIN/ASSISTANTE) always sees category %s', (category) => {
+    expect(isDocumentVisibleToViewer(category, 'COACH')).toBe(true);
+    expect(isDocumentVisibleToViewer(category, 'ADMIN')).toBe(true);
+  });
+
+  it.each(ALL_CATEGORIES)('PARENT sees category %s only when it is not a student academic production', (category) => {
+    expect(isDocumentVisibleToViewer(category, 'PARENT')).toBe(!STUDENT_ACADEMIC_CATEGORIES.has(category));
   });
 });

--- a/__tests__/lib/diagnostics/candidat-libre/serialize.test.ts
+++ b/__tests__/lib/diagnostics/candidat-libre/serialize.test.ts
@@ -1,0 +1,91 @@
+jest.mock('server-only', () => ({}));
+
+import { serializeCandidateDiagnostic } from '@/lib/diagnostics/candidat-libre/serialize.server';
+
+function buildDiagnostic() {
+  return {
+    id: 'diag-1',
+    diagnosticKey: 'BAC_GENERAL_CANDIDAT_INDIVIDUEL_2027',
+    definitionVersion: '2026.08.05-v1',
+    status: 'ACTIVE',
+    targetSession: 2027,
+    student: {
+      id: 'student-1',
+      school: 'Lycée Test',
+      gradeLevel: 'TERMINALE',
+      user: { firstName: 'A', lastName: 'B', email: 'a@b.test' },
+    },
+    modules: [
+      {
+        moduleKey: 'mathematiques',
+        audience: 'ELEVE',
+        status: 'AUTO_SCORED',
+        currentQuestionIndex: 28,
+        elapsedMs: 1000,
+        definitionSnapshot: { questions: new Array(28) },
+        submittedAt: new Date('2026-08-06T10:00:00Z'),
+        startedAt: new Date('2026-08-06T09:00:00Z'),
+        availableAt: null,
+        autoScore: { points: 20, maxPoints: 28, percentage: 71.4, evidence: [{ questionId: 'math-01', status: 'CORRECT' }] },
+        reviewSummary: 'Bon niveau global.',
+      },
+      {
+        moduleKey: 'questionnaire-parent',
+        audience: 'PARENT',
+        status: 'AUTO_SCORED',
+        currentQuestionIndex: 22,
+        elapsedMs: 500,
+        definitionSnapshot: { questions: new Array(22) },
+        submittedAt: new Date('2026-08-06T11:00:00Z'),
+        startedAt: new Date('2026-08-06T10:30:00Z'),
+        availableAt: null,
+        autoScore: { points: 15, maxPoints: 22, percentage: 68.2, evidence: [{ questionId: 'parent-01', status: 'CORRECT' }] },
+        reviewSummary: 'Contexte familial favorable.',
+      },
+    ],
+    documents: [],
+    studentConsentAt: null,
+    parentConsentAt: null,
+    submittedAt: null,
+    retentionDueAt: null,
+    createdAt: new Date('2026-08-06T08:00:00Z'),
+    updatedAt: new Date('2026-08-06T08:00:00Z'),
+  };
+}
+
+describe('serializeCandidateDiagnostic — audience redaction', () => {
+  it('hides the parent module score/review from an ELEVE viewer but keeps status visible', () => {
+    const view = serializeCandidateDiagnostic(buildDiagnostic(), 'ELEVE');
+    const parentModule = view.modules.find((m) => m.key === 'questionnaire-parent')!;
+    const ownModule = view.modules.find((m) => m.key === 'mathematiques')!;
+
+    expect(parentModule.autoScore).toBeNull();
+    expect(parentModule.reviewSummary).toBeNull();
+    expect(parentModule.status).toBe('AUTO_SCORED');
+    expect(parentModule.submittedAt).not.toBeNull();
+
+    expect(ownModule.autoScore).not.toBeNull();
+    expect(ownModule.reviewSummary).not.toBeNull();
+  });
+
+  it('hides the student module score/review from a PARENT viewer but keeps status visible', () => {
+    const view = serializeCandidateDiagnostic(buildDiagnostic(), 'PARENT');
+    const studentModule = view.modules.find((m) => m.key === 'mathematiques')!;
+    const ownModule = view.modules.find((m) => m.key === 'questionnaire-parent')!;
+
+    expect(studentModule.autoScore).toBeNull();
+    expect(studentModule.reviewSummary).toBeNull();
+    expect(studentModule.status).toBe('AUTO_SCORED');
+
+    expect(ownModule.autoScore).not.toBeNull();
+    expect(ownModule.reviewSummary).not.toBeNull();
+  });
+
+  it('keeps full detail for staff viewers (COACH/ADMIN) and when no role is passed', () => {
+    const staffView = serializeCandidateDiagnostic(buildDiagnostic(), 'COACH');
+    expect(staffView.modules.every((m) => m.autoScore !== null)).toBe(true);
+
+    const internalView = serializeCandidateDiagnostic(buildDiagnostic());
+    expect(internalView.modules.every((m) => m.autoScore !== null)).toBe(true);
+  });
+});

--- a/__tests__/lib/diagnostics/candidat-libre/serialize.test.ts
+++ b/__tests__/lib/diagnostics/candidat-libre/serialize.test.ts
@@ -1,7 +1,7 @@
 jest.mock('server-only', () => ({}));
 
 import { serializeCandidateDiagnostic } from '@/lib/diagnostics/candidat-libre/serialize.server';
-import { isDocumentVisibleToViewer } from '@/lib/diagnostics/candidat-libre/access.server';
+import { canViewModuleDetail, isDocumentVisibleToViewer } from '@/lib/diagnostics/candidat-libre/access.server';
 
 /**
  * Exhaustive cross-audience field matrix for the shared diagnostic view.
@@ -107,8 +107,8 @@ const MODULE_CROSS_AUDIENCE_REDACTED_FIELDS = new Set(['autoScore', 'reviewSumma
 describe('serializeCandidateDiagnostic — exhaustive audience matrix', () => {
   it('module view exposes exactly the documented field set (no undocumented field can slip through)', () => {
     const view = serializeCandidateDiagnostic(buildDiagnostic(), 'ELEVE');
-    for (const module of view.modules) {
-      expect(Object.keys(module).sort()).toEqual([...MODULE_FIELD_KEYS].sort());
+    for (const moduleView of view.modules) {
+      expect(Object.keys(moduleView).sort()).toEqual([...MODULE_FIELD_KEYS].sort());
     }
     // every field is classified as either safe-to-cross or must-be-redacted — none left unclassified
     expect(new Set([...MODULE_CROSS_AUDIENCE_SAFE_FIELDS, ...MODULE_CROSS_AUDIENCE_REDACTED_FIELDS])).toEqual(new Set(MODULE_FIELD_KEYS));
@@ -136,11 +136,33 @@ describe('serializeCandidateDiagnostic — exhaustive audience matrix', () => {
     expect(ownModule.reviewSummary).not.toBeNull();
   });
 
-  it('staff viewers (COACH/ADMIN) and internal callers with no role see full detail on every module', () => {
-    for (const viewer of ['COACH', 'ADMIN', undefined] as const) {
+  // Arbitrated 2026-08-07: canEditAudience (WRITE) and read visibility are
+  // distinct rules — a COACH cannot edit either module but CAN read the
+  // ELEVE-audience one (their working material); questionnaire-parent stays
+  // out of reach. ADMIN and internal callers (no role) keep full access
+  // everywhere, unchanged. ASSISTANTE is new here: no academic detail on
+  // any module, stricter than the "staff sees everything" default this
+  // suite used to assert.
+  it('COACH sees full detail on the ELEVE-audience module but not on questionnaire-parent', () => {
+    const view = serializeCandidateDiagnostic(buildDiagnostic(), 'COACH');
+    const eleveModule = view.modules.find((m) => m.key === 'mathematiques')!;
+    const parentModule = view.modules.find((m) => m.key === 'questionnaire-parent')!;
+    expect(eleveModule.autoScore).not.toBeNull();
+    expect(eleveModule.reviewSummary).not.toBeNull();
+    expect(parentModule.autoScore).toBeNull();
+    expect(parentModule.reviewSummary).toBeNull();
+  });
+
+  it('ADMIN and internal callers (no role) see full detail on every module', () => {
+    for (const viewer of ['ADMIN', undefined] as const) {
       const view = serializeCandidateDiagnostic(buildDiagnostic(), viewer);
       expect(view.modules.every((m) => m.autoScore !== null && m.reviewSummary !== null)).toBe(true);
     }
+  });
+
+  it('ASSISTANTE sees no academic detail on any module', () => {
+    const view = serializeCandidateDiagnostic(buildDiagnostic(), 'ASSISTANTE');
+    expect(view.modules.every((m) => m.autoScore === null && m.reviewSummary === null)).toBe(true);
   });
 
   it('PARENT viewer never receives the student academic production documents (written copy, oral recording)', () => {
@@ -155,12 +177,42 @@ describe('serializeCandidateDiagnostic — exhaustive audience matrix', () => {
     expect(categories).toEqual(['IDENTITY', 'ORAL_RECORDING', 'WRITTEN_COPY']);
   });
 
-  it('staff viewers and internal callers see every document regardless of category', () => {
+  it('COACH, ADMIN and internal callers see every document regardless of category', () => {
     for (const viewer of ['COACH', 'ADMIN', undefined] as const) {
       const view = serializeCandidateDiagnostic(buildDiagnostic(), viewer);
       expect(view.documents).toHaveLength(3);
     }
   });
+
+  it('ASSISTANTE never receives the student academic production documents, same boundary as PARENT', () => {
+    const view = serializeCandidateDiagnostic(buildDiagnostic(), 'ASSISTANTE');
+    const categories = view.documents.map((d) => d.category).sort();
+    expect(categories).toEqual(['IDENTITY']);
+  });
+});
+
+describe('canViewModuleDetail — read-visibility matrix, single source of truth for 4 routes', () => {
+  const ROLES = ['ELEVE', 'PARENT', 'COACH', 'ADMIN', 'ASSISTANTE'] as const;
+  const AUDIENCES = ['ELEVE', 'PARENT'] as const;
+
+  // One explicit expectation per (role, audience) pair — a role or audience
+  // added later without updating this table fails type-checking on the
+  // ROLES/AUDIENCES arrays above before it can silently pass a test.
+  const EXPECTED: Record<(typeof ROLES)[number], Record<(typeof AUDIENCES)[number], boolean>> = {
+    ELEVE: { ELEVE: true, PARENT: false },
+    PARENT: { ELEVE: false, PARENT: true },
+    COACH: { ELEVE: true, PARENT: false },
+    ADMIN: { ELEVE: true, PARENT: true },
+    ASSISTANTE: { ELEVE: false, PARENT: false },
+  };
+
+  for (const role of ROLES) {
+    for (const audience of AUDIENCES) {
+      it(`${role} on a ${audience}-audience module → ${EXPECTED[role][audience]}`, () => {
+        expect(canViewModuleDetail(role as any, audience)).toBe(EXPECTED[role][audience]);
+      });
+    }
+  }
 });
 
 describe('isDocumentVisibleToViewer — category × audience matrix', () => {
@@ -174,12 +226,16 @@ describe('isDocumentVisibleToViewer — category × audience matrix', () => {
     expect(isDocumentVisibleToViewer(category, 'ELEVE')).toBe(true);
   });
 
-  it.each(ALL_CATEGORIES)('staff (COACH/ADMIN/ASSISTANTE) always sees category %s', (category) => {
+  it.each(ALL_CATEGORIES)('COACH/ADMIN always see category %s — student productions are their working material', (category) => {
     expect(isDocumentVisibleToViewer(category, 'COACH')).toBe(true);
     expect(isDocumentVisibleToViewer(category, 'ADMIN')).toBe(true);
   });
 
   it.each(ALL_CATEGORIES)('PARENT sees category %s only when it is not a student academic production', (category) => {
     expect(isDocumentVisibleToViewer(category, 'PARENT')).toBe(!STUDENT_ACADEMIC_CATEGORIES.has(category));
+  });
+
+  it.each(ALL_CATEGORIES)('ASSISTANTE sees category %s only when it is not a student academic production — same boundary as PARENT', (category) => {
+    expect(isDocumentVisibleToViewer(category, 'ASSISTANTE')).toBe(!STUDENT_ACADEMIC_CATEGORIES.has(category));
   });
 });

--- a/__tests__/lib/diagnostics/candidat-libre/storage.test.ts
+++ b/__tests__/lib/diagnostics/candidat-libre/storage.test.ts
@@ -1,0 +1,71 @@
+jest.mock('server-only', () => ({}));
+
+const mockMkdir = jest.fn().mockResolvedValue(undefined);
+const mockWriteFile = jest.fn().mockResolvedValue(undefined);
+jest.mock('fs/promises', () => ({
+  mkdir: (...args: unknown[]) => mockMkdir(...args),
+  writeFile: (...args: unknown[]) => mockWriteFile(...args),
+}));
+
+jest.mock('@/lib/documents/storage-root', () => ({
+  getDocumentStorageRoot: () => '/tmp/candidate-diagnostics-test-root',
+}));
+
+import { persistDiagnosticFile } from '@/lib/diagnostics/candidat-libre/storage.server';
+
+function fakeFile(bytes: number[], type: string, name = 'upload.bin'): File {
+  const buffer = Buffer.from(bytes);
+  return {
+    type,
+    size: buffer.byteLength,
+    name,
+    arrayBuffer: async () => buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength),
+  } as unknown as File;
+}
+
+const WAV_HEADER = [0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x41, 0x56, 0x45, ...new Array(8).fill(0)];
+const WEBM_HEADER = [0x1a, 0x45, 0xdf, 0xa3, ...new Array(8).fill(0)];
+const MP3_ID3_HEADER = [0x49, 0x44, 0x33, 3, 0, 0, 0, 0, 0, 0];
+const MP4_HEADER = [0, 0, 0, 0x20, 0x66, 0x74, 0x79, 0x70, ...new Array(8).fill(0)];
+
+describe('persistDiagnosticFile — audio signature validation', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('accepts a WAV file whose bytes match the RIFF/WAVE signature', async () => {
+    await expect(
+      persistDiagnosticFile({ diagnosticId: 'diag-1', category: 'ORAL_RECORDING', file: fakeFile(WAV_HEADER, 'audio/wav') }),
+    ).resolves.toMatchObject({ mimeType: 'audio/wav' });
+  });
+
+  it('accepts a WebM file whose bytes match the EBML signature', async () => {
+    await expect(
+      persistDiagnosticFile({ diagnosticId: 'diag-1', category: 'ORAL_RECORDING', file: fakeFile(WEBM_HEADER, 'audio/webm') }),
+    ).resolves.toMatchObject({ mimeType: 'audio/webm' });
+  });
+
+  it('accepts an MP3 file with an ID3 header', async () => {
+    await expect(
+      persistDiagnosticFile({ diagnosticId: 'diag-1', category: 'ORAL_RECORDING', file: fakeFile(MP3_ID3_HEADER, 'audio/mpeg') }),
+    ).resolves.toMatchObject({ mimeType: 'audio/mpeg' });
+  });
+
+  it('accepts an MP4/M4A file with an ftyp box', async () => {
+    await expect(
+      persistDiagnosticFile({ diagnosticId: 'diag-1', category: 'ORAL_RECORDING', file: fakeFile(MP4_HEADER, 'audio/mp4') }),
+    ).resolves.toMatchObject({ mimeType: 'audio/mp4' });
+  });
+
+  it('rejects a file declared as audio/wav whose bytes do not match the WAV signature', async () => {
+    const spoofed = fakeFile([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], 'audio/wav');
+    await expect(
+      persistDiagnosticFile({ diagnosticId: 'diag-1', category: 'ORAL_RECORDING', file: spoofed }),
+    ).rejects.toThrow('MIME_SIGNATURE_MISMATCH');
+  });
+
+  it('rejects a file declared as audio/webm whose bytes do not match the EBML signature', async () => {
+    const spoofed = fakeFile(WAV_HEADER, 'audio/webm');
+    await expect(
+      persistDiagnosticFile({ diagnosticId: 'diag-1', category: 'ORAL_RECORDING', file: spoofed }),
+    ).rejects.toThrow('MIME_SIGNATURE_MISMATCH');
+  });
+});

--- a/__tests__/lib/guards.coach-assignment.test.ts
+++ b/__tests__/lib/guards.coach-assignment.test.ts
@@ -1,0 +1,75 @@
+/**
+ * requireCoachAssignedToStudent — regression test.
+ *
+ * CoachStudentAssignment.coachId references CoachProfile.id, which is
+ * distinct from User.id. A prior version of this guard compared a coachUserId
+ * directly against coachId, which meant the check could never match a real
+ * assignment (fail-closed for the wrong reason) — it must resolve through the
+ * coach relation instead. Guards data access for a diagnostic feature that
+ * includes a minor's records, so id-space correctness here is non-negotiable.
+ *
+ * Source: lib/guards.ts
+ */
+
+const mockFindFirst = jest.fn();
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    coachStudentAssignment: {
+      findFirst: (...args: unknown[]) => mockFindFirst(...args),
+    },
+  },
+}));
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: jest.fn((body, init) => ({
+      json: jest.fn().mockResolvedValue(body),
+      status: init?.status || 200,
+      headers: new Map(),
+    })),
+  },
+}));
+
+import { requireCoachAssignedToStudent } from '@/lib/guards';
+
+describe('requireCoachAssignedToStudent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('authorizes a coach with an active assignment to the student', async () => {
+    mockFindFirst.mockResolvedValueOnce({ id: 'assignment-1' });
+
+    const result = await requireCoachAssignedToStudent('user-coach-1', 'student-1');
+
+    expect(result).toBe(true);
+    expect(mockFindFirst).toHaveBeenCalledWith({
+      where: { studentId: 'student-1', status: 'ACTIVE', coach: { userId: 'user-coach-1' } },
+      select: { id: true },
+    });
+  });
+
+  it('denies a coach with no assignment to the student (403)', async () => {
+    mockFindFirst.mockResolvedValueOnce(null);
+
+    const result = await requireCoachAssignedToStudent('user-coach-2', 'student-1');
+
+    expect(result).not.toBe(true);
+    expect((result as any).status).toBe(403);
+  });
+
+  it('denies a non-coach actor (no matching CoachProfile at all) with 403', async () => {
+    // A parent/student userId has no CoachProfile, so the relation filter
+    // never matches — the query itself proves it, no separate role check needed.
+    mockFindFirst.mockResolvedValueOnce(null);
+
+    const result = await requireCoachAssignedToStudent('user-parent-not-a-coach', 'student-1');
+
+    expect(result).not.toBe(true);
+    expect((result as any).status).toBe(403);
+    expect(mockFindFirst).toHaveBeenCalledWith({
+      where: { studentId: 'student-1', status: 'ACTIVE', coach: { userId: 'user-parent-not-a-coach' } },
+      select: { id: true },
+    });
+  });
+});

--- a/__tests__/lib/rate-limit.s3-final-contract.test.ts
+++ b/__tests__/lib/rate-limit.s3-final-contract.test.ts
@@ -54,6 +54,10 @@ describe('S3 final distributed rate-limit contract', () => {
       'quotes-pdf', 'bilan-pallier2', 'admin-stats', 'admin-recompute',
       'session-video-ip', 'session-video-user', 'session-book', 'session-cancel',
       'admin-users-read', 'admin-users-create', 'student-credits', 'student-sessions',
+      'candidate-diagnostic-create', 'candidate-diagnostic-final-submit',
+      'candidate-module-draft', 'candidate-module-submit',
+      'candidate-parent-draft', 'candidate-parent-submit',
+      'candidate-document-upload',
     ]
     expect(Object.keys(SENSITIVE_RATE_LIMIT_POLICIES).sort()).toEqual(expectedScopes.sort())
     for (const policy of Object.values(SENSITIVE_RATE_LIMIT_POLICIES)) {

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/[documentId]/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/[documentId]/route.ts
@@ -6,6 +6,7 @@ import { prisma } from '@/lib/prisma';
 import { getDocumentStorageRoot } from '@/lib/documents/storage-root';
 import { isErrorResponse } from '@/lib/guards';
 import { getDiagnosticForActor, requireDiagnosticActor, actorRole, isDocumentVisibleToViewer } from '@/lib/diagnostics/candidat-libre/access.server';
+import { guardCandidateDiagnosticFeature } from '@/lib/diagnostics/candidat-libre/feature-flag';
 
 interface Params { params: Promise<{ diagnosticId: string; documentId: string }> }
 
@@ -17,6 +18,8 @@ function safeAbsolutePath(storageKey: string) {
 }
 
 export async function GET(_request: Request, { params }: Params) {
+  const disabled = guardCandidateDiagnosticFeature();
+  if (disabled) return disabled;
   const { diagnosticId, documentId } = await params;
   const sessionOrError = await requireDiagnosticActor();
   if (isErrorResponse(sessionOrError)) return sessionOrError;
@@ -44,6 +47,8 @@ export async function GET(_request: Request, { params }: Params) {
 }
 
 export async function DELETE(_request: Request, { params }: Params) {
+  const disabled = guardCandidateDiagnosticFeature();
+  if (disabled) return disabled;
   const { diagnosticId, documentId } = await params;
   const sessionOrError = await requireDiagnosticActor();
   if (isErrorResponse(sessionOrError)) return sessionOrError;

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/[documentId]/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/[documentId]/route.ts
@@ -27,7 +27,7 @@ export async function GET(_request: Request, { params }: Params) {
   if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
   const document = diagnosticOrError.documents.find((item: any) => item.id === documentId);
   if (!document) return NextResponse.json({ error: 'Not Found' }, { status: 404 });
-  if (!isDocumentVisibleToViewer(document.category, actorRole(sessionOrError))) {
+  if (!isDocumentVisibleToViewer(document.category, sessionOrError.user.role)) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
   try {

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/[documentId]/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/[documentId]/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from 'next/server';
+import { readFile, unlink } from 'fs/promises';
+import path from 'path';
+import { UserRole } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { getDocumentStorageRoot } from '@/lib/documents/storage-root';
+import { isErrorResponse } from '@/lib/guards';
+import { getDiagnosticForActor, requireDiagnosticActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
+
+interface Params { params: Promise<{ diagnosticId: string; documentId: string }> }
+
+function safeAbsolutePath(storageKey: string) {
+  const root = path.resolve(getDocumentStorageRoot());
+  const absolute = path.resolve(root, storageKey);
+  if (!absolute.startsWith(`${root}${path.sep}`)) throw new Error('UNSAFE_STORAGE_PATH');
+  return absolute;
+}
+
+export async function GET(_request: Request, { params }: Params) {
+  const { diagnosticId, documentId } = await params;
+  const sessionOrError = await requireDiagnosticActor();
+  if (isErrorResponse(sessionOrError)) return sessionOrError;
+  const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
+  if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  const document = diagnosticOrError.documents.find((item: any) => item.id === documentId);
+  if (!document) return NextResponse.json({ error: 'Not Found' }, { status: 404 });
+  try {
+    const buffer = await readFile(safeAbsolutePath(document.storageKey));
+    return new NextResponse(buffer, {
+      headers: {
+        'Content-Type': document.mimeType,
+        'Content-Length': String(buffer.byteLength),
+        'Content-Disposition': `attachment; filename*=UTF-8''${encodeURIComponent(document.originalName)}`,
+        'Cache-Control': 'private, no-store',
+        'X-Content-Type-Options': 'nosniff',
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: 'File unavailable' }, { status: 404 });
+  }
+}
+
+export async function DELETE(_request: Request, { params }: Params) {
+  const { diagnosticId, documentId } = await params;
+  const sessionOrError = await requireDiagnosticActor();
+  if (isErrorResponse(sessionOrError)) return sessionOrError;
+  if (!([UserRole.ELEVE, UserRole.PARENT, UserRole.ADMIN, UserRole.ASSISTANTE] as UserRole[]).includes(sessionOrError.user.role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
+  if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  if (diagnosticOrError.submittedAt) return NextResponse.json({ error: 'Diagnostic locked' }, { status: 423 });
+  const document = diagnosticOrError.documents.find((item: any) => item.id === documentId);
+  if (!document) return NextResponse.json({ error: 'Not Found' }, { status: 404 });
+  if (!([UserRole.ADMIN, UserRole.ASSISTANTE] as UserRole[]).includes(sessionOrError.user.role) && document.uploadedById !== sessionOrError.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.candidateDiagnosticDocument.delete({ where: { id: documentId } });
+    await tx.candidateDiagnosticAuditLog.create({
+      data: {
+        diagnosticId,
+        actorId: sessionOrError.user.id,
+        actorRole: actorRole(sessionOrError),
+        action: 'DOCUMENT_DELETED',
+        entityType: 'CandidateDiagnosticDocument',
+        entityId: documentId,
+        details: { category: document.category, sha256: document.sha256 },
+      },
+    });
+  });
+  await unlink(safeAbsolutePath(document.storageKey)).catch(() => undefined);
+  return NextResponse.json({ success: true });
+}

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/[documentId]/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/[documentId]/route.ts
@@ -5,7 +5,7 @@ import { UserRole } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { getDocumentStorageRoot } from '@/lib/documents/storage-root';
 import { isErrorResponse } from '@/lib/guards';
-import { getDiagnosticForActor, requireDiagnosticActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
+import { getDiagnosticForActor, requireDiagnosticActor, actorRole, isDocumentVisibleToViewer } from '@/lib/diagnostics/candidat-libre/access.server';
 
 interface Params { params: Promise<{ diagnosticId: string; documentId: string }> }
 
@@ -24,6 +24,9 @@ export async function GET(_request: Request, { params }: Params) {
   if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
   const document = diagnosticOrError.documents.find((item: any) => item.id === documentId);
   if (!document) return NextResponse.json({ error: 'Not Found' }, { status: 404 });
+  if (!isDocumentVisibleToViewer(document.category, actorRole(sessionOrError))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
   try {
     const buffer = await readFile(safeAbsolutePath(document.storageKey));
     return new NextResponse(buffer, {

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/route.ts
@@ -4,7 +4,7 @@ import { prisma } from '@/lib/prisma';
 import { isErrorResponse } from '@/lib/guards';
 import { guardRateLimitAsync } from '@/lib/rate-limit';
 import { documentMetadataSchema } from '@/lib/diagnostics/candidat-libre/schemas';
-import { getDiagnosticForActor, requireDiagnosticActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
+import { getDiagnosticForActor, requireDiagnosticActor, actorRole, isDocumentVisibleToViewer } from '@/lib/diagnostics/candidat-libre/access.server';
 import { persistDiagnosticFile, removePersistedDiagnosticFile } from '@/lib/diagnostics/candidat-libre/storage.server';
 import { CANDIDATE_DIAGNOSTIC_MODULES } from '@/lib/diagnostics/candidat-libre/definition.public';
 import { scanDiagnosticFile } from '@/lib/diagnostics/candidat-libre/virus-scan.server';
@@ -23,8 +23,11 @@ export async function GET(_request: Request, { params }: Params) {
   if (isErrorResponse(sessionOrError)) return sessionOrError;
   const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
   if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  const viewerRole = actorRole(sessionOrError);
   return NextResponse.json({
-    documents: diagnosticOrError.documents.map((document: any) => ({
+    documents: diagnosticOrError.documents
+      .filter((document: any) => isDocumentVisibleToViewer(document.category, viewerRole))
+      .map((document: any) => ({
       id: document.id,
       category: document.category,
       title: document.title,

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/route.ts
@@ -8,6 +8,7 @@ import { getDiagnosticForActor, requireDiagnosticActor, actorRole, isDocumentVis
 import { persistDiagnosticFile, removePersistedDiagnosticFile } from '@/lib/diagnostics/candidat-libre/storage.server';
 import { CANDIDATE_DIAGNOSTIC_MODULES } from '@/lib/diagnostics/candidat-libre/definition.public';
 import { scanDiagnosticFile } from '@/lib/diagnostics/candidat-libre/virus-scan.server';
+import { guardCandidateDiagnosticFeature } from '@/lib/diagnostics/candidat-libre/feature-flag';
 
 interface Params { params: Promise<{ diagnosticId: string }> }
 
@@ -18,6 +19,8 @@ const CATEGORY_RULES = new Map(
 );
 
 export async function GET(_request: Request, { params }: Params) {
+  const disabled = guardCandidateDiagnosticFeature();
+  if (disabled) return disabled;
   const { diagnosticId } = await params;
   const sessionOrError = await requireDiagnosticActor();
   if (isErrorResponse(sessionOrError)) return sessionOrError;
@@ -44,6 +47,8 @@ export async function GET(_request: Request, { params }: Params) {
 }
 
 export async function POST(request: Request, { params }: Params) {
+  const disabled = guardCandidateDiagnosticFeature();
+  if (disabled) return disabled;
   const limited = await guardRateLimitAsync(request, { preset: 'api', keySuffix: 'candidate-document-upload' });
   if (limited) return limited;
   const { diagnosticId } = await params;

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { UserRole } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { isErrorResponse } from '@/lib/guards';
-import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { guardSensitiveRateLimit } from '@/lib/rate-limit/sensitive';
 import { documentMetadataSchema } from '@/lib/diagnostics/candidat-libre/schemas';
 import { getDiagnosticForActor, requireDiagnosticActor, actorRole, isDocumentVisibleToViewer } from '@/lib/diagnostics/candidat-libre/access.server';
 import { persistDiagnosticFile, removePersistedDiagnosticFile } from '@/lib/diagnostics/candidat-libre/storage.server';
@@ -49,14 +49,21 @@ export async function GET(_request: Request, { params }: Params) {
 export async function POST(request: Request, { params }: Params) {
   const disabled = guardCandidateDiagnosticFeature();
   if (disabled) return disabled;
-  const limited = await guardRateLimitAsync(request, { preset: 'api', keySuffix: 'candidate-document-upload' });
-  if (limited) return limited;
+  const ipLimited = await guardSensitiveRateLimit(request, { scope: 'candidate-document-upload', dimensions: ['ip'] });
+  if (ipLimited) return ipLimited;
   const { diagnosticId } = await params;
   const sessionOrError = await requireDiagnosticActor();
   if (isErrorResponse(sessionOrError)) return sessionOrError;
   if (!([UserRole.ELEVE, UserRole.PARENT, UserRole.ADMIN, UserRole.ASSISTANTE] as UserRole[]).includes(sessionOrError.user.role)) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
+  const identityLimited = await guardSensitiveRateLimit(request, {
+    scope: 'candidate-document-upload',
+    identity: sessionOrError.user.id,
+    resource: diagnosticId,
+    dimensions: ['identity', 'resource'],
+  });
+  if (identityLimited) return identityLimited;
   const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
   if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
   if (diagnosticOrError.submittedAt) return NextResponse.json({ error: 'Diagnostic locked' }, { status: 423 });

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/route.ts
@@ -26,7 +26,7 @@ export async function GET(_request: Request, { params }: Params) {
   if (isErrorResponse(sessionOrError)) return sessionOrError;
   const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
   if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
-  const viewerRole = actorRole(sessionOrError);
+  const viewerRole = sessionOrError.user.role;
   return NextResponse.json({
     documents: diagnosticOrError.documents
       .filter((document: any) => isDocumentVisibleToViewer(document.category, viewerRole))

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from 'next/server';
+import { UserRole } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { isErrorResponse } from '@/lib/guards';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { documentMetadataSchema } from '@/lib/diagnostics/candidat-libre/schemas';
+import { getDiagnosticForActor, requireDiagnosticActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
+import { persistDiagnosticFile, removePersistedDiagnosticFile } from '@/lib/diagnostics/candidat-libre/storage.server';
+import { CANDIDATE_DIAGNOSTIC_MODULES } from '@/lib/diagnostics/candidat-libre/definition.public';
+import { scanDiagnosticFile } from '@/lib/diagnostics/candidat-libre/virus-scan.server';
+
+interface Params { params: Promise<{ diagnosticId: string }> }
+
+const CATEGORY_RULES = new Map(
+  CANDIDATE_DIAGNOSTIC_MODULES.flatMap((module) => module.questions)
+    .filter((question) => question.type === 'upload' && question.uploadRule)
+    .map((question) => [question.uploadRule!.category, question.uploadRule!] as const),
+);
+
+export async function GET(_request: Request, { params }: Params) {
+  const { diagnosticId } = await params;
+  const sessionOrError = await requireDiagnosticActor();
+  if (isErrorResponse(sessionOrError)) return sessionOrError;
+  const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
+  if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  return NextResponse.json({
+    documents: diagnosticOrError.documents.map((document: any) => ({
+      id: document.id,
+      category: document.category,
+      title: document.title,
+      description: document.description,
+      originalName: document.originalName,
+      mimeType: document.mimeType,
+      sizeBytes: document.sizeBytes,
+      status: document.status,
+      reviewNote: document.reviewNote,
+      createdAt: document.createdAt,
+      downloadUrl: `/api/diagnostics/candidat-libre/${diagnosticId}/documents/${document.id}`,
+    })),
+  });
+}
+
+export async function POST(request: Request, { params }: Params) {
+  const limited = await guardRateLimitAsync(request, { preset: 'api', keySuffix: 'candidate-document-upload' });
+  if (limited) return limited;
+  const { diagnosticId } = await params;
+  const sessionOrError = await requireDiagnosticActor();
+  if (isErrorResponse(sessionOrError)) return sessionOrError;
+  if (!([UserRole.ELEVE, UserRole.PARENT, UserRole.ADMIN, UserRole.ASSISTANTE] as UserRole[]).includes(sessionOrError.user.role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
+  if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  if (diagnosticOrError.submittedAt) return NextResponse.json({ error: 'Diagnostic locked' }, { status: 423 });
+
+  const contentType = request.headers.get('content-type') ?? '';
+  if (!contentType.includes('multipart/form-data')) return NextResponse.json({ error: 'Multipart form-data required' }, { status: 415 });
+  const form = await request.formData();
+  const file = form.get('file');
+  if (!(file instanceof File)) return NextResponse.json({ error: 'File required' }, { status: 400 });
+  const parsed = documentMetadataSchema.safeParse({
+    category: form.get('category'),
+    title: form.get('title') || file.name,
+    description: form.get('description') || undefined,
+    clientMutationId: form.get('clientMutationId'),
+  });
+  if (!parsed.success) return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
+
+  const rule = CATEGORY_RULES.get(parsed.data.category);
+  if (!rule) return NextResponse.json({ error: 'Unsupported document category' }, { status: 400 });
+  if (!rule.accept.includes(file.type)) return NextResponse.json({ error: 'File type not allowed for category' }, { status: 400 });
+  if (file.size > rule.maxBytesPerFile) return NextResponse.json({ error: 'File too large', maxBytes: rule.maxBytesPerFile }, { status: 413 });
+  const count = diagnosticOrError.documents.filter((document: any) => document.category === parsed.data.category && document.status !== 'REJECTED').length;
+  if (count >= rule.maxFiles) return NextResponse.json({ error: 'Maximum number of files reached', maxFiles: rule.maxFiles }, { status: 409 });
+
+  const existing = await prisma.candidateDiagnosticDocument.findUnique({
+    where: { diagnosticId_clientMutationId: { diagnosticId, clientMutationId: parsed.data.clientMutationId } },
+  });
+  if (existing) return NextResponse.json({ success: true, idempotent: true, document: existing });
+
+  let stored: Awaited<ReturnType<typeof persistDiagnosticFile>> | null = null;
+  try {
+    stored = await persistDiagnosticFile({ diagnosticId, file, category: parsed.data.category });
+    await scanDiagnosticFile(stored.storageKey);
+    const storedFile = stored;
+    const document = await prisma.$transaction(async (tx) => {
+      const created = await tx.candidateDiagnosticDocument.create({
+        data: {
+          diagnosticId,
+          uploadedById: sessionOrError.user.id,
+          category: parsed.data.category,
+          title: parsed.data.title,
+          description: parsed.data.description,
+          originalName: storedFile.safeName,
+          storageKey: storedFile.storageKey,
+          mimeType: storedFile.mimeType,
+          sizeBytes: storedFile.sizeBytes,
+          sha256: storedFile.sha256,
+          clientMutationId: parsed.data.clientMutationId,
+        },
+      });
+      await tx.candidateDiagnosticAuditLog.create({
+        data: {
+          diagnosticId,
+          actorId: sessionOrError.user.id,
+          actorRole: actorRole(sessionOrError),
+          action: 'DOCUMENT_UPLOADED',
+          entityType: 'CandidateDiagnosticDocument',
+          entityId: created.id,
+          details: { category: created.category, sizeBytes: created.sizeBytes, sha256: created.sha256 },
+        },
+      });
+      return created;
+    });
+    return NextResponse.json({
+      success: true,
+      document: {
+        id: document.id,
+        category: document.category,
+        title: document.title,
+        originalName: document.originalName,
+        mimeType: document.mimeType,
+        sizeBytes: document.sizeBytes,
+        status: document.status,
+        createdAt: document.createdAt,
+      },
+    }, { status: 201 });
+  } catch (error) {
+    if (stored?.storageKey) await removePersistedDiagnosticFile(stored.storageKey);
+    const code = error instanceof Error ? error.message : 'UPLOAD_FAILED';
+    const status = code === 'INVALID_FILE_SIZE' ? 413 : code === 'AV_SCAN_FAILED' || code === 'AV_NOT_CONFIGURED' ? 503 : 400;
+    return NextResponse.json({ error: code }, { status });
+  }
+}

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/modules/[moduleKey]/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/modules/[moduleKey]/route.ts
@@ -5,7 +5,7 @@ import { prisma } from '@/lib/prisma';
 import { isErrorResponse } from '@/lib/guards';
 import { guardSensitiveRateLimit } from '@/lib/rate-limit/sensitive';
 import type { SensitiveRateLimitScope } from '@/lib/rate-limit/sensitive';
-import { getDiagnosticForActor, requireDiagnosticActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
+import { canViewModuleDetail, getDiagnosticForActor, requireDiagnosticActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
 import { getPublicModuleDefinition, CANDIDATE_DIAGNOSTIC_MODULES } from '@/lib/diagnostics/candidat-libre/definition.public';
 import { moduleDraftSchema, moduleKeySchema } from '@/lib/diagnostics/candidat-libre/schemas';
 import { scoreDiagnosticModule, validateRequiredAnswers } from '@/lib/diagnostics/candidat-libre/scoring.server';
@@ -15,6 +15,22 @@ import type { DiagnosticAnswer, DiagnosticModuleView } from '@/lib/diagnostics/c
 
 interface Params { params: Promise<{ diagnosticId: string; moduleKey: string }> }
 
+// WRITE permission only — who may submit/save answers for this module.
+// Distinct from READ visibility (canViewModuleDetail, access.server.ts):
+// conflating the two previously produced a false parallel (a COACH blocked
+// from editing was wrongly assumed blocked from reading too). This function
+// still governs edit gating below (PUT/POST) and the 403 on GET; the GET
+// response's `answers` field now uses canViewModuleDetail instead (see
+// below) — a COACH can read an ELEVE-audience module's answers without
+// being able to edit them.
+//
+// Known residual inconsistency, not fixed here (flagged, not routed
+// around): ASSISTANTE returns true unconditionally, same as ADMIN — she can
+// still WRITE any module's answers even though canViewModuleDetail now
+// denies her READ access to that same content. Product decision needed:
+// either ASSISTANTE never had a real reason to write academic answers
+// either (tighten this function), or her write access is intentional
+// (e.g. transcribing on behalf of family) and only read is restricted.
 function canEditAudience(role: UserRole, audience: string) {
   if (role === UserRole.ELEVE) return audience === 'ELEVE';
   if (role === UserRole.PARENT) return audience === 'PARENT';
@@ -56,7 +72,7 @@ export async function GET(_request: Request, { params }: Params) {
     module: {
       key: moduleRecord.moduleKey,
       status: moduleRecord.status,
-      answers: canEditAudience(sessionOrError.user.role, definition.audience) ? moduleRecord.answers ?? {} : undefined,
+      answers: canViewModuleDetail(sessionOrError.user.role, definition.audience) ? moduleRecord.answers ?? {} : undefined,
       currentQuestionIndex: moduleRecord.currentQuestionIndex,
       elapsedMs: moduleRecord.elapsedMs,
       integrity: moduleRecord.integrity,

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/modules/[moduleKey]/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/modules/[moduleKey]/route.ts
@@ -1,0 +1,192 @@
+import { NextResponse } from 'next/server';
+import type { Prisma } from '@prisma/client';
+import { UserRole } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { isErrorResponse } from '@/lib/guards';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { getDiagnosticForActor, requireDiagnosticActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
+import { getPublicModuleDefinition, CANDIDATE_DIAGNOSTIC_MODULES } from '@/lib/diagnostics/candidat-libre/definition.public';
+import { moduleDraftSchema, moduleKeySchema } from '@/lib/diagnostics/candidat-libre/schemas';
+import { scoreDiagnosticModule, validateRequiredAnswers } from '@/lib/diagnostics/candidat-libre/scoring.server';
+import { resolveModuleAvailability } from '@/lib/diagnostics/candidat-libre/progression';
+import type { DiagnosticAnswer, DiagnosticModuleView } from '@/lib/diagnostics/candidat-libre/types';
+
+interface Params { params: Promise<{ diagnosticId: string; moduleKey: string }> }
+
+function canEditAudience(role: UserRole, audience: string) {
+  if (role === UserRole.ELEVE) return audience === 'ELEVE';
+  if (role === UserRole.PARENT) return audience === 'PARENT';
+  return role === UserRole.ADMIN || role === UserRole.ASSISTANTE;
+}
+
+function moduleViews(diagnostic: any): DiagnosticModuleView[] {
+  return diagnostic.modules.map((module: any) => ({
+    key: module.moduleKey,
+    status: module.status,
+    progress: module.submittedAt ? 100 : 0,
+    submittedAt: module.submittedAt?.toISOString?.() ?? null,
+    availableAt: module.availableAt?.toISOString?.() ?? null,
+  }));
+}
+
+export async function GET(_request: Request, { params }: Params) {
+  const { diagnosticId, moduleKey: rawModuleKey } = await params;
+  const parsedKey = moduleKeySchema.safeParse(rawModuleKey);
+  if (!parsedKey.success) return NextResponse.json({ error: 'Invalid module key' }, { status: 400 });
+  const definition = getPublicModuleDefinition(parsedKey.data);
+  if (!definition) return NextResponse.json({ error: 'Module not found' }, { status: 404 });
+
+  const sessionOrError = await requireDiagnosticActor();
+  if (isErrorResponse(sessionOrError)) return sessionOrError;
+  const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
+  if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  if (!canEditAudience(sessionOrError.user.role, definition.audience) && sessionOrError.user.role !== UserRole.COACH) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  const moduleRecord = diagnosticOrError.modules.find((item: any) => item.moduleKey === parsedKey.data);
+  if (!moduleRecord) return NextResponse.json({ error: 'Module record not found' }, { status: 404 });
+  const availability = resolveModuleAvailability(parsedKey.data, moduleViews(diagnosticOrError));
+
+  return NextResponse.json({
+    definition,
+    module: {
+      key: moduleRecord.moduleKey,
+      status: moduleRecord.status,
+      answers: canEditAudience(sessionOrError.user.role, definition.audience) ? moduleRecord.answers ?? {} : undefined,
+      currentQuestionIndex: moduleRecord.currentQuestionIndex,
+      elapsedMs: moduleRecord.elapsedMs,
+      integrity: moduleRecord.integrity,
+      submittedAt: moduleRecord.submittedAt,
+      availableAt: availability.availableAt,
+      availability,
+    },
+  });
+}
+
+export async function PUT(request: Request, context: Params) {
+  return saveModule(request, context, 'draft');
+}
+
+export async function POST(request: Request, context: Params) {
+  return saveModule(request, context, 'submit');
+}
+
+async function saveModule(request: Request, { params }: Params, forcedAction: 'draft' | 'submit') {
+  const limited = await guardRateLimitAsync(request, { preset: 'api', keySuffix: `candidate-module-${forcedAction}` });
+  if (limited) return limited;
+  const { diagnosticId, moduleKey: rawModuleKey } = await params;
+  const parsedKey = moduleKeySchema.safeParse(rawModuleKey);
+  if (!parsedKey.success) return NextResponse.json({ error: 'Invalid module key' }, { status: 400 });
+  const definition = getPublicModuleDefinition(parsedKey.data);
+  if (!definition) return NextResponse.json({ error: 'Module not found' }, { status: 404 });
+
+  const sessionOrError = await requireDiagnosticActor();
+  if (isErrorResponse(sessionOrError)) return sessionOrError;
+  if (!canEditAudience(sessionOrError.user.role, definition.audience)) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
+  if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  if (diagnosticOrError.submittedAt) return NextResponse.json({ error: 'Diagnostic locked' }, { status: 423 });
+
+  const parsed = moduleDraftSchema.safeParse({ ...(await request.json()), action: forcedAction });
+  if (!parsed.success) return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
+  const moduleRecord = diagnosticOrError.modules.find((item: any) => item.moduleKey === parsedKey.data);
+  if (!moduleRecord) return NextResponse.json({ error: 'Module record not found' }, { status: 404 });
+  if (moduleRecord.submittedAt) return NextResponse.json({ error: 'Module locked after submission' }, { status: 423 });
+  if (moduleRecord.lastMutationId === parsed.data.clientMutationId) return NextResponse.json({ success: true, idempotent: true, module: moduleRecord });
+
+  const availability = resolveModuleAvailability(parsedKey.data, moduleViews(diagnosticOrError));
+  if (!availability.available) {
+    return NextResponse.json({ error: 'Module locked', availableAt: availability.availableAt, reason: availability.reason }, { status: 423 });
+  }
+
+  if (forcedAction === 'submit') {
+    const required = validateRequiredAnswers(parsedKey.data, parsed.data.answers as Record<string, DiagnosticAnswer>);
+    if (!required.valid) return NextResponse.json({ error: 'Incomplete module', missingQuestionIds: required.missingQuestionIds }, { status: 422 });
+    const requiredUploads = definition.questions.filter((question) => question.type === 'upload' && question.uploadRule?.required);
+    for (const question of requiredUploads) {
+      const count = diagnosticOrError.documents.filter((document: any) => document.category === question.uploadRule?.category && document.status !== 'REJECTED').length;
+      if (count < 1) return NextResponse.json({ error: 'Missing required document', questionId: question.id, category: question.uploadRule?.category }, { status: 422 });
+    }
+  }
+
+  const score = forcedAction === 'submit'
+    ? scoreDiagnosticModule(parsedKey.data, parsed.data.answers as Record<string, DiagnosticAnswer>)
+    : null;
+  const now = new Date();
+  const newStatus = forcedAction === 'submit'
+    ? score && score.manualReviewQuestionIds.length > 0 ? 'NEEDS_REVIEW' : 'AUTO_SCORED'
+    : moduleRecord.status === 'AVAILABLE' ? 'IN_PROGRESS' : moduleRecord.status;
+
+  const result = await prisma.$transaction(async (tx) => {
+    await tx.candidateDiagnosticModule.update({
+      where: { id: moduleRecord.id },
+      data: {
+        answers: parsed.data.answers as unknown as Prisma.InputJsonValue,
+        currentQuestionIndex: parsed.data.currentQuestionIndex,
+        elapsedMs: parsed.data.elapsedMs,
+        integrity: parsed.data.integrity as unknown as Prisma.InputJsonValue,
+        autoScore: score as unknown as Prisma.InputJsonValue | undefined,
+        status: newStatus,
+        startedAt: moduleRecord.startedAt ?? now,
+        submittedAt: forcedAction === 'submit' ? now : undefined,
+        lastMutationId: parsed.data.clientMutationId,
+      },
+    });
+
+    const unlocked: string[] = [];
+    if (forcedAction === 'submit') {
+      if (parsedKey.data === 'accueil-integrite') {
+        await tx.candidateDiagnostic.update({
+          where: { id: diagnosticId },
+          data: { studentConsentAt: now, status: 'ACTIVE' },
+        });
+      }
+      const updatedViews = moduleViews(diagnosticOrError).map((view) => view.key === parsedKey.data ? { ...view, status: newStatus as any, submittedAt: now.toISOString() } : view);
+      for (const candidate of CANDIDATE_DIAGNOSTIC_MODULES) {
+        if (candidate.audience !== definition.audience) continue;
+        const record = diagnosticOrError.modules.find((item: any) => item.moduleKey === candidate.key);
+        if (!record || record.status !== 'LOCKED') continue;
+        const nextAvailability = resolveModuleAvailability(candidate.key, updatedViews, now);
+        if (nextAvailability.available || nextAvailability.availableAt) {
+          await tx.candidateDiagnosticModule.update({
+            where: { id: record.id },
+            data: {
+              status: nextAvailability.available ? 'AVAILABLE' : 'LOCKED',
+              availableAt: nextAvailability.availableAt,
+            },
+          });
+          if (nextAvailability.available) unlocked.push(candidate.key);
+          if (candidate.key === 'retention-transfert' && nextAvailability.availableAt) {
+            await tx.candidateDiagnostic.update({ where: { id: diagnosticId }, data: { retentionDueAt: nextAvailability.availableAt, status: 'WAITING_RETENTION' } });
+          }
+        }
+      }
+    }
+
+    await tx.candidateDiagnosticAuditLog.create({
+      data: {
+        diagnosticId,
+        actorId: sessionOrError.user.id,
+        actorRole: actorRole(sessionOrError),
+        action: forcedAction === 'submit' ? 'MODULE_SUBMITTED' : 'MODULE_AUTOSAVED',
+        entityType: 'CandidateDiagnosticModule',
+        entityId: moduleRecord.id,
+        details: forcedAction === 'submit' ? { moduleKey: parsedKey.data, elapsedMs: parsed.data.elapsedMs } : undefined,
+      },
+    });
+
+    const updated = await tx.candidateDiagnosticModule.findUniqueOrThrow({ where: { id: moduleRecord.id } });
+    return { updated, unlocked };
+  });
+
+  return NextResponse.json({
+    success: true,
+    module: {
+      key: result.updated.moduleKey,
+      status: result.updated.status,
+      submittedAt: result.updated.submittedAt,
+      progress: forcedAction === 'submit' ? 100 : Math.round(((parsed.data.currentQuestionIndex + 1) / definition.questions.length) * 100),
+    },
+    unlockedModuleKeys: result.unlocked,
+  });
+}

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/modules/[moduleKey]/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/modules/[moduleKey]/route.ts
@@ -9,6 +9,7 @@ import { getPublicModuleDefinition, CANDIDATE_DIAGNOSTIC_MODULES } from '@/lib/d
 import { moduleDraftSchema, moduleKeySchema } from '@/lib/diagnostics/candidat-libre/schemas';
 import { scoreDiagnosticModule, validateRequiredAnswers } from '@/lib/diagnostics/candidat-libre/scoring.server';
 import { resolveModuleAvailability } from '@/lib/diagnostics/candidat-libre/progression';
+import { guardCandidateDiagnosticFeature } from '@/lib/diagnostics/candidat-libre/feature-flag';
 import type { DiagnosticAnswer, DiagnosticModuleView } from '@/lib/diagnostics/candidat-libre/types';
 
 interface Params { params: Promise<{ diagnosticId: string; moduleKey: string }> }
@@ -30,6 +31,8 @@ function moduleViews(diagnostic: any): DiagnosticModuleView[] {
 }
 
 export async function GET(_request: Request, { params }: Params) {
+  const disabled = guardCandidateDiagnosticFeature();
+  if (disabled) return disabled;
   const { diagnosticId, moduleKey: rawModuleKey } = await params;
   const parsedKey = moduleKeySchema.safeParse(rawModuleKey);
   if (!parsedKey.success) return NextResponse.json({ error: 'Invalid module key' }, { status: 400 });
@@ -72,6 +75,8 @@ export async function POST(request: Request, context: Params) {
 }
 
 async function saveModule(request: Request, { params }: Params, forcedAction: 'draft' | 'submit') {
+  const disabled = guardCandidateDiagnosticFeature();
+  if (disabled) return disabled;
   const limited = await guardRateLimitAsync(request, { preset: 'api', keySuffix: `candidate-module-${forcedAction}` });
   if (limited) return limited;
   const { diagnosticId, moduleKey: rawModuleKey } = await params;

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/modules/[moduleKey]/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/modules/[moduleKey]/route.ts
@@ -3,7 +3,8 @@ import type { Prisma } from '@prisma/client';
 import { UserRole } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { isErrorResponse } from '@/lib/guards';
-import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { guardSensitiveRateLimit } from '@/lib/rate-limit/sensitive';
+import type { SensitiveRateLimitScope } from '@/lib/rate-limit/sensitive';
 import { getDiagnosticForActor, requireDiagnosticActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
 import { getPublicModuleDefinition, CANDIDATE_DIAGNOSTIC_MODULES } from '@/lib/diagnostics/candidat-libre/definition.public';
 import { moduleDraftSchema, moduleKeySchema } from '@/lib/diagnostics/candidat-libre/schemas';
@@ -77,8 +78,9 @@ export async function POST(request: Request, context: Params) {
 async function saveModule(request: Request, { params }: Params, forcedAction: 'draft' | 'submit') {
   const disabled = guardCandidateDiagnosticFeature();
   if (disabled) return disabled;
-  const limited = await guardRateLimitAsync(request, { preset: 'api', keySuffix: `candidate-module-${forcedAction}` });
-  if (limited) return limited;
+  const scope: SensitiveRateLimitScope = forcedAction === 'submit' ? 'candidate-module-submit' : 'candidate-module-draft';
+  const ipLimited = await guardSensitiveRateLimit(request, { scope, dimensions: ['ip'] });
+  if (ipLimited) return ipLimited;
   const { diagnosticId, moduleKey: rawModuleKey } = await params;
   const parsedKey = moduleKeySchema.safeParse(rawModuleKey);
   if (!parsedKey.success) return NextResponse.json({ error: 'Invalid module key' }, { status: 400 });
@@ -87,6 +89,8 @@ async function saveModule(request: Request, { params }: Params, forcedAction: 'd
 
   const sessionOrError = await requireDiagnosticActor();
   if (isErrorResponse(sessionOrError)) return sessionOrError;
+  const identityLimited = await guardSensitiveRateLimit(request, { scope, identity: sessionOrError.user.id, dimensions: ['identity'] });
+  if (identityLimited) return identityLimited;
   if (!canEditAudience(sessionOrError.user.role, definition.audience)) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
   if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/parent/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/parent/route.ts
@@ -9,11 +9,14 @@ import { getPublicModuleDefinition } from '@/lib/diagnostics/candidat-libre/defi
 import { parentQuestionnaireSchema } from '@/lib/diagnostics/candidat-libre/schemas';
 import { scoreDiagnosticModule, validateRequiredAnswers } from '@/lib/diagnostics/candidat-libre/scoring.server';
 import type { DiagnosticAnswer } from '@/lib/diagnostics/candidat-libre/types';
+import { guardCandidateDiagnosticFeature } from '@/lib/diagnostics/candidat-libre/feature-flag';
 
 interface Params { params: Promise<{ diagnosticId: string }> }
 const MODULE_KEY = 'questionnaire-parent';
 
 export async function GET(_request: Request, { params }: Params) {
+  const disabled = guardCandidateDiagnosticFeature();
+  if (disabled) return disabled;
   const { diagnosticId } = await params;
   const sessionOrError = await requireRole(UserRole.PARENT);
   if (isErrorResponse(sessionOrError)) return sessionOrError;
@@ -46,6 +49,8 @@ export async function POST(request: Request, context: Params) {
 }
 
 async function saveParentQuestionnaire(request: Request, { params }: Params, action: 'draft' | 'submit') {
+  const disabled = guardCandidateDiagnosticFeature();
+  if (disabled) return disabled;
   const limited = await guardRateLimitAsync(request, { preset: 'api', keySuffix: 'candidate-parent-questionnaire' });
   if (limited) return limited;
   const { diagnosticId } = await params;

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/parent/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/parent/route.ts
@@ -3,7 +3,8 @@ import type { Prisma } from '@prisma/client';
 import { UserRole } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { isErrorResponse, requireRole } from '@/lib/guards';
-import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { guardSensitiveRateLimit } from '@/lib/rate-limit/sensitive';
+import type { SensitiveRateLimitScope } from '@/lib/rate-limit/sensitive';
 import { getDiagnosticForActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
 import { getPublicModuleDefinition } from '@/lib/diagnostics/candidat-libre/definition.public';
 import { parentQuestionnaireSchema } from '@/lib/diagnostics/candidat-libre/schemas';
@@ -51,11 +52,14 @@ export async function POST(request: Request, context: Params) {
 async function saveParentQuestionnaire(request: Request, { params }: Params, action: 'draft' | 'submit') {
   const disabled = guardCandidateDiagnosticFeature();
   if (disabled) return disabled;
-  const limited = await guardRateLimitAsync(request, { preset: 'api', keySuffix: 'candidate-parent-questionnaire' });
-  if (limited) return limited;
+  const scope: SensitiveRateLimitScope = action === 'submit' ? 'candidate-parent-submit' : 'candidate-parent-draft';
+  const ipLimited = await guardSensitiveRateLimit(request, { scope, dimensions: ['ip'] });
+  if (ipLimited) return ipLimited;
   const { diagnosticId } = await params;
   const sessionOrError = await requireRole(UserRole.PARENT);
   if (isErrorResponse(sessionOrError)) return sessionOrError;
+  const identityLimited = await guardSensitiveRateLimit(request, { scope, identity: sessionOrError.user.id, dimensions: ['identity'] });
+  if (identityLimited) return identityLimited;
   const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
   if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
   if (diagnosticOrError.submittedAt) return NextResponse.json({ error: 'Diagnostic locked' }, { status: 423 });

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/parent/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/parent/route.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from 'next/server';
+import type { Prisma } from '@prisma/client';
+import { UserRole } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { isErrorResponse, requireRole } from '@/lib/guards';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { getDiagnosticForActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
+import { getPublicModuleDefinition } from '@/lib/diagnostics/candidat-libre/definition.public';
+import { parentQuestionnaireSchema } from '@/lib/diagnostics/candidat-libre/schemas';
+import { scoreDiagnosticModule, validateRequiredAnswers } from '@/lib/diagnostics/candidat-libre/scoring.server';
+import type { DiagnosticAnswer } from '@/lib/diagnostics/candidat-libre/types';
+
+interface Params { params: Promise<{ diagnosticId: string }> }
+const MODULE_KEY = 'questionnaire-parent';
+
+export async function GET(_request: Request, { params }: Params) {
+  const { diagnosticId } = await params;
+  const sessionOrError = await requireRole(UserRole.PARENT);
+  if (isErrorResponse(sessionOrError)) return sessionOrError;
+  const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
+  if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  const moduleRecord = diagnosticOrError.modules.find((item: any) => item.moduleKey === MODULE_KEY);
+  if (!moduleRecord) return NextResponse.json({ error: 'Module not found' }, { status: 404 });
+  return NextResponse.json({
+    definition: getPublicModuleDefinition(MODULE_KEY),
+    module: {
+      status: moduleRecord.status,
+      answers: moduleRecord.answers ?? {},
+      currentQuestionIndex: moduleRecord.currentQuestionIndex,
+      elapsedMs: moduleRecord.elapsedMs,
+      submittedAt: moduleRecord.submittedAt,
+    },
+    student: {
+      firstName: diagnosticOrError.student.user.firstName,
+      lastName: diagnosticOrError.student.user.lastName,
+    },
+  });
+}
+
+export async function PUT(request: Request, context: Params) {
+  return saveParentQuestionnaire(request, context, 'draft');
+}
+
+export async function POST(request: Request, context: Params) {
+  return saveParentQuestionnaire(request, context, 'submit');
+}
+
+async function saveParentQuestionnaire(request: Request, { params }: Params, action: 'draft' | 'submit') {
+  const limited = await guardRateLimitAsync(request, { preset: 'api', keySuffix: 'candidate-parent-questionnaire' });
+  if (limited) return limited;
+  const { diagnosticId } = await params;
+  const sessionOrError = await requireRole(UserRole.PARENT);
+  if (isErrorResponse(sessionOrError)) return sessionOrError;
+  const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
+  if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  if (diagnosticOrError.submittedAt) return NextResponse.json({ error: 'Diagnostic locked' }, { status: 423 });
+  const parsed = parentQuestionnaireSchema.safeParse({ ...(await request.json()), action });
+  if (!parsed.success) return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
+  const moduleRecord = diagnosticOrError.modules.find((item: any) => item.moduleKey === MODULE_KEY);
+  if (!moduleRecord) return NextResponse.json({ error: 'Module not found' }, { status: 404 });
+  if (moduleRecord.submittedAt) return NextResponse.json({ error: 'Questionnaire already submitted' }, { status: 423 });
+  if (moduleRecord.lastMutationId === parsed.data.clientMutationId) return NextResponse.json({ success: true, idempotent: true });
+
+  if (action === 'submit') {
+    if (!parsed.data.consent) return NextResponse.json({ error: 'Parent consent required' }, { status: 422 });
+    const required = validateRequiredAnswers(MODULE_KEY, parsed.data.answers as Record<string, DiagnosticAnswer>);
+    if (!required.valid) return NextResponse.json({ error: 'Incomplete questionnaire', missingQuestionIds: required.missingQuestionIds }, { status: 422 });
+  }
+  const score = action === 'submit' ? scoreDiagnosticModule(MODULE_KEY, parsed.data.answers as Record<string, DiagnosticAnswer>) : null;
+  const now = new Date();
+  await prisma.$transaction(async (tx) => {
+    await tx.candidateDiagnosticModule.update({
+      where: { id: moduleRecord.id },
+      data: {
+        answers: parsed.data.answers as unknown as Prisma.InputJsonValue,
+        currentQuestionIndex: Object.keys(parsed.data.answers).length,
+        autoScore: score as unknown as Prisma.InputJsonValue | undefined,
+        status: action === 'submit' ? (score?.manualReviewQuestionIds.length ? 'NEEDS_REVIEW' : 'AUTO_SCORED') : 'IN_PROGRESS',
+        startedAt: moduleRecord.startedAt ?? now,
+        submittedAt: action === 'submit' ? now : undefined,
+        lastMutationId: parsed.data.clientMutationId,
+      },
+    });
+    if (action === 'submit') {
+      await tx.candidateDiagnostic.update({
+        where: { id: diagnosticId },
+        data: { parentConsentAt: now, parentSubmittedAt: now },
+      });
+    }
+    await tx.candidateDiagnosticAuditLog.create({
+      data: {
+        diagnosticId,
+        actorId: sessionOrError.user.id,
+        actorRole: actorRole(sessionOrError),
+        action: action === 'submit' ? 'PARENT_QUESTIONNAIRE_SUBMITTED' : 'PARENT_QUESTIONNAIRE_AUTOSAVED',
+        entityType: 'CandidateDiagnosticModule',
+        entityId: moduleRecord.id,
+      },
+    });
+  });
+  return NextResponse.json({ success: true, status: action === 'submit' ? 'SUBMITTED' : 'DRAFT' });
+}

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/route.ts
@@ -17,7 +17,7 @@ export async function GET(_request: Request, { params }: Params) {
   if (isErrorResponse(sessionOrError)) return sessionOrError;
   const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
   if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
-  return NextResponse.json({ diagnostic: serializeCandidateDiagnostic(diagnosticOrError, actorRole(sessionOrError)) });
+  return NextResponse.json({ diagnostic: serializeCandidateDiagnostic(diagnosticOrError, sessionOrError.user.role) });
 }
 
 export async function PATCH(request: Request, { params }: Params) {
@@ -61,5 +61,5 @@ export async function PATCH(request: Request, { params }: Params) {
       },
     });
   });
-  return NextResponse.json({ diagnostic: serializeCandidateDiagnostic(updated, actorRole(sessionOrError)) });
+  return NextResponse.json({ diagnostic: serializeCandidateDiagnostic(updated, sessionOrError.user.role) });
 }

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/route.ts
@@ -4,11 +4,14 @@ import { prisma } from '@/lib/prisma';
 import { getDiagnosticForActor, requireDiagnosticActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
 import { updateDiagnosticProfileSchema } from '@/lib/diagnostics/candidat-libre/schemas';
 import { serializeCandidateDiagnostic } from '@/lib/diagnostics/candidat-libre/serialize.server';
+import { guardCandidateDiagnosticFeature } from '@/lib/diagnostics/candidat-libre/feature-flag';
 import type { Prisma } from '@prisma/client';
 
 interface Params { params: Promise<{ diagnosticId: string }> }
 
 export async function GET(_request: Request, { params }: Params) {
+  const disabled = guardCandidateDiagnosticFeature();
+  if (disabled) return disabled;
   const { diagnosticId } = await params;
   const sessionOrError = await requireDiagnosticActor();
   if (isErrorResponse(sessionOrError)) return sessionOrError;
@@ -18,6 +21,8 @@ export async function GET(_request: Request, { params }: Params) {
 }
 
 export async function PATCH(request: Request, { params }: Params) {
+  const disabled = guardCandidateDiagnosticFeature();
+  if (disabled) return disabled;
   const { diagnosticId } = await params;
   const sessionOrError = await requireDiagnosticActor();
   if (isErrorResponse(sessionOrError)) return sessionOrError;

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server';
+import { isErrorResponse } from '@/lib/guards';
+import { prisma } from '@/lib/prisma';
+import { getDiagnosticForActor, requireDiagnosticActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
+import { updateDiagnosticProfileSchema } from '@/lib/diagnostics/candidat-libre/schemas';
+import { serializeCandidateDiagnostic } from '@/lib/diagnostics/candidat-libre/serialize.server';
+import type { Prisma } from '@prisma/client';
+
+interface Params { params: Promise<{ diagnosticId: string }> }
+
+export async function GET(_request: Request, { params }: Params) {
+  const { diagnosticId } = await params;
+  const sessionOrError = await requireDiagnosticActor();
+  if (isErrorResponse(sessionOrError)) return sessionOrError;
+  const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
+  if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  return NextResponse.json({ diagnostic: serializeCandidateDiagnostic(diagnosticOrError, actorRole(sessionOrError)) });
+}
+
+export async function PATCH(request: Request, { params }: Params) {
+  const { diagnosticId } = await params;
+  const sessionOrError = await requireDiagnosticActor();
+  if (isErrorResponse(sessionOrError)) return sessionOrError;
+  const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
+  if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  if (diagnosticOrError.submittedAt) return NextResponse.json({ error: 'Locked' }, { status: 423 });
+
+  const parsed = updateDiagnosticProfileSchema.safeParse(await request.json());
+  if (!parsed.success) return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
+
+  const updated = await prisma.$transaction(async (tx) => {
+    await tx.candidateDiagnostic.update({
+      where: { id: diagnosticId },
+      data: {
+        targetSession: parsed.data.targetSession,
+        studentConsentAt: parsed.data.studentConsent === true ? new Date() : undefined,
+        metadata: parsed.data.metadata as Prisma.InputJsonValue | undefined,
+      },
+    });
+    await tx.candidateDiagnosticAuditLog.create({
+      data: {
+        diagnosticId,
+        actorId: sessionOrError.user.id,
+        actorRole: actorRole(sessionOrError),
+        action: 'DIAGNOSTIC_METADATA_UPDATED',
+        entityType: 'CandidateDiagnostic',
+        entityId: diagnosticId,
+      },
+    });
+    return tx.candidateDiagnostic.findUniqueOrThrow({
+      where: { id: diagnosticId },
+      include: {
+        student: { include: { user: { select: { firstName: true, lastName: true, email: true } } } },
+        modules: { orderBy: { createdAt: 'asc' } },
+        documents: { orderBy: { createdAt: 'desc' } },
+      },
+    });
+  });
+  return NextResponse.json({ diagnostic: serializeCandidateDiagnostic(updated, actorRole(sessionOrError)) });
+}

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/staff-export/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/staff-export/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server';
+import { UserRole } from '@prisma/client';
+import { isErrorResponse } from '@/lib/guards';
+import { getDiagnosticForActor, requireDiagnosticActor } from '@/lib/diagnostics/candidat-libre/access.server';
+import { buildStaffDiagnosticSynthesis } from '@/lib/diagnostics/candidat-libre/synthesis.server';
+
+interface Params { params: Promise<{ diagnosticId: string }> }
+
+export async function GET(_request: Request, { params }: Params) {
+  const { diagnosticId } = await params;
+  const sessionOrError = await requireDiagnosticActor();
+  if (isErrorResponse(sessionOrError)) return sessionOrError;
+  if (!([UserRole.COACH, UserRole.ADMIN, UserRole.ASSISTANTE] as UserRole[]).includes(sessionOrError.user.role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
+  if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+
+  return NextResponse.json({
+    diagnostic: {
+      id: diagnosticOrError.id,
+      diagnosticKey: diagnosticOrError.diagnosticKey,
+      definitionVersion: diagnosticOrError.definitionVersion,
+      targetSession: diagnosticOrError.targetSession,
+      status: diagnosticOrError.status,
+      student: {
+        id: diagnosticOrError.student.id,
+        firstName: diagnosticOrError.student.user.firstName,
+        lastName: diagnosticOrError.student.user.lastName,
+        email: diagnosticOrError.student.user.email,
+        school: diagnosticOrError.student.school,
+        gradeLevel: diagnosticOrError.student.gradeLevel,
+      },
+      modules: diagnosticOrError.modules.map((module: any) => ({
+        moduleKey: module.moduleKey,
+        audience: module.audience,
+        status: module.status,
+        answers: module.answers,
+        autoScore: module.autoScore,
+        manualScore: module.manualScore,
+        integrity: module.integrity,
+        elapsedMs: module.elapsedMs,
+        submittedAt: module.submittedAt,
+        reviewSummary: module.reviewSummary,
+        definitionSnapshot: module.definitionSnapshot,
+      })),
+      documents: diagnosticOrError.documents.map((document: any) => ({
+        id: document.id,
+        category: document.category,
+        title: document.title,
+        originalName: document.originalName,
+        mimeType: document.mimeType,
+        sizeBytes: document.sizeBytes,
+        sha256: document.sha256,
+        status: document.status,
+        reviewNote: document.reviewNote,
+        createdAt: document.createdAt,
+      })),
+      studentConsentAt: diagnosticOrError.studentConsentAt,
+      parentConsentAt: diagnosticOrError.parentConsentAt,
+      parentSubmittedAt: diagnosticOrError.parentSubmittedAt,
+      submittedAt: diagnosticOrError.submittedAt,
+    },
+    synthesis: buildStaffDiagnosticSynthesis(diagnosticOrError),
+  }, {
+    headers: { 'Cache-Control': 'private, no-store', 'X-Content-Type-Options': 'nosniff' },
+  });
+}

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/staff-export/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/staff-export/route.ts
@@ -1,21 +1,11 @@
 import { NextResponse } from 'next/server';
 import { UserRole } from '@prisma/client';
 import { isErrorResponse } from '@/lib/guards';
-import { getDiagnosticForActor, isDocumentVisibleToViewer, requireDiagnosticActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
+import { canViewModuleDetail, getDiagnosticForActor, isDocumentVisibleToViewer, requireDiagnosticActor } from '@/lib/diagnostics/candidat-libre/access.server';
 import { buildStaffDiagnosticSynthesis } from '@/lib/diagnostics/candidat-libre/synthesis.server';
 import { guardCandidateDiagnosticFeature } from '@/lib/diagnostics/candidat-libre/feature-flag';
 
 interface Params { params: Promise<{ diagnosticId: string }> }
-
-// Same rule as modules/[moduleKey]: a COACH sees module structure/status but
-// never raw answers or scores — the questionnaire-parent module in particular
-// is not COACH's audience. Only ADMIN/ASSISTANTE (pedagogical direction) see
-// content. Kept local rather than importing canEditAudience from the module
-// route: that helper is audience-conditional (ELEVE/PARENT edit their own),
-// which doesn't apply here — staff-export is read-only for staff.
-function canViewModuleContent(role: UserRole) {
-  return role === UserRole.ADMIN || role === UserRole.ASSISTANTE;
-}
 
 export async function GET(_request: Request, { params }: Params) {
   const disabled = guardCandidateDiagnosticFeature();
@@ -45,7 +35,7 @@ export async function GET(_request: Request, { params }: Params) {
         gradeLevel: diagnosticOrError.student.gradeLevel,
       },
       modules: diagnosticOrError.modules.map((module: any) => {
-        const canViewContent = canViewModuleContent(sessionOrError.user.role);
+        const canViewContent = canViewModuleDetail(sessionOrError.user.role, module.audience);
         return {
           moduleKey: module.moduleKey,
           audience: module.audience,
@@ -61,7 +51,7 @@ export async function GET(_request: Request, { params }: Params) {
         };
       }),
       documents: diagnosticOrError.documents
-        .filter((document: any) => isDocumentVisibleToViewer(document.category, actorRole(sessionOrError)))
+        .filter((document: any) => isDocumentVisibleToViewer(document.category, sessionOrError.user.role))
         .map((document: any) => ({
           id: document.id,
           category: document.category,
@@ -79,7 +69,14 @@ export async function GET(_request: Request, { params }: Params) {
       parentSubmittedAt: diagnosticOrError.parentSubmittedAt,
       submittedAt: diagnosticOrError.submittedAt,
     },
-    synthesis: buildStaffDiagnosticSynthesis(diagnosticOrError),
+    // The synthesis aggregates academic detail (percentages, coverage,
+    // learning-potential flags derived from module content) across every
+    // module — the same "no academic detail" boundary that governs modules[]
+    // above applies here: ASSISTANTE gets none. Not per-module redacted for
+    // COACH (would need buildStaffDiagnosticSynthesis itself to know audience
+    // per field it derives from) — residual minor exposure documented in the
+    // audit doc, not fixed here.
+    synthesis: sessionOrError.user.role === UserRole.ASSISTANTE ? null : buildStaffDiagnosticSynthesis(diagnosticOrError),
   }, {
     headers: { 'Cache-Control': 'private, no-store', 'X-Content-Type-Options': 'nosniff' },
   });

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/staff-export/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/staff-export/route.ts
@@ -3,10 +3,13 @@ import { UserRole } from '@prisma/client';
 import { isErrorResponse } from '@/lib/guards';
 import { getDiagnosticForActor, requireDiagnosticActor } from '@/lib/diagnostics/candidat-libre/access.server';
 import { buildStaffDiagnosticSynthesis } from '@/lib/diagnostics/candidat-libre/synthesis.server';
+import { guardCandidateDiagnosticFeature } from '@/lib/diagnostics/candidat-libre/feature-flag';
 
 interface Params { params: Promise<{ diagnosticId: string }> }
 
 export async function GET(_request: Request, { params }: Params) {
+  const disabled = guardCandidateDiagnosticFeature();
+  if (disabled) return disabled;
   const { diagnosticId } = await params;
   const sessionOrError = await requireDiagnosticActor();
   if (isErrorResponse(sessionOrError)) return sessionOrError;

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/staff-export/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/staff-export/route.ts
@@ -1,11 +1,21 @@
 import { NextResponse } from 'next/server';
 import { UserRole } from '@prisma/client';
 import { isErrorResponse } from '@/lib/guards';
-import { getDiagnosticForActor, requireDiagnosticActor } from '@/lib/diagnostics/candidat-libre/access.server';
+import { getDiagnosticForActor, isDocumentVisibleToViewer, requireDiagnosticActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
 import { buildStaffDiagnosticSynthesis } from '@/lib/diagnostics/candidat-libre/synthesis.server';
 import { guardCandidateDiagnosticFeature } from '@/lib/diagnostics/candidat-libre/feature-flag';
 
 interface Params { params: Promise<{ diagnosticId: string }> }
+
+// Same rule as modules/[moduleKey]: a COACH sees module structure/status but
+// never raw answers or scores — the questionnaire-parent module in particular
+// is not COACH's audience. Only ADMIN/ASSISTANTE (pedagogical direction) see
+// content. Kept local rather than importing canEditAudience from the module
+// route: that helper is audience-conditional (ELEVE/PARENT edit their own),
+// which doesn't apply here — staff-export is read-only for staff.
+function canViewModuleContent(role: UserRole) {
+  return role === UserRole.ADMIN || role === UserRole.ASSISTANTE;
+}
 
 export async function GET(_request: Request, { params }: Params) {
   const disabled = guardCandidateDiagnosticFeature();
@@ -34,31 +44,36 @@ export async function GET(_request: Request, { params }: Params) {
         school: diagnosticOrError.student.school,
         gradeLevel: diagnosticOrError.student.gradeLevel,
       },
-      modules: diagnosticOrError.modules.map((module: any) => ({
-        moduleKey: module.moduleKey,
-        audience: module.audience,
-        status: module.status,
-        answers: module.answers,
-        autoScore: module.autoScore,
-        manualScore: module.manualScore,
-        integrity: module.integrity,
-        elapsedMs: module.elapsedMs,
-        submittedAt: module.submittedAt,
-        reviewSummary: module.reviewSummary,
-        definitionSnapshot: module.definitionSnapshot,
-      })),
-      documents: diagnosticOrError.documents.map((document: any) => ({
-        id: document.id,
-        category: document.category,
-        title: document.title,
-        originalName: document.originalName,
-        mimeType: document.mimeType,
-        sizeBytes: document.sizeBytes,
-        sha256: document.sha256,
-        status: document.status,
-        reviewNote: document.reviewNote,
-        createdAt: document.createdAt,
-      })),
+      modules: diagnosticOrError.modules.map((module: any) => {
+        const canViewContent = canViewModuleContent(sessionOrError.user.role);
+        return {
+          moduleKey: module.moduleKey,
+          audience: module.audience,
+          status: module.status,
+          answers: canViewContent ? module.answers : undefined,
+          autoScore: canViewContent ? module.autoScore : undefined,
+          manualScore: canViewContent ? module.manualScore : undefined,
+          integrity: module.integrity,
+          elapsedMs: module.elapsedMs,
+          submittedAt: module.submittedAt,
+          reviewSummary: canViewContent ? module.reviewSummary : undefined,
+          definitionSnapshot: module.definitionSnapshot,
+        };
+      }),
+      documents: diagnosticOrError.documents
+        .filter((document: any) => isDocumentVisibleToViewer(document.category, actorRole(sessionOrError)))
+        .map((document: any) => ({
+          id: document.id,
+          category: document.category,
+          title: document.title,
+          originalName: document.originalName,
+          mimeType: document.mimeType,
+          sizeBytes: document.sizeBytes,
+          sha256: document.sha256,
+          status: document.status,
+          reviewNote: document.reviewNote,
+          createdAt: document.createdAt,
+        })),
       studentConsentAt: diagnosticOrError.studentConsentAt,
       parentConsentAt: diagnosticOrError.parentConsentAt,
       parentSubmittedAt: diagnosticOrError.parentSubmittedAt,

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/submit/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/submit/route.ts
@@ -6,10 +6,13 @@ import { guardRateLimitAsync } from '@/lib/rate-limit';
 import { getDiagnosticForActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
 import { CANDIDATE_DIAGNOSTIC_MODULES } from '@/lib/diagnostics/candidat-libre/definition.public';
 import { isModuleComplete } from '@/lib/diagnostics/candidat-libre/progression';
+import { guardCandidateDiagnosticFeature } from '@/lib/diagnostics/candidat-libre/feature-flag';
 
 interface Params { params: Promise<{ diagnosticId: string }> }
 
 export async function POST(request: Request, { params }: Params) {
+  const disabled = guardCandidateDiagnosticFeature();
+  if (disabled) return disabled;
   const limited = await guardRateLimitAsync(request, { preset: 'expensive', keySuffix: 'candidate-diagnostic-final-submit' });
   if (limited) return limited;
   const { diagnosticId } = await params;

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/submit/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/submit/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { UserRole } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { isErrorResponse, requireRole } from '@/lib/guards';
-import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { guardSensitiveRateLimit } from '@/lib/rate-limit/sensitive';
 import { getDiagnosticForActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
 import { CANDIDATE_DIAGNOSTIC_MODULES } from '@/lib/diagnostics/candidat-libre/definition.public';
 import { isModuleComplete } from '@/lib/diagnostics/candidat-libre/progression';
@@ -13,11 +13,17 @@ interface Params { params: Promise<{ diagnosticId: string }> }
 export async function POST(request: Request, { params }: Params) {
   const disabled = guardCandidateDiagnosticFeature();
   if (disabled) return disabled;
-  const limited = await guardRateLimitAsync(request, { preset: 'expensive', keySuffix: 'candidate-diagnostic-final-submit' });
-  if (limited) return limited;
+  const ipLimited = await guardSensitiveRateLimit(request, { scope: 'candidate-diagnostic-final-submit', dimensions: ['ip'] });
+  if (ipLimited) return ipLimited;
   const { diagnosticId } = await params;
   const sessionOrError = await requireRole(UserRole.ELEVE);
   if (isErrorResponse(sessionOrError)) return sessionOrError;
+  const identityLimited = await guardSensitiveRateLimit(request, {
+    scope: 'candidate-diagnostic-final-submit',
+    identity: sessionOrError.user.id,
+    dimensions: ['identity'],
+  });
+  if (identityLimited) return identityLimited;
   const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
   if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
   if (diagnosticOrError.submittedAt) return NextResponse.json({ success: true, idempotent: true, status: diagnosticOrError.status });

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/submit/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/submit/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { UserRole } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { isErrorResponse, requireRole } from '@/lib/guards';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { getDiagnosticForActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
+import { CANDIDATE_DIAGNOSTIC_MODULES } from '@/lib/diagnostics/candidat-libre/definition.public';
+import { isModuleComplete } from '@/lib/diagnostics/candidat-libre/progression';
+
+interface Params { params: Promise<{ diagnosticId: string }> }
+
+export async function POST(request: Request, { params }: Params) {
+  const limited = await guardRateLimitAsync(request, { preset: 'expensive', keySuffix: 'candidate-diagnostic-final-submit' });
+  if (limited) return limited;
+  const { diagnosticId } = await params;
+  const sessionOrError = await requireRole(UserRole.ELEVE);
+  if (isErrorResponse(sessionOrError)) return sessionOrError;
+  const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
+  if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  if (diagnosticOrError.submittedAt) return NextResponse.json({ success: true, idempotent: true, status: diagnosticOrError.status });
+
+  const body = await request.json().catch(() => ({}));
+  if (body.confirm !== true) return NextResponse.json({ error: 'Explicit confirmation required' }, { status: 422 });
+  if (!diagnosticOrError.studentConsentAt) return NextResponse.json({ error: 'Student consent missing' }, { status: 422 });
+  if (!diagnosticOrError.parentConsentAt || !diagnosticOrError.parentSubmittedAt) {
+    return NextResponse.json({ error: 'Parent questionnaire missing' }, { status: 422 });
+  }
+
+  const byKey = new Map(diagnosticOrError.modules.map((module: any) => [module.moduleKey, module]));
+  const required = CANDIDATE_DIAGNOSTIC_MODULES.filter((module) => module.requiredForSubmission);
+  const incomplete = required.filter((definition) => {
+    const moduleRecord = byKey.get(definition.key) as any;
+    return !moduleRecord || !isModuleComplete(moduleRecord.status);
+  }).map((module) => module.key);
+  if (incomplete.length > 0) return NextResponse.json({ error: 'Incomplete diagnostic', incompleteModuleKeys: incomplete }, { status: 422 });
+
+  const now = new Date();
+  await prisma.$transaction(async (tx) => {
+    await tx.candidateDiagnostic.update({
+      where: { id: diagnosticId },
+      data: { status: 'IN_REVIEW', submittedAt: now },
+    });
+    await tx.candidateDiagnosticAuditLog.create({
+      data: {
+        diagnosticId,
+        actorId: sessionOrError.user.id,
+        actorRole: actorRole(sessionOrError),
+        action: 'DIAGNOSTIC_FINAL_SUBMISSION',
+        entityType: 'CandidateDiagnostic',
+        entityId: diagnosticId,
+        details: { moduleCount: required.length, documentCount: diagnosticOrError.documents.length },
+      },
+    });
+  });
+
+  return NextResponse.json({ success: true, status: 'IN_REVIEW', submittedAt: now.toISOString() });
+}

--- a/app/api/diagnostics/candidat-libre/route.ts
+++ b/app/api/diagnostics/candidat-libre/route.ts
@@ -6,7 +6,7 @@ import { isErrorResponse } from '@/lib/guards';
 import { CANDIDATE_DIAGNOSTIC_MODULES } from '@/lib/diagnostics/candidat-libre/definition.public';
 import { createDiagnosticSchema } from '@/lib/diagnostics/candidat-libre/schemas';
 import { DIAGNOSTIC_KEY, DIAGNOSTIC_VERSION } from '@/lib/diagnostics/candidat-libre/types';
-import { getStudentForActor, requireDiagnosticActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
+import { getStudentForActor, requireDiagnosticActor } from '@/lib/diagnostics/candidat-libre/access.server';
 import { serializeCandidateDiagnostic } from '@/lib/diagnostics/candidat-libre/serialize.server';
 import { guardCandidateDiagnosticFeature } from '@/lib/diagnostics/candidat-libre/feature-flag';
 
@@ -36,7 +36,7 @@ export async function GET(request: Request) {
       documents: { orderBy: { createdAt: 'desc' } },
     },
   });
-  return NextResponse.json({ diagnostic: diagnostic ? serializeCandidateDiagnostic(diagnostic, actorRole(sessionOrError)) : null });
+  return NextResponse.json({ diagnostic: diagnostic ? serializeCandidateDiagnostic(diagnostic, sessionOrError.user.role) : null });
 }
 
 export async function POST(request: Request) {
@@ -114,5 +114,5 @@ export async function POST(request: Request) {
     });
   });
 
-  return NextResponse.json({ diagnostic: serializeCandidateDiagnostic(diagnostic, actorRole(sessionOrError)) }, { status: 201 });
+  return NextResponse.json({ diagnostic: serializeCandidateDiagnostic(diagnostic, sessionOrError.user.role) }, { status: 201 });
 }

--- a/app/api/diagnostics/candidat-libre/route.ts
+++ b/app/api/diagnostics/candidat-libre/route.ts
@@ -8,8 +8,11 @@ import { createDiagnosticSchema } from '@/lib/diagnostics/candidat-libre/schemas
 import { DIAGNOSTIC_KEY, DIAGNOSTIC_VERSION } from '@/lib/diagnostics/candidat-libre/types';
 import { getStudentForActor, requireDiagnosticActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
 import { serializeCandidateDiagnostic } from '@/lib/diagnostics/candidat-libre/serialize.server';
+import { guardCandidateDiagnosticFeature } from '@/lib/diagnostics/candidat-libre/feature-flag';
 
 export async function GET(request: Request) {
+  const disabled = guardCandidateDiagnosticFeature();
+  if (disabled) return disabled;
   const sessionOrError = await requireDiagnosticActor();
   if (isErrorResponse(sessionOrError)) return sessionOrError;
   const url = new URL(request.url);
@@ -37,6 +40,8 @@ export async function GET(request: Request) {
 }
 
 export async function POST(request: Request) {
+  const disabled = guardCandidateDiagnosticFeature();
+  if (disabled) return disabled;
   const limited = await guardRateLimitAsync(request, { preset: 'api', keySuffix: 'candidate-diagnostic-create' });
   if (limited) return limited;
   const sessionOrError = await requireDiagnosticActor();

--- a/app/api/diagnostics/candidat-libre/route.ts
+++ b/app/api/diagnostics/candidat-libre/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { Prisma, UserRole } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
-import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { guardSensitiveRateLimit } from '@/lib/rate-limit/sensitive';
 import { isErrorResponse } from '@/lib/guards';
 import { CANDIDATE_DIAGNOSTIC_MODULES } from '@/lib/diagnostics/candidat-libre/definition.public';
 import { createDiagnosticSchema } from '@/lib/diagnostics/candidat-libre/schemas';
@@ -42,13 +42,19 @@ export async function GET(request: Request) {
 export async function POST(request: Request) {
   const disabled = guardCandidateDiagnosticFeature();
   if (disabled) return disabled;
-  const limited = await guardRateLimitAsync(request, { preset: 'api', keySuffix: 'candidate-diagnostic-create' });
-  if (limited) return limited;
+  const ipLimited = await guardSensitiveRateLimit(request, { scope: 'candidate-diagnostic-create', dimensions: ['ip'] });
+  if (ipLimited) return ipLimited;
   const sessionOrError = await requireDiagnosticActor();
   if (isErrorResponse(sessionOrError)) return sessionOrError;
   if (!([UserRole.ELEVE, UserRole.PARENT, UserRole.ADMIN, UserRole.ASSISTANTE] as UserRole[]).includes(sessionOrError.user.role)) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
+  const identityLimited = await guardSensitiveRateLimit(request, {
+    scope: 'candidate-diagnostic-create',
+    identity: sessionOrError.user.id,
+    dimensions: ['identity'],
+  });
+  if (identityLimited) return identityLimited;
 
   const parsed = createDiagnosticSchema.safeParse(await request.json());
   if (!parsed.success) return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });

--- a/app/api/diagnostics/candidat-libre/route.ts
+++ b/app/api/diagnostics/candidat-libre/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from 'next/server';
+import { Prisma, UserRole } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { guardRateLimitAsync } from '@/lib/rate-limit';
+import { isErrorResponse } from '@/lib/guards';
+import { CANDIDATE_DIAGNOSTIC_MODULES } from '@/lib/diagnostics/candidat-libre/definition.public';
+import { createDiagnosticSchema } from '@/lib/diagnostics/candidat-libre/schemas';
+import { DIAGNOSTIC_KEY, DIAGNOSTIC_VERSION } from '@/lib/diagnostics/candidat-libre/types';
+import { getStudentForActor, requireDiagnosticActor, actorRole } from '@/lib/diagnostics/candidat-libre/access.server';
+import { serializeCandidateDiagnostic } from '@/lib/diagnostics/candidat-libre/serialize.server';
+
+export async function GET(request: Request) {
+  const sessionOrError = await requireDiagnosticActor();
+  if (isErrorResponse(sessionOrError)) return sessionOrError;
+  const url = new URL(request.url);
+  const studentId = url.searchParams.get('studentId') ?? undefined;
+  const targetSession = Number(url.searchParams.get('targetSession') ?? 2027);
+  const studentOrError = await getStudentForActor(sessionOrError, studentId);
+  if (studentOrError instanceof NextResponse) return studentOrError;
+  if (!studentOrError) return NextResponse.json({ error: 'Student not found' }, { status: 404 });
+
+  const diagnostic = await prisma.candidateDiagnostic.findUnique({
+    where: {
+      studentId_diagnosticKey_targetSession: {
+        studentId: studentOrError.id,
+        diagnosticKey: DIAGNOSTIC_KEY,
+        targetSession,
+      },
+    },
+    include: {
+      student: { include: { user: { select: { firstName: true, lastName: true, email: true } } } },
+      modules: { orderBy: { createdAt: 'asc' } },
+      documents: { orderBy: { createdAt: 'desc' } },
+    },
+  });
+  return NextResponse.json({ diagnostic: diagnostic ? serializeCandidateDiagnostic(diagnostic, actorRole(sessionOrError)) : null });
+}
+
+export async function POST(request: Request) {
+  const limited = await guardRateLimitAsync(request, { preset: 'api', keySuffix: 'candidate-diagnostic-create' });
+  if (limited) return limited;
+  const sessionOrError = await requireDiagnosticActor();
+  if (isErrorResponse(sessionOrError)) return sessionOrError;
+  if (!([UserRole.ELEVE, UserRole.PARENT, UserRole.ADMIN, UserRole.ASSISTANTE] as UserRole[]).includes(sessionOrError.user.role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const parsed = createDiagnosticSchema.safeParse(await request.json());
+  if (!parsed.success) return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 });
+  const studentOrError = await getStudentForActor(sessionOrError, parsed.data.studentId);
+  if (studentOrError instanceof NextResponse) return studentOrError;
+  if (!studentOrError) return NextResponse.json({ error: 'Student not found' }, { status: 404 });
+
+  const diagnostic = await prisma.$transaction(async (tx) => {
+    const existing = await tx.candidateDiagnostic.findUnique({
+      where: {
+        studentId_diagnosticKey_targetSession: {
+          studentId: studentOrError.id,
+          diagnosticKey: DIAGNOSTIC_KEY,
+          targetSession: parsed.data.targetSession,
+        },
+      },
+      include: {
+        student: { include: { user: { select: { firstName: true, lastName: true, email: true } } } },
+        modules: { orderBy: { createdAt: 'asc' } },
+        documents: { orderBy: { createdAt: 'desc' } },
+      },
+    });
+    if (existing) return existing;
+
+    return tx.candidateDiagnostic.create({
+      data: {
+        diagnosticKey: DIAGNOSTIC_KEY,
+        definitionVersion: DIAGNOSTIC_VERSION,
+        targetSession: parsed.data.targetSession,
+        status: 'ACTIVE',
+        studentId: studentOrError.id,
+        createdById: sessionOrError.user.id,
+        metadata: { source: parsed.data.source } as Prisma.InputJsonValue,
+        modules: {
+          create: CANDIDATE_DIAGNOSTIC_MODULES.map((module) => ({
+            moduleKey: module.key,
+            audience: module.audience,
+            status: module.key === 'accueil-integrite' || module.key === 'questionnaire-parent' ? 'AVAILABLE' : 'LOCKED',
+            definitionSnapshot: JSON.parse(JSON.stringify(module)) as Prisma.InputJsonValue,
+          })),
+        },
+        audits: {
+          create: {
+            actorId: sessionOrError.user.id,
+            actorRole: sessionOrError.user.role === UserRole.PARENT ? 'PARENT' : sessionOrError.user.role === UserRole.ELEVE ? 'ELEVE' : 'ADMIN',
+            action: 'DIAGNOSTIC_CREATED',
+            entityType: 'CandidateDiagnostic',
+            details: { source: parsed.data.source } as Prisma.InputJsonValue,
+          },
+        },
+      },
+      include: {
+        student: { include: { user: { select: { firstName: true, lastName: true, email: true } } } },
+        modules: { orderBy: { createdAt: 'asc' } },
+        documents: { orderBy: { createdAt: 'desc' } },
+      },
+    });
+  });
+
+  return NextResponse.json({ diagnostic: serializeCandidateDiagnostic(diagnostic, actorRole(sessionOrError)) }, { status: 201 });
+}

--- a/app/dashboard/eleve/diagnostic-candidat-libre/page.tsx
+++ b/app/dashboard/eleve/diagnostic-candidat-libre/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import { DiagnosticPortal } from '@/components/diagnostics/candidat-libre/DiagnosticPortal';
+import { isCandidateDiagnosticFeatureEnabled } from '@/lib/diagnostics/candidat-libre/feature-flag';
 
 export const metadata: Metadata = {
   title: 'Diagnostic candidat individuel | Nexus Réussite',
@@ -8,5 +10,6 @@ export const metadata: Metadata = {
 export const dynamic = 'force-dynamic';
 
 export default function StudentCandidateDiagnosticPage() {
+  if (!isCandidateDiagnosticFeatureEnabled()) notFound();
   return <DiagnosticPortal />;
 }

--- a/app/dashboard/eleve/diagnostic-candidat-libre/page.tsx
+++ b/app/dashboard/eleve/diagnostic-candidat-libre/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+import { DiagnosticPortal } from '@/components/diagnostics/candidat-libre/DiagnosticPortal';
+
+export const metadata: Metadata = {
+  title: 'Diagnostic candidat individuel | Nexus Réussite',
+  description: 'Parcours sécurisé de diagnostic académique, méthodologique et documentaire.',
+};
+export const dynamic = 'force-dynamic';
+
+export default function StudentCandidateDiagnosticPage() {
+  return <DiagnosticPortal />;
+}

--- a/app/dashboard/parent/children/[studentId]/diagnostic-candidat-libre/page.tsx
+++ b/app/dashboard/parent/children/[studentId]/diagnostic-candidat-libre/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import { ParentDiagnosticPortal } from '@/components/diagnostics/candidat-libre/ParentDiagnosticPortal';
+
+export const metadata: Metadata = { title: 'Suivi du diagnostic | Nexus Réussite' };
+export const dynamic = 'force-dynamic';
+
+interface Props { params: Promise<{ studentId: string }> }
+export default async function ParentCandidateDiagnosticPage({ params }: Props) {
+  const { studentId } = await params;
+  return <ParentDiagnosticPortal studentId={studentId} />;
+}

--- a/app/dashboard/parent/children/[studentId]/diagnostic-candidat-libre/page.tsx
+++ b/app/dashboard/parent/children/[studentId]/diagnostic-candidat-libre/page.tsx
@@ -1,11 +1,14 @@
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import { ParentDiagnosticPortal } from '@/components/diagnostics/candidat-libre/ParentDiagnosticPortal';
+import { isCandidateDiagnosticFeatureEnabled } from '@/lib/diagnostics/candidat-libre/feature-flag';
 
 export const metadata: Metadata = { title: 'Suivi du diagnostic | Nexus Réussite' };
 export const dynamic = 'force-dynamic';
 
 interface Props { params: Promise<{ studentId: string }> }
 export default async function ParentCandidateDiagnosticPage({ params }: Props) {
+  if (!isCandidateDiagnosticFeatureEnabled()) notFound();
   const { studentId } = await params;
   return <ParentDiagnosticPortal studentId={studentId} />;
 }

--- a/components/diagnostics/candidat-libre/DiagnosticPortal.tsx
+++ b/components/diagnostics/candidat-libre/DiagnosticPortal.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { motion } from 'framer-motion';
+import { AlertTriangle, ArrowRight, BookOpenCheck, CheckCircle2, ClipboardList, Clock3, FileLock2, FileText, GraduationCap, Loader2, LockKeyhole, RefreshCw, ShieldCheck, Sparkles, UploadCloud, Users } from 'lucide-react';
+import { CANDIDATE_DIAGNOSTIC_MODULES } from '@/lib/diagnostics/candidat-libre/definition.public';
+import type { DiagnosticCampaignView, DiagnosticModuleView } from '@/lib/diagnostics/candidat-libre/types';
+import { ModuleRunner } from './ModuleRunner';
+
+function cx(...items: Array<string | false | null | undefined>) { return items.filter(Boolean).join(' '); }
+
+const phaseLabels: Record<string, string> = {
+  questionnaire: 'Profil et méthodes',
+  academic: 'Évaluations académiques',
+  oral: 'Expression orale',
+  'learning-potential': 'Potentiel d’apprentissage',
+  documents: 'Pièces justificatives',
+  review: 'Validation',
+};
+
+const statusMeta: Record<string, { label: string; className: string }> = {
+  LOCKED: { label: 'Verrouillé', className: 'border-slate-700 bg-slate-800/60 text-slate-400' },
+  AVAILABLE: { label: 'À faire', className: 'border-cyan-300/40 bg-cyan-400/10 text-cyan-200' },
+  IN_PROGRESS: { label: 'En cours', className: 'border-amber-300/40 bg-amber-400/10 text-amber-200' },
+  SUBMITTED: { label: 'Soumis', className: 'border-violet-300/40 bg-violet-400/10 text-violet-200' },
+  AUTO_SCORED: { label: 'Terminé', className: 'border-emerald-300/40 bg-emerald-400/10 text-emerald-200' },
+  NEEDS_REVIEW: { label: 'À corriger', className: 'border-violet-300/40 bg-violet-400/10 text-violet-200' },
+  REVIEWED: { label: 'Validé', className: 'border-emerald-300/40 bg-emerald-400/10 text-emerald-200' },
+};
+
+export function DiagnosticPortal() {
+  const [diagnostic, setDiagnostic] = useState<DiagnosticCampaignView | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [activeModule, setActiveModule] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    const response = await fetch('/api/diagnostics/candidat-libre?targetSession=2027', { cache: 'no-store' });
+    const data = await response.json().catch(() => ({}));
+    setLoading(false);
+    if (!response.ok) { setError(data.message ?? data.error ?? 'Impossible de charger le diagnostic.'); return; }
+    setDiagnostic(data.diagnostic ?? null);
+  }, []);
+  useEffect(() => { void refresh(); }, [refresh]);
+
+  async function createDiagnostic() {
+    setCreating(true); setError(null);
+    const response = await fetch('/api/diagnostics/candidat-libre', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ targetSession: 2027, source: 'STUDENT_DASHBOARD' }) });
+    const data = await response.json().catch(() => ({}));
+    setCreating(false);
+    if (!response.ok) { setError(data.message ?? data.error ?? 'Création impossible.'); return; }
+    setDiagnostic(data.diagnostic);
+  }
+
+  async function finalSubmit() {
+    if (!diagnostic || !window.confirm('Confirmer la transmission définitive du dossier à l’équipe pédagogique ? Les modules ne seront plus modifiables.')) return;
+    setSubmitting(true); setError(null);
+    const response = await fetch(`/api/diagnostics/candidat-libre/${diagnostic.id}/submit`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ confirm: true }) });
+    const data = await response.json().catch(() => ({}));
+    setSubmitting(false);
+    if (!response.ok) { setError(data.error ?? 'Soumission impossible.'); return; }
+    await refresh();
+  }
+
+  const studentDefinitions = useMemo(() => CANDIDATE_DIAGNOSTIC_MODULES.filter((module) => module.audience === 'ELEVE'), []);
+  const moduleByKey = useMemo(() => new Map((diagnostic?.modules ?? []).map((module) => [module.key, module])), [diagnostic]);
+  const parentModule = diagnostic?.modules.find((module) => module.key === 'questionnaire-parent');
+  const totalMinutes = studentDefinitions.reduce((sum, module) => sum + module.estimatedMinutes, 0);
+  const finalReady = diagnostic?.completionPercentage === 100 && Boolean(diagnostic.studentConsentAt) && Boolean(diagnostic.parentConsentAt) && !diagnostic.submittedAt;
+
+  if (loading) return <main className="flex min-h-screen items-center justify-center bg-[#050816] text-white"><div className="text-center"><Loader2 className="mx-auto h-10 w-10 animate-spin text-cyan-300" /><p className="mt-4 text-sm text-slate-400">Chargement du parcours diagnostic…</p></div></main>;
+
+  if (!diagnostic) {
+    return (
+      <main className="min-h-screen bg-[#050816] px-4 py-10 text-white md:px-8">
+        <section className="mx-auto max-w-5xl overflow-hidden rounded-[2rem] border border-slate-800 bg-gradient-to-br from-slate-900 via-[#09152b] to-slate-950 shadow-2xl">
+          <div className="grid gap-8 p-6 md:grid-cols-[1.15fr_.85fr] md:p-10">
+            <div><div className="inline-flex items-center gap-2 rounded-full border border-cyan-300/30 bg-cyan-400/10 px-4 py-2 text-sm text-cyan-100"><Sparkles className="h-4 w-4" /> Dossier candidat individuel 2027</div><h1 className="mt-6 text-3xl font-bold leading-tight md:text-5xl">Votre parcours complet de diagnostic Nexus</h1><p className="mt-5 max-w-2xl text-base leading-7 text-slate-300">Ce parcours évalue votre niveau réel, vos méthodes, votre autonomie, votre capacité de progression et votre situation administrative. Il ne s’agit pas d’un concours, mais d’une aide à la décision entre une préparation accélérée en un an et une reprise scolaire sur deux ans.</p>
+              <div className="mt-7 grid gap-3 sm:grid-cols-2">{[[ClipboardList,'266 items structurés'],[Clock3,`Environ ${Math.floor(totalMinutes/60)} h ${totalMinutes%60} de passation`],[UploadCloud,'Documents et copies à déposer'],[Users,'Volet confidentiel du parent']].map(([Icon,label]) => { const C=Icon as typeof ClipboardList; return <div key={String(label)} className="flex items-center gap-3 rounded-2xl border border-slate-800 bg-slate-950/50 p-4 text-sm text-slate-200"><C className="h-5 w-5 text-cyan-300" />{String(label)}</div>; })}</div>
+              {error && <p className="mt-5 rounded-xl border border-rose-400/30 bg-rose-400/10 p-3 text-sm text-rose-200">{error}</p>}
+              <button type="button" disabled={creating} onClick={() => void createDiagnostic()} className="mt-7 inline-flex items-center gap-2 rounded-xl bg-cyan-300 px-6 py-3 font-bold text-slate-950 disabled:opacity-50">{creating ? <Loader2 className="h-5 w-5 animate-spin" /> : <ArrowRight className="h-5 w-5" />} Commencer mon diagnostic</button>
+            </div>
+            <aside className="rounded-3xl border border-violet-300/20 bg-violet-400/5 p-6"><ShieldCheck className="h-9 w-9 text-violet-300" /><h2 className="mt-5 text-xl font-bold">Conditions essentielles</h2><ul className="mt-4 space-y-3 text-sm leading-6 text-slate-300"><li>Travail personnel, sans aide extérieure pendant les tests.</li><li>Possibilité d’indiquer honnêtement « notion non étudiée ».</li><li>Sauvegarde automatique et reprise ultérieure.</li><li>Réponses académiques non visibles par le parent.</li><li>Aucune promesse automatique de réussite : l’avis final est validé par l’équipe pédagogique.</li></ul></aside>
+          </div>
+        </section>
+      </main>
+    );
+  }
+
+  const studentName = [diagnostic.student.firstName, diagnostic.student.lastName].filter(Boolean).join(' ') || 'Élève';
+  return (
+    <main className="min-h-screen bg-[#050816] px-4 py-6 text-white md:px-8 md:py-10">
+      <div className="mx-auto max-w-7xl">
+        <header className="rounded-3xl border border-slate-800 bg-gradient-to-br from-slate-900 via-[#09152b] to-slate-950 p-6 shadow-2xl md:p-8">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between"><div><p className="text-sm font-semibold uppercase tracking-[0.2em] text-cyan-300">Espace élève · session 2027</p><h1 className="mt-2 text-3xl font-bold md:text-4xl">Diagnostic de {studentName}</h1><p className="mt-3 max-w-3xl text-sm leading-6 text-slate-300">Progressez module par module. Les productions longues seront corrigées par un enseignant. Les scores automatiques ne constituent jamais, seuls, la décision finale.</p></div><button type="button" onClick={() => void refresh()} className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-700 px-4 py-2 text-sm text-slate-300 hover:border-slate-500"><RefreshCw className="h-4 w-4" /> Actualiser</button></div>
+          <div className="mt-7 grid gap-4 md:grid-cols-4"><Metric label="Avancement global" value={`${diagnostic.completionPercentage} %`} icon={BookOpenCheck} /><Metric label="Statut" value={diagnostic.status.replaceAll('_',' ')} icon={GraduationCap} /><Metric label="Parent" value={parentModule && ['AUTO_SCORED','NEEDS_REVIEW','REVIEWED'].includes(parentModule.status) ? 'Questionnaire reçu' : 'En attente'} icon={Users} /><Metric label="Documents" value={`${diagnostic.documents.length} déposé(s)`} icon={FileText} /></div>
+          <div className="mt-6 h-3 overflow-hidden rounded-full bg-slate-800"><div className="h-full rounded-full bg-gradient-to-r from-cyan-300 via-violet-400 to-emerald-300 transition-all duration-700" style={{ width: `${diagnostic.completionPercentage}%` }} /></div>
+        </header>
+
+        {error && <div className="mt-5 flex items-start gap-3 rounded-2xl border border-rose-400/30 bg-rose-400/10 p-4 text-sm text-rose-100"><AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" /><span>{error}</span></div>}
+        {diagnostic.retentionDueAt && new Date(diagnostic.retentionDueAt) > new Date() && <div className="mt-5 flex items-start gap-3 rounded-2xl border border-amber-300/30 bg-amber-400/10 p-4 text-sm text-amber-100"><Clock3 className="mt-0.5 h-5 w-5 shrink-0" /><span>Le test de rétention s’ouvrira le {new Date(diagnostic.retentionDueAt).toLocaleString('fr-FR')}. Ne relisez pas la micro-leçon avant cette échéance.</span></div>}
+
+        <section className="mt-8 space-y-8">
+          {Object.entries(phaseLabels).map(([kind, label]) => {
+            const definitions = studentDefinitions.filter((module) => module.kind === kind);
+            if (!definitions.length) return null;
+            return <div key={kind}><div className="mb-4 flex items-center gap-3"><div className="h-px flex-1 bg-slate-800" /><h2 className="text-sm font-bold uppercase tracking-[0.18em] text-slate-400">{label}</h2><div className="h-px flex-1 bg-slate-800" /></div><div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">{definitions.map((definition) => <ModuleCard key={definition.key} definition={definition} view={moduleByKey.get(definition.key)} onOpen={() => setActiveModule(definition.key)} />)}</div></div>;
+          })}
+        </section>
+
+        <section className="mt-8 rounded-3xl border border-slate-800 bg-slate-900/60 p-6 md:p-8"><div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between"><div><p className="text-sm font-semibold uppercase tracking-[0.16em] text-emerald-300">Transmission finale</p><h2 className="mt-2 text-2xl font-bold">Envoyer le dossier à l’équipe pédagogique</h2><p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">La transmission devient possible lorsque tous les modules élève et parent sont terminés. Elle verrouille les réponses. Les documents restent soumis à un contrôle d’authenticité et de lisibilité.</p></div><button type="button" disabled={!finalReady || submitting} onClick={() => void finalSubmit()} className="inline-flex shrink-0 items-center justify-center gap-2 rounded-xl bg-emerald-300 px-6 py-3 font-bold text-slate-950 disabled:cursor-not-allowed disabled:opacity-35">{submitting ? <Loader2 className="h-5 w-5 animate-spin" /> : <FileLock2 className="h-5 w-5" />} Transmettre définitivement</button></div></section>
+      </div>
+      {activeModule && <ModuleRunner diagnosticId={diagnostic.id} moduleKey={activeModule} onClose={() => setActiveModule(null)} onUpdated={() => void refresh()} />}
+    </main>
+  );
+}
+
+function Metric({ label, value, icon: Icon }: { label: string; value: string; icon: typeof GraduationCap }) {
+  return <div className="rounded-2xl border border-slate-800 bg-slate-950/55 p-4"><div className="flex items-center gap-2 text-xs uppercase tracking-wider text-slate-500"><Icon className="h-4 w-4 text-cyan-300" />{label}</div><p className="mt-2 text-lg font-bold text-white">{value}</p></div>;
+}
+
+function ModuleCard({ definition, view, onOpen }: { definition: (typeof CANDIDATE_DIAGNOSTIC_MODULES)[number]; view?: DiagnosticModuleView; onOpen: () => void }) {
+  const status = view?.status ?? 'LOCKED';
+  const meta = statusMeta[status] ?? statusMeta.LOCKED;
+  const locked = status === 'LOCKED';
+  const completed = ['SUBMITTED','AUTO_SCORED','NEEDS_REVIEW','REVIEWED'].includes(status);
+  const availableAt = view?.availableAt ? new Date(view.availableAt) : null;
+  return <motion.article whileHover={!locked ? { y: -3 } : undefined} className={cx('group rounded-3xl border p-5 transition', locked ? 'border-slate-800 bg-slate-950/40' : 'border-slate-700 bg-slate-900/70 hover:border-cyan-300/40')}><div className="flex items-start justify-between gap-3"><div className={cx('flex h-11 w-11 items-center justify-center rounded-2xl border', completed ? 'border-emerald-300/30 bg-emerald-400/10 text-emerald-300' : locked ? 'border-slate-700 bg-slate-800 text-slate-500' : 'border-cyan-300/30 bg-cyan-400/10 text-cyan-300')}>{completed ? <CheckCircle2 className="h-5 w-5" /> : locked ? <LockKeyhole className="h-5 w-5" /> : definition.kind === 'documents' ? <UploadCloud className="h-5 w-5" /> : <ClipboardList className="h-5 w-5" />}</div><span className={cx('rounded-full border px-2.5 py-1 text-[11px] font-semibold', meta.className)}>{meta.label}</span></div><h3 className="mt-5 text-lg font-bold leading-6 text-white">{definition.shortTitle}</h3><p className="mt-2 line-clamp-3 text-sm leading-6 text-slate-400">{definition.description}</p><div className="mt-4 flex items-center justify-between text-xs text-slate-500"><span>{definition.questions.length} items</span><span>≈ {definition.estimatedMinutes} min</span></div>{availableAt && availableAt > new Date() && <p className="mt-3 text-xs text-amber-300">Ouverture : {availableAt.toLocaleString('fr-FR')}</p>}<button type="button" disabled={locked || completed} onClick={onOpen} className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-slate-700 px-4 py-2.5 text-sm font-semibold text-slate-200 transition hover:border-cyan-300 hover:text-cyan-100 disabled:cursor-not-allowed disabled:opacity-35">{status === 'IN_PROGRESS' ? 'Reprendre' : completed ? 'Terminé' : 'Ouvrir le module'} {!locked && !completed && <ArrowRight className="h-4 w-4" />}</button></motion.article>;
+}

--- a/components/diagnostics/candidat-libre/ModuleRunner.tsx
+++ b/components/diagnostics/candidat-libre/ModuleRunner.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { ArrowLeft, ArrowRight, CheckCircle2, Clock3, Loader2, Save, ShieldCheck, X } from 'lucide-react';
+import type { DiagnosticAnswer, DiagnosticModuleDefinition } from '@/lib/diagnostics/candidat-libre/types';
+import { ConfidenceSelector, NotStudiedButton, QuestionRenderer } from './QuestionRenderer';
+
+interface ModulePayload {
+  definition: DiagnosticModuleDefinition;
+  module: {
+    status: string;
+    answers?: Record<string, DiagnosticAnswer>;
+    currentQuestionIndex: number;
+    elapsedMs: number;
+    submittedAt?: string | null;
+    availability?: { available: boolean; availableAt?: string | null; reason?: string };
+  };
+}
+
+interface Props {
+  diagnosticId: string;
+  moduleKey: string;
+  parentMode?: boolean;
+  onClose: () => void;
+  onUpdated: () => void;
+}
+
+function mutationId() {
+  return typeof crypto !== 'undefined' && 'randomUUID' in crypto ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`;
+}
+
+function formatDuration(ms: number) {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return `${hours ? `${hours} h ` : ''}${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
+export function ModuleRunner({ diagnosticId, moduleKey, parentMode, onClose, onUpdated }: Props) {
+  const endpoint = parentMode
+    ? `/api/diagnostics/candidat-libre/${diagnosticId}/parent`
+    : `/api/diagnostics/candidat-libre/${diagnosticId}/modules/${moduleKey}`;
+  const [payload, setPayload] = useState<ModulePayload | null>(null);
+  const [answers, setAnswers] = useState<Record<string, DiagnosticAnswer>>({});
+  const [index, setIndex] = useState(0);
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const integrity = useRef({ accepted: true, focusLossCount: 0, fullscreenExitCount: 0, copyPasteCount: 0 });
+  const startedAt = useRef(Date.now());
+
+  const load = useCallback(async () => {
+    const response = await fetch(endpoint, { cache: 'no-store' });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) throw new Error(data.reason ?? data.message ?? data.error ?? 'Impossible de charger le module.');
+    setPayload(data);
+    setAnswers(data.module.answers ?? {});
+    setIndex(Math.min(data.module.currentQuestionIndex ?? 0, Math.max(0, data.definition.questions.length - 1)));
+    setElapsedMs(data.module.elapsedMs ?? 0);
+    startedAt.current = Date.now();
+  }, [endpoint]);
+
+  useEffect(() => { void load().catch((reason) => setError(reason instanceof Error ? reason.message : 'Erreur de chargement.')); }, [load]);
+
+  useEffect(() => {
+    if (!payload || payload.module.submittedAt) return;
+    const timer = window.setInterval(() => setElapsedMs((current) => current + 1000), 1000);
+    const onVisibility = () => { if (document.hidden) integrity.current.focusLossCount += 1; };
+    const onPaste = () => { integrity.current.copyPasteCount += 1; };
+    const onFullscreen = () => { if (!document.fullscreenElement) integrity.current.fullscreenExitCount += 1; };
+    document.addEventListener('visibilitychange', onVisibility);
+    document.addEventListener('paste', onPaste);
+    document.addEventListener('fullscreenchange', onFullscreen);
+    return () => {
+      window.clearInterval(timer);
+      document.removeEventListener('visibilitychange', onVisibility);
+      document.removeEventListener('paste', onPaste);
+      document.removeEventListener('fullscreenchange', onFullscreen);
+    };
+  }, [payload]);
+
+  const save = useCallback(async (action: 'draft' | 'submit') => {
+    if (!payload || payload.module.submittedAt) return true;
+    action === 'submit' ? setIsSubmitting(true) : setIsSaving(true);
+    setError(null);
+    const body = parentMode
+      ? { answers, consent: action === 'submit', clientMutationId: mutationId() }
+      : { answers, currentQuestionIndex: index, elapsedMs, integrity: integrity.current, clientMutationId: mutationId() };
+    const response = await fetch(endpoint, {
+      method: action === 'submit' ? 'POST' : 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await response.json().catch(() => ({}));
+    action === 'submit' ? setIsSubmitting(false) : setIsSaving(false);
+    if (!response.ok) {
+      const suffix = data.missingQuestionIds?.length ? ` Questions manquantes : ${data.missingQuestionIds.join(', ')}.` : '';
+      setError(`${data.reason ?? data.message ?? data.error ?? 'Enregistrement impossible.'}${suffix}`);
+      return false;
+    }
+    setDirty(false);
+    setLastSavedAt(new Date());
+    if (action === 'submit') {
+      onUpdated();
+      onClose();
+    }
+    return true;
+  }, [answers, elapsedMs, endpoint, index, onClose, onUpdated, parentMode, payload]);
+
+  useEffect(() => {
+    if (!dirty || !payload || payload.module.submittedAt) return;
+    const timer = window.setTimeout(() => void save('draft'), 1800);
+    return () => window.clearTimeout(timer);
+  }, [answers, index, dirty, payload, save]);
+
+  const handleClose = useCallback(async () => {
+    if (dirty && payload && !payload.module.submittedAt) {
+      const saved = await save('draft');
+      if (saved === false) return;
+    }
+    onClose();
+  }, [dirty, onClose, payload, save]);
+
+  const definition = payload?.definition;
+  const question = definition?.questions[index];
+  const answer = question ? answers[question.id] : undefined;
+  const progress = definition ? Math.round(((index + 1) / definition.questions.length) * 100) : 0;
+  const requiredAnswered = !question || question.required === false || question.type === 'information' || question.type === 'upload' || Boolean(answer && answer.status !== 'SKIPPED' && (answer.status === 'NOT_STUDIED' || answer.value !== null && answer.value !== ''));
+  const isLast = Boolean(definition && index === definition.questions.length - 1);
+
+  const updateAnswer = (next: DiagnosticAnswer) => {
+    setAnswers((current) => ({ ...current, [next.questionId]: next }));
+    setDirty(true);
+  };
+
+  return (
+    <AnimatePresence>
+      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="fixed inset-0 z-50 overflow-y-auto bg-[#050816]/95 backdrop-blur-md">
+        <div className="mx-auto min-h-screen max-w-6xl px-4 py-5 md:px-8">
+          <header className="sticky top-0 z-10 rounded-2xl border border-slate-800 bg-[#081020]/95 p-4 shadow-2xl backdrop-blur md:p-5">
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-300">Diagnostic candidat individuel</p>
+                <h1 className="mt-1 truncate text-lg font-bold text-white md:text-2xl">{definition?.title ?? 'Chargement…'}</h1>
+              </div>
+              <button type="button" onClick={() => void handleClose()} className="rounded-xl border border-slate-700 p-2 text-slate-300 hover:border-slate-500 hover:bg-slate-800" aria-label="Fermer"><X className="h-5 w-5" /></button>
+            </div>
+            <div className="mt-4 flex flex-wrap items-center gap-3 text-xs text-slate-400">
+              <span className="inline-flex items-center gap-1.5"><Clock3 className="h-4 w-4" /> {formatDuration(elapsedMs)}</span>
+              <span className="inline-flex items-center gap-1.5"><ShieldCheck className="h-4 w-4" /> Sauvegarde sécurisée</span>
+              <span className="inline-flex items-center gap-1.5"><Save className="h-4 w-4" /> {isSaving ? 'Enregistrement…' : lastSavedAt ? `Enregistré à ${lastSavedAt.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })}` : 'Brouillon automatique'}</span>
+            </div>
+            <div className="mt-4 h-2 overflow-hidden rounded-full bg-slate-800"><div className="h-full rounded-full bg-gradient-to-r from-cyan-300 to-violet-400 transition-all" style={{ width: `${progress}%` }} /></div>
+            <p className="mt-2 text-right text-xs text-slate-500">Question {index + 1} sur {definition?.questions.length ?? 0} · {progress} %</p>
+          </header>
+
+          <main className="py-6">
+            {!payload && !error && <div className="flex min-h-[50vh] items-center justify-center"><Loader2 className="h-10 w-10 animate-spin text-cyan-300" /></div>}
+            {error && !payload && <div className="mx-auto max-w-2xl rounded-2xl border border-rose-400/30 bg-rose-400/10 p-6 text-rose-100">{error}</div>}
+            {payload && question && (
+              <motion.section key={question.id} initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} className="mx-auto max-w-4xl rounded-3xl border border-slate-800 bg-slate-900/70 p-5 shadow-2xl md:p-8">
+                <div className="mb-6">
+                  <div className="flex flex-wrap items-center gap-2"><span className="rounded-full border border-cyan-300/30 bg-cyan-400/10 px-3 py-1 text-xs font-semibold text-cyan-200">{definition.shortTitle}</span>{question.required !== false && <span className="text-xs text-amber-300">Réponse requise</span>}</div>
+                  <h2 className="mt-4 text-xl font-bold leading-8 text-white md:text-2xl">{question.prompt}</h2>
+                  {question.description && question.type !== 'information' && <p className="mt-3 whitespace-pre-line text-sm leading-6 text-slate-300">{question.description}</p>}
+                  {question.instruction && <p className="mt-3 rounded-xl border border-amber-300/20 bg-amber-400/5 p-3 text-sm leading-6 text-amber-100">{question.instruction}</p>}
+                </div>
+                <QuestionRenderer diagnosticId={diagnosticId} question={question} answer={answer} disabled={Boolean(payload.module.submittedAt)} onChange={updateAnswer} />
+                {question.maxPoints > 0 && question.type !== 'upload' && question.type !== 'information' && <ConfidenceSelector answer={answer} onChange={(confidence) => updateAnswer({ ...(answer ?? { questionId: question.id, value: null, status: 'SKIPPED' }), confidence })} />}
+                <NotStudiedButton question={question} answer={answer} onChange={updateAnswer} />
+                {error && <p role="alert" className="mt-5 rounded-xl border border-rose-400/30 bg-rose-400/10 p-3 text-sm text-rose-200">{error}</p>}
+                <div className="mt-8 flex flex-col-reverse gap-3 border-t border-slate-800 pt-5 sm:flex-row sm:justify-between">
+                  <button type="button" disabled={index === 0} onClick={() => { setIndex((current) => Math.max(0, current - 1)); setDirty(true); window.scrollTo({ top: 0, behavior: 'smooth' }); }} className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-700 px-4 py-3 text-sm font-semibold text-slate-300 disabled:opacity-30"><ArrowLeft className="h-4 w-4" /> Précédent</button>
+                  {!isLast ? <button type="button" disabled={!requiredAnswered} onClick={() => { setIndex((current) => Math.min(definition.questions.length - 1, current + 1)); setDirty(true); window.scrollTo({ top: 0, behavior: 'smooth' }); }} className="inline-flex items-center justify-center gap-2 rounded-xl bg-cyan-300 px-5 py-3 text-sm font-bold text-slate-950 disabled:cursor-not-allowed disabled:opacity-40">Suivant <ArrowRight className="h-4 w-4" /></button> : <button type="button" disabled={isSubmitting || !requiredAnswered} onClick={() => void save('submit')} className="inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-300 px-5 py-3 text-sm font-bold text-slate-950 disabled:opacity-50">{isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />} Soumettre définitivement</button>}
+                </div>
+              </motion.section>
+            )}
+          </main>
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/components/diagnostics/candidat-libre/ParentDiagnosticPortal.tsx
+++ b/components/diagnostics/candidat-libre/ParentDiagnosticPortal.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { ArrowRight, CheckCircle2, ClipboardList, EyeOff, FileText, Loader2, ShieldCheck, Users } from 'lucide-react';
+import type { DiagnosticCampaignView } from '@/lib/diagnostics/candidat-libre/types';
+import { ModuleRunner } from './ModuleRunner';
+
+export function ParentDiagnosticPortal({ studentId }: { studentId: string }) {
+  const [diagnostic, setDiagnostic] = useState<DiagnosticCampaignView | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    const response = await fetch(`/api/diagnostics/candidat-libre?studentId=${encodeURIComponent(studentId)}&targetSession=2027`, { cache: 'no-store' });
+    const data = await response.json().catch(() => ({}));
+    setLoading(false);
+    if (!response.ok) { setError(data.message ?? data.error ?? 'Chargement impossible.'); return; }
+    setDiagnostic(data.diagnostic ?? null);
+  }, [studentId]);
+  useEffect(() => { void refresh(); }, [refresh]);
+
+  async function create() {
+    setCreating(true);
+    const response = await fetch('/api/diagnostics/candidat-libre', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ targetSession: 2027, source: 'PARENT_DASHBOARD', studentId }) });
+    const data = await response.json().catch(() => ({}));
+    setCreating(false);
+    if (!response.ok) { setError(data.message ?? data.error ?? 'Création impossible.'); return; }
+    setDiagnostic(data.diagnostic);
+  }
+
+  if (loading) return <main className="flex min-h-screen items-center justify-center bg-[#050816] text-white"><Loader2 className="h-10 w-10 animate-spin text-cyan-300" /></main>;
+  if (!diagnostic) return <main className="min-h-screen bg-[#050816] px-4 py-10 text-white"><div className="mx-auto max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/70 p-8"><Users className="h-10 w-10 text-cyan-300" /><h1 className="mt-5 text-3xl font-bold">Ouvrir le dossier diagnostic</h1><p className="mt-4 leading-7 text-slate-300">Le dossier regroupe le parcours de l’élève et un questionnaire parent séparé. Vos réponses ne sont pas affichées à l’élève.</p>{error && <p className="mt-4 text-rose-300">{error}</p>}<button type="button" disabled={creating} onClick={() => void create()} className="mt-6 inline-flex items-center gap-2 rounded-xl bg-cyan-300 px-5 py-3 font-bold text-slate-950">{creating ? <Loader2 className="h-5 w-5 animate-spin" /> : <ArrowRight className="h-5 w-5" />} Créer le dossier</button></div></main>;
+
+  const parentModule = diagnostic.modules.find((module) => module.key === 'questionnaire-parent');
+  const parentDone = Boolean(parentModule && ['AUTO_SCORED','NEEDS_REVIEW','REVIEWED','SUBMITTED'].includes(parentModule.status));
+  const studentName = [diagnostic.student.firstName, diagnostic.student.lastName].filter(Boolean).join(' ') || 'l’élève';
+  return <main className="min-h-screen bg-[#050816] px-4 py-8 text-white md:px-8"><div className="mx-auto max-w-6xl"><header className="rounded-3xl border border-slate-800 bg-gradient-to-br from-slate-900 to-[#09152b] p-7"><p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-300">Espace parent</p><h1 className="mt-2 text-3xl font-bold">Diagnostic de {studentName}</h1><p className="mt-3 max-w-3xl text-sm leading-6 text-slate-300">Vous suivez l’avancement général et complétez un volet confidentiel. Les réponses académiques détaillées de l’élève restent privées afin de préserver son autonomie et l’intégrité de l’évaluation.</p><div className="mt-6 grid gap-4 md:grid-cols-3"><Card icon={ClipboardList} label="Avancement élève" value={`${diagnostic.completionPercentage} %`} /><Card icon={FileText} label="Documents déposés" value={String(diagnostic.documents.length)} /><Card icon={ShieldCheck} label="Votre questionnaire" value={parentDone ? 'Transmis' : 'À compléter'} /></div></header>
+    <section className="mt-6 grid gap-6 lg:grid-cols-[1fr_.85fr]"><div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6"><h2 className="text-xl font-bold">Progression par module</h2><div className="mt-5 space-y-3">{diagnostic.modules.filter((module) => module.key !== 'questionnaire-parent').map((module) => <div key={module.key} className="flex items-center justify-between gap-3 rounded-xl border border-slate-800 bg-slate-950/45 p-3"><span className="text-sm text-slate-300">{module.key.replaceAll('-',' ')}</span><span className="text-xs font-semibold text-slate-500">{module.status.replaceAll('_',' ')}</span></div>)}</div></div>
+    <aside className="space-y-5"><div className="rounded-3xl border border-violet-300/20 bg-violet-400/5 p-6"><EyeOff className="h-8 w-8 text-violet-300" /><h2 className="mt-4 text-xl font-bold">Questionnaire confidentiel</h2><p className="mt-3 text-sm leading-6 text-slate-300">Il porte sur l’autonomie observée, les antécédents, les contraintes familiales, le financement et votre arbitrage. Répondez séparément de l’élève.</p><button type="button" disabled={parentDone} onClick={() => setOpen(true)} className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-violet-300 px-5 py-3 font-bold text-slate-950 disabled:opacity-40">{parentDone ? <CheckCircle2 className="h-5 w-5" /> : <ArrowRight className="h-5 w-5" />}{parentDone ? 'Questionnaire transmis' : 'Compléter le questionnaire'}</button></div><div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6 text-sm leading-6 text-slate-400"><strong className="text-slate-200">Limite de l’outil.</strong> Le portail organise les preuves et facilite l’analyse. La recommandation finale demeure une décision pédagogique humaine, argumentée et traçable.</div></aside></section></div>{open && <ModuleRunner diagnosticId={diagnostic.id} moduleKey="questionnaire-parent" parentMode onClose={() => setOpen(false)} onUpdated={() => void refresh()} />}</main>;
+}
+
+function Card({ icon: Icon, label, value }: { icon: typeof Users; label: string; value: string }) { return <div className="rounded-2xl border border-slate-800 bg-slate-950/50 p-4"><div className="flex items-center gap-2 text-xs uppercase tracking-wider text-slate-500"><Icon className="h-4 w-4 text-cyan-300" />{label}</div><p className="mt-2 text-xl font-bold">{value}</p></div>; }

--- a/components/diagnostics/candidat-libre/QuestionRenderer.tsx
+++ b/components/diagnostics/candidat-libre/QuestionRenderer.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { Check, FileUp, HelpCircle } from 'lucide-react';
+import type { DiagnosticAnswer, DiagnosticQuestion } from '@/lib/diagnostics/candidat-libre/types';
+import { UploadPanel } from './UploadPanel';
+
+interface Props {
+  diagnosticId: string;
+  question: DiagnosticQuestion;
+  answer?: DiagnosticAnswer;
+  disabled?: boolean;
+  onChange: (answer: DiagnosticAnswer) => void;
+}
+
+function cx(...items: Array<string | false | null | undefined>) {
+  return items.filter(Boolean).join(' ');
+}
+
+export function QuestionRenderer({ diagnosticId, question, answer, disabled, onChange }: Props) {
+  const value = answer?.value;
+  const setValue = (next: DiagnosticAnswer['value'], status: DiagnosticAnswer['status'] = 'ANSWERED') => {
+    onChange({ questionId: question.id, value: next, status, confidence: answer?.confidence, answeredAt: new Date().toISOString() });
+  };
+
+  if (question.type === 'information') {
+    return <div className="whitespace-pre-line rounded-2xl border border-cyan-400/20 bg-cyan-400/5 p-5 text-sm leading-7 text-slate-200">{question.description ?? question.prompt}</div>;
+  }
+
+  if (question.type === 'upload' && question.uploadRule) {
+    return (
+      <UploadPanel
+        diagnosticId={diagnosticId}
+        question={question}
+        disabled={disabled}
+        onUploaded={() => setValue('UPLOADED')}
+      />
+    );
+  }
+
+  if (question.type === 'single') {
+    return (
+      <div className="grid gap-3">
+        {question.options?.map((option) => {
+          const selected = value === option.id && answer?.status !== 'NOT_STUDIED';
+          return (
+            <button key={option.id} type="button" disabled={disabled} onClick={() => setValue(option.id)}
+              className={cx('flex items-start gap-3 rounded-2xl border px-4 py-3 text-left text-sm transition focus:outline-none focus:ring-4 focus:ring-cyan-400/20', selected ? 'border-cyan-300 bg-cyan-400/15 text-white' : 'border-slate-700 bg-slate-950/50 text-slate-300 hover:border-slate-500')}>
+              <span className={cx('mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border', selected ? 'border-cyan-200 bg-cyan-300 text-slate-950' : 'border-slate-500')}>{selected && <Check className="h-3.5 w-3.5" />}</span>
+              <span><strong className="mr-2 text-slate-400">{option.id.toUpperCase()}.</strong>{option.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  if (question.type === 'multiple') {
+    const selected = Array.isArray(value) ? value : [];
+    return (
+      <div className="grid gap-3 md:grid-cols-2">
+        {question.options?.map((option) => {
+          const active = selected.includes(option.id) && answer?.status !== 'NOT_STUDIED';
+          return (
+            <button key={option.id} type="button" disabled={disabled} onClick={() => setValue(active ? selected.filter((id) => id !== option.id) : [...selected, option.id])}
+              className={cx('flex items-start gap-3 rounded-2xl border px-4 py-3 text-left text-sm transition focus:outline-none focus:ring-4 focus:ring-violet-400/20', active ? 'border-violet-300 bg-violet-400/15 text-white' : 'border-slate-700 bg-slate-950/50 text-slate-300 hover:border-slate-500')}>
+              <span className={cx('mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded border', active ? 'border-violet-200 bg-violet-300 text-slate-950' : 'border-slate-500')}>{active && <Check className="h-3.5 w-3.5" />}</span>
+              <span>{option.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  if (question.type === 'acknowledgement') {
+    const checked = value === true;
+    return (
+      <button type="button" disabled={disabled} onClick={() => setValue(!checked)}
+        className={cx('flex w-full items-start gap-3 rounded-2xl border p-4 text-left text-sm transition', checked ? 'border-emerald-300 bg-emerald-400/10 text-emerald-50' : 'border-slate-700 bg-slate-950/50 text-slate-300')}>
+        <span className={cx('mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded border', checked ? 'border-emerald-200 bg-emerald-300 text-slate-950' : 'border-slate-500')}>{checked && <Check className="h-3.5 w-3.5" />}</span>
+        <span>Je confirme cette déclaration.</span>
+      </button>
+    );
+  }
+
+  if (question.type === 'scale') {
+    const min = question.min ?? 1;
+    const max = question.max ?? 5;
+    const values = Array.from({ length: max - min + 1 }, (_, index) => min + index);
+    return (
+      <div className="rounded-2xl border border-slate-700 bg-slate-950/50 p-4">
+        <div className="flex flex-wrap gap-2">
+          {values.map((item) => <button key={item} type="button" disabled={disabled} onClick={() => setValue(item)} className={cx('h-11 min-w-11 rounded-xl border px-3 text-sm font-bold transition', value === item ? 'border-amber-300 bg-amber-300 text-slate-950' : 'border-slate-700 bg-slate-900 text-slate-300 hover:border-slate-500')}>{item}</button>)}
+        </div>
+        <div className="mt-3 flex justify-between text-xs text-slate-500"><span>{question.leftLabel}</span><span>{question.rightLabel}</span></div>
+      </div>
+    );
+  }
+
+  if (question.type === 'numeric') {
+    return <input type="number" disabled={disabled} min={question.min} max={question.max} step={question.step ?? 'any'} value={typeof value === 'number' ? value : ''} onChange={(event) => setValue(event.target.value === '' ? null : Number(event.target.value))} placeholder={question.placeholder} className="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-white outline-none transition focus:border-cyan-300 focus:ring-4 focus:ring-cyan-400/10" />;
+  }
+
+  const multiline = question.type === 'long';
+  const text = typeof value === 'string' ? value : '';
+  return (
+    <div className="space-y-2">
+      {multiline ? (
+        <textarea disabled={disabled} rows={question.wordLimit && question.wordLimit > 250 ? 12 : 7} value={text} onChange={(event) => setValue(event.target.value)} placeholder={question.placeholder} className="w-full resize-y rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm leading-6 text-white outline-none transition placeholder:text-slate-600 focus:border-cyan-300 focus:ring-4 focus:ring-cyan-400/10" />
+      ) : (
+        <input disabled={disabled} value={text} onChange={(event) => setValue(event.target.value)} placeholder={question.placeholder} className="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-white outline-none transition placeholder:text-slate-600 focus:border-cyan-300 focus:ring-4 focus:ring-cyan-400/10" />
+      )}
+      {question.wordLimit && <p className="text-right text-xs text-slate-500">{text.trim() ? text.trim().split(/\s+/).length : 0} / {question.wordLimit} mots conseillés</p>}
+    </div>
+  );
+}
+
+export function ConfidenceSelector({ answer, onChange }: { answer?: DiagnosticAnswer; onChange: (confidence: 0 | 1 | 2 | 3) => void }) {
+  const labels = ['Au hasard', 'Peu sûr', 'Assez sûr', 'Très sûr'] as const;
+  return <div className="mt-5 rounded-2xl border border-slate-800 bg-slate-950/40 p-4"><p className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-slate-400"><HelpCircle className="h-4 w-4" /> Degré de confiance</p><div className="flex flex-wrap gap-2">{labels.map((label, index) => <button type="button" key={label} onClick={() => onChange(index as 0|1|2|3)} className={cx('rounded-xl border px-3 py-2 text-xs transition', answer?.confidence === index ? 'border-cyan-300 bg-cyan-400/15 text-cyan-50' : 'border-slate-700 text-slate-400 hover:border-slate-500')}>{label}</button>)}</div></div>;
+}
+
+export function NotStudiedButton({ question, answer, onChange }: { question: DiagnosticQuestion; answer?: DiagnosticAnswer; onChange: (answer: DiagnosticAnswer) => void }) {
+  if (!question.allowNotStudied) return null;
+  const active = answer?.status === 'NOT_STUDIED';
+  return <button type="button" onClick={() => onChange({ questionId: question.id, value: active ? null : 'NOT_STUDIED', status: active ? 'SKIPPED' : 'NOT_STUDIED', answeredAt: new Date().toISOString() })} className={cx('mt-4 inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-xs transition', active ? 'border-amber-300 bg-amber-400/15 text-amber-100' : 'border-slate-700 text-slate-400 hover:border-amber-400/60')}><FileUp className="h-4 w-4" /> Notion non étudiée</button>;
+}

--- a/components/diagnostics/candidat-libre/UploadPanel.tsx
+++ b/components/diagnostics/candidat-libre/UploadPanel.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { FileAudio, FileCheck2, FileUp, Loader2, Mic, Square, Trash2 } from 'lucide-react';
+import type { DiagnosticQuestion } from '@/lib/diagnostics/candidat-libre/types';
+
+interface DocumentItem { id: string; category: string; originalName: string; sizeBytes: number; status: string; }
+
+export function UploadPanel({ diagnosticId, question, disabled, onUploaded }: { diagnosticId: string; question: DiagnosticQuestion; disabled?: boolean; onUploaded: () => void }) {
+  const rule = question.uploadRule!;
+  const [documents, setDocuments] = useState<DocumentItem[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  async function refresh() {
+    const response = await fetch(`/api/diagnostics/candidat-libre/${diagnosticId}/documents`, { cache: 'no-store' });
+    if (!response.ok) return;
+    const data = await response.json();
+    setDocuments((data.documents ?? []).filter((item: DocumentItem) => item.category === rule.category));
+  }
+  useEffect(() => { void refresh(); }, [diagnosticId, rule.category]);
+
+  async function upload(file: File) {
+    setError(null);
+    if (!rule.accept.includes(file.type)) { setError('Format de fichier non autorisé.'); return; }
+    if (file.size > rule.maxBytesPerFile) { setError(`Fichier trop volumineux. Limite : ${Math.round(rule.maxBytesPerFile / 1024 / 1024)} Mo.`); return; }
+    setUploading(true);
+    const form = new FormData();
+    form.set('file', file);
+    form.set('category', rule.category);
+    form.set('title', question.prompt);
+    form.set('clientMutationId', crypto.randomUUID());
+    const response = await fetch(`/api/diagnostics/candidat-libre/${diagnosticId}/documents`, { method: 'POST', body: form });
+    const data = await response.json().catch(() => ({}));
+    setUploading(false);
+    if (!response.ok) { setError(data.error ?? 'Échec du dépôt.'); return; }
+    await refresh();
+    onUploaded();
+  }
+
+  async function remove(id: string) {
+    const response = await fetch(`/api/diagnostics/candidat-libre/${diagnosticId}/documents/${id}`, { method: 'DELETE' });
+    if (response.ok) await refresh();
+  }
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-dashed border-slate-600 bg-slate-950/40 p-5">
+      <div className="flex items-start gap-3"><FileUp className="mt-0.5 h-5 w-5 text-cyan-300" /><div><p className="text-sm font-semibold text-white">Déposer le document</p><p className="mt-1 text-xs leading-5 text-slate-400">{rule.help} Formats : PDF, JPEG, PNG ou WebP. Limite : {Math.round(rule.maxBytesPerFile/1024/1024)} Mo.</p></div></div>
+      <input ref={inputRef} type="file" className="hidden" accept={rule.accept.join(',')} disabled={disabled || uploading || documents.length >= rule.maxFiles} onChange={(event) => { const file = event.target.files?.[0]; if (file) void upload(file); event.currentTarget.value=''; }} />
+      <div className="flex flex-wrap gap-3">
+        <button type="button" disabled={disabled || uploading || documents.length >= rule.maxFiles} onClick={() => inputRef.current?.click()} className="inline-flex items-center gap-2 rounded-xl bg-cyan-300 px-4 py-2 text-sm font-bold text-slate-950 disabled:opacity-50">{uploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <FileUp className="h-4 w-4" />} Choisir un fichier</button>
+        {rule.category === 'ORAL_RECORDING' && <AudioRecorder disabled={disabled || uploading || documents.length >= rule.maxFiles} onRecorded={(file) => void upload(file)} />}
+      </div>
+      {error && <p role="alert" className="text-sm text-rose-300">{error}</p>}
+      <div className="space-y-2">{documents.map((document) => <div key={document.id} className="flex items-center justify-between gap-3 rounded-xl border border-slate-700 bg-slate-900/70 p-3"><div className="flex min-w-0 items-center gap-3"><FileCheck2 className="h-5 w-5 shrink-0 text-emerald-300" /><div className="min-w-0"><p className="truncate text-sm text-white">{document.originalName}</p><p className="text-xs text-slate-500">{(document.sizeBytes/1024/1024).toFixed(2)} Mo · {document.status}</p></div></div><button type="button" disabled={disabled} onClick={() => void remove(document.id)} aria-label="Supprimer le document" className="rounded-lg p-2 text-slate-400 hover:bg-rose-400/10 hover:text-rose-300"><Trash2 className="h-4 w-4" /></button></div>)}</div>
+    </div>
+  );
+}
+
+function AudioRecorder({ disabled, onRecorded }: { disabled?: boolean; onRecorded: (file: File) => void }) {
+  const [recording, setRecording] = useState(false);
+  const recorder = useRef<MediaRecorder | null>(null);
+  const chunks = useRef<Blob[]>([]);
+  async function start() {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const mediaRecorder = new MediaRecorder(stream);
+    chunks.current = [];
+    mediaRecorder.ondataavailable = (event) => { if (event.data.size) chunks.current.push(event.data); };
+    mediaRecorder.onstop = () => {
+      const blob = new Blob(chunks.current, { type: mediaRecorder.mimeType || 'audio/webm' });
+      onRecorded(new File([blob], `grand-oral-${Date.now()}.webm`, { type: blob.type }));
+      stream.getTracks().forEach((track) => track.stop());
+    };
+    recorder.current = mediaRecorder;
+    mediaRecorder.start();
+    setRecording(true);
+  }
+  function stop() { recorder.current?.stop(); setRecording(false); }
+  return <button type="button" disabled={disabled} onClick={() => recording ? stop() : void start()} className="inline-flex items-center gap-2 rounded-xl border border-violet-300/50 bg-violet-400/10 px-4 py-2 text-sm font-semibold text-violet-100 disabled:opacity-50">{recording ? <Square className="h-4 w-4" /> : <Mic className="h-4 w-4" />}{recording ? 'Arrêter et déposer' : 'Enregistrer l’oral'}</button>;
+}

--- a/docs/DIAGNOSTIC_CANDIDAT_LIBRE_CROSS_AUDIENCE_AUDIT.md
+++ b/docs/DIAGNOSTIC_CANDIDAT_LIBRE_CROSS_AUDIENCE_AUDIT.md
@@ -2,138 +2,108 @@
 
 ## Source de vérité
 
-- Sérialiseur partagé : `lib/diagnostics/candidat-libre/serialize.server.ts`
-- Filtre documents par audience : `lib/diagnostics/candidat-libre/access.server.ts` (`isDocumentVisibleToViewer`)
-- Guard coach : `lib/guards.ts` (`requireCoachAssignedToStudent`)
-- Routes API : `app/api/diagnostics/candidat-libre/**`
-- Preuve tests : `__tests__/lib/diagnostics/candidat-libre/serialize.test.ts`,
-  `__tests__/api/diagnostics/candidat-libre/staff-export-content-visibility.test.ts`
+- Matrice de lecture (single source of truth) : `lib/diagnostics/candidat-libre/access.server.ts` —
+  `canViewModuleDetail(role, moduleAudience)` pour le détail des modules,
+  `isDocumentVisibleToViewer(category, role)` pour les documents.
+- Sérialiseur partagé (routes racine) : `lib/diagnostics/candidat-libre/serialize.server.ts` — délègue
+  entièrement à `canViewModuleDetail`/`isDocumentVisibleToViewer`, ne réimplémente rien.
+- Permission d'écriture (distincte de la lecture) : `canEditAudience` dans
+  `app/api/diagnostics/candidat-libre/[diagnosticId]/modules/[moduleKey]/route.ts`.
+- Preuve tests : `__tests__/lib/diagnostics/candidat-libre/serialize.test.ts` (matrice `canViewModuleDetail`
+  exhaustive par couple rôle × audience, `isDocumentVisibleToViewer` par catégorie × rôle),
+  `__tests__/api/diagnostics/candidat-libre/staff-export-content-visibility.test.ts`,
+  `__tests__/api/diagnostics/candidat-libre/module-detail-visibility.test.ts`.
 
-## Pourquoi cette révision (V2)
+## V3 — le critère change de nouveau, et pourquoi
 
-La V1 de cet audit (classification par route, colonne unique « Staff ») a laissé passer un trou réel :
-`GET .../staff-export` renvoyait `answers`/`autoScore`/`manualScore`/`reviewSummary` de tous les modules,
-y compris `questionnaire-parent`, à tout `COACH` — alors que `GET .../modules/{moduleKey}` refuse
-explicitement ce même contenu à ce même rôle. Le défaut de méthode : la V1 classait par « qui passe le
-gate de rôle » (ELEVE/PARENT exclus ⇒ jugé sûr), pas par **l'audience réelle que chaque champ vise**. Un
-COACH n'est ni ELEVE ni PARENT, donc il passait le gate — mais passer le gate ne veut pas dire être
-l'audience légitime du contenu.
+**V1** classait par rôle exclu par le gate (« ELEVE/PARENT bloqués ⇒ jugé sûr ») — a laissé passer le trou
+`staff-export`/COACH.
 
-**Nouveau critère de classification, appliqué ci-dessous à toutes les routes, pas seulement à
-`staff-export`** : pour chaque champ, on ne demande plus « quels rôles sont bloqués ? » mais « à qui ce
-contenu est-il fonctionnellement destiné ? ». Deux familles de légitimité, distinctes :
+**V2** classait par « quelle audience le champ vise », mais a fait une erreur inverse : elle a traité
+`canEditAudience` (qui gouverne qui peut MODIFIER une réponse) comme si elle gouvernait aussi qui peut la
+LIRE. Sur cette base, un COACH — qui ne peut jamais éditer — a été considéré comme ne devant jamais lire
+non plus. C'est un faux parallèle : le COACH travaille précisément à partir du détail des modules ELEVE de
+l'élève qu'il accompagne ; le priver de lecture aurait rendu le diagnostic illisible pour la personne même
+qui en a l'usage pédagogique.
 
-- **Audience directe** : ELEVE et PARENT sur leurs propres modules (l'élève sur son travail, le parent sur
-  son propre questionnaire — jamais l'inverse).
-- **Pilotage administratif du dossier** : ADMIN/ASSISTANTE, qui arbitrent le dossier dans son ensemble et
-  en ont besoin pour cette fonction — une légitimité différente de « être l'audience », documentée comme
-  telle, pas fusionnée avec elle.
+**V3 (arbitrée 2026-08-07)** sépare explicitement deux matrices :
+- **Écriture** — `canEditAudience(role, audience)` : qui peut soumettre des réponses. Inchangée.
+- **Lecture** — `canViewModuleDetail(role, audience)` : qui peut voir `answers`/`autoScore`/`manualScore`/
+  `reviewSummary`. Nouvelle, c'est le sujet de cette révision.
 
-`COACH` n'appartient à aucune des deux familles pour le **contenu** (réponses/scores/avis de correction).
-Il reste légitime sur la **structure/statut** (suivi pédagogique du parcours) et sur les **productions
-académiques de l'élève** (`WRITTEN_COPY`/`ORAL_RECORDING` — pertinentes à l'accompagnement), ce qui est une
-troisième famille de légitimité distincte, documentée séparément par champ/catégorie ci-dessous plutôt que
-supposée.
+## Matrice de lecture arbitrée
 
-## Routes partagées entre plusieurs audiences (candidates à une fuite)
-
-| Route | Audiences pouvant l'atteindre | Vecteur de fuite possible | Statut (critère audience-du-champ) |
+| Rôle | Modules audience ELEVE | Module audience PARENT (`questionnaire-parent`) | Justification |
 |---|---|---|---|
-| `GET /api/diagnostics/candidat-libre` | ELEVE, PARENT, COACH, ADMIN, ASSISTANTE | `serializeCandidateDiagnostic` | ⚠️ **gap ouvert** — voir ci-dessous |
-| `POST /api/diagnostics/candidat-libre` | ELEVE, PARENT, ADMIN, ASSISTANTE | `serializeCandidateDiagnostic` | pas de COACH sur ce verbe — sûr |
-| `GET /api/diagnostics/candidat-libre/{id}` | ELEVE, PARENT, COACH, ADMIN, ASSISTANTE | `serializeCandidateDiagnostic` | ⚠️ **gap ouvert** — voir ci-dessous |
-| `PATCH /api/diagnostics/candidat-libre/{id}` | idem | `serializeCandidateDiagnostic` | ⚠️ **gap ouvert** — voir ci-dessous |
-| `GET /api/diagnostics/candidat-libre/{id}/documents` | idem | liste de documents non filtrée | ✅ correct (COACH légitime sur les productions académiques, PARENT exclu) |
-| `GET .../documents/{documentId}` | idem | téléchargement du fichier lui-même | ✅ correct, même filtre |
-| `DELETE .../documents/{documentId}` | idem | — | ✅ déjà sûr (ownership `uploadedById`) |
-| `GET .../modules/{moduleKey}` | ELEVE, PARENT, COACH, ADMIN, ASSISTANTE | `canEditAudience` | ✅ correct — implémentation de référence du critère audience-du-champ |
+| ELEVE | Détail complet (propre travail) | Statut/progression uniquement | Élève ne lit jamais le questionnaire parent |
+| PARENT | Statut/progression uniquement | Détail complet (propre questionnaire) | Parent ne lit jamais le détail académique de l'enfant |
+| **COACH** | **Détail complet** — matière de travail | Statut/progression uniquement | Le coach travaille à partir du diagnostic académique réel de l'élève ; le questionnaire parent est un instrument famille/direction, pas un outil de coaching |
+| **ASSISTANTE** | **Aucun détail** — statut/progression uniquement | **Aucun détail** — statut/progression uniquement | Rôle logistique, moindre privilège sur les données d'un mineur, sur toute la surface académique |
+| ADMIN | Détail complet | Détail complet | Direction pédagogique — c'est là qu'atterrit l'instrument confidentiel famille |
+
+Le critère n'est donc ni « qui est exclu par rôle » (V1) ni « qui peut éditer » (V2), mais **le besoin
+légitime établi par rôle, évalué séparément de la permission d'écriture**.
+
+## Routes partagées entre plusieurs audiences
+
+| Route | Audiences pouvant l'atteindre | Mécanisme | Statut |
+|---|---|---|---|
+| `GET /api/diagnostics/candidat-libre` | ELEVE, PARENT, COACH, ADMIN, ASSISTANTE | `serializeCandidateDiagnostic` → `canViewModuleDetail` | ✅ conforme à la matrice V3 |
+| `GET /api/diagnostics/candidat-libre/{id}` | idem | idem | ✅ |
+| `PATCH /api/diagnostics/candidat-libre/{id}` | idem | idem | ✅ |
+| `GET .../documents` | idem | `isDocumentVisibleToViewer` | ✅ PARENT et ASSISTANTE exclus de `WRITTEN_COPY`/`ORAL_RECORDING`, COACH/ADMIN les voient (matière de travail) |
+| `GET .../documents/{documentId}` | idem | idem | ✅ même filtre sur le téléchargement direct |
+| `DELETE .../documents/{documentId}` | idem | ownership `uploadedById`, ADMIN/ASSISTANTE bypass | déjà sûr, non changé par cette révision |
+| `GET .../modules/{moduleKey}` | ELEVE, PARENT, COACH, ADMIN, ASSISTANTE | `canViewModuleDetail` pour `answers` (changé — utilisait `canEditAudience` avant), `canEditAudience` toujours pour le 403 cross-audience ELEVE/PARENT et pour PUT/POST | ✅ conforme à la matrice V3 |
 | `GET/PUT/POST .../parent` | PARENT uniquement | — | pas de surface cross-audience |
-| `GET .../staff-export` | COACH, ADMIN, ASSISTANTE uniquement | `answers`/`autoScore`/`manualScore`/`reviewSummary` par module | ✅ **corrigé** (alignement sur `canEditAudience`, voir commit `3d29af76`) |
+| `GET .../staff-export` | COACH, ADMIN, ASSISTANTE uniquement | `canViewModuleDetail` par module, `isDocumentVisibleToViewer`, `synthesis` masqué à ASSISTANTE | ✅ conforme à la matrice V3 |
 | `POST .../submit` | ELEVE uniquement | — | pas de surface cross-audience |
 
-## ⚠️ Gap ouvert — `serializeCandidateDiagnostic` (routes racine, pas `staff-export`)
+## Champ `synthesis` (`staff-export` uniquement) — décision prise, résidu documenté
 
-`lib/diagnostics/candidat-libre/serialize.server.ts` calcule `restrictToAudience = viewerRole === 'ELEVE'
-|| viewerRole === 'PARENT' ? viewerRole : null`. Pour `COACH`, `viewerRole` ne vaut ni `'ELEVE'` ni
-`'PARENT'`, donc `restrictToAudience = null`, donc `ownAudience = true` pour **tous** les modules — un
-`COACH` reçoit `autoScore`/`reviewSummary` de `questionnaire-parent` par `GET /candidat-libre` et
-`GET .../{id}`, exactement le même contenu que `staff-export` exposait avant correction. Le docstring de
-la fonction documente ce choix comme intentionnel (« Staff (COACH/ADMIN/ASSISTANTE) ... see everything »)
-et `serialize.test.ts` le verrouille par un test explicite (« pour le staff ... détail complet partout »)
-— ce n'est donc pas un défaut ponctuel isolé, c'est la même décision de conception que `staff-export`
-avait, prise à un autre endroit, testée, et jamais reconsidérée à la lumière de la décision sur
-`staff-export`.
+`buildStaffDiagnosticSynthesis` agrège des pourcentages/couvertures/flags dérivés du contenu académique de
+tous les modules, sans distinction d'audience par champ interne. Puisque ASSISTANTE ne doit voir aucun
+détail académique, `synthesis` lui est retourné `null` en bloc — cohérent avec la matrice, pas une
+extension arbitraire.
 
-**Pas corrigé dans ce commit.** Contrairement à `staff-export` (aucun test préexistant, verrouillait un
-comportement jamais examiné), toucher `serializeCandidateDiagnostic` casserait un contrat testé
-explicitement et partagé par plusieurs routes (`GET /candidat-libre`, `GET/PATCH {id}`) — un changement
-silencieux ici est plus risqué qu'un gap documenté. Décision produit nécessaire avant correctif : un COACH
-doit-il perdre l'accès à `autoScore`/`reviewSummary` de **tous** les modules hors de son audience (symétrie
-stricte avec `modules/{moduleKey}`), ou seulement à ceux d'audience `PARENT` (le coach garde le détail des
-modules `ELEVE`, pertinent à l'accompagnement) ? Les deux corrigent la fuite sur `questionnaire-parent` ;
-elles diffèrent sur ce qu'un coach voit du travail de l'élève lui-même, question hors du périmètre
-sécurité de cet audit.
+**Résidu non traité, documenté explicitement** : pour un COACH, `synthesis.moduleScores` inclut une
+entrée `questionnaire-parent` (percentage/coverage — vraisemblablement `null` en pratique puisque ces
+items ne sont pas notés, `Points max: 0` dans la banque), et le flag `PARENT_MISSING` (un fait procédural,
+pas un contenu). C'est une fuite structurelle mineure de la matrice de lecture stricte : pour la corriger
+complètement, `buildStaffDiagnosticSynthesis` devrait connaître l'audience de chaque module qu'il agrège
+et exclure `questionnaire-parent` du calcul pour un viewer COACH. Non fait dans cette révision — hors
+périmètre de ce qui a été arbitré, signalé pour arbitrage séparé si jugé nécessaire.
 
-## Matrice champ × audience — vue diagnostic (`DiagnosticCampaignView`)
+## Incohérences trouvées, remontées et non contournées
 
-### Niveau racine
-
-| Champ | ELEVE | PARENT | COACH | ADMIN/ASSISTANTE | Audience visée |
-|---|---|---|---|---|---|
-| `id`, `diagnosticKey`, `definitionVersion`, `status`, `targetSession` | ✅ | ✅ | ✅ | ✅ | métadonnées de campagne — dossier entier |
-| `student.{id,firstName,lastName,email,school,gradeLevel}` | ✅ | ✅ | ✅ | ✅ | identité de l'élève — légitime aux 4 (le parent est le tuteur légal, le coach suit cet élève nommément) |
-| `completionPercentage` | ✅ | ✅ | ✅ | ✅ | agrégat de progression, jamais de contenu |
-| `studentConsentAt`, `parentConsentAt`, `submittedAt`, `retentionDueAt`, `createdAt`, `updatedAt` | ✅ | ✅ | ✅ | ✅ | jalons de statut, nécessaires au suivi par les 4 |
-
-### `modules[]` — un élément par module (16 au total, 15 audience ELEVE + 1 audience PARENT)
-
-| Champ | Audience visée | ELEVE (même audience) | ELEVE (autre audience) | PARENT (même audience) | PARENT (autre audience) | COACH | ADMIN/ASSISTANTE |
-|---|---|---|---|---|---|---|---|
-| `key`, `status`, `progress`, `startedAt`, `submittedAt`, `availableAt`, `elapsedMs` | dossier entier | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `autoScore`, `reviewSummary` | ELEVE **ou** PARENT selon `module.audience` — jamais l'autre, jamais COACH | ✅ | ❌ null | ✅ | ❌ null | ⚠️ **voir gap ci-dessus** | ✅ (pilotage dossier) |
-| `answers` | idem, uniquement via `modules/{moduleKey}` | n/a (champ absent de cette vue) | | | | | |
-
-Aucun champ `answers` n'apparaît dans `DiagnosticCampaignView` — les réponses brutes ne transitent que par
-`GET .../modules/{moduleKey}`, qui a son propre contrôle (`canEditAudience`, déjà correct pour COACH).
-
-### `documents[]`
-
-| Catégorie | Audience visée | ELEVE | PARENT | COACH | ADMIN/ASSISTANTE |
-|---|---|---|---|---|---|
-| `IDENTITY`, `CYCLADES`, `FRENCH_BAC_TRANSCRIPT`, `TUNISIAN_BAC_TRANSCRIPT`, `SCHOOL_REPORT`, `EXAM_ACCOMMODATION`, `OTHER` | dossier entier | ✅ | ✅ | ✅ | ✅ | pièces administratives, gérées conjointement |
-| `WRITTEN_COPY` (copie français/maths/tronc commun) | ELEVE + suivi pédagogique | ✅ | ❌ | ✅ | ✅ | production académique — pertinente au coach qui accompagne, pas au parent |
-| `ORAL_RECORDING` (Grand oral) | idem | ✅ | ❌ | ✅ | ✅ | idem |
-
-Filtrage appliqué sur la **liste** (`GET .../documents`, `serializeCandidateDiagnostic`), le
-**téléchargement** (`GET .../documents/{documentId}`) et désormais aussi sur `staff-export`
-(`isDocumentVisibleToViewer`, ajouté par cohérence — sans effet pratique aujourd'hui puisque `PARENT`
-n'atteint pas cette route).
-
-## Route `modules/{moduleKey}` — implémentation de référence du critère audience-du-champ
-
-`canEditAudience(role, audience)` bloque tout accès cross-audience élève/parent (403 en écriture). En
-lecture, un `COACH` passe le gate de rôle (n'est bloqué ni ELEVE ni PARENT) mais `canEditAudience(COACH,
-*)` vaut toujours `false` pour toute audience — donc `answers` est explicitement `undefined`, **quelle que
-soit l'audience du module**, y compris les modules ELEVE. C'est plus strict que la classification retenue
-pour `documents[]` (où COACH garde `WRITTEN_COPY`/`ORAL_RECORDING`) : cette route ne distingue pas
-« module ELEVE » de « module PARENT » pour COACH, elle exclut COACH du contenu partout. `staff-export` est
-maintenant aligné sur exactement ce comportement (commit `3d29af76`). `serializeCandidateDiagnostic` ne
-l'est pas encore (gap documenté plus haut).
+1. **`canEditAudience` autorise toujours ASSISTANTE à écrire des réponses** (`return role === ADMIN ||
+   role === ASSISTANTE`), y compris sur des modules dont elle ne peut désormais plus rien lire — elle
+   pourrait écraser un contenu qu'elle ne voit jamais. Décision produit nécessaire : soit ASSISTANTE
+   perd aussi l'écriture (cohérence stricte avec la lecture), soit c'est un cas d'usage réel (ex. saisie
+   pour le compte de la famille) et seule la lecture doit rester restreinte. Non tranché, non codé.
+2. **L'upload de documents ne restreint aucune catégorie par rôle** (`documents/route.ts` POST) —
+   ASSISTANTE peut aujourd'hui déposer un `WRITTEN_COPY`/`ORAL_RECORDING` qu'elle ne peut plus voir dans
+   la liste une fois déposé. Comportement inchangé par cette révision (l'upload n'était pas dans le
+   périmètre arbitré), signalé pour cohérence future.
 
 ## Ce qui reste hors périmètre de cet audit
 
-- **Qui a le droit d'uploader dans quelle catégorie** (ex. un parent peut aujourd'hui POSTer un document
-  `WRITTEN_COPY`) n'a pas été modifié — question de permission d'écriture, pas de fuite de lecture.
+- Qui a le droit d'uploader dans quelle catégorie — question de permission d'écriture, cf. point 2
+  ci-dessus.
 - Les points ops/légal identifiés au Gate 5 (RGPD, rétention, sauvegarde chiffrée, CSP, alerting) restent
   ouverts et hors code.
-- Le gap `serializeCandidateDiagnostic` documenté ci-dessus attend une décision produit avant correctif.
+- Le résidu `synthesis`/COACH documenté ci-dessus.
 
 ## Preuve
 
-- `__tests__/lib/diagnostics/candidat-libre/serialize.test.ts` verrouille l'ensemble exact des clés d'une
-  vue de module, le masquage ELEVE/PARENT réciproque, le comportement staff actuel (y compris le gap COACH
-  documenté ci-dessus — ce test devra changer le jour où ce gap sera tranché), et la matrice catégorie ×
-  audience de `isDocumentVisibleToViewer` sur les 9 catégories existantes.
-- `__tests__/api/diagnostics/candidat-libre/staff-export-content-visibility.test.ts` verrouille le
-  comportement corrigé de `staff-export` : COACH sans contenu sur `questionnaire-parent`, ADMIN/ASSISTANTE
-  avec contenu complet.
+- `canViewModuleDetail` : verrouillé exhaustivement pour les 5 rôles × 2 audiences (10 cas explicites,
+  `__tests__/lib/diagnostics/candidat-libre/serialize.test.ts`).
+- `isDocumentVisibleToViewer` : verrouillé pour les 9 catégories × ELEVE/COACH/ADMIN/PARENT/ASSISTANTE.
+- `serializeCandidateDiagnostic` : verrouille l'ensemble exact des clés d'une vue de module, le masquage
+  réciproque ELEVE/PARENT, le comportement COACH (détail ELEVE, pas PARENT), ASSISTANTE (aucun détail),
+  ADMIN et appelant interne (détail complet).
+- `staff-export` : verrouille COACH (détail ELEVE, pas PARENT, synthesis non nul), ADMIN (tout),
+  ASSISTANTE (rien, `synthesis: null`, documents administratifs uniquement).
+- `modules/{moduleKey}` GET : verrouille que `answers` suit désormais `canViewModuleDetail`, pas
+  `canEditAudience` — COACH lit `mathematiques` sans pouvoir l'éditer, ASSISTANTE ne lit rien malgré une
+  permission d'édition inchangée.

--- a/docs/DIAGNOSTIC_CANDIDAT_LIBRE_CROSS_AUDIENCE_AUDIT.md
+++ b/docs/DIAGNOSTIC_CANDIDAT_LIBRE_CROSS_AUDIENCE_AUDIT.md
@@ -6,92 +6,134 @@
 - Filtre documents par audience : `lib/diagnostics/candidat-libre/access.server.ts` (`isDocumentVisibleToViewer`)
 - Guard coach : `lib/guards.ts` (`requireCoachAssignedToStudent`)
 - Routes API : `app/api/diagnostics/candidat-libre/**`
-- Preuve tests : `__tests__/lib/diagnostics/candidat-libre/serialize.test.ts`
+- Preuve tests : `__tests__/lib/diagnostics/candidat-libre/serialize.test.ts`,
+  `__tests__/api/diagnostics/candidat-libre/staff-export-content-visibility.test.ts`
 
-## Pourquoi cet audit
+## Pourquoi cette révision (V2)
 
-La fuite corrigée au Gate 5 (scores/avis cross-audience) touchait des données concernant un mineur. Cet
-audit énumère **chaque route partagée entre audiences**, **chaque champ** qu'elle renvoie, et prouve par
-un test que la frontière élève/parent/staff est étanche — pas seulement pour les deux cas déjà trouvés.
+La V1 de cet audit (classification par route, colonne unique « Staff ») a laissé passer un trou réel :
+`GET .../staff-export` renvoyait `answers`/`autoScore`/`manualScore`/`reviewSummary` de tous les modules,
+y compris `questionnaire-parent`, à tout `COACH` — alors que `GET .../modules/{moduleKey}` refuse
+explicitement ce même contenu à ce même rôle. Le défaut de méthode : la V1 classait par « qui passe le
+gate de rôle » (ELEVE/PARENT exclus ⇒ jugé sûr), pas par **l'audience réelle que chaque champ vise**. Un
+COACH n'est ni ELEVE ni PARENT, donc il passait le gate — mais passer le gate ne veut pas dire être
+l'audience légitime du contenu.
+
+**Nouveau critère de classification, appliqué ci-dessous à toutes les routes, pas seulement à
+`staff-export`** : pour chaque champ, on ne demande plus « quels rôles sont bloqués ? » mais « à qui ce
+contenu est-il fonctionnellement destiné ? ». Deux familles de légitimité, distinctes :
+
+- **Audience directe** : ELEVE et PARENT sur leurs propres modules (l'élève sur son travail, le parent sur
+  son propre questionnaire — jamais l'inverse).
+- **Pilotage administratif du dossier** : ADMIN/ASSISTANTE, qui arbitrent le dossier dans son ensemble et
+  en ont besoin pour cette fonction — une légitimité différente de « être l'audience », documentée comme
+  telle, pas fusionnée avec elle.
+
+`COACH` n'appartient à aucune des deux familles pour le **contenu** (réponses/scores/avis de correction).
+Il reste légitime sur la **structure/statut** (suivi pédagogique du parcours) et sur les **productions
+académiques de l'élève** (`WRITTEN_COPY`/`ORAL_RECORDING` — pertinentes à l'accompagnement), ce qui est une
+troisième famille de légitimité distincte, documentée séparément par champ/catégorie ci-dessous plutôt que
+supposée.
 
 ## Routes partagées entre plusieurs audiences (candidates à une fuite)
 
-| Route | Audiences pouvant l'atteindre | Vecteur de fuite possible | Statut |
+| Route | Audiences pouvant l'atteindre | Vecteur de fuite possible | Statut (critère audience-du-champ) |
 |---|---|---|---|
-| `GET /api/diagnostics/candidat-libre` | ELEVE, PARENT, COACH, ADMIN, ASSISTANTE | `serializeCandidateDiagnostic` | ✅ corrigé |
-| `POST /api/diagnostics/candidat-libre` | ELEVE, PARENT, ADMIN, ASSISTANTE | `serializeCandidateDiagnostic` | ✅ corrigé |
-| `GET /api/diagnostics/candidat-libre/{id}` | ELEVE, PARENT, COACH, ADMIN, ASSISTANTE | `serializeCandidateDiagnostic` | ✅ corrigé |
-| `PATCH /api/diagnostics/candidat-libre/{id}` | idem | `serializeCandidateDiagnostic` | ✅ corrigé |
-| `GET /api/diagnostics/candidat-libre/{id}/documents` | idem | liste de documents non filtrée | ✅ corrigé |
-| `GET .../documents/{documentId}` | idem | téléchargement du fichier lui-même | ✅ corrigé |
-| `DELETE .../documents/{documentId}` | idem | — | déjà sûr (ownership `uploadedById`, cf. note) |
-| `GET .../modules/{moduleKey}` | ELEVE, PARENT, COACH, ADMIN, ASSISTANTE | `canEditAudience` | déjà sûr (403 cross-audience élève/parent ; coach reçoit la structure sans `answers`) |
-| `GET/PUT/POST .../parent` | PARENT uniquement | — | pas de surface cross-audience (`requireRole(PARENT)`) |
-| `GET .../staff-export` | COACH, ADMIN, ASSISTANTE uniquement | — | pas de surface cross-audience (ELEVE/PARENT exclus par rôle) |
+| `GET /api/diagnostics/candidat-libre` | ELEVE, PARENT, COACH, ADMIN, ASSISTANTE | `serializeCandidateDiagnostic` | ⚠️ **gap ouvert** — voir ci-dessous |
+| `POST /api/diagnostics/candidat-libre` | ELEVE, PARENT, ADMIN, ASSISTANTE | `serializeCandidateDiagnostic` | pas de COACH sur ce verbe — sûr |
+| `GET /api/diagnostics/candidat-libre/{id}` | ELEVE, PARENT, COACH, ADMIN, ASSISTANTE | `serializeCandidateDiagnostic` | ⚠️ **gap ouvert** — voir ci-dessous |
+| `PATCH /api/diagnostics/candidat-libre/{id}` | idem | `serializeCandidateDiagnostic` | ⚠️ **gap ouvert** — voir ci-dessous |
+| `GET /api/diagnostics/candidat-libre/{id}/documents` | idem | liste de documents non filtrée | ✅ correct (COACH légitime sur les productions académiques, PARENT exclu) |
+| `GET .../documents/{documentId}` | idem | téléchargement du fichier lui-même | ✅ correct, même filtre |
+| `DELETE .../documents/{documentId}` | idem | — | ✅ déjà sûr (ownership `uploadedById`) |
+| `GET .../modules/{moduleKey}` | ELEVE, PARENT, COACH, ADMIN, ASSISTANTE | `canEditAudience` | ✅ correct — implémentation de référence du critère audience-du-champ |
+| `GET/PUT/POST .../parent` | PARENT uniquement | — | pas de surface cross-audience |
+| `GET .../staff-export` | COACH, ADMIN, ASSISTANTE uniquement | `answers`/`autoScore`/`manualScore`/`reviewSummary` par module | ✅ **corrigé** (alignement sur `canEditAudience`, voir commit `3d29af76`) |
 | `POST .../submit` | ELEVE uniquement | — | pas de surface cross-audience |
 
-**Note DELETE document** : un `PARENT` non-staff ne peut supprimer que les documents dont `uploadedById`
-correspond à son propre `User.id`. Comme les documents `WRITTEN_COPY`/`ORAL_RECORDING` sont uploadés par
-l'élève, ce check d'ownership bloque déjà un parent qui tenterait de les supprimer — aucun correctif requis,
-vérifié par lecture de code (pas de nouveau test ajouté, la protection existante suffit).
+## ⚠️ Gap ouvert — `serializeCandidateDiagnostic` (routes racine, pas `staff-export`)
+
+`lib/diagnostics/candidat-libre/serialize.server.ts` calcule `restrictToAudience = viewerRole === 'ELEVE'
+|| viewerRole === 'PARENT' ? viewerRole : null`. Pour `COACH`, `viewerRole` ne vaut ni `'ELEVE'` ni
+`'PARENT'`, donc `restrictToAudience = null`, donc `ownAudience = true` pour **tous** les modules — un
+`COACH` reçoit `autoScore`/`reviewSummary` de `questionnaire-parent` par `GET /candidat-libre` et
+`GET .../{id}`, exactement le même contenu que `staff-export` exposait avant correction. Le docstring de
+la fonction documente ce choix comme intentionnel (« Staff (COACH/ADMIN/ASSISTANTE) ... see everything »)
+et `serialize.test.ts` le verrouille par un test explicite (« pour le staff ... détail complet partout »)
+— ce n'est donc pas un défaut ponctuel isolé, c'est la même décision de conception que `staff-export`
+avait, prise à un autre endroit, testée, et jamais reconsidérée à la lumière de la décision sur
+`staff-export`.
+
+**Pas corrigé dans ce commit.** Contrairement à `staff-export` (aucun test préexistant, verrouillait un
+comportement jamais examiné), toucher `serializeCandidateDiagnostic` casserait un contrat testé
+explicitement et partagé par plusieurs routes (`GET /candidat-libre`, `GET/PATCH {id}`) — un changement
+silencieux ici est plus risqué qu'un gap documenté. Décision produit nécessaire avant correctif : un COACH
+doit-il perdre l'accès à `autoScore`/`reviewSummary` de **tous** les modules hors de son audience (symétrie
+stricte avec `modules/{moduleKey}`), ou seulement à ceux d'audience `PARENT` (le coach garde le détail des
+modules `ELEVE`, pertinent à l'accompagnement) ? Les deux corrigent la fuite sur `questionnaire-parent` ;
+elles diffèrent sur ce qu'un coach voit du travail de l'élève lui-même, question hors du périmètre
+sécurité de cet audit.
 
 ## Matrice champ × audience — vue diagnostic (`DiagnosticCampaignView`)
 
 ### Niveau racine
 
-| Champ | ELEVE | PARENT | Staff | Justification |
-|---|---|---|---|---|
-| `id`, `diagnosticKey`, `definitionVersion`, `status`, `targetSession` | ✅ | ✅ | ✅ | métadonnées de campagne, non sensibles |
-| `student.{id,firstName,lastName,email,school,gradeLevel}` | ✅ | ✅ | ✅ | identité de l'élève, légitime pour les 3 audiences (le parent est le tuteur légal) |
-| `completionPercentage` | ✅ | ✅ | ✅ | agrégat calculé uniquement sur les modules requis ELEVE, jamais de contenu |
-| `studentConsentAt`, `parentConsentAt`, `submittedAt`, `retentionDueAt`, `createdAt`, `updatedAt` | ✅ | ✅ | ✅ | jalons de consentement/statut, nécessaires aux deux portails pour le suivi de soumission |
+| Champ | ELEVE | PARENT | COACH | ADMIN/ASSISTANTE | Audience visée |
+|---|---|---|---|---|---|
+| `id`, `diagnosticKey`, `definitionVersion`, `status`, `targetSession` | ✅ | ✅ | ✅ | ✅ | métadonnées de campagne — dossier entier |
+| `student.{id,firstName,lastName,email,school,gradeLevel}` | ✅ | ✅ | ✅ | ✅ | identité de l'élève — légitime aux 4 (le parent est le tuteur légal, le coach suit cet élève nommément) |
+| `completionPercentage` | ✅ | ✅ | ✅ | ✅ | agrégat de progression, jamais de contenu |
+| `studentConsentAt`, `parentConsentAt`, `submittedAt`, `retentionDueAt`, `createdAt`, `updatedAt` | ✅ | ✅ | ✅ | ✅ | jalons de statut, nécessaires au suivi par les 4 |
 
-### `modules[]` — un élément par module (16 au total, 15 ELEVE + 1 PARENT)
+### `modules[]` — un élément par module (16 au total, 15 audience ELEVE + 1 audience PARENT)
 
-| Champ | Own audience | Cross audience | Justification |
-|---|---|---|---|
-| `key`, `status`, `progress`, `startedAt`, `submittedAt`, `availableAt`, `elapsedMs` | ✅ | ✅ **visible** | nécessaire à l'UX « en attente du parent » / « élève en cours » ; ne révèle ni contenu ni score |
-| `autoScore` | ✅ | ❌ **null** | contient `evidence[]` (statut CORRECT/INCORRECT par question), `domainScores`, `percentage` — équivalent à une réponse détaillée |
-| `reviewSummary` | ✅ | ❌ **null** | avis de correction humaine, même registre que `autoScore` |
+| Champ | Audience visée | ELEVE (même audience) | ELEVE (autre audience) | PARENT (même audience) | PARENT (autre audience) | COACH | ADMIN/ASSISTANTE |
+|---|---|---|---|---|---|---|---|
+| `key`, `status`, `progress`, `startedAt`, `submittedAt`, `availableAt`, `elapsedMs` | dossier entier | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `autoScore`, `reviewSummary` | ELEVE **ou** PARENT selon `module.audience` — jamais l'autre, jamais COACH | ✅ | ❌ null | ✅ | ❌ null | ⚠️ **voir gap ci-dessus** | ✅ (pilotage dossier) |
+| `answers` | idem, uniquement via `modules/{moduleKey}` | n/a (champ absent de cette vue) | | | | | |
 
-Aucun champ `answers` n'apparaît dans `DiagnosticModuleView` — les réponses brutes ne transitent jamais par
-cette route, uniquement par `GET .../modules/{moduleKey}` qui a son propre contrôle d'audience strict.
+Aucun champ `answers` n'apparaît dans `DiagnosticCampaignView` — les réponses brutes ne transitent que par
+`GET .../modules/{moduleKey}`, qui a son propre contrôle (`canEditAudience`, déjà correct pour COACH).
 
 ### `documents[]`
 
-| Catégorie | ELEVE | PARENT | Staff | Nature |
-|---|---|---|---|---|
-| `IDENTITY`, `CYCLADES`, `FRENCH_BAC_TRANSCRIPT`, `TUNISIAN_BAC_TRANSCRIPT`, `SCHOOL_REPORT`, `EXAM_ACCOMMODATION`, `OTHER` | ✅ | ✅ | ✅ | pièces administratives, gérées conjointement par la famille |
-| `WRITTEN_COPY` (copie français/maths/tronc commun) | ✅ | ❌ | ✅ | production académique de l'élève — équivalent à une réponse détaillée |
-| `ORAL_RECORDING` (Grand oral) | ✅ | ❌ | ✅ | idem, enregistrement de la prestation orale |
+| Catégorie | Audience visée | ELEVE | PARENT | COACH | ADMIN/ASSISTANTE |
+|---|---|---|---|---|---|
+| `IDENTITY`, `CYCLADES`, `FRENCH_BAC_TRANSCRIPT`, `TUNISIAN_BAC_TRANSCRIPT`, `SCHOOL_REPORT`, `EXAM_ACCOMMODATION`, `OTHER` | dossier entier | ✅ | ✅ | ✅ | ✅ | pièces administratives, gérées conjointement |
+| `WRITTEN_COPY` (copie français/maths/tronc commun) | ELEVE + suivi pédagogique | ✅ | ❌ | ✅ | ✅ | production académique — pertinente au coach qui accompagne, pas au parent |
+| `ORAL_RECORDING` (Grand oral) | idem | ✅ | ❌ | ✅ | ✅ | idem |
 
-Filtrage appliqué à la fois sur la **liste** (`GET .../documents`, `serializeCandidateDiagnostic`) et sur le
-**téléchargement** (`GET .../documents/{documentId}`) — un parent ne peut ni lister ni récupérer le fichier
-par accès direct à l'identifiant.
+Filtrage appliqué sur la **liste** (`GET .../documents`, `serializeCandidateDiagnostic`), le
+**téléchargement** (`GET .../documents/{documentId}`) et désormais aussi sur `staff-export`
+(`isDocumentVisibleToViewer`, ajouté par cohérence — sans effet pratique aujourd'hui puisque `PARENT`
+n'atteint pas cette route).
 
-## Route `modules/{moduleKey}` — déjà sûre, documentée pour mémoire
+## Route `modules/{moduleKey}` — implémentation de référence du critère audience-du-champ
 
-`canEditAudience(role, audience)` bloque tout accès cross-audience élève/parent (403). Un `COACH` passe le
-gate (n'est bloqué ni ELEVE ni PARENT) mais `canEditAudience(COACH, *)` vaut toujours `false`, donc
-`answers` est explicitement `undefined` dans la réponse — un coach voit la structure/le statut de n'importe
-quel module (y compris le questionnaire parent) mais jamais son contenu. Comportement déjà correct dans le
-lot d'origine, vérifié par relecture de code.
+`canEditAudience(role, audience)` bloque tout accès cross-audience élève/parent (403 en écriture). En
+lecture, un `COACH` passe le gate de rôle (n'est bloqué ni ELEVE ni PARENT) mais `canEditAudience(COACH,
+*)` vaut toujours `false` pour toute audience — donc `answers` est explicitement `undefined`, **quelle que
+soit l'audience du module**, y compris les modules ELEVE. C'est plus strict que la classification retenue
+pour `documents[]` (où COACH garde `WRITTEN_COPY`/`ORAL_RECORDING`) : cette route ne distingue pas
+« module ELEVE » de « module PARENT » pour COACH, elle exclut COACH du contenu partout. `staff-export` est
+maintenant aligné sur exactement ce comportement (commit `3d29af76`). `serializeCandidateDiagnostic` ne
+l'est pas encore (gap documenté plus haut).
 
 ## Ce qui reste hors périmètre de cet audit
 
 - **Qui a le droit d'uploader dans quelle catégorie** (ex. un parent peut aujourd'hui POSTer un document
-  `WRITTEN_COPY`) n'a pas été modifié — c'est une question de permission d'écriture, pas de fuite de
-  lecture, et un changement là-dessus est un choix produit, pas un correctif de sécurité.
+  `WRITTEN_COPY`) n'a pas été modifié — question de permission d'écriture, pas de fuite de lecture.
 - Les points ops/légal identifiés au Gate 5 (RGPD, rétention, sauvegarde chiffrée, CSP, alerting) restent
   ouverts et hors code.
+- Le gap `serializeCandidateDiagnostic` documenté ci-dessus attend une décision produit avant correctif.
 
 ## Preuve
 
-`__tests__/lib/diagnostics/candidat-libre/serialize.test.ts` verrouille :
-- l'ensemble exact des clés d'une vue de module (`Object.keys().sort()` contre une liste explicite) —
-  un champ non classé fait échouer le test de classification ;
-- pour ELEVE et PARENT : le module de leur propre audience garde son détail, le module de l'autre audience
-  a `autoScore`/`reviewSummary` à `null` mais conserve les champs de statut ;
-- pour le staff et les appels internes (pas de rôle passé) : détail complet partout ;
-- la matrice catégorie × audience de `isDocumentVisibleToViewer`, testée exhaustivement sur les 9 catégories
-  existantes pour ELEVE, PARENT et staff.
+- `__tests__/lib/diagnostics/candidat-libre/serialize.test.ts` verrouille l'ensemble exact des clés d'une
+  vue de module, le masquage ELEVE/PARENT réciproque, le comportement staff actuel (y compris le gap COACH
+  documenté ci-dessus — ce test devra changer le jour où ce gap sera tranché), et la matrice catégorie ×
+  audience de `isDocumentVisibleToViewer` sur les 9 catégories existantes.
+- `__tests__/api/diagnostics/candidat-libre/staff-export-content-visibility.test.ts` verrouille le
+  comportement corrigé de `staff-export` : COACH sans contenu sur `questionnaire-parent`, ADMIN/ASSISTANTE
+  avec contenu complet.

--- a/docs/DIAGNOSTIC_CANDIDAT_LIBRE_CROSS_AUDIENCE_AUDIT.md
+++ b/docs/DIAGNOSTIC_CANDIDAT_LIBRE_CROSS_AUDIENCE_AUDIT.md
@@ -1,0 +1,97 @@
+# Diagnostic candidat libre 2027 — Audit de séparation élève/parent/staff
+
+## Source de vérité
+
+- Sérialiseur partagé : `lib/diagnostics/candidat-libre/serialize.server.ts`
+- Filtre documents par audience : `lib/diagnostics/candidat-libre/access.server.ts` (`isDocumentVisibleToViewer`)
+- Guard coach : `lib/guards.ts` (`requireCoachAssignedToStudent`)
+- Routes API : `app/api/diagnostics/candidat-libre/**`
+- Preuve tests : `__tests__/lib/diagnostics/candidat-libre/serialize.test.ts`
+
+## Pourquoi cet audit
+
+La fuite corrigée au Gate 5 (scores/avis cross-audience) touchait des données concernant un mineur. Cet
+audit énumère **chaque route partagée entre audiences**, **chaque champ** qu'elle renvoie, et prouve par
+un test que la frontière élève/parent/staff est étanche — pas seulement pour les deux cas déjà trouvés.
+
+## Routes partagées entre plusieurs audiences (candidates à une fuite)
+
+| Route | Audiences pouvant l'atteindre | Vecteur de fuite possible | Statut |
+|---|---|---|---|
+| `GET /api/diagnostics/candidat-libre` | ELEVE, PARENT, COACH, ADMIN, ASSISTANTE | `serializeCandidateDiagnostic` | ✅ corrigé |
+| `POST /api/diagnostics/candidat-libre` | ELEVE, PARENT, ADMIN, ASSISTANTE | `serializeCandidateDiagnostic` | ✅ corrigé |
+| `GET /api/diagnostics/candidat-libre/{id}` | ELEVE, PARENT, COACH, ADMIN, ASSISTANTE | `serializeCandidateDiagnostic` | ✅ corrigé |
+| `PATCH /api/diagnostics/candidat-libre/{id}` | idem | `serializeCandidateDiagnostic` | ✅ corrigé |
+| `GET /api/diagnostics/candidat-libre/{id}/documents` | idem | liste de documents non filtrée | ✅ corrigé |
+| `GET .../documents/{documentId}` | idem | téléchargement du fichier lui-même | ✅ corrigé |
+| `DELETE .../documents/{documentId}` | idem | — | déjà sûr (ownership `uploadedById`, cf. note) |
+| `GET .../modules/{moduleKey}` | ELEVE, PARENT, COACH, ADMIN, ASSISTANTE | `canEditAudience` | déjà sûr (403 cross-audience élève/parent ; coach reçoit la structure sans `answers`) |
+| `GET/PUT/POST .../parent` | PARENT uniquement | — | pas de surface cross-audience (`requireRole(PARENT)`) |
+| `GET .../staff-export` | COACH, ADMIN, ASSISTANTE uniquement | — | pas de surface cross-audience (ELEVE/PARENT exclus par rôle) |
+| `POST .../submit` | ELEVE uniquement | — | pas de surface cross-audience |
+
+**Note DELETE document** : un `PARENT` non-staff ne peut supprimer que les documents dont `uploadedById`
+correspond à son propre `User.id`. Comme les documents `WRITTEN_COPY`/`ORAL_RECORDING` sont uploadés par
+l'élève, ce check d'ownership bloque déjà un parent qui tenterait de les supprimer — aucun correctif requis,
+vérifié par lecture de code (pas de nouveau test ajouté, la protection existante suffit).
+
+## Matrice champ × audience — vue diagnostic (`DiagnosticCampaignView`)
+
+### Niveau racine
+
+| Champ | ELEVE | PARENT | Staff | Justification |
+|---|---|---|---|---|
+| `id`, `diagnosticKey`, `definitionVersion`, `status`, `targetSession` | ✅ | ✅ | ✅ | métadonnées de campagne, non sensibles |
+| `student.{id,firstName,lastName,email,school,gradeLevel}` | ✅ | ✅ | ✅ | identité de l'élève, légitime pour les 3 audiences (le parent est le tuteur légal) |
+| `completionPercentage` | ✅ | ✅ | ✅ | agrégat calculé uniquement sur les modules requis ELEVE, jamais de contenu |
+| `studentConsentAt`, `parentConsentAt`, `submittedAt`, `retentionDueAt`, `createdAt`, `updatedAt` | ✅ | ✅ | ✅ | jalons de consentement/statut, nécessaires aux deux portails pour le suivi de soumission |
+
+### `modules[]` — un élément par module (16 au total, 15 ELEVE + 1 PARENT)
+
+| Champ | Own audience | Cross audience | Justification |
+|---|---|---|---|
+| `key`, `status`, `progress`, `startedAt`, `submittedAt`, `availableAt`, `elapsedMs` | ✅ | ✅ **visible** | nécessaire à l'UX « en attente du parent » / « élève en cours » ; ne révèle ni contenu ni score |
+| `autoScore` | ✅ | ❌ **null** | contient `evidence[]` (statut CORRECT/INCORRECT par question), `domainScores`, `percentage` — équivalent à une réponse détaillée |
+| `reviewSummary` | ✅ | ❌ **null** | avis de correction humaine, même registre que `autoScore` |
+
+Aucun champ `answers` n'apparaît dans `DiagnosticModuleView` — les réponses brutes ne transitent jamais par
+cette route, uniquement par `GET .../modules/{moduleKey}` qui a son propre contrôle d'audience strict.
+
+### `documents[]`
+
+| Catégorie | ELEVE | PARENT | Staff | Nature |
+|---|---|---|---|---|
+| `IDENTITY`, `CYCLADES`, `FRENCH_BAC_TRANSCRIPT`, `TUNISIAN_BAC_TRANSCRIPT`, `SCHOOL_REPORT`, `EXAM_ACCOMMODATION`, `OTHER` | ✅ | ✅ | ✅ | pièces administratives, gérées conjointement par la famille |
+| `WRITTEN_COPY` (copie français/maths/tronc commun) | ✅ | ❌ | ✅ | production académique de l'élève — équivalent à une réponse détaillée |
+| `ORAL_RECORDING` (Grand oral) | ✅ | ❌ | ✅ | idem, enregistrement de la prestation orale |
+
+Filtrage appliqué à la fois sur la **liste** (`GET .../documents`, `serializeCandidateDiagnostic`) et sur le
+**téléchargement** (`GET .../documents/{documentId}`) — un parent ne peut ni lister ni récupérer le fichier
+par accès direct à l'identifiant.
+
+## Route `modules/{moduleKey}` — déjà sûre, documentée pour mémoire
+
+`canEditAudience(role, audience)` bloque tout accès cross-audience élève/parent (403). Un `COACH` passe le
+gate (n'est bloqué ni ELEVE ni PARENT) mais `canEditAudience(COACH, *)` vaut toujours `false`, donc
+`answers` est explicitement `undefined` dans la réponse — un coach voit la structure/le statut de n'importe
+quel module (y compris le questionnaire parent) mais jamais son contenu. Comportement déjà correct dans le
+lot d'origine, vérifié par relecture de code.
+
+## Ce qui reste hors périmètre de cet audit
+
+- **Qui a le droit d'uploader dans quelle catégorie** (ex. un parent peut aujourd'hui POSTer un document
+  `WRITTEN_COPY`) n'a pas été modifié — c'est une question de permission d'écriture, pas de fuite de
+  lecture, et un changement là-dessus est un choix produit, pas un correctif de sécurité.
+- Les points ops/légal identifiés au Gate 5 (RGPD, rétention, sauvegarde chiffrée, CSP, alerting) restent
+  ouverts et hors code.
+
+## Preuve
+
+`__tests__/lib/diagnostics/candidat-libre/serialize.test.ts` verrouille :
+- l'ensemble exact des clés d'une vue de module (`Object.keys().sort()` contre une liste explicite) —
+  un champ non classé fait échouer le test de classification ;
+- pour ELEVE et PARENT : le module de leur propre audience garde son détail, le module de l'autre audience
+  a `autoScore`/`reviewSummary` à `null` mais conserve les champs de statut ;
+- pour le staff et les appels internes (pas de rôle passé) : détail complet partout ;
+- la matrice catégorie × audience de `isDocumentVisibleToViewer`, testée exhaustivement sur les 9 catégories
+  existantes pour ELEVE, PARENT et staff.

--- a/docs/DIAGNOSTIC_CANDIDAT_LIBRE_ROLLBACK.md
+++ b/docs/DIAGNOSTIC_CANDIDAT_LIBRE_ROLLBACK.md
@@ -1,0 +1,80 @@
+# Rollback — migration `20260807140000_add_candidate_diagnostic`
+
+## Contexte
+
+La migration est purement additive : 4 `CREATE TYPE`, 4 `CREATE TABLE` (`candidate_diagnostics`,
+`candidate_diagnostic_modules`, `candidate_diagnostic_documents`, `candidate_diagnostic_audit_logs`),
+des index sur ces seules nouvelles tables, et des `ALTER TABLE ... ADD CONSTRAINT` qui ajoutent des
+clés étrangères **depuis** les nouvelles tables **vers** `users`/`students` (aucune modification des
+tables existantes elles-mêmes). Prisma ne génère pas de down-migration : ce document est le SQL de
+revert et l'ordre des opérations.
+
+Le flag produit `CANDIDATE_DIAGNOSTIC_ENABLED` est OFF partout, y compris en prod (`lib/diagnostics/
+candidat-libre/feature-flag.ts`) — aucune route ne lit/écrit ces tables en usage normal tant qu'il
+n'est pas explicitement activé (prouvé par `__tests__/api/diagnostics/candidat-libre/
+feature-flag-dark.test.ts`, 24 tests : chaque route renvoie 404 avant toute résolution de rôle).
+
+## Ordre des opérations : code d'abord, schéma ensuite
+
+**Revert du déploiement applicatif d'abord, revert du schéma SQL ensuite — jamais l'inverse.**
+
+Raison : le flag OFF garantit qu'en fonctionnement normal aucune requête ne touche ces tables, mais
+un rollback n'est pas un fonctionnement normal. Le Prisma Client généré par la release à annuler
+contient ces modèles dans son schéma introspecté même si aucune route ne les appelle ; un flip
+accidentel du flag (erreur humaine, variable d'environnement mal propagée) pendant la fenêtre de
+rollback ferait passer des requêtes contre des tables sur le point de disparaître. Revenir d'abord au
+code de la release précédente élimine tout risque de collision, quelle que soit l'hypothèse sur le
+flag :
+1. Rebasculer `<APP_DIR>` vers la release précédente (celle sans le lot candidat libre), redémarrer
+   `<APP_PROCESS>`, attendre la disponibilité, prouver une connexion réelle — même protocole que le
+   rollback de l'incident du 3 août (`docs/audits/2026-08-03-incident-authentification.md`).
+2. Une fois le code revenu en arrière confirmé (aucun Prisma Client connaissant `CandidateDiagnostic*`
+   n'est plus en cours d'exécution), exécuter le SQL de revert ci-dessous.
+3. Marquer la migration comme annulée dans l'historique Prisma pour que `migrate deploy` reste cohérent :
+   ```bash
+   npx prisma migrate resolve --rolled-back 20260807140000_add_candidate_diagnostic
+   ```
+
+Si pour une raison opérationnelle le schéma doit être annulé avant le code (non recommandé), le pire
+cas est un 500 Prisma explicite sur les tables manquantes — fail-closed, pas de corruption silencieuse —
+mais l'ordre recommandé reste code puis schéma.
+
+## SQL de revert
+
+Ordre imposé par les FK : tables filles d'abord (elles référencent `candidate_diagnostics`), table
+mère ensuite, puis les types énumérés une fois qu'aucune colonne ne les utilise plus.
+
+```sql
+BEGIN;
+
+DROP TABLE IF EXISTS "candidate_diagnostic_audit_logs";
+DROP TABLE IF EXISTS "candidate_diagnostic_documents";
+DROP TABLE IF EXISTS "candidate_diagnostic_modules";
+DROP TABLE IF EXISTS "candidate_diagnostics";
+
+DROP TYPE IF EXISTS "CandidateDiagnosticActorRole";
+DROP TYPE IF EXISTS "CandidateDiagnosticDocumentStatus";
+DROP TYPE IF EXISTS "CandidateDiagnosticModuleStatus";
+DROP TYPE IF EXISTS "CandidateDiagnosticStatus";
+
+COMMIT;
+```
+
+`DROP TABLE` sans `CASCADE` : si l'ordre ci-dessus est respecté, chaque `DROP TABLE` s'exécute sans
+dépendance restante (les tables filles sont tombées avant la table mère). Ne pas ajouter `CASCADE` —
+un `CASCADE` masquerait une erreur d'ordre au lieu de la faire échouer bruyamment.
+
+Aucune table préexistante (`users`, `students`) n'est modifiée par ce revert : le rollback ne fait que
+supprimer ce que la migration a créé, il ne touche à aucune donnée hors du périmètre candidat libre.
+
+## Vérification post-rollback
+
+```bash
+npx prisma migrate status
+# attendu : la migration 20260807140000_add_candidate_diagnostic n'apparaît plus comme appliquée
+npx prisma migrate diff --from-schema-datasource prisma/schema.prisma --to-schema-datamodel prisma/schema.prisma
+```
+
+Avant tout revert réel en production : rejouer cette procédure sur la copie anonymisée de production
+utilisée pour le Gate 2 (dry-run), dans le même ordre — CREATE puis DROP — pour prouver l'aller-retour
+complet sur un clone fidèle, pas seulement en lecture du SQL.

--- a/docs/audits/2026-08-07-gate2-migration-dryrun-pg15.md
+++ b/docs/audits/2026-08-07-gate2-migration-dryrun-pg15.md
@@ -1,0 +1,94 @@
+# Gate 2 — dry-run de migration `20260807140000_add_candidate_diagnostic` sur pg15
+
+## Date
+
+2026-08-07.
+
+## Pourquoi ce redo
+
+Le dry-run précédent (référencé dans `STATUT-candidat-libre.md`) a tourné sur `pgvector/pgvector:pg16`.
+La version réelle de production n'est pas `pg16` : `docs/audits/2026-08-02-a82-migration-passation-dry-run.md`
+établit `pgvector/pgvector:pg15` par accès SSH direct au host de production (`pg_dump` réel, image du
+conteneur vérifiée sur le serveur). Le dry-run précédent était donc sur la mauvaise version majeure.
+
+Décision prise avec le responsable : pas besoin d'un dump de production restauré pour ce redo. La
+migration est confirmée additive (voir plus bas) — aucune donnée existante n'est lue, modifiée ou
+verrouillée d'une façon qui dépendrait du volume de lignes dans `users`/`students`. Ce qui manquait était
+la version majeure, pas le volume de données.
+
+## Méthode
+
+`docker run pgvector/pgvector:pg15` (image identique à celle confirmée en prod), `--tmpfs` pour les
+données (jetable), port éphémère local. Rejeu de `npx prisma migrate deploy` : 61 migrations existantes de
+`main` (post-#98) + `20260807140000_add_candidate_diagnostic` par-dessus, dans le même ordre qu'un
+déploiement réel.
+
+## Résultat
+
+```
+PostgreSQL 15.15 (Debian 15.15-1.pgdg12+1) on x86_64-pc-linux-gnu
+62 migrations appliquées, dont la nôtre en dernier — succès, 0 erreur.
+prisma migrate deploy (62 migrations) : 1.62 s temps réel total (élapsed wall-clock).
+```
+
+### Durée — migration candidat libre isolée
+
+Rejouée seule (`psql -f migration.sql`, `\timing on`) sur une base déjà à jour des 61 autres migrations :
+**12.3 ms de temps d'exécution SQL cumulé** sur les 26 instructions (4 `CREATE TYPE`, 4 `CREATE TABLE`,
+10 `CREATE INDEX`, 8 `ALTER TABLE ... ADD CONSTRAINT`). Négligeable, cohérent avec des tables neuves vides.
+
+### Nature des locks pris — vérifié empiriquement, pas seulement déduit
+
+4 des 8 `ADD CONSTRAINT` référencent des tables **existantes** (`users`, `students`), potentiellement
+peuplées en prod : `candidate_diagnostics_studentId_fkey` → `students`, `candidate_diagnostics_createdById_fkey`
+→ `users`, `candidate_diagnostic_documents_uploadedById_fkey` → `users`,
+`candidate_diagnostic_audit_logs_actorId_fkey` → `users`.
+
+Vérifié en ouvrant une transaction non commitée et en lisant `pg_locks` pendant qu'elle est en cours (puis
+`ROLLBACK`, rien de persisté) :
+
+```
+ relname                | mode                   | granted
+------------------------+------------------------+--------
+ candidate_diagnostics   | ShareRowExclusiveLock  | t
+ users                   | ShareRowExclusiveLock  | t
+```
+
+`ShareRowExclusiveLock` sur `users` (la table référencée) : bloque les écritures concurrentes
+(INSERT/UPDATE/DELETE) sur `users` pendant la durée de l'instruction, **ne bloque pas les lectures**
+(`SELECT`). La validation de la contrainte parcourt la table qui **reçoit** la FK
+(`candidate_diagnostics`, `candidate_diagnostic_documents`, `candidate_diagnostic_audit_logs` — toutes
+vides à la création), pas la table référencée (`users`/`students`) — la durée du verrou est donc bornée
+par la taille des nouvelles tables (zéro ligne), indépendante du volume réel de `users`/`students` en
+production. C'est la preuve technique précise de ce que l'additivité impliquait déjà : le volume de
+données de prod n'a pas d'effet sur la durée ou la nature de ce verrou.
+
+### `CREATE INDEX` non concurrents sur table peuplée — confirmé absent
+
+Les 10 `CREATE INDEX` de cette migration portent tous sur les 4 tables **nouvellement créées** par cette
+même migration (donc vides au moment de leur création) — aucun ne porte sur `users`, `students`, ni sur
+aucune autre table préexistante. Aucun `CREATE INDEX CONCURRENTLY` n'est nécessaire ici : la forme non
+concurrente est le choix correct sur une table vide (plus rapide, verrou sans conséquence puisque rien
+d'autre n'écrit encore dans une table qui vient d'être créée dans la même transaction).
+
+### `migrate diff` — un écart trouvé, préexistant sur `main`, sans rapport avec cette migration
+
+```
+[*] Changed the `eam_progress` table
+  [+] Added index on columns (user_id)
+```
+
+`prisma/schema.prisma:2189` déclare `@@index([userId], map: "idx_eam_progress_user_id")`, mais la
+migration `20260621100200_add_eam_progress_model` a explicitement **supprimé** cet index
+(`DROP INDEX IF EXISTS idx_eam_progress_user_id`, jugé redondant avec l'index unique existant) sans que
+`schema.prisma` soit mis à jour en conséquence. Vérifié présent tel quel sur `origin/main:prisma/schema.prisma`
+(ligne 2181) — **préexistant, sans rapport avec le lot candidat libre**, non modifié par cette branche.
+Sans impact fonctionnel connu (Prisma Client ne s'appuie pas sur cet index pour générer de requêtes
+invalides), mais `prisma migrate diff --exit-code` ne peut pas être "propre" tant que ce n'est pas
+corrigé sur `main` — signalé ici, non traité (hors périmètre de cette PR).
+
+## Conclusion
+
+Gate 2 fermée sur la version correcte (pg15). Additivité, durée, nature des locks et absence de
+`CREATE INDEX` non concurrent sur table peuplée : tous vérifiés directement sur cette version, pas
+seulement rapportés depuis le run pg16 précédent.

--- a/e2e/candidate-diagnostic.spec.ts
+++ b/e2e/candidate-diagnostic.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+// Requires an authenticated ELEVE fixture and the migration/seed described in README.md.
+test.describe('candidate diagnostic portal', () => {
+  test.skip(!process.env.E2E_STUDENT_STORAGE_STATE, 'E2E_STUDENT_STORAGE_STATE is required');
+  test.use({ storageState: process.env.E2E_STUDENT_STORAGE_STATE });
+
+  test('creates, autosaves and resumes the first module', async ({ page }) => {
+    await page.goto('/dashboard/eleve/diagnostic-candidat-libre');
+    const start = page.getByRole('button', { name: /commencer mon diagnostic/i });
+    if (await start.isVisible().catch(() => false)) await start.click();
+    await page.getByRole('button', { name: /ouvrir le module/i }).first().click();
+    await page.getByText(/je réalise les épreuves seul/i).waitFor();
+    await page.getByRole('button', { name: /je confirme cette déclaration/i }).click();
+    await page.waitForTimeout(2200);
+    await page.getByRole('button', { name: /fermer/i }).click();
+    await page.reload();
+    await expect(page.getByText(/diagnostic de/i)).toBeVisible();
+  });
+});

--- a/lib/diagnostics/candidat-libre/access.server.ts
+++ b/lib/diagnostics/candidat-libre/access.server.ts
@@ -5,6 +5,7 @@ import { isErrorResponse, requireAnyRole, requireParentOwnsStudent } from '@/lib
 import { prisma } from '@/lib/prisma';
 import { NextResponse } from 'next/server';
 import { UserRole } from '@prisma/client';
+import type { DiagnosticAudience } from './types';
 
 export async function requireDiagnosticActor() {
   return requireAnyRole([UserRole.ELEVE, UserRole.PARENT, UserRole.COACH, UserRole.ADMIN, UserRole.ASSISTANTE]);
@@ -56,6 +57,17 @@ export async function getDiagnosticForActor(session: AuthSession, diagnosticId: 
   return diagnostic;
 }
 
+// actorRole feeds ONLY the CandidateDiagnosticActorRole audit-log column,
+// whose Postgres enum has no ASSISTANTE value (ELEVE/PARENT/COACH/ADMIN/
+// SYSTEM only — see prisma/migrations/20260807140000_add_candidate_diagnostic).
+// It has always collapsed ASSISTANTE into ADMIN for that reason, and still
+// does — this is not a new gap. Read-visibility rules (canViewModuleDetail,
+// isDocumentVisibleToViewer) need ASSISTANTE distinguished from ADMIN, so
+// they take the raw UserRole from the session instead of routing through
+// this function. Do not repurpose actorRole() for anything read-visibility
+// related without also deciding whether ASSISTANTE needs its own DB enum
+// value (a new migration) — collapsing it silently here would misattribute
+// audit entries.
 export function actorRole(session: AuthSession): 'ELEVE' | 'PARENT' | 'COACH' | 'ADMIN' | 'SYSTEM' {
   if (session.user.role === UserRole.ELEVE) return 'ELEVE';
   if (session.user.role === UserRole.PARENT) return 'PARENT';
@@ -63,13 +75,52 @@ export function actorRole(session: AuthSession): 'ELEVE' | 'PARENT' | 'COACH' | 
   return 'ADMIN';
 }
 
+// Single source of truth for READ visibility of a module's content
+// (answers/autoScore/manualScore/reviewSummary), separate from
+// canEditAudience (lib/diagnostics/candidat-libre/[diagnosticId]/modules/
+// [moduleKey]/route.ts) which governs who may WRITE answers — conflating
+// the two previously produced a false parallel: a role blocked from
+// editing was assumed blocked from reading too, which isn't true for COACH
+// (works from the student's own detail, never edits it) and isn't the
+// right default for ASSISTANTE either (logistics role, no academic or
+// family-confidential detail, on ANY module — see below).
+//
+// Arbitrated matrix (2026-08-07):
+// - ELEVE/PARENT: full detail on their own audience's modules only.
+// - COACH: full detail on ELEVE-audience modules (their working material);
+//   status/progress only on the PARENT-audience module (questionnaire-parent).
+// - ASSISTANTE: no academic detail anywhere — status/progress only, on
+//   every module regardless of audience. Logistics role, least privilege
+//   on a minor's data.
+// - ADMIN: full detail everywhere, including questionnaire-parent — this
+//   is where the confidential family instrument is meant to land.
+export function canViewModuleDetail(role: UserRole, moduleAudience: DiagnosticAudience): boolean {
+  if (role === UserRole.ADMIN) return true;
+  if (role === UserRole.ASSISTANTE) return false;
+  if (role === UserRole.COACH) return moduleAudience === 'ELEVE';
+  if (role === UserRole.ELEVE) return moduleAudience === 'ELEVE';
+  if (role === UserRole.PARENT) return moduleAudience === 'PARENT';
+  return false;
+}
+
 // Documents in these categories are the student's own academic productions
 // (a written copy, an oral recording) — equivalent in sensitivity to a
 // detailed academic answer, not an administrative/identity document the
-// family jointly manages. A PARENT viewer must not list or download them.
+// family jointly manages. A PARENT viewer must not list or download them
+// (arbitrated 2026-08-07, ADR pending: the parent portal never serves them
+// in self-service — a parent request goes through pedagogical direction in
+// a review meeting, not through this API). ASSISTANTE is excluded for the
+// same least-privilege reason as canViewModuleDetail: logistics role, no
+// standing to view a minor's academic productions. COACH keeps access —
+// it is their working material for coaching the student.
 const STUDENT_ACADEMIC_DOCUMENT_CATEGORIES = new Set(['WRITTEN_COPY', 'ORAL_RECORDING']);
 
-export function isDocumentVisibleToViewer(category: string, viewerRole: ReturnType<typeof actorRole>): boolean {
-  if (viewerRole === 'PARENT' && STUDENT_ACADEMIC_DOCUMENT_CATEGORIES.has(category)) return false;
+export function isDocumentVisibleToViewer(category: string, viewerRole: UserRole): boolean {
+  if (
+    STUDENT_ACADEMIC_DOCUMENT_CATEGORIES.has(category)
+    && (viewerRole === UserRole.PARENT || viewerRole === UserRole.ASSISTANTE)
+  ) {
+    return false;
+  }
   return true;
 }

--- a/lib/diagnostics/candidat-libre/access.server.ts
+++ b/lib/diagnostics/candidat-libre/access.server.ts
@@ -1,0 +1,64 @@
+import 'server-only';
+
+import type { AuthSession } from '@/lib/guards';
+import { isErrorResponse, requireAnyRole, requireParentOwnsStudent } from '@/lib/guards';
+import { prisma } from '@/lib/prisma';
+import { NextResponse } from 'next/server';
+import { UserRole } from '@prisma/client';
+
+export async function requireDiagnosticActor() {
+  return requireAnyRole([UserRole.ELEVE, UserRole.PARENT, UserRole.COACH, UserRole.ADMIN, UserRole.ASSISTANTE]);
+}
+
+export async function getStudentForActor(session: AuthSession, requestedStudentId?: string) {
+  if (session.user.role === UserRole.ELEVE) {
+    return prisma.student.findUnique({
+      where: { userId: session.user.id },
+      include: { user: { select: { firstName: true, lastName: true, email: true } } },
+    });
+  }
+  if (!requestedStudentId) return null;
+  if (session.user.role === UserRole.PARENT) {
+    const ownership = await requireParentOwnsStudent(session.user.id, requestedStudentId);
+    if (isErrorResponse(ownership)) return ownership;
+  }
+  return prisma.student.findUnique({
+    where: { id: requestedStudentId },
+    include: { user: { select: { firstName: true, lastName: true, email: true } } },
+  });
+}
+
+export async function getDiagnosticForActor(session: AuthSession, diagnosticId: string) {
+  const diagnostic = await prisma.candidateDiagnostic.findUnique({
+    where: { id: diagnosticId },
+    include: {
+      student: { include: { user: { select: { firstName: true, lastName: true, email: true } } } },
+      modules: { orderBy: { createdAt: 'asc' } },
+      documents: { orderBy: { createdAt: 'desc' } },
+    },
+  });
+  if (!diagnostic) return NextResponse.json({ error: 'Not Found', message: 'Diagnostic introuvable.' }, { status: 404 });
+
+  if (session.user.role === UserRole.ELEVE && diagnostic.student.userId !== session.user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  if (session.user.role === UserRole.PARENT) {
+    const ownership = await requireParentOwnsStudent(session.user.id, diagnostic.studentId);
+    if (isErrorResponse(ownership)) return ownership;
+  }
+  if (session.user.role === UserRole.COACH) {
+    const assignment = await prisma.coachStudentAssignment.findFirst({
+      where: { studentId: diagnostic.studentId, coach: { userId: session.user.id }, status: 'ACTIVE' },
+      select: { id: true },
+    });
+    if (!assignment) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  return diagnostic;
+}
+
+export function actorRole(session: AuthSession): 'ELEVE' | 'PARENT' | 'COACH' | 'ADMIN' | 'SYSTEM' {
+  if (session.user.role === UserRole.ELEVE) return 'ELEVE';
+  if (session.user.role === UserRole.PARENT) return 'PARENT';
+  if (session.user.role === UserRole.COACH) return 'COACH';
+  return 'ADMIN';
+}

--- a/lib/diagnostics/candidat-libre/access.server.ts
+++ b/lib/diagnostics/candidat-libre/access.server.ts
@@ -62,3 +62,14 @@ export function actorRole(session: AuthSession): 'ELEVE' | 'PARENT' | 'COACH' | 
   if (session.user.role === UserRole.COACH) return 'COACH';
   return 'ADMIN';
 }
+
+// Documents in these categories are the student's own academic productions
+// (a written copy, an oral recording) — equivalent in sensitivity to a
+// detailed academic answer, not an administrative/identity document the
+// family jointly manages. A PARENT viewer must not list or download them.
+const STUDENT_ACADEMIC_DOCUMENT_CATEGORIES = new Set(['WRITTEN_COPY', 'ORAL_RECORDING']);
+
+export function isDocumentVisibleToViewer(category: string, viewerRole: ReturnType<typeof actorRole>): boolean {
+  if (viewerRole === 'PARENT' && STUDENT_ACADEMIC_DOCUMENT_CATEGORIES.has(category)) return false;
+  return true;
+}

--- a/lib/diagnostics/candidat-libre/answer-key.server.ts
+++ b/lib/diagnostics/candidat-libre/answer-key.server.ts
@@ -1,0 +1,1055 @@
+import 'server-only';
+
+export type DiagnosticAnswerKey =
+  | { kind: 'single'; correct: string }
+  | { kind: 'multiple'; correct: string[]; partial?: boolean }
+  | { kind: 'numeric'; value: number; tolerance: number }
+  | { kind: 'scale'; min: number; max: number; direction: 1 | -1 }
+  | { kind: 'ack'; expected: boolean }
+  | { kind: 'manual' }
+  | { kind: 'neutral' };
+
+export const CANDIDATE_DIAGNOSTIC_ANSWER_KEYS: Record<string, DiagnosticAnswerKey> = {
+  "integrity-01": {
+    "kind": "ack",
+    "expected": true
+  },
+  "integrity-02": {
+    "kind": "ack",
+    "expected": true
+  },
+  "integrity-03": {
+    "kind": "ack",
+    "expected": true
+  },
+  "integrity-04": {
+    "kind": "neutral"
+  },
+  "integrity-05": {
+    "kind": "neutral"
+  },
+  "integrity-06": {
+    "kind": "neutral"
+  },
+  "integrity-07": {
+    "kind": "ack",
+    "expected": true
+  },
+  "integrity-08": {
+    "kind": "ack",
+    "expected": true
+  },
+  "profil-01": {
+    "kind": "neutral"
+  },
+  "profil-02": {
+    "kind": "neutral"
+  },
+  "profil-03": {
+    "kind": "neutral"
+  },
+  "profil-04": {
+    "kind": "neutral"
+  },
+  "profil-05": {
+    "kind": "neutral"
+  },
+  "profil-06": {
+    "kind": "neutral"
+  },
+  "profil-07": {
+    "kind": "neutral"
+  },
+  "profil-08": {
+    "kind": "neutral"
+  },
+  "profil-09": {
+    "kind": "neutral"
+  },
+  "profil-10": {
+    "kind": "neutral"
+  },
+  "profil-11": {
+    "kind": "neutral"
+  },
+  "profil-12": {
+    "kind": "manual"
+  },
+  "profil-13": {
+    "kind": "neutral"
+  },
+  "profil-14": {
+    "kind": "neutral"
+  },
+  "profil-15": {
+    "kind": "neutral"
+  },
+  "profil-16": {
+    "kind": "neutral"
+  },
+  "profil-17": {
+    "kind": "manual"
+  },
+  "profil-18": {
+    "kind": "manual"
+  },
+  "profil-19": {
+    "kind": "neutral"
+  },
+  "profil-20": {
+    "kind": "manual"
+  },
+  "auto-01": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-02": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-03": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-04": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-05": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-06": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-07": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-08": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-09": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-10": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-11": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-12": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-13": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-14": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-15": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-16": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-17": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-18": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-19": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-20": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-21": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-22": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-23": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-24": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "auto-25": {
+    "kind": "manual"
+  },
+  "auto-26": {
+    "kind": "manual"
+  },
+  "auto-27": {
+    "kind": "manual"
+  },
+  "auto-28": {
+    "kind": "neutral"
+  },
+  "fr-info": {
+    "kind": "neutral"
+  },
+  "fr-01": {
+    "kind": "single",
+    "correct": "c"
+  },
+  "fr-02": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "fr-03": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "fr-04": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "fr-05": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "fr-06": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "fr-07": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "fr-08": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "fr-09": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "fr-10": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "fr-11": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "fr-12": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "fr-13": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "fr-14": {
+    "kind": "single",
+    "correct": "c"
+  },
+  "fr-15": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "fr-16": {
+    "kind": "manual"
+  },
+  "fr-17": {
+    "kind": "manual"
+  },
+  "fr-18": {
+    "kind": "manual"
+  },
+  "fr-19": {
+    "kind": "manual"
+  },
+  "fr-20": {
+    "kind": "manual"
+  },
+  "fr-21": {
+    "kind": "neutral"
+  },
+  "fr-22": {
+    "kind": "neutral"
+  },
+  "fr-23": {
+    "kind": "manual"
+  },
+  "fr-24": {
+    "kind": "neutral"
+  },
+  "math-01": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "math-02": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "math-03": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "math-04": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "math-05": {
+    "kind": "single",
+    "correct": "c"
+  },
+  "math-06": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "math-07": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "math-08": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "math-09": {
+    "kind": "single",
+    "correct": "c"
+  },
+  "math-10": {
+    "kind": "single",
+    "correct": "c"
+  },
+  "math-11": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "math-12": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "math-13": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "math-14": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "math-15": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "math-16": {
+    "kind": "single",
+    "correct": "c"
+  },
+  "math-17": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "math-18": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "math-19": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "math-20": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "math-21": {
+    "kind": "single",
+    "correct": "c"
+  },
+  "math-22": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "math-23": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "math-24": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "math-25": {
+    "kind": "manual"
+  },
+  "math-26": {
+    "kind": "manual"
+  },
+  "math-27": {
+    "kind": "manual"
+  },
+  "math-28": {
+    "kind": "manual"
+  },
+  "nsi-01": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "nsi-02": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "nsi-03": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "nsi-04": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "nsi-05": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "nsi-06": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "nsi-07": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "nsi-08": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "nsi-09": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "nsi-10": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "nsi-11": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "nsi-12": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "nsi-13": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "nsi-14": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "nsi-15": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "nsi-16": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "nsi-17": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "nsi-18": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "nsi-19": {
+    "kind": "single",
+    "correct": "d"
+  },
+  "nsi-20": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "nsi-21": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "nsi-22": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "nsi-23": {
+    "kind": "manual"
+  },
+  "nsi-24": {
+    "kind": "manual"
+  },
+  "nsi-25": {
+    "kind": "manual"
+  },
+  "nsi-26": {
+    "kind": "manual"
+  },
+  "ses-01": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "ses-02": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "ses-03": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "ses-04": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "ses-05": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "ses-06": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "ses-07": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "ses-08": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "ses-09": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "ses-10": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "ses-11": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "ses-12": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "ses-13": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "ses-14": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "ses-15": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "ses-16": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "ses-17": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "ses-18": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "ses-19": {
+    "kind": "manual"
+  },
+  "ses-20": {
+    "kind": "manual"
+  },
+  "ses-21": {
+    "kind": "manual"
+  },
+  "ses-22": {
+    "kind": "manual"
+  },
+  "tc-01": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "tc-02": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "tc-03": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "tc-04": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "tc-05": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "tc-06": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "tc-07": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "tc-08": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "tc-09": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "tc-10": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "tc-11": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "tc-12": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "tc-en-info": {
+    "kind": "neutral"
+  },
+  "tc-13": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "tc-14": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "tc-15": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "tc-16": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "tc-17": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "tc-18": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "tc-19": {
+    "kind": "manual"
+  },
+  "tc-20": {
+    "kind": "neutral"
+  },
+  "tc-21": {
+    "kind": "manual"
+  },
+  "tc-22": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "tc-23": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "tc-24": {
+    "kind": "manual"
+  },
+  "tc-25": {
+    "kind": "manual"
+  },
+  "tc-26": {
+    "kind": "manual"
+  },
+  "go-01": {
+    "kind": "neutral"
+  },
+  "go-02": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "go-03": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "go-04": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "go-05": {
+    "kind": "neutral"
+  },
+  "go-06": {
+    "kind": "manual"
+  },
+  "go-07": {
+    "kind": "manual"
+  },
+  "go-08": {
+    "kind": "manual"
+  },
+  "go-09": {
+    "kind": "manual"
+  },
+  "go-10": {
+    "kind": "manual"
+  },
+  "go-11": {
+    "kind": "neutral"
+  },
+  "go-12": {
+    "kind": "neutral"
+  },
+  "t0-01": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "t0-02": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "t0-03": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "t0-04": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "t0-05": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "t0-06": {
+    "kind": "single",
+    "correct": "c"
+  },
+  "t0-07": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "t0-08": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "t0-09": {
+    "kind": "single",
+    "correct": "c"
+  },
+  "t0-10": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "rem-info": {
+    "kind": "neutral"
+  },
+  "rem-01": {
+    "kind": "ack",
+    "expected": true
+  },
+  "rem-02": {
+    "kind": "manual"
+  },
+  "t1-01": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "t1-02": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "t1-03": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "t1-04": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "t1-05": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "t1-06": {
+    "kind": "single",
+    "correct": "c"
+  },
+  "t1-07": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "t1-08": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "t1-09": {
+    "kind": "single",
+    "correct": "c"
+  },
+  "t1-10": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "ret-03": {
+    "kind": "manual"
+  },
+  "ret-04": {
+    "kind": "manual"
+  },
+  "ret-05": {
+    "kind": "manual"
+  },
+  "ret-06": {
+    "kind": "numeric",
+    "value": 8.333,
+    "tolerance": 0.6
+  },
+  "ret-07": {
+    "kind": "manual"
+  },
+  "ret-08": {
+    "kind": "manual"
+  },
+  "ret-01": {
+    "kind": "single",
+    "correct": "b"
+  },
+  "ret-02": {
+    "kind": "single",
+    "correct": "a"
+  },
+  "doc-01": {
+    "kind": "manual"
+  },
+  "doc-02": {
+    "kind": "manual"
+  },
+  "doc-03": {
+    "kind": "manual"
+  },
+  "doc-04": {
+    "kind": "manual"
+  },
+  "doc-05": {
+    "kind": "manual"
+  },
+  "doc-06": {
+    "kind": "manual"
+  },
+  "doc-07": {
+    "kind": "manual"
+  },
+  "doc-08": {
+    "kind": "manual"
+  },
+  "doc-09": {
+    "kind": "manual"
+  },
+  "final-01": {
+    "kind": "ack",
+    "expected": true
+  },
+  "final-02": {
+    "kind": "ack",
+    "expected": true
+  },
+  "final-03": {
+    "kind": "ack",
+    "expected": true
+  },
+  "final-04": {
+    "kind": "neutral"
+  },
+  "final-05": {
+    "kind": "manual"
+  },
+  "final-06": {
+    "kind": "manual"
+  },
+  "final-07": {
+    "kind": "neutral"
+  },
+  "final-08": {
+    "kind": "manual"
+  },
+  "parent-01": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "parent-02": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "parent-03": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "parent-04": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "parent-05": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "parent-06": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "parent-07": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "parent-08": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "parent-09": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "parent-10": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "parent-11": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "parent-12": {
+    "kind": "scale",
+    "min": 1,
+    "max": 5,
+    "direction": 1
+  },
+  "parent-13": {
+    "kind": "neutral"
+  },
+  "parent-14": {
+    "kind": "manual"
+  },
+  "parent-15": {
+    "kind": "neutral"
+  },
+  "parent-16": {
+    "kind": "neutral"
+  },
+  "parent-17": {
+    "kind": "manual"
+  },
+  "parent-18": {
+    "kind": "neutral"
+  },
+  "parent-19": {
+    "kind": "neutral"
+  },
+  "parent-20": {
+    "kind": "manual"
+  },
+  "parent-21": {
+    "kind": "neutral"
+  },
+  "parent-22": {
+    "kind": "ack",
+    "expected": true
+  }
+};

--- a/lib/diagnostics/candidat-libre/definition.public.ts
+++ b/lib/diagnostics/candidat-libre/definition.public.ts
@@ -1,0 +1,7433 @@
+import type { DiagnosticModuleDefinition } from './types';
+
+export const CANDIDATE_DIAGNOSTIC_MODULES: DiagnosticModuleDefinition[] = [
+  {
+    "key": "accueil-integrite",
+    "title": "Conditions de passation et consentement",
+    "shortTitle": "Démarrage",
+    "description": "Vérification des conditions matérielles, du consentement et de l’intégrité de la passation.",
+    "audience": "ELEVE",
+    "kind": "questionnaire",
+    "estimatedMinutes": 10,
+    "timed": false,
+    "prerequisites": [],
+    "instructions": [
+      "Installez-vous dans un endroit calme.",
+      "Préparez vos relevés de notes et vos documents.",
+      "Les réponses peuvent être enregistrées en brouillon."
+    ],
+    "questions": [
+      {
+        "id": "integrity-01",
+        "type": "acknowledgement",
+        "prompt": "Je réalise les épreuves seul, sans aide extérieure ni moteur de recherche.",
+        "competencies": [
+          "integrite"
+        ],
+        "domains": [
+          "conditions_passation"
+        ],
+        "maxPoints": 0,
+        "required": true
+      },
+      {
+        "id": "integrity-02",
+        "type": "acknowledgement",
+        "prompt": "Je comprends que certaines parties sont chronométrées et ne peuvent pas être recommencées sans autorisation.",
+        "competencies": [
+          "integrite"
+        ],
+        "domains": [
+          "conditions_passation"
+        ],
+        "maxPoints": 0,
+        "required": true
+      },
+      {
+        "id": "integrity-03",
+        "type": "acknowledgement",
+        "prompt": "Je signalerai honnêtement une notion non étudiée au lieu de répondre au hasard.",
+        "competencies": [
+          "metacognition"
+        ],
+        "domains": [
+          "conditions_passation"
+        ],
+        "maxPoints": 0,
+        "required": true
+      },
+      {
+        "id": "integrity-04",
+        "type": "single",
+        "prompt": "Quel appareil utiliserez-vous principalement ?",
+        "competencies": [
+          "conditions_techniques"
+        ],
+        "domains": [
+          "logistique"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Ordinateur portable ou fixe"
+          },
+          {
+            "id": "b",
+            "label": "Tablette"
+          },
+          {
+            "id": "c",
+            "label": "Téléphone uniquement"
+          },
+          {
+            "id": "d",
+            "label": "Autre"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "integrity-05",
+        "type": "single",
+        "prompt": "Votre connexion internet est-elle suffisamment stable pour déposer des fichiers ?",
+        "competencies": [
+          "conditions_techniques"
+        ],
+        "domains": [
+          "logistique"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Oui, stable"
+          },
+          {
+            "id": "b",
+            "label": "Variable mais utilisable"
+          },
+          {
+            "id": "c",
+            "label": "Souvent instable"
+          },
+          {
+            "id": "d",
+            "label": "Je ne sais pas"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "integrity-06",
+        "type": "single",
+        "prompt": "Disposez-vous d’un lieu calme pendant les épreuves ?",
+        "competencies": [
+          "conditions_passation"
+        ],
+        "domains": [
+          "logistique"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Toujours"
+          },
+          {
+            "id": "b",
+            "label": "Le plus souvent"
+          },
+          {
+            "id": "c",
+            "label": "Rarement"
+          },
+          {
+            "id": "d",
+            "label": "Jamais"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "integrity-07",
+        "type": "acknowledgement",
+        "prompt": "J’autorise l’enregistrement de mes réponses et traces de passation pour établir le diagnostic Nexus.",
+        "competencies": [
+          "consentement"
+        ],
+        "domains": [
+          "consentement"
+        ],
+        "maxPoints": 0,
+        "required": true
+      },
+      {
+        "id": "integrity-08",
+        "type": "acknowledgement",
+        "prompt": "Je comprends que le diagnostic peut conclure qu’une préparation en un an est trop risquée.",
+        "competencies": [
+          "consentement"
+        ],
+        "domains": [
+          "consentement"
+        ],
+        "maxPoints": 0,
+        "required": true
+      }
+    ],
+    "scoreDomains": [
+      "conditions_passation",
+      "logistique",
+      "consentement"
+    ],
+    "requiredForSubmission": true
+  },
+  {
+    "key": "profil-parcours",
+    "title": "Profil scolaire, parcours et projet",
+    "shortTitle": "Profil",
+    "description": "Comprendre le parcours, les échecs antérieurs, les objectifs et les contraintes avant d’interpréter les scores.",
+    "audience": "ELEVE",
+    "kind": "questionnaire",
+    "estimatedMinutes": 25,
+    "timed": false,
+    "prerequisites": [
+      "accueil-integrite"
+    ],
+    "instructions": [
+      "Répondez factuellement.",
+      "Une difficulté signalée n’est pas une faute : elle aide à choisir le bon parcours."
+    ],
+    "questions": [
+      {
+        "id": "profil-01",
+        "type": "single",
+        "prompt": "Dans quel système avez-vous été principalement scolarisé en 2025/2026 ?",
+        "competencies": [
+          "analyse_parcours"
+        ],
+        "domains": [
+          "parcours"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Système tunisien"
+          },
+          {
+            "id": "b",
+            "label": "Système français homologué"
+          },
+          {
+            "id": "c",
+            "label": "Cours à distance / CNED"
+          },
+          {
+            "id": "d",
+            "label": "Parcours mixte"
+          },
+          {
+            "id": "e",
+            "label": "Autre"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "profil-02",
+        "type": "single",
+        "prompt": "Quel a été votre résultat au baccalauréat tunisien 2026 ?",
+        "competencies": [
+          "analyse_parcours"
+        ],
+        "domains": [
+          "parcours"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Admis"
+          },
+          {
+            "id": "b",
+            "label": "Ajourné"
+          },
+          {
+            "id": "c",
+            "label": "Absent à une ou plusieurs épreuves"
+          },
+          {
+            "id": "d",
+            "label": "Résultat incomplet / contesté"
+          },
+          {
+            "id": "e",
+            "label": "Non concerné"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "profil-03",
+        "type": "single",
+        "prompt": "Avez-vous passé des épreuves du baccalauréat français en 2026 ?",
+        "competencies": [
+          "analyse_parcours"
+        ],
+        "domains": [
+          "parcours"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Oui, toutes les épreuves prévues de première"
+          },
+          {
+            "id": "b",
+            "label": "Oui, seulement certaines"
+          },
+          {
+            "id": "c",
+            "label": "Inscrit mais absent"
+          },
+          {
+            "id": "d",
+            "label": "Non"
+          },
+          {
+            "id": "e",
+            "label": "Je ne sais pas précisément"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "profil-04",
+        "type": "single",
+        "prompt": "Quelles spécialités avez-vous déclarées en première ?",
+        "competencies": [
+          "analyse_parcours"
+        ],
+        "domains": [
+          "parcours"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Mathématiques, NSI et SES"
+          },
+          {
+            "id": "b",
+            "label": "Mathématiques et NSI seulement"
+          },
+          {
+            "id": "c",
+            "label": "Mathématiques et SES seulement"
+          },
+          {
+            "id": "d",
+            "label": "NSI et SES seulement"
+          },
+          {
+            "id": "e",
+            "label": "Autre / à confirmer"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "profil-05",
+        "type": "single",
+        "prompt": "Quelle spécialité pensez-vous abandonner ?",
+        "competencies": [
+          "analyse_parcours"
+        ],
+        "domains": [
+          "parcours"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Mathématiques"
+          },
+          {
+            "id": "b",
+            "label": "NSI"
+          },
+          {
+            "id": "c",
+            "label": "SES"
+          },
+          {
+            "id": "d",
+            "label": "Je ne sais pas"
+          },
+          {
+            "id": "e",
+            "label": "La décision est déjà enregistrée dans Cyclades"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "profil-06",
+        "type": "single",
+        "prompt": "Combien d’heures de travail personnel effectif faisiez-vous par semaine ?",
+        "competencies": [
+          "analyse_parcours"
+        ],
+        "domains": [
+          "parcours"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Moins de 3 h"
+          },
+          {
+            "id": "b",
+            "label": "3 à 6 h"
+          },
+          {
+            "id": "c",
+            "label": "7 à 10 h"
+          },
+          {
+            "id": "d",
+            "label": "11 à 15 h"
+          },
+          {
+            "id": "e",
+            "label": "Plus de 15 h"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "profil-07",
+        "type": "single",
+        "prompt": "À quelle fréquence rendiez-vous les devoirs demandés ?",
+        "competencies": [
+          "analyse_parcours"
+        ],
+        "domains": [
+          "parcours"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Toujours"
+          },
+          {
+            "id": "b",
+            "label": "Souvent"
+          },
+          {
+            "id": "c",
+            "label": "Environ une fois sur deux"
+          },
+          {
+            "id": "d",
+            "label": "Rarement"
+          },
+          {
+            "id": "e",
+            "label": "Presque jamais"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "profil-08",
+        "type": "single",
+        "prompt": "Votre difficulté principale pendant l’année était surtout…",
+        "competencies": [
+          "analyse_parcours"
+        ],
+        "domains": [
+          "parcours"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Le niveau des connaissances"
+          },
+          {
+            "id": "b",
+            "label": "La compréhension du français scolaire"
+          },
+          {
+            "id": "c",
+            "label": "La méthode des épreuves françaises"
+          },
+          {
+            "id": "d",
+            "label": "L’organisation et la régularité"
+          },
+          {
+            "id": "e",
+            "label": "Le stress ou la santé"
+          },
+          {
+            "id": "f",
+            "label": "Plusieurs de ces facteurs"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "profil-09",
+        "type": "single",
+        "prompt": "Quel est votre projet principal pour 2027 ?",
+        "competencies": [
+          "analyse_parcours"
+        ],
+        "domains": [
+          "parcours"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Obtenir le baccalauréat français"
+          },
+          {
+            "id": "b",
+            "label": "Préparer une orientation précise"
+          },
+          {
+            "id": "c",
+            "label": "Reprendre confiance"
+          },
+          {
+            "id": "d",
+            "label": "Éviter de perdre une année"
+          },
+          {
+            "id": "e",
+            "label": "Je n’ai pas encore de projet clair"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "profil-10",
+        "type": "single",
+        "prompt": "Quel environnement de préparation vous conviendrait le mieux ?",
+        "competencies": [
+          "analyse_parcours"
+        ],
+        "domains": [
+          "parcours"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Présentiel quotidien très encadré"
+          },
+          {
+            "id": "b",
+            "label": "Mixte : présentiel régulier + travail en ligne"
+          },
+          {
+            "id": "c",
+            "label": "Principalement en ligne avec suivi"
+          },
+          {
+            "id": "d",
+            "label": "Travail autonome avec bilans ponctuels"
+          },
+          {
+            "id": "e",
+            "label": "Je ne sais pas"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "profil-11",
+        "type": "short",
+        "prompt": "Indiquez votre établissement 2025/2026.",
+        "competencies": [
+          "analyse_parcours"
+        ],
+        "domains": [
+          "parcours"
+        ],
+        "maxPoints": 0,
+        "placeholder": "Nom de l’établissement et ville",
+        "required": true
+      },
+      {
+        "id": "profil-12",
+        "type": "long",
+        "prompt": "Décrivez brièvement votre parcours depuis la classe de seconde.",
+        "competencies": [
+          "analyse_parcours"
+        ],
+        "domains": [
+          "parcours"
+        ],
+        "maxPoints": 0,
+        "placeholder": "Changements d’établissement, interruptions, redoublements, cours particuliers…",
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 300
+      },
+      {
+        "id": "profil-13",
+        "type": "multiple",
+        "prompt": "Quelles matières vous semblent aujourd’hui les plus solides ?",
+        "competencies": [
+          "metacognition"
+        ],
+        "domains": [
+          "auto_evaluation"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Français"
+          },
+          {
+            "id": "b",
+            "label": "Mathématiques"
+          },
+          {
+            "id": "c",
+            "label": "NSI"
+          },
+          {
+            "id": "d",
+            "label": "SES"
+          },
+          {
+            "id": "e",
+            "label": "Histoire-géographie"
+          },
+          {
+            "id": "f",
+            "label": "Enseignement scientifique"
+          },
+          {
+            "id": "g",
+            "label": "Philosophie"
+          },
+          {
+            "id": "h",
+            "label": "Anglais"
+          },
+          {
+            "id": "i",
+            "label": "LVB"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "profil-14",
+        "type": "multiple",
+        "prompt": "Quelles matières vous semblent aujourd’hui les plus fragiles ?",
+        "competencies": [
+          "metacognition"
+        ],
+        "domains": [
+          "auto_evaluation"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Français"
+          },
+          {
+            "id": "b",
+            "label": "Mathématiques"
+          },
+          {
+            "id": "c",
+            "label": "NSI"
+          },
+          {
+            "id": "d",
+            "label": "SES"
+          },
+          {
+            "id": "e",
+            "label": "Histoire-géographie"
+          },
+          {
+            "id": "f",
+            "label": "Enseignement scientifique"
+          },
+          {
+            "id": "g",
+            "label": "Philosophie"
+          },
+          {
+            "id": "h",
+            "label": "Anglais"
+          },
+          {
+            "id": "i",
+            "label": "LVB"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "profil-15",
+        "type": "numeric",
+        "prompt": "Quelle note globale pensez-vous pouvoir atteindre au bac français avec un accompagnement intensif ?",
+        "competencies": [
+          "projection"
+        ],
+        "domains": [
+          "auto_evaluation"
+        ],
+        "maxPoints": 0,
+        "min": 0,
+        "max": 20,
+        "step": 0.25,
+        "required": true
+      },
+      {
+        "id": "profil-16",
+        "type": "single",
+        "prompt": "Quel volume hebdomadaire total êtes-vous réellement prêt à consacrer aux cours et au travail personnel ?",
+        "competencies": [
+          "engagement"
+        ],
+        "domains": [
+          "disponibilite"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Moins de 10 h"
+          },
+          {
+            "id": "b",
+            "label": "10 à 15 h"
+          },
+          {
+            "id": "c",
+            "label": "16 à 20 h"
+          },
+          {
+            "id": "d",
+            "label": "21 à 25 h"
+          },
+          {
+            "id": "e",
+            "label": "26 à 30 h"
+          },
+          {
+            "id": "f",
+            "label": "Plus de 30 h"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "profil-17",
+        "type": "long",
+        "prompt": "Décrivez votre projet d’études ou de métier, même s’il est encore incertain.",
+        "competencies": [
+          "projection"
+        ],
+        "domains": [
+          "orientation"
+        ],
+        "maxPoints": 0,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 250
+      },
+      {
+        "id": "profil-18",
+        "type": "long",
+        "prompt": "Qu’attendez-vous concrètement de Nexus Réussite ?",
+        "competencies": [
+          "projection"
+        ],
+        "domains": [
+          "attentes"
+        ],
+        "maxPoints": 0,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 250
+      },
+      {
+        "id": "profil-19",
+        "type": "single",
+        "prompt": "Avez-vous un aménagement officiel d’examen ou un besoin d’accessibilité à signaler ?",
+        "competencies": [
+          "accessibilite"
+        ],
+        "domains": [
+          "accessibilite"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Non"
+          },
+          {
+            "id": "b",
+            "label": "Oui, décision officielle disponible"
+          },
+          {
+            "id": "c",
+            "label": "Demande en cours"
+          },
+          {
+            "id": "d",
+            "label": "Je souhaite en parler confidentiellement"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "profil-20",
+        "type": "long",
+        "prompt": "Y a-t-il une contrainte importante de santé, de déplacement ou de calendrier qui peut affecter la préparation ?",
+        "competencies": [
+          "analyse_risque"
+        ],
+        "domains": [
+          "contraintes"
+        ],
+        "maxPoints": 0,
+        "required": false,
+        "manualReview": true,
+        "wordLimit": 250
+      }
+    ],
+    "scoreDomains": [
+      "parcours",
+      "auto_evaluation",
+      "disponibilite",
+      "orientation",
+      "contraintes"
+    ],
+    "requiredForSubmission": true
+  },
+  {
+    "key": "autonomie-methodes",
+    "title": "Autonomie, méthodes et fonctions exécutives",
+    "shortTitle": "Autonomie",
+    "description": "Mesurer la capacité à travailler hors établissement, planifier, persévérer, corriger ses erreurs et respecter un contrat pédagogique.",
+    "audience": "ELEVE",
+    "kind": "questionnaire",
+    "estimatedMinutes": 35,
+    "timed": false,
+    "prerequisites": [
+      "profil-parcours"
+    ],
+    "instructions": [
+      "Répondez selon vos comportements réels des trois derniers mois.",
+      "Les réponses seront confrontées aux données de passation et au questionnaire parent."
+    ],
+    "questions": [
+      {
+        "id": "auto-01",
+        "type": "scale",
+        "prompt": "Je commence un travail sans attendre qu’un adulte me relance.",
+        "competencies": [
+          "initiative"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-02",
+        "type": "scale",
+        "prompt": "Je sais transformer un objectif mensuel en tâches hebdomadaires.",
+        "competencies": [
+          "planification"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-03",
+        "type": "scale",
+        "prompt": "Je respecte les horaires que je me fixe.",
+        "competencies": [
+          "regularite"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-04",
+        "type": "scale",
+        "prompt": "Je rends les travaux même lorsqu’ils ne sont pas notés.",
+        "competencies": [
+          "engagement"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-05",
+        "type": "scale",
+        "prompt": "Je relis une correction et je refais l’exercice sans regarder.",
+        "competencies": [
+          "remediation"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-06",
+        "type": "scale",
+        "prompt": "Je répartis les révisions au lieu de tout faire la veille.",
+        "competencies": [
+          "espacement"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-07",
+        "type": "scale",
+        "prompt": "Je peux travailler 90 minutes avec une pause planifiée sans consulter mon téléphone.",
+        "competencies": [
+          "attention"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-08",
+        "type": "scale",
+        "prompt": "Je demande de l’aide avant d’accumuler plusieurs semaines de retard.",
+        "competencies": [
+          "alerte"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-09",
+        "type": "scale",
+        "prompt": "Je classe mes cours et retrouve rapidement un document.",
+        "competencies": [
+          "organisation"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-10",
+        "type": "scale",
+        "prompt": "Je sauvegarde mes fichiers sur au moins deux supports.",
+        "competencies": [
+          "organisation_numerique"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-11",
+        "type": "scale",
+        "prompt": "Je vérifie les consignes avant de commencer un devoir.",
+        "competencies": [
+          "lecture_consigne"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-12",
+        "type": "scale",
+        "prompt": "Je réserve du temps pour relire et corriger ma copie.",
+        "competencies": [
+          "gestion_temps"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-13",
+        "type": "scale",
+        "prompt": "Je sais distinguer ce que je comprends de ce que je mémorise seulement.",
+        "competencies": [
+          "metacognition"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-14",
+        "type": "scale",
+        "prompt": "Après une mauvaise note, je peux identifier deux causes précises et modifiables.",
+        "competencies": [
+          "metacognition"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-15",
+        "type": "scale",
+        "prompt": "Je tiens un calendrier des échéances.",
+        "competencies": [
+          "planification"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-16",
+        "type": "scale",
+        "prompt": "Je peux suivre un cours en ligne sans faire autre chose en parallèle.",
+        "competencies": [
+          "attention"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-17",
+        "type": "scale",
+        "prompt": "Je dors suffisamment avant une épreuve importante.",
+        "competencies": [
+          "hygiene_travail"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-18",
+        "type": "scale",
+        "prompt": "Je peux expliquer à mon parent ce qui est terminé, en retard et prioritaire.",
+        "competencies": [
+          "reporting"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-19",
+        "type": "scale",
+        "prompt": "Je supporte de ne pas réussir immédiatement un exercice difficile.",
+        "competencies": [
+          "perseverance"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-20",
+        "type": "scale",
+        "prompt": "Je corrige une méthode inefficace lorsque les résultats ne progressent pas.",
+        "competencies": [
+          "adaptation"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-21",
+        "type": "scale",
+        "prompt": "Je travaille régulièrement même quand la motivation baisse.",
+        "competencies": [
+          "regularite"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-22",
+        "type": "scale",
+        "prompt": "Je peux préparer seul mon matériel avant une séance.",
+        "competencies": [
+          "autonomie"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-23",
+        "type": "scale",
+        "prompt": "Je signale honnêtement une absence ou un travail non fait.",
+        "competencies": [
+          "fiabilite"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-24",
+        "type": "scale",
+        "prompt": "Je suis prêt à accepter un suivi d’assiduité et des alertes parent.",
+        "competencies": [
+          "contractualisation"
+        ],
+        "domains": [
+          "autonomie"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "auto-25",
+        "type": "long",
+        "prompt": "Construisez un planning réaliste pour une semaine comprenant 12 h de cours Nexus, 15 h de travail personnel, deux examens blancs et une contrainte familiale de 4 h.",
+        "competencies": [
+          "planification",
+          "priorisation"
+        ],
+        "domains": [
+          "fonctions_executives"
+        ],
+        "maxPoints": 8,
+        "instruction": "Indiquez les créneaux, les pauses, les priorités et les temps de reprise des corrections.",
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 500
+      },
+      {
+        "id": "auto-26",
+        "type": "long",
+        "prompt": "Un devoir de mathématiques est en retard, une épreuve de SES a lieu demain et un oral est prévu dans trois jours. Que faites-vous dans les prochaines 24 heures ?",
+        "competencies": [
+          "priorisation",
+          "arbitrage"
+        ],
+        "domains": [
+          "fonctions_executives"
+        ],
+        "maxPoints": 5,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 250
+      },
+      {
+        "id": "auto-27",
+        "type": "long",
+        "prompt": "Quelle stratégie utilisez-vous lorsqu’une consigne vous paraît incompréhensible ?",
+        "competencies": [
+          "strategie_aide"
+        ],
+        "domains": [
+          "methodes"
+        ],
+        "maxPoints": 4,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 180
+      },
+      {
+        "id": "auto-28",
+        "type": "single",
+        "prompt": "Acceptez-vous les conditions minimales suivantes : assiduité ≥ 90 %, remise de tous les travaux évalués, examens blancs et point hebdomadaire ?",
+        "competencies": [
+          "contractualisation"
+        ],
+        "domains": [
+          "engagement"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Oui, sans réserve"
+          },
+          {
+            "id": "b",
+            "label": "Oui, avec une contrainte à discuter"
+          },
+          {
+            "id": "c",
+            "label": "Non pour le moment"
+          }
+        ],
+        "required": true
+      }
+    ],
+    "scoreDomains": [
+      "autonomie",
+      "fonctions_executives",
+      "methodes",
+      "engagement"
+    ],
+    "requiredForSubmission": true
+  },
+  {
+    "key": "francais-academique",
+    "title": "Français académique : comprendre, rédiger, argumenter",
+    "shortTitle": "Français",
+    "description": "Compétence seuil transversale pour comprendre les sujets, rédiger en SES et philosophie, justifier en mathématiques et réussir l’oral.",
+    "audience": "ELEVE",
+    "kind": "academic",
+    "estimatedMinutes": 95,
+    "timed": true,
+    "prerequisites": [
+      "profil-parcours"
+    ],
+    "instructions": [
+      "Travaillez sans dictionnaire ni correcteur automatique.",
+      "Le texte support est original et propre au diagnostic Nexus.",
+      "Les productions longues seront corrigées par un enseignant."
+    ],
+    "questions": [
+      {
+        "id": "fr-info",
+        "type": "information",
+        "prompt": "Texte support",
+        "competencies": [
+          "lecture"
+        ],
+        "domains": [
+          "comprehension"
+        ],
+        "maxPoints": 0,
+        "description": "Une décision fondée sur des données n’est pas nécessairement une décision raisonnable. Les nombres décrivent certains aspects du réel, mais ils ne choisissent ni les critères pertinents ni les valeurs à privilégier. Un établissement peut constater qu’un élève obtient de meilleurs résultats lorsqu’il travaille davantage. Cette corrélation n’autorise pourtant pas à conclure que toute heure ajoutée produit mécaniquement le même progrès : la qualité du travail, le sommeil et la difficulté des tâches modifient la relation. La donnée devient donc utile lorsqu’elle éclaire un jugement explicite, contrôlable et révisable. Elle devient dangereuse lorsqu’elle remplace le jugement tout en donnant l’apparence de l’objectivité.",
+        "required": true
+      },
+      {
+        "id": "fr-01",
+        "type": "single",
+        "prompt": "Quelle est la thèse principale du texte ?",
+        "competencies": [
+          "comprehension_globale"
+        ],
+        "domains": [
+          "francais_academique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "Les données rendent toutes les décisions objectives."
+          },
+          {
+            "id": "b",
+            "label": "Les données sont inutiles sans calcul statistique."
+          },
+          {
+            "id": "c",
+            "label": "Les données peuvent éclairer une décision mais ne remplacent pas le jugement."
+          },
+          {
+            "id": "d",
+            "label": "Le temps de travail explique entièrement la réussite."
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "fr-02",
+        "type": "single",
+        "prompt": "Dans le texte, le mot « pourtant » introduit…",
+        "competencies": [
+          "connecteurs"
+        ],
+        "domains": [
+          "francais_academique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "une cause"
+          },
+          {
+            "id": "b",
+            "label": "une opposition ou une restriction"
+          },
+          {
+            "id": "c",
+            "label": "un exemple"
+          },
+          {
+            "id": "d",
+            "label": "une conclusion définitive"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "fr-03",
+        "type": "single",
+        "prompt": "Pourquoi l’auteur évoque-t-il le sommeil ?",
+        "competencies": [
+          "raisonnement"
+        ],
+        "domains": [
+          "francais_academique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "Pour prouver que les élèves dorment trop."
+          },
+          {
+            "id": "b",
+            "label": "Pour montrer qu’une corrélation simple peut dépendre d’autres facteurs."
+          },
+          {
+            "id": "c",
+            "label": "Pour changer de sujet."
+          },
+          {
+            "id": "d",
+            "label": "Pour définir le mot donnée."
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "fr-04",
+        "type": "single",
+        "prompt": "Quelle proposition reformule le plus fidèlement la dernière phrase ?",
+        "competencies": [
+          "reformulation"
+        ],
+        "domains": [
+          "francais_academique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "L’objectivité interdit le jugement."
+          },
+          {
+            "id": "b",
+            "label": "Une donnée peut donner une fausse impression de neutralité lorsqu’elle est utilisée sans expliciter les choix."
+          },
+          {
+            "id": "c",
+            "label": "Les décisions chiffrées sont toujours dangereuses."
+          },
+          {
+            "id": "d",
+            "label": "Il faut supprimer toutes les statistiques."
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "fr-05",
+        "type": "single",
+        "prompt": "Le texte distingue principalement…",
+        "competencies": [
+          "distinction_conceptuelle"
+        ],
+        "domains": [
+          "francais_academique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "la mémoire et l’attention"
+          },
+          {
+            "id": "b",
+            "label": "la corrélation et la causalité"
+          },
+          {
+            "id": "c",
+            "label": "le présent et le passé"
+          },
+          {
+            "id": "d",
+            "label": "l’école et la famille"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "fr-06",
+        "type": "single",
+        "prompt": "Quel titre convient le mieux ?",
+        "competencies": [
+          "synthese"
+        ],
+        "domains": [
+          "francais_academique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "Travailler plus pour réussir"
+          },
+          {
+            "id": "b",
+            "label": "Mesurer sans renoncer à juger"
+          },
+          {
+            "id": "c",
+            "label": "Pourquoi les nombres mentent toujours"
+          },
+          {
+            "id": "d",
+            "label": "Le sommeil des lycéens"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "fr-07",
+        "type": "single",
+        "prompt": "Dans « les valeurs à privilégier », le mot « valeurs » désigne surtout…",
+        "competencies": [
+          "vocabulaire_contexte"
+        ],
+        "domains": [
+          "francais_academique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "des nombres"
+          },
+          {
+            "id": "b",
+            "label": "des principes ou finalités"
+          },
+          {
+            "id": "c",
+            "label": "des prix"
+          },
+          {
+            "id": "d",
+            "label": "des notes"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "fr-08",
+        "type": "single",
+        "prompt": "Quelle affirmation est explicitement soutenue ?",
+        "competencies": [
+          "preuve_textuelle"
+        ],
+        "domains": [
+          "francais_academique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "Toute heure de travail augmente la note."
+          },
+          {
+            "id": "b",
+            "label": "La qualité du travail influence l’efficacité du temps consacré."
+          },
+          {
+            "id": "c",
+            "label": "Les statistiques doivent être interdites à l’école."
+          },
+          {
+            "id": "d",
+            "label": "Le sommeil est la seule cause de réussite."
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "fr-09",
+        "type": "single",
+        "prompt": "Choisissez la phrase correctement accordée.",
+        "competencies": [
+          "accord_participe"
+        ],
+        "domains": [
+          "francais_academique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "Les données que nous avons recueilli sont utiles."
+          },
+          {
+            "id": "b",
+            "label": "Les données que nous avons recueillies sont utiles."
+          },
+          {
+            "id": "c",
+            "label": "Les données que nous avons recueillis est utile."
+          },
+          {
+            "id": "d",
+            "label": "Les données que nous avons recueillie sont utiles."
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "fr-10",
+        "type": "single",
+        "prompt": "Choisissez la ponctuation la plus claire.",
+        "competencies": [
+          "ponctuation"
+        ],
+        "domains": [
+          "francais_academique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "Cependant les résultats, restent fragiles."
+          },
+          {
+            "id": "b",
+            "label": "Cependant, les résultats restent fragiles."
+          },
+          {
+            "id": "c",
+            "label": "Cependant les résultats restent, fragiles."
+          },
+          {
+            "id": "d",
+            "label": "Cependant : les résultats, restent fragiles."
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "fr-11",
+        "type": "single",
+        "prompt": "Quel mot est le plus proche de « révisable » dans le contexte ?",
+        "competencies": [
+          "vocabulaire"
+        ],
+        "domains": [
+          "francais_academique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "modifiable après examen"
+          },
+          {
+            "id": "b",
+            "label": "visible immédiatement"
+          },
+          {
+            "id": "c",
+            "label": "impossible à justifier"
+          },
+          {
+            "id": "d",
+            "label": "calculable exactement"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "fr-12",
+        "type": "single",
+        "prompt": "Quelle phrase exprime une concession correcte ?",
+        "competencies": [
+          "syntaxe"
+        ],
+        "domains": [
+          "francais_academique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "Bien que les données soient utiles, elles ne suffisent pas à décider."
+          },
+          {
+            "id": "b",
+            "label": "Parce que les données soient utiles, elles ne suffisent pas."
+          },
+          {
+            "id": "c",
+            "label": "Les données sont utiles afin qu’elles ne suffisent pas."
+          },
+          {
+            "id": "d",
+            "label": "Si les données utiles, elles ne suffisent pas."
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "fr-13",
+        "type": "single",
+        "prompt": "Quelle formulation évite le contresens ?",
+        "competencies": [
+          "interpretation"
+        ],
+        "domains": [
+          "francais_academique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "Le texte affirme que les chiffres sont faux."
+          },
+          {
+            "id": "b",
+            "label": "Le texte affirme que les chiffres doivent être interprétés dans un cadre explicite."
+          },
+          {
+            "id": "c",
+            "label": "Le texte affirme que travailler est inutile."
+          },
+          {
+            "id": "d",
+            "label": "Le texte affirme que le jugement est toujours subjectif."
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "fr-14",
+        "type": "single",
+        "prompt": "Dans une réponse argumentée, citer le texte sert d’abord à…",
+        "competencies": [
+          "methode_citation"
+        ],
+        "domains": [
+          "francais_academique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "remplir la copie"
+          },
+          {
+            "id": "b",
+            "label": "remplacer l’analyse"
+          },
+          {
+            "id": "c",
+            "label": "appuyer une interprétation précise"
+          },
+          {
+            "id": "d",
+            "label": "montrer que l’on connaît la ponctuation"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "fr-15",
+        "type": "single",
+        "prompt": "Une synthèse fidèle doit…",
+        "competencies": [
+          "synthese"
+        ],
+        "domains": [
+          "francais_academique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "reprendre toutes les phrases"
+          },
+          {
+            "id": "b",
+            "label": "hiérarchiser les idées sans ajouter d’opinion personnelle"
+          },
+          {
+            "id": "c",
+            "label": "donner seulement un exemple"
+          },
+          {
+            "id": "d",
+            "label": "contester obligatoirement l’auteur"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "fr-16",
+        "type": "long",
+        "prompt": "Résumez le texte en 70 à 90 mots.",
+        "competencies": [
+          "synthese",
+          "fidelite",
+          "cohesion"
+        ],
+        "domains": [
+          "production_ecrite"
+        ],
+        "maxPoints": 10,
+        "instruction": "Ne donnez pas votre opinion. Conservez la progression logique.",
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 90
+      },
+      {
+        "id": "fr-17",
+        "type": "long",
+        "prompt": "Expliquez en 120 à 180 mots la différence entre corrélation et causalité à partir d’un exemple personnel ou scolaire.",
+        "competencies": [
+          "explication",
+          "exemple",
+          "precision"
+        ],
+        "domains": [
+          "production_ecrite"
+        ],
+        "maxPoints": 10,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 180
+      },
+      {
+        "id": "fr-18",
+        "type": "long",
+        "prompt": "Rédigez une introduction argumentée sur le sujet : « Peut-on décider justement à partir de chiffres ? »",
+        "competencies": [
+          "problematique",
+          "introduction",
+          "argumentation"
+        ],
+        "domains": [
+          "production_ecrite"
+        ],
+        "maxPoints": 12,
+        "instruction": "Votre introduction doit amener le sujet, définir les termes, formuler un problème et annoncer une démarche.",
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 280
+      },
+      {
+        "id": "fr-19",
+        "type": "short",
+        "prompt": "Réécrivez cette phrase en corrigeant toutes les erreurs : « Les informations qu’il a collecté ne permet pas de conclure, malgré qu’elles semblent précise. »",
+        "competencies": [
+          "orthographe",
+          "syntaxe"
+        ],
+        "domains": [
+          "langue"
+        ],
+        "maxPoints": 6,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 60
+      },
+      {
+        "id": "fr-20",
+        "type": "upload",
+        "prompt": "Présentez oralement en deux minutes la thèse du texte, un argument et une limite.",
+        "competencies": [
+          "oral",
+          "structure",
+          "expression"
+        ],
+        "domains": [
+          "expression_orale"
+        ],
+        "maxPoints": 15,
+        "instruction": "Déposez un fichier audio ou vidéo, sans montage.",
+        "required": true,
+        "manualReview": true,
+        "uploadRule": {
+          "category": "ORAL_RECORDING",
+          "accept": [
+            "audio/mpeg",
+            "audio/mp4",
+            "audio/webm",
+            "video/mp4",
+            "video/webm"
+          ],
+          "maxFiles": 1,
+          "maxBytesPerFile": 52428800,
+          "required": true,
+          "help": "2 minutes environ, fichier brut."
+        }
+      },
+      {
+        "id": "fr-21",
+        "type": "scale",
+        "prompt": "À quel point avez-vous compris le texte sans relire plus de deux fois ?",
+        "competencies": [
+          "metacognition"
+        ],
+        "domains": [
+          "auto_evaluation"
+        ],
+        "maxPoints": 0,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Très difficile",
+        "rightLabel": "Très facile",
+        "required": true
+      },
+      {
+        "id": "fr-22",
+        "type": "single",
+        "prompt": "Quelle partie vous a demandé le plus d’effort ?",
+        "competencies": [
+          "metacognition"
+        ],
+        "domains": [
+          "auto_evaluation"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Comprendre la thèse"
+          },
+          {
+            "id": "b",
+            "label": "Comprendre les mots"
+          },
+          {
+            "id": "c",
+            "label": "Suivre le raisonnement"
+          },
+          {
+            "id": "d",
+            "label": "Rédiger"
+          },
+          {
+            "id": "e",
+            "label": "Parler à l’oral"
+          },
+          {
+            "id": "f",
+            "label": "Aucune difficulté majeure"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "fr-23",
+        "type": "long",
+        "prompt": "Décrivez une erreur que vous pensez avoir commise dans cette épreuve.",
+        "competencies": [
+          "metacognition"
+        ],
+        "domains": [
+          "auto_evaluation"
+        ],
+        "maxPoints": 2,
+        "required": false,
+        "manualReview": true,
+        "wordLimit": 120
+      },
+      {
+        "id": "fr-24",
+        "type": "scale",
+        "prompt": "Quel niveau de confiance accordez-vous à vos réponses ?",
+        "competencies": [
+          "metacognition"
+        ],
+        "domains": [
+          "auto_evaluation"
+        ],
+        "maxPoints": 0,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Très faible",
+        "rightLabel": "Très élevé",
+        "required": true
+      }
+    ],
+    "scoreDomains": [
+      "francais_academique",
+      "production_ecrite",
+      "langue",
+      "expression_orale"
+    ],
+    "requiredForSubmission": true
+  },
+  {
+    "key": "mathematiques",
+    "title": "Mathématiques : prérequis, raisonnement et entrée en terminale",
+    "shortTitle": "Mathématiques",
+    "description": "Évaluer les automatismes de première, le raisonnement, la rédaction et la capacité à entrer dans les notions de terminale.",
+    "audience": "ELEVE",
+    "kind": "academic",
+    "estimatedMinutes": 105,
+    "timed": true,
+    "prerequisites": [
+      "profil-parcours"
+    ],
+    "instructions": [
+      "Calculatrice simple autorisée uniquement pour les questions longues si nécessaire.",
+      "Toute réponse doit être justifiée dans les productions ouvertes.",
+      "Signalez « non étudié » plutôt que répondre au hasard."
+    ],
+    "questions": [
+      {
+        "id": "math-01",
+        "type": "single",
+        "prompt": "Calculer : 3/4 − 5/8.",
+        "competencies": [
+          "calcul_exact"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "1/8"
+          },
+          {
+            "id": "b",
+            "label": "-1/8"
+          },
+          {
+            "id": "c",
+            "label": "2/8"
+          },
+          {
+            "id": "d",
+            "label": "-2/8"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-02",
+        "type": "single",
+        "prompt": "Après une hausse de 20 %, un prix vaut 120 DT. Quel était le prix initial ?",
+        "competencies": [
+          "pourcentage"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "96 DT"
+          },
+          {
+            "id": "b",
+            "label": "100 DT"
+          },
+          {
+            "id": "c",
+            "label": "104 DT"
+          },
+          {
+            "id": "d",
+            "label": "144 DT"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-03",
+        "type": "single",
+        "prompt": "Résoudre 3x − 7 = 11.",
+        "competencies": [
+          "equation"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "x = 4/3"
+          },
+          {
+            "id": "b",
+            "label": "x = 6"
+          },
+          {
+            "id": "c",
+            "label": "x = 18"
+          },
+          {
+            "id": "d",
+            "label": "x = -6"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-04",
+        "type": "single",
+        "prompt": "Les solutions de x² − 5x + 6 = 0 sont…",
+        "competencies": [
+          "second_degre"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "−2 et −3"
+          },
+          {
+            "id": "b",
+            "label": "2 et 3"
+          },
+          {
+            "id": "c",
+            "label": "1 et 6"
+          },
+          {
+            "id": "d",
+            "label": "aucune"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-05",
+        "type": "single",
+        "prompt": "Pour f(x)=2x²−3x+1, f(−1)=…",
+        "competencies": [
+          "fonction"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "0"
+          },
+          {
+            "id": "b",
+            "label": "2"
+          },
+          {
+            "id": "c",
+            "label": "6"
+          },
+          {
+            "id": "d",
+            "label": "-4"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-06",
+        "type": "single",
+        "prompt": "Si f est croissante sur [0;4] et f(1)=2, f(3)=7, alors…",
+        "competencies": [
+          "variations"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "f(2)<2"
+          },
+          {
+            "id": "b",
+            "label": "2≤f(2)≤7"
+          },
+          {
+            "id": "c",
+            "label": "f(2)>7"
+          },
+          {
+            "id": "d",
+            "label": "f(2)=4,5 nécessairement"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-07",
+        "type": "single",
+        "prompt": "La dérivée de x³−4x est…",
+        "competencies": [
+          "derivation"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "3x²−4"
+          },
+          {
+            "id": "b",
+            "label": "x²−4"
+          },
+          {
+            "id": "c",
+            "label": "3x−4"
+          },
+          {
+            "id": "d",
+            "label": "3x²"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-08",
+        "type": "single",
+        "prompt": "Une tangente à la courbe de f en a a pour coefficient directeur…",
+        "competencies": [
+          "tangente"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "f(a)"
+          },
+          {
+            "id": "b",
+            "label": "f’(a)"
+          },
+          {
+            "id": "c",
+            "label": "a/f(a)"
+          },
+          {
+            "id": "d",
+            "label": "f’(0)"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-09",
+        "type": "single",
+        "prompt": "Une suite arithmétique vérifie u₀=5 et raison −2. Alors u₄ vaut…",
+        "competencies": [
+          "suites"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "13"
+          },
+          {
+            "id": "b",
+            "label": "3"
+          },
+          {
+            "id": "c",
+            "label": "−3"
+          },
+          {
+            "id": "d",
+            "label": "−8"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-10",
+        "type": "single",
+        "prompt": "Une suite géométrique vérifie v₀=3 et raison 2. Alors v₅ vaut…",
+        "competencies": [
+          "suites"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "30"
+          },
+          {
+            "id": "b",
+            "label": "48"
+          },
+          {
+            "id": "c",
+            "label": "96"
+          },
+          {
+            "id": "d",
+            "label": "192"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-11",
+        "type": "single",
+        "prompt": "Si P(A)=0,4 et P(B|A)=0,5, alors P(A∩B)=…",
+        "competencies": [
+          "probabilites_conditionnelles"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "0,2"
+          },
+          {
+            "id": "b",
+            "label": "0,45"
+          },
+          {
+            "id": "c",
+            "label": "0,9"
+          },
+          {
+            "id": "d",
+            "label": "1,25"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-12",
+        "type": "single",
+        "prompt": "Deux événements A et B sont indépendants lorsque…",
+        "competencies": [
+          "independance"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "P(A∩B)=0"
+          },
+          {
+            "id": "b",
+            "label": "P(A∩B)=P(A)P(B)"
+          },
+          {
+            "id": "c",
+            "label": "P(A)=P(B)"
+          },
+          {
+            "id": "d",
+            "label": "P(A∪B)=1"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-13",
+        "type": "single",
+        "prompt": "Dans un schéma de Bernoulli de paramètres n=10 et p=0,3, l’espérance de X est…",
+        "competencies": [
+          "loi_binomiale"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "0,3"
+          },
+          {
+            "id": "b",
+            "label": "3"
+          },
+          {
+            "id": "c",
+            "label": "7"
+          },
+          {
+            "id": "d",
+            "label": "10"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-14",
+        "type": "single",
+        "prompt": "La fonction exponentielle vérifie…",
+        "competencies": [
+          "exponentielle"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "e^(a+b)=e^a+e^b"
+          },
+          {
+            "id": "b",
+            "label": "e^(a+b)=e^a e^b"
+          },
+          {
+            "id": "c",
+            "label": "e^0=0"
+          },
+          {
+            "id": "d",
+            "label": "e^(-a)=-e^a"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-15",
+        "type": "single",
+        "prompt": "ln(e³)=…",
+        "competencies": [
+          "logarithme"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "e ln 3"
+          },
+          {
+            "id": "b",
+            "label": "3"
+          },
+          {
+            "id": "c",
+            "label": "1/3"
+          },
+          {
+            "id": "d",
+            "label": "0"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-16",
+        "type": "single",
+        "prompt": "La limite de 1/x lorsque x tend vers +∞ est…",
+        "competencies": [
+          "limites"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "1"
+          },
+          {
+            "id": "b",
+            "label": "+∞"
+          },
+          {
+            "id": "c",
+            "label": "0"
+          },
+          {
+            "id": "d",
+            "label": "−∞"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-17",
+        "type": "single",
+        "prompt": "Le vecteur AB avec A(1;2) et B(4;−1) a pour coordonnées…",
+        "competencies": [
+          "vecteurs"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "(5;1)"
+          },
+          {
+            "id": "b",
+            "label": "(3;−3)"
+          },
+          {
+            "id": "c",
+            "label": "(−3;3)"
+          },
+          {
+            "id": "d",
+            "label": "(4;−2)"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-18",
+        "type": "single",
+        "prompt": "Une droite de vecteur directeur (2;−1) peut avoir pour vecteur normal…",
+        "competencies": [
+          "geometrie_analytique"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "(2;−1)"
+          },
+          {
+            "id": "b",
+            "label": "(1;2)"
+          },
+          {
+            "id": "c",
+            "label": "(−1;−2)"
+          },
+          {
+            "id": "d",
+            "label": "(2;1)"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-19",
+        "type": "single",
+        "prompt": "La négation de « pour tout réel x, f(x)>0 » est…",
+        "competencies": [
+          "logique"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "pour tout x, f(x)≤0"
+          },
+          {
+            "id": "b",
+            "label": "il existe x tel que f(x)≤0"
+          },
+          {
+            "id": "c",
+            "label": "il existe x tel que f(x)>0"
+          },
+          {
+            "id": "d",
+            "label": "f est nulle"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-20",
+        "type": "single",
+        "prompt": "Pour prouver qu’une proposition « si P alors Q » est fausse, il suffit…",
+        "competencies": [
+          "raisonnement"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "de montrer un cas où P est faux"
+          },
+          {
+            "id": "b",
+            "label": "de trouver un cas où P est vrai et Q faux"
+          },
+          {
+            "id": "c",
+            "label": "de trouver un cas où P et Q sont vrais"
+          },
+          {
+            "id": "d",
+            "label": "de montrer Q sans P"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-21",
+        "type": "single",
+        "prompt": "Dans l’algorithme suivant, quelle est la valeur finale de s ? s=0 ; pour k de 1 à 4 : s=s+k",
+        "competencies": [
+          "algorithmique"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "4"
+          },
+          {
+            "id": "b",
+            "label": "6"
+          },
+          {
+            "id": "c",
+            "label": "10"
+          },
+          {
+            "id": "d",
+            "label": "15"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-22",
+        "type": "single",
+        "prompt": "Une valeur passe de 80 à 68. Le taux d’évolution est…",
+        "competencies": [
+          "pourcentage"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "−12 %"
+          },
+          {
+            "id": "b",
+            "label": "−15 %"
+          },
+          {
+            "id": "c",
+            "label": "15 %"
+          },
+          {
+            "id": "d",
+            "label": "−20 %"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-23",
+        "type": "single",
+        "prompt": "La moyenne de 4, 7, 9 et 10 est…",
+        "competencies": [
+          "statistiques"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "7"
+          },
+          {
+            "id": "b",
+            "label": "7,5"
+          },
+          {
+            "id": "c",
+            "label": "8"
+          },
+          {
+            "id": "d",
+            "label": "30"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-24",
+        "type": "single",
+        "prompt": "Si une fonction dérivable admet un minimum local en a et si a est intérieur à l’intervalle, alors nécessairement…",
+        "competencies": [
+          "extremum"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "f(a)=0"
+          },
+          {
+            "id": "b",
+            "label": "f’(a)=0"
+          },
+          {
+            "id": "c",
+            "label": "f’’(a)=0"
+          },
+          {
+            "id": "d",
+            "label": "a=0"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "math-25",
+        "type": "long",
+        "prompt": "Résoudre et justifier l’inéquation (2x−1)(x+3)≤0.",
+        "competencies": [
+          "calcul",
+          "raisonnement",
+          "redaction"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 8,
+        "instruction": "Présentez un tableau de signes ou une justification équivalente.",
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 250
+      },
+      {
+        "id": "math-26",
+        "type": "long",
+        "prompt": "Une population de 2 000 individus augmente de 4 % par an. Modélisez la situation, calculez l’effectif après 5 ans et expliquez la limite du modèle.",
+        "competencies": [
+          "modelisation",
+          "suites",
+          "interpretation"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 10,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 300
+      },
+      {
+        "id": "math-27",
+        "type": "long",
+        "prompt": "On choisit au hasard une pièce dans une boîte contenant 6 pièces conformes et 4 défectueuses. Après contrôle, un détecteur signale « défaut » avec probabilité 0,9 pour une pièce défectueuse et 0,1 pour une pièce conforme. Calculer la probabilité qu’une pièce signalée défectueuse le soit réellement.",
+        "competencies": [
+          "probabilites_conditionnelles",
+          "arbre",
+          "redaction"
+        ],
+        "domains": [
+          "mathematiques"
+        ],
+        "maxPoints": 12,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 350
+      },
+      {
+        "id": "math-28",
+        "type": "upload",
+        "prompt": "Déposez une photo ou un PDF de votre brouillon et de vos calculs pour les questions 25 à 27.",
+        "competencies": [
+          "trace_raisonnement"
+        ],
+        "domains": [
+          "preuves"
+        ],
+        "maxPoints": 0,
+        "required": true,
+        "manualReview": true,
+        "uploadRule": {
+          "category": "WRITTEN_COPY",
+          "accept": [
+            "application/pdf",
+            "image/jpeg",
+            "image/png",
+            "image/webp"
+          ],
+          "maxFiles": 3,
+          "maxBytesPerFile": 12582912,
+          "required": true,
+          "help": "Photos nettes, pages dans l’ordre."
+        }
+      }
+    ],
+    "scoreDomains": [
+      "mathematiques",
+      "preuves"
+    ],
+    "requiredForSubmission": true
+  },
+  {
+    "key": "nsi",
+    "title": "NSI : algorithmique, programmation, données et systèmes",
+    "shortTitle": "NSI",
+    "description": "Évaluer la compréhension informatique et la capacité à raisonner sur une épreuve entièrement écrite pour un candidat individuel.",
+    "audience": "ELEVE",
+    "kind": "academic",
+    "estimatedMinutes": 95,
+    "timed": true,
+    "prerequisites": [
+      "profil-parcours"
+    ],
+    "instructions": [
+      "Python est le langage de référence.",
+      "N’exécutez pas le code pendant les questions de trace.",
+      "Les réponses ouvertes seront relues par un enseignant de NSI."
+    ],
+    "questions": [
+      {
+        "id": "nsi-01",
+        "type": "single",
+        "prompt": "Quelle est l’écriture binaire de 13 ?",
+        "competencies": [
+          "representation_entiers"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "1011"
+          },
+          {
+            "id": "b",
+            "label": "1101"
+          },
+          {
+            "id": "c",
+            "label": "1110"
+          },
+          {
+            "id": "d",
+            "label": "1001"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-02",
+        "type": "single",
+        "prompt": "En Python, que vaut 7 // 2 ?",
+        "competencies": [
+          "python_operateurs"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "3"
+          },
+          {
+            "id": "b",
+            "label": "3.5"
+          },
+          {
+            "id": "c",
+            "label": "4"
+          },
+          {
+            "id": "d",
+            "label": "1"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-03",
+        "type": "single",
+        "prompt": "Que vaut len([2,4,6]) ?",
+        "competencies": [
+          "listes"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "2"
+          },
+          {
+            "id": "b",
+            "label": "3"
+          },
+          {
+            "id": "c",
+            "label": "6"
+          },
+          {
+            "id": "d",
+            "label": "12"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-04",
+        "type": "single",
+        "prompt": "Après d={\"a\":2}; d[\"b\"]=5, que vaut len(d) ?",
+        "competencies": [
+          "dictionnaires"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "1"
+          },
+          {
+            "id": "b",
+            "label": "2"
+          },
+          {
+            "id": "c",
+            "label": "5"
+          },
+          {
+            "id": "d",
+            "label": "7"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-05",
+        "type": "single",
+        "prompt": "Que renvoie [x*x for x in range(4)] ?",
+        "competencies": [
+          "comprehension_liste"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "[1,4,9,16]"
+          },
+          {
+            "id": "b",
+            "label": "[0,1,4,9]"
+          },
+          {
+            "id": "c",
+            "label": "[0,1,2,3]"
+          },
+          {
+            "id": "d",
+            "label": "[0,2,4,6]"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-06",
+        "type": "single",
+        "prompt": "Une fonction récursive doit notamment posséder…",
+        "competencies": [
+          "recursivite"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "une boucle infinie"
+          },
+          {
+            "id": "b",
+            "label": "un cas de base"
+          },
+          {
+            "id": "c",
+            "label": "deux paramètres"
+          },
+          {
+            "id": "d",
+            "label": "une variable globale"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-07",
+        "type": "single",
+        "prompt": "La complexité d’une recherche dichotomique dans une liste triée est typiquement…",
+        "competencies": [
+          "complexite"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "O(1)"
+          },
+          {
+            "id": "b",
+            "label": "O(log n)"
+          },
+          {
+            "id": "c",
+            "label": "O(n)"
+          },
+          {
+            "id": "d",
+            "label": "O(n²)"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-08",
+        "type": "single",
+        "prompt": "Dans une pile, l’élément retiré en premier est…",
+        "competencies": [
+          "structures_lineaires"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "le premier ajouté"
+          },
+          {
+            "id": "b",
+            "label": "le dernier ajouté"
+          },
+          {
+            "id": "c",
+            "label": "le plus petit"
+          },
+          {
+            "id": "d",
+            "label": "choisi au hasard"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-09",
+        "type": "single",
+        "prompt": "Dans une file, l’élément retiré en premier est…",
+        "competencies": [
+          "structures_lineaires"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "le premier ajouté"
+          },
+          {
+            "id": "b",
+            "label": "le dernier ajouté"
+          },
+          {
+            "id": "c",
+            "label": "le plus grand"
+          },
+          {
+            "id": "d",
+            "label": "le milieu"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-10",
+        "type": "single",
+        "prompt": "Dans un arbre binaire de recherche, les valeurs du sous-arbre gauche d’un nœud sont en général…",
+        "competencies": [
+          "arbres"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "supérieures"
+          },
+          {
+            "id": "b",
+            "label": "inférieures"
+          },
+          {
+            "id": "c",
+            "label": "égales"
+          },
+          {
+            "id": "d",
+            "label": "sans relation"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-11",
+        "type": "single",
+        "prompt": "Quelle requête sélectionne tous les élèves dont la note est au moins 10 ?",
+        "competencies": [
+          "sql"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "SELECT * FROM eleves WHERE note >= 10;"
+          },
+          {
+            "id": "b",
+            "label": "GET eleves IF note = 10;"
+          },
+          {
+            "id": "c",
+            "label": "SELECT note > 10 IN eleves;"
+          },
+          {
+            "id": "d",
+            "label": "FROM eleves SELECT >=10;"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-12",
+        "type": "single",
+        "prompt": "Une clé primaire sert principalement à…",
+        "competencies": [
+          "bases_donnees"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "chiffrer la table"
+          },
+          {
+            "id": "b",
+            "label": "identifier de manière unique une ligne"
+          },
+          {
+            "id": "c",
+            "label": "trier automatiquement les colonnes"
+          },
+          {
+            "id": "d",
+            "label": "supprimer les doublons de texte"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-13",
+        "type": "single",
+        "prompt": "Le protocole HTTP est principalement utilisé pour…",
+        "competencies": [
+          "reseaux"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "adresser les paquets sur un réseau local"
+          },
+          {
+            "id": "b",
+            "label": "échanger des ressources web"
+          },
+          {
+            "id": "c",
+            "label": "chiffrer les disques"
+          },
+          {
+            "id": "d",
+            "label": "compiler Python"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-14",
+        "type": "single",
+        "prompt": "Une adresse IPv4 contient…",
+        "competencies": [
+          "reseaux"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "16 bits"
+          },
+          {
+            "id": "b",
+            "label": "32 bits"
+          },
+          {
+            "id": "c",
+            "label": "64 bits"
+          },
+          {
+            "id": "d",
+            "label": "128 bits"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-15",
+        "type": "single",
+        "prompt": "Le rôle principal du DNS est de…",
+        "competencies": [
+          "reseaux"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "traduire un nom de domaine en adresse IP"
+          },
+          {
+            "id": "b",
+            "label": "compresser les pages web"
+          },
+          {
+            "id": "c",
+            "label": "attribuer les mots de passe"
+          },
+          {
+            "id": "d",
+            "label": "exécuter les requêtes SQL"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-16",
+        "type": "single",
+        "prompt": "Un système d’exploitation gère notamment…",
+        "competencies": [
+          "architecture_systeme"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "uniquement les fichiers texte"
+          },
+          {
+            "id": "b",
+            "label": "les processus, la mémoire et les périphériques"
+          },
+          {
+            "id": "c",
+            "label": "la syntaxe HTML seulement"
+          },
+          {
+            "id": "d",
+            "label": "les notes des élèves"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-17",
+        "type": "single",
+        "prompt": "Dans un graphe non orienté, une arête relie…",
+        "competencies": [
+          "graphes"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "un sommet à une table SQL"
+          },
+          {
+            "id": "b",
+            "label": "deux sommets sans orientation"
+          },
+          {
+            "id": "c",
+            "label": "toujours trois sommets"
+          },
+          {
+            "id": "d",
+            "label": "deux fonctions Python"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-18",
+        "type": "single",
+        "prompt": "Un parcours en largeur utilise naturellement…",
+        "competencies": [
+          "graphes"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "une pile"
+          },
+          {
+            "id": "b",
+            "label": "une file"
+          },
+          {
+            "id": "c",
+            "label": "un dictionnaire uniquement"
+          },
+          {
+            "id": "d",
+            "label": "une récursion obligatoire"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-19",
+        "type": "single",
+        "prompt": "Que vaut f(4) pour f(n): si n==0 retourner 1 sinon retourner n*f(n-1) ?",
+        "competencies": [
+          "recursivite"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "4"
+          },
+          {
+            "id": "b",
+            "label": "10"
+          },
+          {
+            "id": "c",
+            "label": "16"
+          },
+          {
+            "id": "d",
+            "label": "24"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-20",
+        "type": "single",
+        "prompt": "Une collision dans une table de hachage se produit lorsque…",
+        "competencies": [
+          "hachage"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "deux clés obtiennent le même indice"
+          },
+          {
+            "id": "b",
+            "label": "une clé est trop longue"
+          },
+          {
+            "id": "c",
+            "label": "la table est triée"
+          },
+          {
+            "id": "d",
+            "label": "un programme compile"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-21",
+        "type": "single",
+        "prompt": "Quel principe réduit le risque d’accès non autorisé ?",
+        "competencies": [
+          "securite"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "Donner tous les droits à tous"
+          },
+          {
+            "id": "b",
+            "label": "Principe du moindre privilège"
+          },
+          {
+            "id": "c",
+            "label": "Réutiliser le même mot de passe"
+          },
+          {
+            "id": "d",
+            "label": "Désactiver les sauvegardes"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-22",
+        "type": "single",
+        "prompt": "Dans le modèle client-serveur…",
+        "competencies": [
+          "architecture_reseau"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "le client fournit toujours le service"
+          },
+          {
+            "id": "b",
+            "label": "le serveur répond à des requêtes de clients"
+          },
+          {
+            "id": "c",
+            "label": "aucun réseau n’est nécessaire"
+          },
+          {
+            "id": "d",
+            "label": "les rôles ne peuvent jamais changer"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "nsi-23",
+        "type": "long",
+        "prompt": "Sans exécuter le programme, donner la valeur affichée et expliquer :\n\nL=[3,1,4,1,5]\ns=0\nfor i in range(len(L)):\n    if L[i] > i:\n        s += L[i]\nprint(s)",
+        "competencies": [
+          "trace_programme",
+          "explication"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 8,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 220
+      },
+      {
+        "id": "nsi-24",
+        "type": "long",
+        "prompt": "Écrire une fonction Python `indices_pairs(L)` qui renvoie la liste des indices où l’élément de L est pair. Préciser un jeu de tests.",
+        "competencies": [
+          "programmation",
+          "tests"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 10,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 300
+      },
+      {
+        "id": "nsi-25",
+        "type": "long",
+        "prompt": "On dispose des tables ELEVE(id, nom) et NOTE(id_eleve, matiere, valeur). Écrire une requête qui renvoie le nom et la moyenne de chaque élève en mathématiques.",
+        "competencies": [
+          "sql",
+          "jointure",
+          "agregation"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 10,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 250
+      },
+      {
+        "id": "nsi-26",
+        "type": "long",
+        "prompt": "Expliquer pourquoi un algorithme correct sur quelques exemples peut néanmoins être incorrect en général. Donner un exemple ou une méthode de preuve.",
+        "competencies": [
+          "preuve_algorithme",
+          "esprit_critique"
+        ],
+        "domains": [
+          "nsi"
+        ],
+        "maxPoints": 8,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 250
+      }
+    ],
+    "scoreDomains": [
+      "nsi"
+    ],
+    "requiredForSubmission": true
+  },
+  {
+    "key": "ses",
+    "title": "SES : connaissances, données et argumentation",
+    "shortTitle": "SES",
+    "description": "Évaluer les mécanismes, l’analyse de documents et la capacité à produire une démonstration écrite de niveau baccalauréat.",
+    "audience": "ELEVE",
+    "kind": "academic",
+    "estimatedMinutes": 95,
+    "timed": true,
+    "prerequisites": [
+      "profil-parcours"
+    ],
+    "instructions": [
+      "Les notions de première doivent être mobilisables.",
+      "Justifiez les réponses ouvertes par des mécanismes et des exemples."
+    ],
+    "questions": [
+      {
+        "id": "ses-01",
+        "type": "single",
+        "prompt": "Sur un marché concurrentiel, une hausse du prix tend, toutes choses égales par ailleurs, à…",
+        "competencies": [
+          "marche"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "augmenter la demande"
+          },
+          {
+            "id": "b",
+            "label": "réduire la quantité demandée"
+          },
+          {
+            "id": "c",
+            "label": "supprimer l’offre"
+          },
+          {
+            "id": "d",
+            "label": "rendre la demande verticale"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ses-02",
+        "type": "single",
+        "prompt": "Une externalité négative est…",
+        "competencies": [
+          "externalites"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "un coût subi par un tiers sans compensation"
+          },
+          {
+            "id": "b",
+            "label": "une taxe volontaire"
+          },
+          {
+            "id": "c",
+            "label": "un bénéfice privé"
+          },
+          {
+            "id": "d",
+            "label": "une baisse de salaire"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ses-03",
+        "type": "single",
+        "prompt": "Le PIB mesure principalement…",
+        "competencies": [
+          "croissance"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "le bonheur"
+          },
+          {
+            "id": "b",
+            "label": "la valeur des biens et services produits sur un territoire"
+          },
+          {
+            "id": "c",
+            "label": "le patrimoine total"
+          },
+          {
+            "id": "d",
+            "label": "l’égalité des revenus"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ses-04",
+        "type": "single",
+        "prompt": "Le chômage au sens du BIT suppose notamment…",
+        "competencies": [
+          "chomage"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "d’être sans emploi et disponible pour travailler"
+          },
+          {
+            "id": "b",
+            "label": "d’être étudiant"
+          },
+          {
+            "id": "c",
+            "label": "d’avoir un emploi à temps partiel"
+          },
+          {
+            "id": "d",
+            "label": "de refuser toute recherche"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ses-05",
+        "type": "single",
+        "prompt": "La socialisation primaire se déroule surtout…",
+        "competencies": [
+          "socialisation"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "uniquement à l’université"
+          },
+          {
+            "id": "b",
+            "label": "pendant l’enfance, notamment dans la famille"
+          },
+          {
+            "id": "c",
+            "label": "après la retraite"
+          },
+          {
+            "id": "d",
+            "label": "dans les entreprises seulement"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ses-06",
+        "type": "single",
+        "prompt": "La mobilité sociale intergénérationnelle compare…",
+        "competencies": [
+          "mobilite_sociale"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "deux emplois du même individu"
+          },
+          {
+            "id": "b",
+            "label": "la position sociale d’un individu à celle de ses parents"
+          },
+          {
+            "id": "c",
+            "label": "les salaires de deux pays"
+          },
+          {
+            "id": "d",
+            "label": "les notes de deux classes"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ses-07",
+        "type": "single",
+        "prompt": "Une corrélation positive entre X et Y signifie que…",
+        "competencies": [
+          "donnees"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "X cause nécessairement Y"
+          },
+          {
+            "id": "b",
+            "label": "les deux variables tendent à évoluer dans le même sens"
+          },
+          {
+            "id": "c",
+            "label": "X et Y sont égales"
+          },
+          {
+            "id": "d",
+            "label": "aucune relation n’existe"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ses-08",
+        "type": "single",
+        "prompt": "Une politique budgétaire de relance consiste typiquement à…",
+        "competencies": [
+          "politique_economique"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "réduire toute dépense publique"
+          },
+          {
+            "id": "b",
+            "label": "augmenter les dépenses publiques ou réduire certains prélèvements"
+          },
+          {
+            "id": "c",
+            "label": "interdire le crédit"
+          },
+          {
+            "id": "d",
+            "label": "fixer tous les prix"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ses-09",
+        "type": "single",
+        "prompt": "Le capital culturel peut inclure…",
+        "competencies": [
+          "inegalites"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "uniquement l’argent disponible"
+          },
+          {
+            "id": "b",
+            "label": "des connaissances, dispositions et titres scolaires"
+          },
+          {
+            "id": "c",
+            "label": "le nombre de machines"
+          },
+          {
+            "id": "d",
+            "label": "la monnaie détenue par la banque centrale"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ses-10",
+        "type": "single",
+        "prompt": "Un bien public pur est en principe…",
+        "competencies": [
+          "action_publique"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "rival et excluable"
+          },
+          {
+            "id": "b",
+            "label": "non rival et non excluable"
+          },
+          {
+            "id": "c",
+            "label": "toujours vendu par une entreprise"
+          },
+          {
+            "id": "d",
+            "label": "un bien de luxe"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ses-11",
+        "type": "single",
+        "prompt": "La spécialisation internationale peut s’expliquer par…",
+        "competencies": [
+          "commerce_international"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "des avantages comparatifs"
+          },
+          {
+            "id": "b",
+            "label": "l’absence totale de coûts"
+          },
+          {
+            "id": "c",
+            "label": "l’identité des technologies"
+          },
+          {
+            "id": "d",
+            "label": "l’interdiction des échanges"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ses-12",
+        "type": "single",
+        "prompt": "Une élasticité-prix de la demande égale à −2 signifie approximativement qu’une hausse du prix de 1 % entraîne…",
+        "competencies": [
+          "elasticite"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "une hausse de demande de 2 %"
+          },
+          {
+            "id": "b",
+            "label": "une baisse de demande de 2 %"
+          },
+          {
+            "id": "c",
+            "label": "une baisse de prix de 2 %"
+          },
+          {
+            "id": "d",
+            "label": "aucun effet"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ses-13",
+        "type": "single",
+        "prompt": "Un sondage représentatif exige notamment…",
+        "competencies": [
+          "methodologie"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "un échantillon composé uniquement de volontaires proches"
+          },
+          {
+            "id": "b",
+            "label": "une méthode d’échantillonnage adaptée à la population"
+          },
+          {
+            "id": "c",
+            "label": "le plus petit échantillon possible"
+          },
+          {
+            "id": "d",
+            "label": "aucune définition de la population"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ses-14",
+        "type": "single",
+        "prompt": "Le marché peut être défaillant lorsque…",
+        "competencies": [
+          "defaillances_marche"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "les prix existent"
+          },
+          {
+            "id": "b",
+            "label": "des externalités ou asymétries d’information empêchent une allocation efficace"
+          },
+          {
+            "id": "c",
+            "label": "les entreprises font des calculs"
+          },
+          {
+            "id": "d",
+            "label": "les consommateurs choisissent"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ses-15",
+        "type": "single",
+        "prompt": "La stratification sociale désigne…",
+        "competencies": [
+          "stratification"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "la succession des saisons"
+          },
+          {
+            "id": "b",
+            "label": "l’organisation hiérarchisée des groupes sociaux"
+          },
+          {
+            "id": "c",
+            "label": "la seule différence d’âge"
+          },
+          {
+            "id": "d",
+            "label": "le classement alphabétique"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ses-16",
+        "type": "single",
+        "prompt": "Une institution est…",
+        "competencies": [
+          "institutions"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "une habitude individuelle sans règle"
+          },
+          {
+            "id": "b",
+            "label": "un ensemble relativement stable de règles et pratiques sociales"
+          },
+          {
+            "id": "c",
+            "label": "un prix de marché"
+          },
+          {
+            "id": "d",
+            "label": "un algorithme"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ses-17",
+        "type": "single",
+        "prompt": "Pour établir une causalité, il faut au minimum…",
+        "competencies": [
+          "causalite"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "observer une seule coïncidence"
+          },
+          {
+            "id": "b",
+            "label": "écarter des explications alternatives et identifier un mécanisme"
+          },
+          {
+            "id": "c",
+            "label": "avoir deux pourcentages égaux"
+          },
+          {
+            "id": "d",
+            "label": "interroger une personne"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ses-18",
+        "type": "single",
+        "prompt": "Dans une dissertation, la problématique sert à…",
+        "competencies": [
+          "methode_dissertation"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "répéter le sujet"
+          },
+          {
+            "id": "b",
+            "label": "transformer le sujet en problème organisé qui guide la démonstration"
+          },
+          {
+            "id": "c",
+            "label": "annoncer seulement les exemples"
+          },
+          {
+            "id": "d",
+            "label": "éviter de définir les termes"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ses-19",
+        "type": "long",
+        "prompt": "Un tableau indique que la part des diplômés du supérieur est de 52 % chez les enfants de cadres et de 18 % chez les enfants d’ouvriers. Rédigez deux phrases de lecture rigoureuses, puis formulez une limite d’interprétation.",
+        "competencies": [
+          "lecture_donnees",
+          "comparaison",
+          "prudence"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 10,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 220
+      },
+      {
+        "id": "ses-20",
+        "type": "long",
+        "prompt": "Expliquez comment une externalité négative peut justifier une intervention publique. Présentez un mécanisme et deux instruments possibles.",
+        "competencies": [
+          "mecanisme",
+          "action_publique",
+          "argumentation"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 12,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 320
+      },
+      {
+        "id": "ses-21",
+        "type": "long",
+        "prompt": "Construisez un plan détaillé pour le sujet : « L’égalité des chances suffit-elle à réduire les inégalités ? »",
+        "competencies": [
+          "problematique",
+          "plan",
+          "connaissances"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 14,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 450
+      },
+      {
+        "id": "ses-22",
+        "type": "long",
+        "prompt": "Rédigez un paragraphe AEI (Affirmation–Explication–Illustration) sur le rôle de la socialisation dans la différenciation des comportements.",
+        "competencies": [
+          "aei",
+          "redaction",
+          "illustration"
+        ],
+        "domains": [
+          "ses"
+        ],
+        "maxPoints": 10,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 250
+      }
+    ],
+    "scoreDomains": [
+      "ses"
+    ],
+    "requiredForSubmission": true
+  },
+  {
+    "key": "tronc-commun",
+    "title": "Tronc commun, langues et philosophie",
+    "shortTitle": "Tronc commun",
+    "description": "Évaluer les compétences transversales qui comptent dans les évaluations ponctuelles et les épreuves finales.",
+    "audience": "ELEVE",
+    "kind": "academic",
+    "estimatedMinutes": 105,
+    "timed": true,
+    "prerequisites": [
+      "profil-parcours"
+    ],
+    "instructions": [
+      "La partie LVB peut être complétée après confirmation de la langue.",
+      "Les productions longues sont corrigées manuellement."
+    ],
+    "questions": [
+      {
+        "id": "tc-01",
+        "type": "single",
+        "prompt": "Une source historique produite au moment des faits est…",
+        "competencies": [
+          "critique_source"
+        ],
+        "domains": [
+          "histoire_geo"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "toujours vraie"
+          },
+          {
+            "id": "b",
+            "label": "une source primaire à contextualiser et critiquer"
+          },
+          {
+            "id": "c",
+            "label": "inutile"
+          },
+          {
+            "id": "d",
+            "label": "une statistique"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "tc-02",
+        "type": "single",
+        "prompt": "Pour analyser une carte, il faut d’abord…",
+        "competencies": [
+          "analyse_carte"
+        ],
+        "domains": [
+          "histoire_geo"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "ignorer la légende"
+          },
+          {
+            "id": "b",
+            "label": "identifier le titre, l’échelle, la légende et la source"
+          },
+          {
+            "id": "c",
+            "label": "compter les couleurs"
+          },
+          {
+            "id": "d",
+            "label": "donner son opinion"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "tc-03",
+        "type": "single",
+        "prompt": "Une démocratie représentative repose notamment sur…",
+        "competencies": [
+          "emc"
+        ],
+        "domains": [
+          "histoire_geo"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "l’absence d’élections"
+          },
+          {
+            "id": "b",
+            "label": "la désignation de représentants par les citoyens"
+          },
+          {
+            "id": "c",
+            "label": "un parti unique obligatoire"
+          },
+          {
+            "id": "d",
+            "label": "la suppression des lois"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "tc-04",
+        "type": "single",
+        "prompt": "Un taux de variation de 25 % à 30 % correspond à…",
+        "competencies": [
+          "lecture_donnees"
+        ],
+        "domains": [
+          "histoire_geo"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "5 %"
+          },
+          {
+            "id": "b",
+            "label": "5 points et 20 % d’augmentation relative"
+          },
+          {
+            "id": "c",
+            "label": "20 points"
+          },
+          {
+            "id": "d",
+            "label": "30 %"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "tc-05",
+        "type": "single",
+        "prompt": "Dans une argumentation géographique, un changement d’échelle sert à…",
+        "competencies": [
+          "echelles"
+        ],
+        "domains": [
+          "histoire_geo"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "répéter la même information"
+          },
+          {
+            "id": "b",
+            "label": "comparer les phénomènes du local au mondial"
+          },
+          {
+            "id": "c",
+            "label": "éviter les exemples"
+          },
+          {
+            "id": "d",
+            "label": "remplacer les cartes"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "tc-06",
+        "type": "single",
+        "prompt": "Un document officiel doit être interrogé notamment sur…",
+        "competencies": [
+          "critique_source"
+        ],
+        "domains": [
+          "histoire_geo"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "son auteur, sa date, son contexte et son objectif"
+          },
+          {
+            "id": "b",
+            "label": "sa longueur seulement"
+          },
+          {
+            "id": "c",
+            "label": "la couleur du papier"
+          },
+          {
+            "id": "d",
+            "label": "le nombre de paragraphes"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "tc-07",
+        "type": "single",
+        "prompt": "L’unité de l’énergie dans le Système international est…",
+        "competencies": [
+          "energie"
+        ],
+        "domains": [
+          "enseignement_scientifique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "le watt"
+          },
+          {
+            "id": "b",
+            "label": "le joule"
+          },
+          {
+            "id": "c",
+            "label": "le volt"
+          },
+          {
+            "id": "d",
+            "label": "le kelvin"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "tc-08",
+        "type": "single",
+        "prompt": "Le watt mesure…",
+        "competencies": [
+          "energie"
+        ],
+        "domains": [
+          "enseignement_scientifique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "une énergie"
+          },
+          {
+            "id": "b",
+            "label": "une puissance"
+          },
+          {
+            "id": "c",
+            "label": "une masse"
+          },
+          {
+            "id": "d",
+            "label": "une température"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "tc-09",
+        "type": "single",
+        "prompt": "L’effet de serre naturel…",
+        "competencies": [
+          "climat"
+        ],
+        "domains": [
+          "enseignement_scientifique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "n’existe pas"
+          },
+          {
+            "id": "b",
+            "label": "contribue à rendre la Terre habitable, mais son renforcement modifie le climat"
+          },
+          {
+            "id": "c",
+            "label": "est uniquement dû à l’ozone"
+          },
+          {
+            "id": "d",
+            "label": "refroidit toujours la planète"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "tc-10",
+        "type": "single",
+        "prompt": "Une corrélation entre deux grandeurs expérimentales…",
+        "competencies": [
+          "demarche_scientifique"
+        ],
+        "domains": [
+          "enseignement_scientifique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "prouve toujours la causalité"
+          },
+          {
+            "id": "b",
+            "label": "doit être interprétée avec un modèle et des contrôles"
+          },
+          {
+            "id": "c",
+            "label": "est impossible"
+          },
+          {
+            "id": "d",
+            "label": "supprime l’incertitude"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "tc-11",
+        "type": "single",
+        "prompt": "Une mesure scientifique doit idéalement préciser…",
+        "competencies": [
+          "mesure"
+        ],
+        "domains": [
+          "enseignement_scientifique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "seulement le nombre obtenu"
+          },
+          {
+            "id": "b",
+            "label": "l’unité et une estimation de l’incertitude"
+          },
+          {
+            "id": "c",
+            "label": "le nom de l’élève uniquement"
+          },
+          {
+            "id": "d",
+            "label": "une opinion"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "tc-12",
+        "type": "single",
+        "prompt": "L’ADN porte une information sous forme…",
+        "competencies": [
+          "genetique"
+        ],
+        "domains": [
+          "enseignement_scientifique"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "d’une séquence de nucléotides"
+          },
+          {
+            "id": "b",
+            "label": "d’une température"
+          },
+          {
+            "id": "c",
+            "label": "d’une force"
+          },
+          {
+            "id": "d",
+            "label": "d’un signal sonore uniquement"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "tc-en-info",
+        "type": "information",
+        "prompt": "English reading text",
+        "competencies": [
+          "reading"
+        ],
+        "domains": [
+          "anglais"
+        ],
+        "maxPoints": 0,
+        "description": "A school introduced a weekly study-planning session. After three months, late assignments decreased, but the improvement was uneven. Students who reviewed their plans every Friday progressed more than those who only filled in the form once. The school therefore concluded that the tool itself was less important than the habit of revising decisions in light of new information.",
+        "required": true
+      },
+      {
+        "id": "tc-13",
+        "type": "single",
+        "prompt": "What changed after three months?",
+        "competencies": [
+          "reading_detail"
+        ],
+        "domains": [
+          "anglais"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "All students obtained the same grades."
+          },
+          {
+            "id": "b",
+            "label": "Late assignments decreased."
+          },
+          {
+            "id": "c",
+            "label": "The planning session was cancelled."
+          },
+          {
+            "id": "d",
+            "label": "Students stopped reviewing plans."
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "tc-14",
+        "type": "single",
+        "prompt": "Which students progressed more?",
+        "competencies": [
+          "reading_detail"
+        ],
+        "domains": [
+          "anglais"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "Those who never used a plan."
+          },
+          {
+            "id": "b",
+            "label": "Those who reviewed their plans weekly."
+          },
+          {
+            "id": "c",
+            "label": "Only the oldest students."
+          },
+          {
+            "id": "d",
+            "label": "Those who filled the form once."
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "tc-15",
+        "type": "single",
+        "prompt": "What is the main conclusion?",
+        "competencies": [
+          "reading_inference"
+        ],
+        "domains": [
+          "anglais"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "A form is sufficient by itself."
+          },
+          {
+            "id": "b",
+            "label": "Regular revision of decisions matters more than the tool alone."
+          },
+          {
+            "id": "c",
+            "label": "Planning has no effect."
+          },
+          {
+            "id": "d",
+            "label": "Friday is the best day for exams."
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "tc-16",
+        "type": "single",
+        "prompt": "In the text, “uneven” is closest to…",
+        "competencies": [
+          "vocabulary"
+        ],
+        "domains": [
+          "anglais"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "identical"
+          },
+          {
+            "id": "b",
+            "label": "not equal or consistent"
+          },
+          {
+            "id": "c",
+            "label": "impossible"
+          },
+          {
+            "id": "d",
+            "label": "immediate"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "tc-17",
+        "type": "single",
+        "prompt": "Choose the correct sentence.",
+        "competencies": [
+          "grammar"
+        ],
+        "domains": [
+          "anglais"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "Students has improved."
+          },
+          {
+            "id": "b",
+            "label": "Students have improved."
+          },
+          {
+            "id": "c",
+            "label": "Students is improving yesterday."
+          },
+          {
+            "id": "d",
+            "label": "Students have improve."
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "tc-18",
+        "type": "single",
+        "prompt": "Choose the most appropriate connector: “The tool was simple; ___, it became useful only when students reviewed it regularly.”",
+        "competencies": [
+          "connectors"
+        ],
+        "domains": [
+          "anglais"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "however"
+          },
+          {
+            "id": "b",
+            "label": "because of"
+          },
+          {
+            "id": "c",
+            "label": "unless"
+          },
+          {
+            "id": "d",
+            "label": "during"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "tc-19",
+        "type": "long",
+        "prompt": "Write 120–160 words in English: explain one study habit you need to change and how you will measure progress.",
+        "competencies": [
+          "writing",
+          "argumentation"
+        ],
+        "domains": [
+          "anglais"
+        ],
+        "maxPoints": 10,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 160
+      },
+      {
+        "id": "tc-20",
+        "type": "single",
+        "prompt": "Choisissez votre LVB.",
+        "competencies": [
+          "langues"
+        ],
+        "domains": [
+          "lvb"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Arabe"
+          },
+          {
+            "id": "b",
+            "label": "Espagnol"
+          },
+          {
+            "id": "c",
+            "label": "Allemand"
+          },
+          {
+            "id": "d",
+            "label": "Italien"
+          },
+          {
+            "id": "e",
+            "label": "Autre"
+          },
+          {
+            "id": "f",
+            "label": "Aucune / à confirmer"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "tc-21",
+        "type": "upload",
+        "prompt": "Déposez un enregistrement de 90 secondes dans votre LVB : présentez-vous et expliquez votre projet pour l’année.",
+        "competencies": [
+          "expression_orale"
+        ],
+        "domains": [
+          "lvb"
+        ],
+        "maxPoints": 8,
+        "required": false,
+        "manualReview": true,
+        "uploadRule": {
+          "category": "ORAL_RECORDING",
+          "accept": [
+            "audio/mpeg",
+            "audio/mp4",
+            "audio/webm",
+            "video/mp4",
+            "video/webm"
+          ],
+          "maxFiles": 1,
+          "maxBytesPerFile": 41943040,
+          "required": false,
+          "help": "Facultatif tant que la LVB n’est pas confirmée."
+        }
+      },
+      {
+        "id": "tc-22",
+        "type": "single",
+        "prompt": "En philosophie, définir un terme du sujet sert à…",
+        "competencies": [
+          "conceptualisation"
+        ],
+        "domains": [
+          "philosophie"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "réciter le dictionnaire"
+          },
+          {
+            "id": "b",
+            "label": "fixer le sens pertinent et faire apparaître une difficulté"
+          },
+          {
+            "id": "c",
+            "label": "éviter la problématique"
+          },
+          {
+            "id": "d",
+            "label": "annoncer seulement un auteur"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "tc-23",
+        "type": "single",
+        "prompt": "Une objection dans une dissertation sert à…",
+        "competencies": [
+          "argumentation"
+        ],
+        "domains": [
+          "philosophie"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "détruire tout raisonnement"
+          },
+          {
+            "id": "b",
+            "label": "tester et nuancer une thèse"
+          },
+          {
+            "id": "c",
+            "label": "changer de sujet"
+          },
+          {
+            "id": "d",
+            "label": "remplacer les arguments"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "tc-24",
+        "type": "long",
+        "prompt": "Analysez le sujet : « Être libre, est-ce faire tout ce que l’on veut ? » Définissez les termes et formulez un problème.",
+        "competencies": [
+          "analyse_sujet",
+          "problematique"
+        ],
+        "domains": [
+          "philosophie"
+        ],
+        "maxPoints": 12,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 320
+      },
+      {
+        "id": "tc-25",
+        "type": "long",
+        "prompt": "Rédigez un argument et une objection sur l’affirmation : « La technique nous rend plus libres. »",
+        "competencies": [
+          "argument",
+          "objection"
+        ],
+        "domains": [
+          "philosophie"
+        ],
+        "maxPoints": 10,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 280
+      },
+      {
+        "id": "tc-26",
+        "type": "long",
+        "prompt": "Décrivez votre méthode habituelle pour apprendre un chapitre d’histoire-géographie ou de philosophie.",
+        "competencies": [
+          "methodes"
+        ],
+        "domains": [
+          "methodes_tronc_commun"
+        ],
+        "maxPoints": 4,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 180
+      }
+    ],
+    "scoreDomains": [
+      "histoire_geo",
+      "enseignement_scientifique",
+      "anglais",
+      "lvb",
+      "philosophie"
+    ],
+    "requiredForSubmission": true
+  },
+  {
+    "key": "grand-oral",
+    "title": "Grand oral : question, structure et prestation",
+    "shortTitle": "Grand oral",
+    "description": "Évaluer la capacité à construire une question, organiser un exposé et répondre sans récitation intégrale.",
+    "audience": "ELEVE",
+    "kind": "oral",
+    "estimatedMinutes": 45,
+    "timed": true,
+    "prerequisites": [
+      "profil-parcours"
+    ],
+    "instructions": [
+      "L’enregistrement doit être réalisé en une prise.",
+      "La qualité technique de la vidéo n’est pas notée."
+    ],
+    "questions": [
+      {
+        "id": "go-01",
+        "type": "single",
+        "prompt": "Avez-vous déjà préparé deux questions adossées à vos spécialités ?",
+        "competencies": [
+          "grand_oral"
+        ],
+        "domains": [
+          "grand_oral"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Oui, elles sont stabilisées"
+          },
+          {
+            "id": "b",
+            "label": "Oui, mais elles doivent être retravaillées"
+          },
+          {
+            "id": "c",
+            "label": "J’ai seulement des thèmes"
+          },
+          {
+            "id": "d",
+            "label": "Non"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "go-02",
+        "type": "single",
+        "prompt": "Une bonne question de Grand oral doit surtout…",
+        "competencies": [
+          "grand_oral"
+        ],
+        "domains": [
+          "grand_oral"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "être très large"
+          },
+          {
+            "id": "b",
+            "label": "permettre une démonstration personnelle et structurée liée aux spécialités"
+          },
+          {
+            "id": "c",
+            "label": "appeler une réponse par oui/non seulement"
+          },
+          {
+            "id": "d",
+            "label": "être copiée d’un sujet trouvé en ligne"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "go-03",
+        "type": "single",
+        "prompt": "Pendant l’exposé, un exemple sert à…",
+        "competencies": [
+          "grand_oral"
+        ],
+        "domains": [
+          "grand_oral"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "remplacer l’argument"
+          },
+          {
+            "id": "b",
+            "label": "rendre concret et étayer le raisonnement"
+          },
+          {
+            "id": "c",
+            "label": "gagner du temps seulement"
+          },
+          {
+            "id": "d",
+            "label": "éviter les notions du programme"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "go-04",
+        "type": "single",
+        "prompt": "Face à une question imprévue du jury, la meilleure stratégie est…",
+        "competencies": [
+          "grand_oral"
+        ],
+        "domains": [
+          "grand_oral"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "inventer une réponse"
+          },
+          {
+            "id": "b",
+            "label": "reformuler, raisonner à voix haute et reconnaître précisément une limite"
+          },
+          {
+            "id": "c",
+            "label": "rester silencieux"
+          },
+          {
+            "id": "d",
+            "label": "changer de sujet"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "go-05",
+        "type": "single",
+        "prompt": "Quel est votre niveau actuel de stress à l’oral ?",
+        "competencies": [
+          "grand_oral"
+        ],
+        "domains": [
+          "grand_oral"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "0 à 2 / 10"
+          },
+          {
+            "id": "b",
+            "label": "3 à 4 / 10"
+          },
+          {
+            "id": "c",
+            "label": "5 à 6 / 10"
+          },
+          {
+            "id": "d",
+            "label": "7 à 8 / 10"
+          },
+          {
+            "id": "e",
+            "label": "9 à 10 / 10"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "go-06",
+        "type": "long",
+        "prompt": "Proposez deux questions possibles : une liée à chacune de vos spécialités ou une question transversale clairement justifiée.",
+        "competencies": [
+          "choix_question",
+          "ancrage_programme"
+        ],
+        "domains": [
+          "grand_oral"
+        ],
+        "maxPoints": 8,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 250
+      },
+      {
+        "id": "go-07",
+        "type": "long",
+        "prompt": "Pour votre meilleure question, rédigez une problématique et un plan en trois mouvements.",
+        "competencies": [
+          "problematique",
+          "structure"
+        ],
+        "domains": [
+          "grand_oral"
+        ],
+        "maxPoints": 10,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 350
+      },
+      {
+        "id": "go-08",
+        "type": "upload",
+        "prompt": "Déposez un exposé vidéo de 5 minutes, sans lire un texte intégral.",
+        "competencies": [
+          "oral",
+          "posture",
+          "structure",
+          "precision"
+        ],
+        "domains": [
+          "grand_oral"
+        ],
+        "maxPoints": 20,
+        "required": true,
+        "manualReview": true,
+        "uploadRule": {
+          "category": "ORAL_RECORDING",
+          "accept": [
+            "video/mp4",
+            "video/webm"
+          ],
+          "maxFiles": 1,
+          "maxBytesPerFile": 125829120,
+          "required": true,
+          "help": "Cadrez le buste et le visage, sans montage."
+        }
+      },
+      {
+        "id": "go-09",
+        "type": "short",
+        "prompt": "Après l’enregistrement, indiquez une force observable.",
+        "competencies": [
+          "auto_evaluation"
+        ],
+        "domains": [
+          "grand_oral"
+        ],
+        "maxPoints": 2,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 80
+      },
+      {
+        "id": "go-10",
+        "type": "short",
+        "prompt": "Après l’enregistrement, indiquez une priorité de progrès.",
+        "competencies": [
+          "auto_evaluation"
+        ],
+        "domains": [
+          "grand_oral"
+        ],
+        "maxPoints": 2,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 80
+      },
+      {
+        "id": "go-11",
+        "type": "single",
+        "prompt": "Avez-vous lu un texte pendant plus d’un tiers de l’exposé ?",
+        "competencies": [
+          "integrite_oral"
+        ],
+        "domains": [
+          "grand_oral"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Non"
+          },
+          {
+            "id": "b",
+            "label": "Oui, ponctuellement"
+          },
+          {
+            "id": "c",
+            "label": "Oui, la plupart du temps"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "go-12",
+        "type": "single",
+        "prompt": "Quel temps de préparation hebdomadaire êtes-vous prêt à consacrer au Grand oral ?",
+        "competencies": [
+          "engagement"
+        ],
+        "domains": [
+          "grand_oral"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Moins de 30 min"
+          },
+          {
+            "id": "b",
+            "label": "30 à 60 min"
+          },
+          {
+            "id": "c",
+            "label": "1 à 2 h"
+          },
+          {
+            "id": "d",
+            "label": "Plus de 2 h"
+          }
+        ],
+        "required": true
+      }
+    ],
+    "scoreDomains": [
+      "grand_oral"
+    ],
+    "requiredForSubmission": true
+  },
+  {
+    "key": "potentiel-t0",
+    "title": "Prétest T0 : raisonnement et transfert",
+    "shortTitle": "Prétest T0",
+    "description": "Mesure initiale sur des notions de proportion, condition, probabilité et preuve avant une micro-remédiation.",
+    "audience": "ELEVE",
+    "kind": "learning-potential",
+    "estimatedMinutes": 25,
+    "timed": true,
+    "prerequisites": [
+      "autonomie-methodes"
+    ],
+    "instructions": [
+      "Ne cherchez pas de cours pendant le prétest.",
+      "La progression entre T0 et T1 compte autant que le niveau initial."
+    ],
+    "questions": [
+      {
+        "id": "t0-01",
+        "type": "single",
+        "prompt": "Une classe compte 40 % de filles. Parmi les filles, 30 % pratiquent un sport en club. Quelle proportion de la classe est composée de filles pratiquant un sport en club ?",
+        "competencies": [
+          "proportion_composee"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "12 %"
+          },
+          {
+            "id": "b",
+            "label": "30 %"
+          },
+          {
+            "id": "c",
+            "label": "40 %"
+          },
+          {
+            "id": "d",
+            "label": "70 %"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "t0-02",
+        "type": "single",
+        "prompt": "Un test est positif chez 90 % des personnes malades et chez 10 % des personnes non malades. Peut-on déterminer P(malade | positif) sans connaître la fréquence de la maladie ?",
+        "competencies": [
+          "probabilite_inverse"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "Oui, toujours 90 %"
+          },
+          {
+            "id": "b",
+            "label": "Non, il manque la prévalence"
+          },
+          {
+            "id": "c",
+            "label": "Oui, toujours 50 %"
+          },
+          {
+            "id": "d",
+            "label": "Non, car les probabilités sont interdites"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "t0-03",
+        "type": "single",
+        "prompt": "Si A implique B et B est faux, que peut-on conclure ?",
+        "competencies": [
+          "contraposition"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "A est vrai"
+          },
+          {
+            "id": "b",
+            "label": "A est faux"
+          },
+          {
+            "id": "c",
+            "label": "B implique A"
+          },
+          {
+            "id": "d",
+            "label": "Rien sur A"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "t0-04",
+        "type": "single",
+        "prompt": "Une quantité augmente de 10 %, puis baisse de 10 %. Le résultat final est…",
+        "competencies": [
+          "evolutions_successives"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "identique"
+          },
+          {
+            "id": "b",
+            "label": "1 % plus faible"
+          },
+          {
+            "id": "c",
+            "label": "1 % plus élevé"
+          },
+          {
+            "id": "d",
+            "label": "20 % plus faible"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "t0-05",
+        "type": "single",
+        "prompt": "Dans un groupe, 60 % parlent anglais, 35 % parlent espagnol et 20 % parlent les deux. Quelle proportion parle au moins une des deux langues ?",
+        "competencies": [
+          "union"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "75 %"
+          },
+          {
+            "id": "b",
+            "label": "95 %"
+          },
+          {
+            "id": "c",
+            "label": "115 %"
+          },
+          {
+            "id": "d",
+            "label": "20 %"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "t0-06",
+        "type": "single",
+        "prompt": "Une moyenne passe de 8 à 10. L’augmentation relative est…",
+        "competencies": [
+          "taux_evolution"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "2 %"
+          },
+          {
+            "id": "b",
+            "label": "20 %"
+          },
+          {
+            "id": "c",
+            "label": "25 %"
+          },
+          {
+            "id": "d",
+            "label": "80 %"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "t0-07",
+        "type": "single",
+        "prompt": "La phrase « Tous les élèves qui révisent réussissent » est contredite par…",
+        "competencies": [
+          "contre_exemple"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "un élève qui ne révise pas et échoue"
+          },
+          {
+            "id": "b",
+            "label": "un élève qui révise et échoue"
+          },
+          {
+            "id": "c",
+            "label": "un élève qui révise et réussit"
+          },
+          {
+            "id": "d",
+            "label": "un élève qui ne révise pas et réussit"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "t0-08",
+        "type": "single",
+        "prompt": "Un tableau montre une hausse simultanée de l’usage d’une application et des résultats. Quelle conclusion est la plus rigoureuse ?",
+        "competencies": [
+          "correlation_causalite"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "L’application cause nécessairement la hausse"
+          },
+          {
+            "id": "b",
+            "label": "Il existe une association, mais des facteurs confondants sont possibles"
+          },
+          {
+            "id": "c",
+            "label": "La hausse est fausse"
+          },
+          {
+            "id": "d",
+            "label": "Aucune analyse n’est possible"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "t0-09",
+        "type": "single",
+        "prompt": "Si 3 objets coûtent 18 DT au même prix unitaire, 7 objets coûtent…",
+        "competencies": [
+          "proportionnalite"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "24 DT"
+          },
+          {
+            "id": "b",
+            "label": "36 DT"
+          },
+          {
+            "id": "c",
+            "label": "42 DT"
+          },
+          {
+            "id": "d",
+            "label": "54 DT"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "t0-10",
+        "type": "single",
+        "prompt": "Une règle fonctionne pour 5 exemples testés. Cela prouve-t-il qu’elle fonctionne toujours ?",
+        "competencies": [
+          "preuve"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "Oui"
+          },
+          {
+            "id": "b",
+            "label": "Non, il faut une preuve ou un test exhaustif adapté"
+          },
+          {
+            "id": "c",
+            "label": "Oui si les exemples sont simples"
+          },
+          {
+            "id": "d",
+            "label": "Non seulement en mathématiques"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      }
+    ],
+    "scoreDomains": [
+      "potentiel_apprentissage"
+    ],
+    "requiredForSubmission": true
+  },
+  {
+    "key": "micro-remediation",
+    "title": "Micro-remédiation explicite",
+    "shortTitle": "Micro-leçon",
+    "description": "Enseignement court, ciblé et contrôlé avant un post-test parallèle.",
+    "audience": "ELEVE",
+    "kind": "learning-potential",
+    "estimatedMinutes": 20,
+    "timed": false,
+    "prerequisites": [
+      "potentiel-t0"
+    ],
+    "instructions": [
+      "Prenez des notes.",
+      "Vous pourrez consulter cette leçon pendant 20 minutes, puis elle sera masquée au début de T1."
+    ],
+    "questions": [
+      {
+        "id": "rem-info",
+        "type": "information",
+        "prompt": "Micro-leçon guidée",
+        "competencies": [
+          "apprentissage_explicite"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 0,
+        "description": "Micro-leçon — Quatre idées à maîtriser :\n1. Une proportion conditionnelle P(B|A) décrit B parmi les cas où A est réalisé. Pour remonter de P(B|A) à P(A|B), il faut aussi connaître la fréquence de A.\n2. Deux évolutions successives se composent par multiplication des coefficients : +10 % puis −10 % donne 1,10 × 0,90 = 0,99.\n3. Pour réfuter « pour tout x, P(x) », un seul contre-exemple suffit.\n4. Une corrélation ne prouve pas une causalité : il faut examiner la temporalité, un mécanisme et les facteurs confondants.",
+        "required": true
+      },
+      {
+        "id": "rem-01",
+        "type": "acknowledgement",
+        "prompt": "J’ai lu la micro-leçon et refait les quatre exemples sur papier.",
+        "competencies": [
+          "engagement"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 0,
+        "required": true
+      },
+      {
+        "id": "rem-02",
+        "type": "short",
+        "prompt": "Formulez avec vos mots une différence entre P(B|A) et P(A|B).",
+        "competencies": [
+          "explication"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 4,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 100
+      }
+    ],
+    "scoreDomains": [
+      "potentiel_apprentissage"
+    ],
+    "requiredForSubmission": true
+  },
+  {
+    "key": "potentiel-t1",
+    "title": "Post-test T1 : apprentissage immédiat",
+    "shortTitle": "Post-test T1",
+    "description": "Test parallèle pour mesurer le gain après une micro-remédiation explicite.",
+    "audience": "ELEVE",
+    "kind": "learning-potential",
+    "estimatedMinutes": 25,
+    "timed": true,
+    "prerequisites": [
+      "micro-remediation"
+    ],
+    "instructions": [
+      "La micro-leçon n’est plus consultable pendant ce test.",
+      "Répondez sans aide."
+    ],
+    "questions": [
+      {
+        "id": "t1-01",
+        "type": "single",
+        "prompt": "Dans un établissement, 50 % des élèves sont demi-pensionnaires. Parmi eux, 24 % prennent le bus. Quelle proportion de tous les élèves est demi-pensionnaire et prend le bus ?",
+        "competencies": [
+          "proportion_composee"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "12 %"
+          },
+          {
+            "id": "b",
+            "label": "24 %"
+          },
+          {
+            "id": "c",
+            "label": "50 %"
+          },
+          {
+            "id": "d",
+            "label": "74 %"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "t1-02",
+        "type": "single",
+        "prompt": "Un contrôle signale une fraude chez 80 % des fraudeurs et chez 5 % des non-fraudeurs. Pour calculer la probabilité qu’un élève signalé soit réellement fraudeur, il faut aussi connaître…",
+        "competencies": [
+          "probabilite_inverse"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "le nombre de questions"
+          },
+          {
+            "id": "b",
+            "label": "la fréquence initiale de la fraude"
+          },
+          {
+            "id": "c",
+            "label": "la durée du contrôle seulement"
+          },
+          {
+            "id": "d",
+            "label": "le nom du surveillant"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "t1-03",
+        "type": "single",
+        "prompt": "Si P implique Q et Q est faux, alors…",
+        "competencies": [
+          "contraposition"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "P est faux"
+          },
+          {
+            "id": "b",
+            "label": "P est vrai"
+          },
+          {
+            "id": "c",
+            "label": "Q implique P"
+          },
+          {
+            "id": "d",
+            "label": "aucune conclusion logique"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "t1-04",
+        "type": "single",
+        "prompt": "Une quantité baisse de 20 %, puis augmente de 20 %. Elle devient…",
+        "competencies": [
+          "evolutions_successives"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "identique"
+          },
+          {
+            "id": "b",
+            "label": "4 % plus faible"
+          },
+          {
+            "id": "c",
+            "label": "4 % plus élevée"
+          },
+          {
+            "id": "d",
+            "label": "40 % plus faible"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "t1-05",
+        "type": "single",
+        "prompt": "70 % utilisent A, 40 % utilisent B et 25 % utilisent les deux. Quelle proportion utilise A ou B ?",
+        "competencies": [
+          "union"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "85 %"
+          },
+          {
+            "id": "b",
+            "label": "110 %"
+          },
+          {
+            "id": "c",
+            "label": "45 %"
+          },
+          {
+            "id": "d",
+            "label": "25 %"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "t1-06",
+        "type": "single",
+        "prompt": "Un score passe de 12 à 15. Le taux d’augmentation est…",
+        "competencies": [
+          "taux_evolution"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "3 %"
+          },
+          {
+            "id": "b",
+            "label": "20 %"
+          },
+          {
+            "id": "c",
+            "label": "25 %"
+          },
+          {
+            "id": "d",
+            "label": "30 %"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "t1-07",
+        "type": "single",
+        "prompt": "La phrase « Tout nombre pair est divisible par 4 » est réfutée par…",
+        "competencies": [
+          "contre_exemple"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "2"
+          },
+          {
+            "id": "b",
+            "label": "4"
+          },
+          {
+            "id": "c",
+            "label": "8"
+          },
+          {
+            "id": "d",
+            "label": "12"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "t1-08",
+        "type": "single",
+        "prompt": "Après l’installation d’un tutorat, les notes augmentent. Quelle vérification renforce le plus l’hypothèse causale ?",
+        "competencies": [
+          "correlation_causalite"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "les élèves aiment le logo"
+          },
+          {
+            "id": "b",
+            "label": "comparer à un groupe similaire sans tutorat et contrôler les différences initiales"
+          },
+          {
+            "id": "c",
+            "label": "mesurer une seule note"
+          },
+          {
+            "id": "d",
+            "label": "demander à un élève"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "t1-09",
+        "type": "single",
+        "prompt": "5 cahiers coûtent 35 DT au même prix. 8 cahiers coûtent…",
+        "competencies": [
+          "proportionnalite"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "40 DT"
+          },
+          {
+            "id": "b",
+            "label": "48 DT"
+          },
+          {
+            "id": "c",
+            "label": "56 DT"
+          },
+          {
+            "id": "d",
+            "label": "64 DT"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "t1-10",
+        "type": "single",
+        "prompt": "Pourquoi plusieurs exemples favorables ne suffisent-ils pas toujours à prouver une règle générale ?",
+        "competencies": [
+          "preuve"
+        ],
+        "domains": [
+          "potentiel_apprentissage"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "Un cas non testé peut la contredire"
+          },
+          {
+            "id": "b",
+            "label": "Les exemples sont interdits"
+          },
+          {
+            "id": "c",
+            "label": "Une règle générale est toujours fausse"
+          },
+          {
+            "id": "d",
+            "label": "Les calculs ne servent à rien"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      }
+    ],
+    "scoreDomains": [
+      "potentiel_apprentissage"
+    ],
+    "requiredForSubmission": true
+  },
+  {
+    "key": "retention-transfert",
+    "title": "Rétention et transfert différé",
+    "shortTitle": "Rétention 72 h",
+    "description": "Mesure la stabilité après plusieurs jours et la capacité à transférer les principes dans une situation nouvelle.",
+    "audience": "ELEVE",
+    "kind": "learning-potential",
+    "estimatedMinutes": 30,
+    "timed": true,
+    "prerequisites": [
+      "potentiel-t1"
+    ],
+    "instructions": [
+      "Ce module s’ouvre normalement 72 heures après T1.",
+      "Ne relisez pas la micro-leçon avant de répondre."
+    ],
+    "questions": [
+      {
+        "id": "ret-01",
+        "type": "single",
+        "prompt": "Une population baisse de 15 %, puis augmente de 15 %. Le coefficient global vaut…",
+        "competencies": [
+          "evolutions_successives"
+        ],
+        "domains": [
+          "retention"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "1"
+          },
+          {
+            "id": "b",
+            "label": "0,9775"
+          },
+          {
+            "id": "c",
+            "label": "1,0225"
+          },
+          {
+            "id": "d",
+            "label": "0,70"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ret-02",
+        "type": "single",
+        "prompt": "Pour calculer une probabilité inverse après un test, quelle donnée est indispensable en plus des sensibilités ?",
+        "competencies": [
+          "probabilite_inverse"
+        ],
+        "domains": [
+          "retention"
+        ],
+        "maxPoints": 2,
+        "options": [
+          {
+            "id": "a",
+            "label": "la prévalence du phénomène"
+          },
+          {
+            "id": "b",
+            "label": "la couleur du test"
+          },
+          {
+            "id": "c",
+            "label": "le nombre de pages"
+          },
+          {
+            "id": "d",
+            "label": "le nom du candidat"
+          }
+        ],
+        "required": true,
+        "allowNotStudied": true
+      },
+      {
+        "id": "ret-03",
+        "type": "short",
+        "prompt": "Donnez un contre-exemple à : « si n² est multiple de 4, alors n est multiple de 4 ».",
+        "competencies": [
+          "contre_exemple"
+        ],
+        "domains": [
+          "retention"
+        ],
+        "maxPoints": 4,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 80
+      },
+      {
+        "id": "ret-04",
+        "type": "short",
+        "prompt": "Expliquez en deux phrases pourquoi une corrélation temporelle ne suffit pas à établir une causalité.",
+        "competencies": [
+          "correlation_causalite"
+        ],
+        "domains": [
+          "retention"
+        ],
+        "maxPoints": 4,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 100
+      },
+      {
+        "id": "ret-05",
+        "type": "short",
+        "prompt": "Une enquête observe que les élèves qui lisent davantage ont de meilleures notes. Citez un facteur confondant plausible.",
+        "competencies": [
+          "facteur_confondu"
+        ],
+        "domains": [
+          "transfert"
+        ],
+        "maxPoints": 4,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 80
+      },
+      {
+        "id": "ret-06",
+        "type": "numeric",
+        "prompt": "Parmi 1 000 personnes, 10 sont malades. Un test détecte 9 malades et signale à tort 99 personnes saines. Parmi les tests positifs, quelle proportion environ est réellement malade ?",
+        "competencies": [
+          "probabilite_inverse"
+        ],
+        "domains": [
+          "transfert"
+        ],
+        "maxPoints": 6,
+        "min": 0,
+        "max": 100,
+        "step": 0.1,
+        "required": true
+      },
+      {
+        "id": "ret-07",
+        "type": "long",
+        "prompt": "Dans votre propre travail scolaire, donnez un exemple où mesurer un indicateur sans examiner sa qualité pourrait conduire à une mauvaise décision.",
+        "competencies": [
+          "transfert",
+          "esprit_critique"
+        ],
+        "domains": [
+          "transfert"
+        ],
+        "maxPoints": 8,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 180
+      },
+      {
+        "id": "ret-08",
+        "type": "long",
+        "prompt": "Sans relire la leçon, indiquez l’idée que vous avez le mieux retenue et celle qui reste fragile.",
+        "competencies": [
+          "metacognition",
+          "retention"
+        ],
+        "domains": [
+          "retention"
+        ],
+        "maxPoints": 4,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 150
+      }
+    ],
+    "scoreDomains": [
+      "retention",
+      "transfert"
+    ],
+    "requiredForSubmission": true,
+    "unlockDelayHours": 72
+  },
+  {
+    "key": "documents",
+    "title": "Dossier documentaire et pièces officielles",
+    "shortTitle": "Documents",
+    "description": "Réunir les pièces nécessaires pour vérifier la situation scolaire, les notes et l’inscription.",
+    "audience": "ELEVE",
+    "kind": "documents",
+    "estimatedMinutes": 30,
+    "timed": false,
+    "prerequisites": [
+      "accueil-integrite"
+    ],
+    "instructions": [
+      "Les documents sont stockés hors du dossier public.",
+      "Masquez les informations sans rapport avec le diagnostic si nécessaire.",
+      "Un document reçu n’est considéré authentifié qu’après contrôle Nexus."
+    ],
+    "questions": [
+      {
+        "id": "doc-01",
+        "type": "upload",
+        "prompt": "Pièce d’identité du candidat",
+        "competencies": [
+          "integrite_documentaire"
+        ],
+        "domains": [
+          "documents"
+        ],
+        "maxPoints": 0,
+        "required": true,
+        "manualReview": true,
+        "uploadRule": {
+          "category": "IDENTITY",
+          "accept": [
+            "application/pdf",
+            "image/jpeg",
+            "image/png",
+            "image/webp"
+          ],
+          "maxFiles": 1,
+          "maxBytesPerFile": 12582912,
+          "required": true,
+          "help": "Carte d’identité ou passeport lisible."
+        }
+      },
+      {
+        "id": "doc-02",
+        "type": "upload",
+        "prompt": "Récapitulatif d’inscription Cyclades",
+        "competencies": [
+          "integrite_documentaire"
+        ],
+        "domains": [
+          "documents"
+        ],
+        "maxPoints": 0,
+        "required": true,
+        "manualReview": true,
+        "uploadRule": {
+          "category": "CYCLADES",
+          "accept": [
+            "application/pdf",
+            "image/jpeg",
+            "image/png",
+            "image/webp"
+          ],
+          "maxFiles": 1,
+          "maxBytesPerFile": 12582912,
+          "required": true,
+          "help": "Toutes les pages, avec session et options."
+        }
+      },
+      {
+        "id": "doc-03",
+        "type": "upload",
+        "prompt": "Relevé officiel des notes du baccalauréat français 2026",
+        "competencies": [
+          "integrite_documentaire"
+        ],
+        "domains": [
+          "documents"
+        ],
+        "maxPoints": 0,
+        "required": true,
+        "manualReview": true,
+        "uploadRule": {
+          "category": "FRENCH_BAC_TRANSCRIPT",
+          "accept": [
+            "application/pdf",
+            "image/jpeg",
+            "image/png",
+            "image/webp"
+          ],
+          "maxFiles": 1,
+          "maxBytesPerFile": 12582912,
+          "required": true,
+          "help": "Document officiel complet."
+        }
+      },
+      {
+        "id": "doc-04",
+        "type": "upload",
+        "prompt": "Relevé officiel du baccalauréat tunisien 2026",
+        "competencies": [
+          "integrite_documentaire"
+        ],
+        "domains": [
+          "documents"
+        ],
+        "maxPoints": 0,
+        "required": true,
+        "manualReview": true,
+        "uploadRule": {
+          "category": "TUNISIAN_BAC_TRANSCRIPT",
+          "accept": [
+            "application/pdf",
+            "image/jpeg",
+            "image/png",
+            "image/webp"
+          ],
+          "maxFiles": 1,
+          "maxBytesPerFile": 12582912,
+          "required": true,
+          "help": "Relevé ou attestation officielle."
+        }
+      },
+      {
+        "id": "doc-05",
+        "type": "upload",
+        "prompt": "Bulletins de l’année 2025/2026",
+        "competencies": [
+          "integrite_documentaire"
+        ],
+        "domains": [
+          "documents"
+        ],
+        "maxPoints": 0,
+        "required": true,
+        "manualReview": true,
+        "uploadRule": {
+          "category": "SCHOOL_REPORT",
+          "accept": [
+            "application/pdf",
+            "image/jpeg",
+            "image/png",
+            "image/webp"
+          ],
+          "maxFiles": 5,
+          "maxBytesPerFile": 12582912,
+          "required": true,
+          "help": "Un PDF par trimestre ou un fichier fusionné."
+        }
+      },
+      {
+        "id": "doc-06",
+        "type": "upload",
+        "prompt": "Copies d’épreuves françaises disponibles",
+        "competencies": [
+          "integrite_documentaire"
+        ],
+        "domains": [
+          "documents"
+        ],
+        "maxPoints": 0,
+        "required": false,
+        "manualReview": true,
+        "uploadRule": {
+          "category": "WRITTEN_COPY",
+          "accept": [
+            "application/pdf",
+            "image/jpeg",
+            "image/png",
+            "image/webp"
+          ],
+          "maxFiles": 5,
+          "maxBytesPerFile": 12582912,
+          "required": false,
+          "help": "Français, mathématiques, spécialités ou autres."
+        }
+      },
+      {
+        "id": "doc-07",
+        "type": "upload",
+        "prompt": "Décision d’aménagement d’examen",
+        "competencies": [
+          "integrite_documentaire"
+        ],
+        "domains": [
+          "documents"
+        ],
+        "maxPoints": 0,
+        "required": false,
+        "manualReview": true,
+        "uploadRule": {
+          "category": "EXAM_ACCOMMODATION",
+          "accept": [
+            "application/pdf",
+            "image/jpeg",
+            "image/png",
+            "image/webp"
+          ],
+          "maxFiles": 1,
+          "maxBytesPerFile": 12582912,
+          "required": false,
+          "help": "Uniquement si applicable."
+        }
+      },
+      {
+        "id": "doc-08",
+        "type": "upload",
+        "prompt": "Anciennes évaluations significatives",
+        "competencies": [
+          "integrite_documentaire"
+        ],
+        "domains": [
+          "documents"
+        ],
+        "maxPoints": 0,
+        "required": false,
+        "manualReview": true,
+        "uploadRule": {
+          "category": "WRITTEN_COPY",
+          "accept": [
+            "application/pdf",
+            "image/jpeg",
+            "image/png",
+            "image/webp"
+          ],
+          "maxFiles": 5,
+          "maxBytesPerFile": 12582912,
+          "required": false,
+          "help": "Copies représentatives, bonnes ou faibles."
+        }
+      },
+      {
+        "id": "doc-09",
+        "type": "upload",
+        "prompt": "Autre document utile",
+        "competencies": [
+          "integrite_documentaire"
+        ],
+        "domains": [
+          "documents"
+        ],
+        "maxPoints": 0,
+        "required": false,
+        "manualReview": true,
+        "uploadRule": {
+          "category": "OTHER",
+          "accept": [
+            "application/pdf",
+            "image/jpeg",
+            "image/png",
+            "image/webp"
+          ],
+          "maxFiles": 1,
+          "maxBytesPerFile": 12582912,
+          "required": false,
+          "help": "Attestation, emploi du temps, justificatif pertinent."
+        }
+      }
+    ],
+    "scoreDomains": [
+      "documents"
+    ],
+    "requiredForSubmission": true
+  },
+  {
+    "key": "validation-finale",
+    "title": "Vérification et soumission finale",
+    "shortTitle": "Finalisation",
+    "description": "Contrôler l’intégrité du dossier et transmettre le diagnostic à l’équipe pédagogique.",
+    "audience": "ELEVE",
+    "kind": "review",
+    "estimatedMinutes": 15,
+    "timed": false,
+    "prerequisites": [
+      "francais-academique",
+      "mathematiques",
+      "nsi",
+      "ses",
+      "tronc-commun",
+      "grand-oral",
+      "autonomie-methodes",
+      "potentiel-t1",
+      "documents"
+    ],
+    "instructions": [
+      "Vérifiez les modules incomplets avant de soumettre.",
+      "Le module de rétention peut rester programmé si le responsable autorise une pré-soumission."
+    ],
+    "questions": [
+      {
+        "id": "final-01",
+        "type": "acknowledgement",
+        "prompt": "J’ai vérifié que mes réponses sont complètes et sincères.",
+        "competencies": [
+          "integrite"
+        ],
+        "domains": [
+          "validation"
+        ],
+        "maxPoints": 0,
+        "required": true
+      },
+      {
+        "id": "final-02",
+        "type": "acknowledgement",
+        "prompt": "Je comprends qu’une soumission finale verrouille les modules académiques.",
+        "competencies": [
+          "consentement"
+        ],
+        "domains": [
+          "validation"
+        ],
+        "maxPoints": 0,
+        "required": true
+      },
+      {
+        "id": "final-03",
+        "type": "acknowledgement",
+        "prompt": "J’accepte qu’un enseignant corrige mes productions écrites et orales.",
+        "competencies": [
+          "consentement"
+        ],
+        "domains": [
+          "validation"
+        ],
+        "maxPoints": 0,
+        "required": true
+      },
+      {
+        "id": "final-04",
+        "type": "single",
+        "prompt": "Quelle épreuve vous paraît avoir le mieux reflété votre niveau réel ?",
+        "competencies": [
+          "metacognition"
+        ],
+        "domains": [
+          "validation"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Français"
+          },
+          {
+            "id": "b",
+            "label": "Mathématiques"
+          },
+          {
+            "id": "c",
+            "label": "NSI"
+          },
+          {
+            "id": "d",
+            "label": "SES"
+          },
+          {
+            "id": "e",
+            "label": "Tronc commun"
+          },
+          {
+            "id": "f",
+            "label": "Grand oral"
+          },
+          {
+            "id": "g",
+            "label": "Aucune"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "final-05",
+        "type": "long",
+        "prompt": "Quelle épreuve vous paraît avoir sous-estimé votre niveau réel, et pourquoi ?",
+        "competencies": [
+          "metacognition"
+        ],
+        "domains": [
+          "validation"
+        ],
+        "maxPoints": 2,
+        "required": false,
+        "manualReview": true,
+        "wordLimit": 180
+      },
+      {
+        "id": "final-06",
+        "type": "long",
+        "prompt": "Décrivez une difficulté technique ou un incident de passation.",
+        "competencies": [
+          "integrite"
+        ],
+        "domains": [
+          "validation"
+        ],
+        "maxPoints": 0,
+        "required": false,
+        "manualReview": true,
+        "wordLimit": 180
+      },
+      {
+        "id": "final-07",
+        "type": "scale",
+        "prompt": "Sur une échelle de 1 à 5, êtes-vous toujours prêt à suivre une préparation intensive en un an ?",
+        "competencies": [
+          "engagement"
+        ],
+        "domains": [
+          "validation"
+        ],
+        "maxPoints": 0,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Pas du tout",
+        "rightLabel": "Tout à fait",
+        "required": true
+      },
+      {
+        "id": "final-08",
+        "type": "long",
+        "prompt": "Quel engagement concret prenez-vous pour les 30 prochains jours ?",
+        "competencies": [
+          "engagement",
+          "plan_action"
+        ],
+        "domains": [
+          "validation"
+        ],
+        "maxPoints": 4,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 200
+      }
+    ],
+    "scoreDomains": [
+      "validation"
+    ],
+    "requiredForSubmission": true
+  },
+  {
+    "key": "questionnaire-parent",
+    "title": "Questionnaire confidentiel du parent",
+    "shortTitle": "Parent",
+    "description": "Recueillir une observation indépendante sur l’autonomie, les causes d’échec, les contraintes et le niveau de risque acceptable.",
+    "audience": "PARENT",
+    "kind": "questionnaire",
+    "estimatedMinutes": 30,
+    "timed": false,
+    "prerequisites": [],
+    "instructions": [
+      "À remplir sans consulter les réponses de l’élève.",
+      "Les réponses brutes du parent ne sont pas affichées à l’élève."
+    ],
+    "questions": [
+      {
+        "id": "parent-01",
+        "type": "scale",
+        "prompt": "Mon enfant commence son travail sans relance répétée.",
+        "competencies": [
+          "autonomie"
+        ],
+        "domains": [
+          "observation_parent"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "parent-02",
+        "type": "scale",
+        "prompt": "Il respecte un emploi du temps convenu.",
+        "competencies": [
+          "regularite"
+        ],
+        "domains": [
+          "observation_parent"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "parent-03",
+        "type": "scale",
+        "prompt": "Il remet les travaux demandés dans les délais.",
+        "competencies": [
+          "fiabilite"
+        ],
+        "domains": [
+          "observation_parent"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "parent-04",
+        "type": "scale",
+        "prompt": "Il accepte de montrer ses résultats réels, même faibles.",
+        "competencies": [
+          "transparence"
+        ],
+        "domains": [
+          "observation_parent"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "parent-05",
+        "type": "scale",
+        "prompt": "Il peut travailler sans téléphone pendant une période définie.",
+        "competencies": [
+          "attention"
+        ],
+        "domains": [
+          "observation_parent"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "parent-06",
+        "type": "scale",
+        "prompt": "Il demande de l’aide avant que le retard devienne important.",
+        "competencies": [
+          "alerte"
+        ],
+        "domains": [
+          "observation_parent"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "parent-07",
+        "type": "scale",
+        "prompt": "Il supporte la frustration d’un exercice difficile.",
+        "competencies": [
+          "perseverance"
+        ],
+        "domains": [
+          "observation_parent"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "parent-08",
+        "type": "scale",
+        "prompt": "Il applique les corrections données.",
+        "competencies": [
+          "remediation"
+        ],
+        "domains": [
+          "observation_parent"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "parent-09",
+        "type": "scale",
+        "prompt": "Son rythme de sommeil est compatible avec une préparation intensive.",
+        "competencies": [
+          "hygiene"
+        ],
+        "domains": [
+          "observation_parent"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "parent-10",
+        "type": "scale",
+        "prompt": "La famille peut garantir un environnement de travail stable.",
+        "competencies": [
+          "logistique"
+        ],
+        "domains": [
+          "observation_parent"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "parent-11",
+        "type": "scale",
+        "prompt": "La famille accepte un suivi d’assiduité et des alertes.",
+        "competencies": [
+          "contractualisation"
+        ],
+        "domains": [
+          "observation_parent"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "parent-12",
+        "type": "scale",
+        "prompt": "La famille peut éviter de faire le travail à la place de l’élève.",
+        "competencies": [
+          "autonomie_familiale"
+        ],
+        "domains": [
+          "observation_parent"
+        ],
+        "maxPoints": 1,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Jamais / faux",
+        "rightLabel": "Toujours / vrai",
+        "required": true
+      },
+      {
+        "id": "parent-13",
+        "type": "multiple",
+        "prompt": "Quelle est, selon vous, la cause principale des échecs de 2026 ?",
+        "competencies": [
+          "analyse_parcours"
+        ],
+        "domains": [
+          "observation_parent"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Lacunes anciennes"
+          },
+          {
+            "id": "b",
+            "label": "Méthode française mal comprise"
+          },
+          {
+            "id": "c",
+            "label": "Manque de travail"
+          },
+          {
+            "id": "d",
+            "label": "Manque d’encadrement"
+          },
+          {
+            "id": "e",
+            "label": "Double préparation tunisienne/française"
+          },
+          {
+            "id": "f",
+            "label": "Stress ou santé"
+          },
+          {
+            "id": "g",
+            "label": "Absences"
+          },
+          {
+            "id": "h",
+            "label": "Orientation peu claire"
+          },
+          {
+            "id": "i",
+            "label": "Autre"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "parent-14",
+        "type": "long",
+        "prompt": "Décrivez les cours particuliers, stages ou accompagnements déjà suivis et leurs effets.",
+        "competencies": [
+          "historique_accompagnement"
+        ],
+        "domains": [
+          "observation_parent"
+        ],
+        "maxPoints": 0,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 350
+      },
+      {
+        "id": "parent-15",
+        "type": "single",
+        "prompt": "Combien d’heures de travail effectif observez-vous actuellement par semaine ?",
+        "competencies": [
+          "charge_travail"
+        ],
+        "domains": [
+          "observation_parent"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Moins de 3 h"
+          },
+          {
+            "id": "b",
+            "label": "3 à 6 h"
+          },
+          {
+            "id": "c",
+            "label": "7 à 10 h"
+          },
+          {
+            "id": "d",
+            "label": "11 à 15 h"
+          },
+          {
+            "id": "e",
+            "label": "Plus de 15 h"
+          },
+          {
+            "id": "f",
+            "label": "Impossible à estimer"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "parent-16",
+        "type": "single",
+        "prompt": "La famille peut-elle garantir une disponibilité totale de 25 à 30 h par semaine pour cours et travail personnel ?",
+        "competencies": [
+          "faisabilite"
+        ],
+        "domains": [
+          "logistique_familiale"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Oui"
+          },
+          {
+            "id": "b",
+            "label": "Oui sous conditions"
+          },
+          {
+            "id": "c",
+            "label": "Non"
+          },
+          {
+            "id": "d",
+            "label": "À déterminer"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "parent-17",
+        "type": "long",
+        "prompt": "Quelles contraintes familiales, financières, géographiques ou de santé doivent être prises en compte ?",
+        "competencies": [
+          "analyse_risque"
+        ],
+        "domains": [
+          "logistique_familiale"
+        ],
+        "maxPoints": 0,
+        "required": false,
+        "manualReview": true,
+        "wordLimit": 300
+      },
+      {
+        "id": "parent-18",
+        "type": "single",
+        "prompt": "Quelle priorité guide votre décision ?",
+        "competencies": [
+          "priorite_familiale"
+        ],
+        "domains": [
+          "arbitrage"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Sécuriser le diplôme"
+          },
+          {
+            "id": "b",
+            "label": "Éviter de perdre une année"
+          },
+          {
+            "id": "c",
+            "label": "Réduire le coût"
+          },
+          {
+            "id": "d",
+            "label": "Préserver l’orientation post-bac"
+          },
+          {
+            "id": "e",
+            "label": "Restaurer la confiance"
+          },
+          {
+            "id": "f",
+            "label": "Combinaison de plusieurs priorités"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "parent-19",
+        "type": "scale",
+        "prompt": "Quel niveau de risque scolaire êtes-vous prêt à accepter pour tenter le parcours en un an ?",
+        "competencies": [
+          "tolerance_risque"
+        ],
+        "domains": [
+          "arbitrage"
+        ],
+        "maxPoints": 0,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "leftLabel": "Très faible",
+        "rightLabel": "Élevé",
+        "required": true
+      },
+      {
+        "id": "parent-20",
+        "type": "long",
+        "prompt": "Quelles preuves attendez-vous de Nexus avant de décider ?",
+        "competencies": [
+          "attentes"
+        ],
+        "domains": [
+          "arbitrage"
+        ],
+        "maxPoints": 0,
+        "required": true,
+        "manualReview": true,
+        "wordLimit": 300
+      },
+      {
+        "id": "parent-21",
+        "type": "single",
+        "prompt": "Acceptez-vous qu’un avis défavorable puisse recommander une scolarité sur deux ans ?",
+        "competencies": [
+          "acceptation_decision"
+        ],
+        "domains": [
+          "arbitrage"
+        ],
+        "maxPoints": 0,
+        "options": [
+          {
+            "id": "a",
+            "label": "Oui"
+          },
+          {
+            "id": "b",
+            "label": "Oui, après échange contradictoire"
+          },
+          {
+            "id": "c",
+            "label": "Non"
+          }
+        ],
+        "required": true
+      },
+      {
+        "id": "parent-22",
+        "type": "acknowledgement",
+        "prompt": "Je certifie avoir répondu séparément de l’élève et autorise Nexus à utiliser ces informations pour le diagnostic.",
+        "competencies": [
+          "consentement_parent"
+        ],
+        "domains": [
+          "consentement"
+        ],
+        "maxPoints": 0,
+        "required": true
+      }
+    ],
+    "scoreDomains": [
+      "observation_parent",
+      "logistique_familiale",
+      "arbitrage",
+      "consentement"
+    ],
+    "requiredForSubmission": true
+  }
+];
+
+export const CANDIDATE_DIAGNOSTIC_MODULE_MAP = Object.fromEntries(
+  CANDIDATE_DIAGNOSTIC_MODULES.map((module) => [module.key, module]),
+) as Record<string, DiagnosticModuleDefinition>;
+
+export function getPublicModuleDefinition(moduleKey: string): DiagnosticModuleDefinition | null {
+  return CANDIDATE_DIAGNOSTIC_MODULE_MAP[moduleKey] ?? null;
+}

--- a/lib/diagnostics/candidat-libre/feature-flag.ts
+++ b/lib/diagnostics/candidat-libre/feature-flag.ts
@@ -1,0 +1,23 @@
+import 'server-only';
+
+import { NextResponse } from 'next/server';
+
+/**
+ * Global kill switch for the whole candidate-libre diagnostic feature.
+ *
+ * Independent of the per-user entitlement system in lib/access/ — that
+ * system grants features to paying accounts, this is a repo-wide dark
+ * switch. OFF means dark for every role, including staff and ADMIN, with
+ * no exemption, until a real dossier is explicitly activated (Phase P).
+ * Defaults to disabled: an unset or misconfigured env var must never
+ * accidentally turn the feature on.
+ */
+export function isCandidateDiagnosticFeatureEnabled(): boolean {
+  return process.env.CANDIDATE_DIAGNOSTIC_ENABLED === 'true';
+}
+
+/** For API routes: returns a 404 (not 403 — the route must look absent) when the flag is off, else null. */
+export function guardCandidateDiagnosticFeature(): NextResponse | null {
+  if (isCandidateDiagnosticFeatureEnabled()) return null;
+  return NextResponse.json({ error: 'Not Found' }, { status: 404 });
+}

--- a/lib/diagnostics/candidat-libre/index.ts
+++ b/lib/diagnostics/candidat-libre/index.ts
@@ -1,0 +1,4 @@
+export * from './types';
+export * from './schemas';
+export * from './definition.public';
+export * from './progression';

--- a/lib/diagnostics/candidat-libre/progression.ts
+++ b/lib/diagnostics/candidat-libre/progression.ts
@@ -1,0 +1,74 @@
+import { CANDIDATE_DIAGNOSTIC_MODULES } from './definition.public';
+import type { DiagnosticCampaignStatus, DiagnosticModuleStatus, DiagnosticModuleView } from './types';
+
+const COMPLETE_STATUSES: DiagnosticModuleStatus[] = ['SUBMITTED', 'AUTO_SCORED', 'NEEDS_REVIEW', 'REVIEWED'];
+
+export function isModuleComplete(status: DiagnosticModuleStatus) {
+  return COMPLETE_STATUSES.includes(status);
+}
+
+export function resolveModuleAvailability(
+  moduleKey: string,
+  moduleViews: DiagnosticModuleView[],
+  now = new Date(),
+): { available: boolean; availableAt: Date | null; reason?: string } {
+  const definition = CANDIDATE_DIAGNOSTIC_MODULES.find((module) => module.key === moduleKey);
+  if (!definition) return { available: false, availableAt: null, reason: 'Module inconnu.' };
+
+  const byKey = new Map(moduleViews.map((module) => [module.key, module]));
+  for (const prerequisite of definition.prerequisites) {
+    const prerequisiteView = byKey.get(prerequisite);
+    if (!prerequisiteView || !isModuleComplete(prerequisiteView.status)) {
+      return { available: false, availableAt: null, reason: `Le module « ${prerequisite} » doit être terminé.` };
+    }
+  }
+
+  if (definition.unlockDelayHours && definition.prerequisites.length > 0) {
+    const reference = byKey.get(definition.prerequisites[definition.prerequisites.length - 1]);
+    const submittedAt = reference?.submittedAt ? new Date(reference.submittedAt) : null;
+    if (submittedAt) {
+      const availableAt = new Date(submittedAt.getTime() + definition.unlockDelayHours * 60 * 60 * 1_000);
+      if (availableAt > now) {
+        return { available: false, availableAt, reason: 'Ce module mesure une rétention différée.' };
+      }
+      return { available: true, availableAt };
+    }
+  }
+
+  return { available: true, availableAt: null };
+}
+
+export function computeCompletionPercentage(moduleViews: DiagnosticModuleView[]) {
+  const requiredKeys = CANDIDATE_DIAGNOSTIC_MODULES
+    .filter((module) => module.audience === 'ELEVE' && module.requiredForSubmission)
+    .map((module) => module.key);
+  if (requiredKeys.length === 0) return 0;
+  const byKey = new Map(moduleViews.map((module) => [module.key, module]));
+  const completed = requiredKeys.filter((key) => {
+    const moduleView = byKey.get(key);
+    return moduleView && isModuleComplete(moduleView.status);
+  }).length;
+  return Math.round((completed / requiredKeys.length) * 100);
+}
+
+export function deriveCampaignStatus(input: {
+  moduleViews: DiagnosticModuleView[];
+  parentSubmitted: boolean;
+  finalSubmitted: boolean;
+  retentionDueAt?: Date | null;
+  now?: Date;
+}): DiagnosticCampaignStatus {
+  const now = input.now ?? new Date();
+  if (input.finalSubmitted) return 'SUBMITTED';
+  if (input.retentionDueAt && input.retentionDueAt > now) return 'WAITING_RETENTION';
+  const studentRequired = CANDIDATE_DIAGNOSTIC_MODULES.filter(
+    (module) => module.audience === 'ELEVE' && module.requiredForSubmission && module.key !== 'validation-finale',
+  );
+  const byKey = new Map(input.moduleViews.map((module) => [module.key, module]));
+  const studentDone = studentRequired.every((definition) => {
+    const view = byKey.get(definition.key);
+    return view && isModuleComplete(view.status);
+  });
+  if (studentDone && !input.parentSubmitted) return 'WAITING_PARENT';
+  return 'ACTIVE';
+}

--- a/lib/diagnostics/candidat-libre/schemas.ts
+++ b/lib/diagnostics/candidat-libre/schemas.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+
+export const diagnosticAnswerValueSchema = z.union([
+  z.string().max(20_000),
+  z.number().finite(),
+  z.boolean(),
+  z.array(z.string().max(500)).max(30),
+  z.null(),
+]);
+
+export const diagnosticAnswerSchema = z.object({
+  questionId: z.string().min(1).max(160),
+  value: diagnosticAnswerValueSchema,
+  status: z.enum(['ANSWERED', 'NOT_STUDIED', 'SKIPPED']).optional(),
+  confidence: z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3)]).optional(),
+  answeredAt: z.string().datetime().optional(),
+}).strict();
+
+export const moduleDraftSchema = z.object({
+  answers: z.record(z.string().max(160), diagnosticAnswerSchema).default({}),
+  currentQuestionIndex: z.number().int().min(0).max(1_000).default(0),
+  elapsedMs: z.number().int().min(0).max(24 * 60 * 60 * 1_000).default(0),
+  integrity: z.object({
+    accepted: z.boolean(),
+    focusLossCount: z.number().int().min(0).max(10_000).default(0),
+    fullscreenExitCount: z.number().int().min(0).max(10_000).default(0),
+    copyPasteCount: z.number().int().min(0).max(10_000).default(0),
+  }).strict(),
+  action: z.enum(['draft', 'submit']).default('draft'),
+  clientMutationId: z.string().min(8).max(160),
+}).strict();
+
+export const createDiagnosticSchema = z.object({
+  targetSession: z.number().int().min(2027).max(2032).default(2027),
+  source: z.enum(['STUDENT_DASHBOARD', 'PARENT_DASHBOARD', 'STAFF']).default('STUDENT_DASHBOARD'),
+  studentId: z.string().min(1).max(160).optional(),
+}).strict();
+
+export const updateDiagnosticProfileSchema = z.object({
+  targetSession: z.number().int().min(2027).max(2032).optional(),
+  studentConsent: z.boolean().optional(),
+  metadata: z.record(z.string().max(80), z.union([
+    z.string().max(4_000),
+    z.number().finite(),
+    z.boolean(),
+    z.array(z.string().max(500)).max(50),
+    z.null(),
+  ])).optional(),
+}).strict();
+
+export const parentQuestionnaireSchema = z.object({
+  answers: z.record(z.string().max(160), diagnosticAnswerSchema).default({}),
+  action: z.enum(['draft', 'submit']).default('draft'),
+  consent: z.boolean(),
+  clientMutationId: z.string().min(8).max(160),
+}).strict();
+
+export const routeIdSchema = z.string().min(1).max(160);
+export const moduleKeySchema = z.string().regex(/^[a-z0-9-]+$/).max(100);
+
+export const documentMetadataSchema = z.object({
+  category: z.enum([
+    'IDENTITY',
+    'CYCLADES',
+    'FRENCH_BAC_TRANSCRIPT',
+    'TUNISIAN_BAC_TRANSCRIPT',
+    'SCHOOL_REPORT',
+    'EXAM_ACCOMMODATION',
+    'WRITTEN_COPY',
+    'ORAL_RECORDING',
+    'OTHER',
+  ]),
+  title: z.string().min(1).max(200),
+  description: z.string().max(1_000).optional(),
+  clientMutationId: z.string().min(8).max(160),
+}).strict();
+
+export type ModuleDraftInput = z.infer<typeof moduleDraftSchema>;
+export type ParentQuestionnaireInput = z.infer<typeof parentQuestionnaireSchema>;

--- a/lib/diagnostics/candidat-libre/scoring.server.ts
+++ b/lib/diagnostics/candidat-libre/scoring.server.ts
@@ -1,0 +1,168 @@
+import 'server-only';
+
+import { CANDIDATE_DIAGNOSTIC_ANSWER_KEYS } from './answer-key.server';
+import { getPublicModuleDefinition } from './definition.public';
+import type {
+  DiagnosticAnswer,
+  DiagnosticAutoScore,
+  DiagnosticQuestion,
+  QuestionScoreEvidence,
+} from './types';
+
+function asString(value: DiagnosticAnswer['value']): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function asNumber(value: DiagnosticAnswer['value']): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function asBoolean(value: DiagnosticAnswer['value']): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
+function asStringArray(value: DiagnosticAnswer['value']): string[] | null {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string') ? value : null;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function scoreQuestion(question: DiagnosticQuestion, answer?: DiagnosticAnswer): QuestionScoreEvidence {
+  const key = CANDIDATE_DIAGNOSTIC_ANSWER_KEYS[question.id];
+  const base = {
+    questionId: question.id,
+    maxPoints: question.maxPoints,
+    domains: question.domains,
+    competencies: question.competencies,
+    confidence: answer?.confidence,
+  };
+
+  if (answer?.status === 'NOT_STUDIED') {
+    return { ...base, points: 0, status: 'NOT_STUDIED' };
+  }
+
+  if (!answer || answer.status === 'SKIPPED' || answer.value === null || answer.value === '') {
+    return { ...base, points: 0, status: question.manualReview ? 'MANUAL_REVIEW' : 'INCORRECT' };
+  }
+
+  if (!key || key.kind === 'manual') {
+    return { ...base, points: 0, status: 'MANUAL_REVIEW' };
+  }
+
+  if (key.kind === 'neutral') {
+    return { ...base, points: 0, status: question.manualReview ? 'MANUAL_REVIEW' : 'CORRECT' };
+  }
+
+  if (key.kind === 'single') {
+    const correct = asString(answer.value) === key.correct;
+    return { ...base, points: correct ? question.maxPoints : 0, status: correct ? 'CORRECT' : 'INCORRECT' };
+  }
+
+  if (key.kind === 'multiple') {
+    const selected = new Set(asStringArray(answer.value) ?? []);
+    const expected = new Set(key.correct);
+    const truePositives = [...selected].filter((item) => expected.has(item)).length;
+    const falsePositives = [...selected].filter((item) => !expected.has(item)).length;
+    const exact = truePositives === expected.size && falsePositives === 0;
+    if (exact) return { ...base, points: question.maxPoints, status: 'CORRECT' };
+    if (key.partial && truePositives > 0) {
+      const ratio = clamp((truePositives - falsePositives) / expected.size, 0, 1);
+      const points = Math.round(question.maxPoints * ratio * 100) / 100;
+      return { ...base, points, status: points > 0 ? 'PARTIAL' : 'INCORRECT' };
+    }
+    return { ...base, points: 0, status: 'INCORRECT' };
+  }
+
+  if (key.kind === 'numeric') {
+    const numeric = asNumber(answer.value);
+    const correct = numeric !== null && Math.abs(numeric - key.value) <= key.tolerance;
+    return { ...base, points: correct ? question.maxPoints : 0, status: correct ? 'CORRECT' : 'INCORRECT' };
+  }
+
+  if (key.kind === 'ack') {
+    const correct = asBoolean(answer.value) === key.expected;
+    return { ...base, points: correct ? question.maxPoints : 0, status: correct ? 'CORRECT' : 'INCORRECT' };
+  }
+
+  const scaleValue = asNumber(answer.value);
+  if (scaleValue === null) return { ...base, points: 0, status: 'INCORRECT' };
+  const normalized = (scaleValue - key.min) / Math.max(1, key.max - key.min);
+  const directed = key.direction === 1 ? normalized : 1 - normalized;
+  const points = Math.round(clamp(directed, 0, 1) * question.maxPoints * 100) / 100;
+  return {
+    ...base,
+    points,
+    status: points >= question.maxPoints * 0.8 ? 'CORRECT' : points > 0 ? 'PARTIAL' : 'INCORRECT',
+  };
+}
+
+export function scoreDiagnosticModule(
+  moduleKey: string,
+  answers: Record<string, DiagnosticAnswer>,
+): DiagnosticAutoScore {
+  const definition = getPublicModuleDefinition(moduleKey);
+  if (!definition) throw new Error(`Unknown diagnostic module: ${moduleKey}`);
+
+  const evidence = definition.questions.map((question) => scoreQuestion(question, answers[question.id]));
+  const scorable = evidence.filter((item) => item.maxPoints > 0 && item.status !== 'MANUAL_REVIEW');
+  const covered = scorable.filter((item) => item.status !== 'NOT_STUDIED');
+  const points = covered.reduce((sum, item) => sum + item.points, 0);
+  const maxPoints = covered.reduce((sum, item) => sum + item.maxPoints, 0);
+  const potentialMaxPoints = scorable.reduce((sum, item) => sum + item.maxPoints, 0);
+
+  const domainScores: DiagnosticAutoScore['domainScores'] = {};
+  for (const item of covered) {
+    for (const domain of item.domains) {
+      domainScores[domain] ??= { points: 0, maxPoints: 0, percentage: null };
+      domainScores[domain].points += item.points;
+      domainScores[domain].maxPoints += item.maxPoints;
+    }
+  }
+  for (const value of Object.values(domainScores)) {
+    value.points = Math.round(value.points * 100) / 100;
+    value.maxPoints = Math.round(value.maxPoints * 100) / 100;
+    value.percentage = value.maxPoints > 0 ? Math.round((value.points / value.maxPoints) * 10_000) / 100 : null;
+  }
+
+  const confidenceAnswered = evidence.filter((item) => typeof item.confidence === 'number' && item.status !== 'MANUAL_REVIEW');
+  const overconfidenceCount = confidenceAnswered.filter(
+    (item) => (item.confidence ?? 0) >= 2 && (item.status === 'INCORRECT' || item.status === 'NOT_STUDIED'),
+  ).length;
+  const underconfidenceCount = confidenceAnswered.filter(
+    (item) => (item.confidence ?? 0) <= 1 && item.status === 'CORRECT',
+  ).length;
+
+  return {
+    points: Math.round(points * 100) / 100,
+    maxPoints: Math.round(maxPoints * 100) / 100,
+    percentage: maxPoints > 0 ? Math.round((points / maxPoints) * 10_000) / 100 : null,
+    coveragePercentage: potentialMaxPoints > 0 ? Math.round((maxPoints / potentialMaxPoints) * 10_000) / 100 : 100,
+    domainScores,
+    evidence,
+    manualReviewQuestionIds: evidence.filter((item) => item.status === 'MANUAL_REVIEW').map((item) => item.questionId),
+    confidenceCalibration: {
+      answeredWithConfidence: confidenceAnswered.length,
+      overconfidenceCount,
+      underconfidenceCount,
+    },
+  };
+}
+
+export function validateRequiredAnswers(
+  moduleKey: string,
+  answers: Record<string, DiagnosticAnswer>,
+): { valid: boolean; missingQuestionIds: string[] } {
+  const definition = getPublicModuleDefinition(moduleKey);
+  if (!definition) throw new Error(`Unknown diagnostic module: ${moduleKey}`);
+  const missingQuestionIds = definition.questions
+    .filter((question) => question.required !== false && question.type !== 'information')
+    .filter((question) => {
+      const answer = answers[question.id];
+      if (question.type === 'upload') return false; // Validated against persisted documents by the API route.
+      return !answer || answer.status === 'SKIPPED' || answer.value === null || answer.value === '';
+    })
+    .map((question) => question.id);
+  return { valid: missingQuestionIds.length === 0, missingQuestionIds };
+}

--- a/lib/diagnostics/candidat-libre/serialize.server.ts
+++ b/lib/diagnostics/candidat-libre/serialize.server.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { computeCompletionPercentage } from './progression';
+import { isDocumentVisibleToViewer } from './access.server';
 import type { DiagnosticCampaignView, DiagnosticModuleView } from './types';
 
 /**
@@ -48,17 +49,19 @@ export function serializeCandidateDiagnostic(
       gradeLevel: diagnostic.student.gradeLevel,
     },
     modules,
-    documents: diagnostic.documents.map((document: any) => ({
-      id: document.id,
-      category: document.category,
-      originalName: document.originalName,
-      mimeType: document.mimeType,
-      sizeBytes: document.sizeBytes,
-      status: document.status,
-      reviewNote: document.reviewNote,
-      createdAt: document.createdAt?.toISOString?.() ?? document.createdAt,
-      downloadUrl: `/api/diagnostics/candidat-libre/${diagnostic.id}/documents/${document.id}`,
-    })),
+    documents: diagnostic.documents
+      .filter((document: any) => !viewerRole || isDocumentVisibleToViewer(document.category, viewerRole))
+      .map((document: any) => ({
+        id: document.id,
+        category: document.category,
+        originalName: document.originalName,
+        mimeType: document.mimeType,
+        sizeBytes: document.sizeBytes,
+        status: document.status,
+        reviewNote: document.reviewNote,
+        createdAt: document.createdAt?.toISOString?.() ?? document.createdAt,
+        downloadUrl: `/api/diagnostics/candidat-libre/${diagnostic.id}/documents/${document.id}`,
+      })),
     completionPercentage: computeCompletionPercentage(modules),
     studentConsentAt: diagnostic.studentConsentAt?.toISOString?.() ?? diagnostic.studentConsentAt ?? null,
     parentConsentAt: diagnostic.parentConsentAt?.toISOString?.() ?? diagnostic.parentConsentAt ?? null,

--- a/lib/diagnostics/candidat-libre/serialize.server.ts
+++ b/lib/diagnostics/candidat-libre/serialize.server.ts
@@ -1,0 +1,70 @@
+import 'server-only';
+
+import { computeCompletionPercentage } from './progression';
+import type { DiagnosticCampaignView, DiagnosticModuleView } from './types';
+
+/**
+ * viewerRole scopes cross-audience module detail: a diagnostic has both ELEVE
+ * and PARENT modules, and this serializer backs the shared GET/PATCH routes
+ * both audiences call. Without this, an ELEVE viewer received the parent
+ * module's autoScore (per-question evidence) and vice versa — completion
+ * status/progress stay visible (the UI needs "waiting on parent" states),
+ * only score/review detail outside the viewer's own audience is redacted.
+ * Staff (COACH/ADMIN/ASSISTANTE) or no role (internal callers) see everything.
+ */
+export function serializeCandidateDiagnostic(
+  diagnostic: any,
+  viewerRole?: 'ELEVE' | 'PARENT' | 'COACH' | 'ADMIN' | 'SYSTEM',
+): DiagnosticCampaignView {
+  const restrictToAudience = viewerRole === 'ELEVE' || viewerRole === 'PARENT' ? viewerRole : null;
+
+  const modules: DiagnosticModuleView[] = diagnostic.modules.map((module: any) => {
+    const ownAudience = !restrictToAudience || module.audience === restrictToAudience;
+    return {
+      key: module.moduleKey,
+      status: module.status,
+      progress: module.status === 'REVIEWED' ? 100 : module.submittedAt ? 100 : Math.min(99, Math.max(0, Math.round(((module.currentQuestionIndex ?? 0) / Math.max(1, module.definitionSnapshot?.questions?.length ?? 1)) * 100))),
+      startedAt: module.startedAt?.toISOString?.() ?? module.startedAt ?? null,
+      submittedAt: module.submittedAt?.toISOString?.() ?? module.submittedAt ?? null,
+      availableAt: module.availableAt?.toISOString?.() ?? module.availableAt ?? null,
+      elapsedMs: module.elapsedMs,
+      autoScore: ownAudience ? module.autoScore ?? null : null,
+      reviewSummary: ownAudience ? module.reviewSummary ?? null : null,
+    };
+  });
+
+  return {
+    id: diagnostic.id,
+    diagnosticKey: diagnostic.diagnosticKey,
+    definitionVersion: diagnostic.definitionVersion,
+    status: diagnostic.status,
+    targetSession: diagnostic.targetSession,
+    student: {
+      id: diagnostic.student.id,
+      firstName: diagnostic.student.user.firstName,
+      lastName: diagnostic.student.user.lastName,
+      email: diagnostic.student.user.email,
+      school: diagnostic.student.school,
+      gradeLevel: diagnostic.student.gradeLevel,
+    },
+    modules,
+    documents: diagnostic.documents.map((document: any) => ({
+      id: document.id,
+      category: document.category,
+      originalName: document.originalName,
+      mimeType: document.mimeType,
+      sizeBytes: document.sizeBytes,
+      status: document.status,
+      reviewNote: document.reviewNote,
+      createdAt: document.createdAt?.toISOString?.() ?? document.createdAt,
+      downloadUrl: `/api/diagnostics/candidat-libre/${diagnostic.id}/documents/${document.id}`,
+    })),
+    completionPercentage: computeCompletionPercentage(modules),
+    studentConsentAt: diagnostic.studentConsentAt?.toISOString?.() ?? diagnostic.studentConsentAt ?? null,
+    parentConsentAt: diagnostic.parentConsentAt?.toISOString?.() ?? diagnostic.parentConsentAt ?? null,
+    submittedAt: diagnostic.submittedAt?.toISOString?.() ?? diagnostic.submittedAt ?? null,
+    retentionDueAt: diagnostic.retentionDueAt?.toISOString?.() ?? diagnostic.retentionDueAt ?? null,
+    createdAt: diagnostic.createdAt.toISOString(),
+    updatedAt: diagnostic.updatedAt.toISOString(),
+  };
+}

--- a/lib/diagnostics/candidat-libre/serialize.server.ts
+++ b/lib/diagnostics/candidat-libre/serialize.server.ts
@@ -1,26 +1,26 @@
 import 'server-only';
 
+import type { UserRole } from '@prisma/client';
 import { computeCompletionPercentage } from './progression';
-import { isDocumentVisibleToViewer } from './access.server';
+import { canViewModuleDetail, isDocumentVisibleToViewer } from './access.server';
 import type { DiagnosticCampaignView, DiagnosticModuleView } from './types';
 
 /**
- * viewerRole scopes cross-audience module detail: a diagnostic has both ELEVE
- * and PARENT modules, and this serializer backs the shared GET/PATCH routes
- * both audiences call. Without this, an ELEVE viewer received the parent
- * module's autoScore (per-question evidence) and vice versa — completion
- * status/progress stay visible (the UI needs "waiting on parent" states),
- * only score/review detail outside the viewer's own audience is redacted.
- * Staff (COACH/ADMIN/ASSISTANTE) or no role (internal callers) see everything.
+ * viewerRole scopes cross-audience module detail — a diagnostic has both
+ * ELEVE and PARENT modules, and this serializer backs the shared GET/PATCH
+ * routes every role calls. Detail visibility (autoScore/reviewSummary) is
+ * delegated to canViewModuleDetail (access.server.ts), the single source of
+ * truth for this rule shared with modules/[moduleKey] and staff-export —
+ * do not re-implement the matrix here. completion status/progress stay
+ * visible regardless of role (the UI needs "waiting on parent" states).
+ * No role (internal callers) sees everything, same as before.
  */
 export function serializeCandidateDiagnostic(
   diagnostic: any,
-  viewerRole?: 'ELEVE' | 'PARENT' | 'COACH' | 'ADMIN' | 'SYSTEM',
+  viewerRole?: UserRole,
 ): DiagnosticCampaignView {
-  const restrictToAudience = viewerRole === 'ELEVE' || viewerRole === 'PARENT' ? viewerRole : null;
-
   const modules: DiagnosticModuleView[] = diagnostic.modules.map((module: any) => {
-    const ownAudience = !restrictToAudience || module.audience === restrictToAudience;
+    const canViewDetail = !viewerRole || canViewModuleDetail(viewerRole, module.audience);
     return {
       key: module.moduleKey,
       status: module.status,
@@ -29,8 +29,8 @@ export function serializeCandidateDiagnostic(
       submittedAt: module.submittedAt?.toISOString?.() ?? module.submittedAt ?? null,
       availableAt: module.availableAt?.toISOString?.() ?? module.availableAt ?? null,
       elapsedMs: module.elapsedMs,
-      autoScore: ownAudience ? module.autoScore ?? null : null,
-      reviewSummary: ownAudience ? module.reviewSummary ?? null : null,
+      autoScore: canViewDetail ? module.autoScore ?? null : null,
+      reviewSummary: canViewDetail ? module.reviewSummary ?? null : null,
     };
   });
 

--- a/lib/diagnostics/candidat-libre/storage.server.ts
+++ b/lib/diagnostics/candidat-libre/storage.server.ts
@@ -1,0 +1,72 @@
+import 'server-only';
+
+import { createHash, randomUUID } from 'crypto';
+import { mkdir, writeFile } from 'fs/promises';
+import path from 'path';
+import { getDocumentStorageRoot } from '@/lib/documents/storage-root';
+
+export const MAX_DOCUMENT_BYTES = 12 * 1024 * 1024;
+export const MAX_AUDIO_BYTES = 30 * 1024 * 1024;
+export const ALLOWED_MIME_TYPES = new Set([
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'audio/mpeg',
+  'audio/mp4',
+  'audio/webm',
+  'audio/wav',
+]);
+
+const MAGIC: Record<string, (buffer: Buffer) => boolean> = {
+  'application/pdf': (b) => b.subarray(0, 5).toString('ascii') === '%PDF-',
+  'image/jpeg': (b) => b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff,
+  'image/png': (b) => b.subarray(0, 8).equals(Buffer.from([0x89,0x50,0x4e,0x47,0x0d,0x0a,0x1a,0x0a])),
+  'image/webp': (b) => b.subarray(0,4).toString('ascii') === 'RIFF' && b.subarray(8,12).toString('ascii') === 'WEBP',
+  // MP3: either an ID3v2 tag or a raw MPEG frame sync (0xFF followed by 3 set high bits).
+  'audio/mpeg': (b) => b.subarray(0, 3).toString('ascii') === 'ID3' || (b[0] === 0xff && (b[1] & 0xe0) === 0xe0),
+  // MP4/M4A container: ISO base media file format, "ftyp" box at offset 4.
+  'audio/mp4': (b) => b.subarray(4, 8).toString('ascii') === 'ftyp',
+  // WebM/Matroska: EBML header.
+  'audio/webm': (b) => b.subarray(0, 4).equals(Buffer.from([0x1a, 0x45, 0xdf, 0xa3])),
+  'audio/wav': (b) => b.subarray(0, 4).toString('ascii') === 'RIFF' && b.subarray(8, 12).toString('ascii') === 'WAVE',
+};
+
+
+export function resolveDiagnosticStoragePath(storageKey: string) {
+  const root = path.resolve(getDocumentStorageRoot());
+  const absolute = path.resolve(root, storageKey);
+  if (!absolute.startsWith(`${root}${path.sep}`)) throw new Error('UNSAFE_STORAGE_PATH');
+  return absolute;
+}
+
+export function sanitizeOriginalName(value: string) {
+  return value.replace(/[\u0000-\u001f\\/:*?"<>|]/g, '_').slice(0, 180) || 'document';
+}
+
+export async function persistDiagnosticFile(input: {
+  diagnosticId: string;
+  file: File;
+  category: string;
+}) {
+  if (!ALLOWED_MIME_TYPES.has(input.file.type)) throw new Error('UNSUPPORTED_FILE_TYPE');
+  const max = input.file.type.startsWith('audio/') ? MAX_AUDIO_BYTES : MAX_DOCUMENT_BYTES;
+  if (input.file.size <= 0 || input.file.size > max) throw new Error('INVALID_FILE_SIZE');
+  const buffer = Buffer.from(await input.file.arrayBuffer());
+  const validator = MAGIC[input.file.type];
+  if (validator && !validator(buffer)) throw new Error('MIME_SIGNATURE_MISMATCH');
+
+  const sha256 = createHash('sha256').update(buffer).digest('hex');
+  const safeName = sanitizeOriginalName(input.file.name);
+  const storageKey = path.join('candidate-diagnostics', input.diagnosticId, input.category, `${randomUUID()}-${safeName}`);
+  const absolute = resolveDiagnosticStoragePath(storageKey);
+  await mkdir(path.dirname(absolute), { recursive: true });
+  await writeFile(absolute, buffer, { flag: 'wx', mode: 0o600 });
+  return { storageKey, sha256, safeName, sizeBytes: buffer.byteLength, mimeType: input.file.type };
+}
+
+export async function removePersistedDiagnosticFile(storageKey: string) {
+  const { unlink } = await import('fs/promises');
+  const absolute = resolveDiagnosticStoragePath(storageKey);
+  await unlink(absolute).catch(() => undefined);
+}

--- a/lib/diagnostics/candidat-libre/synthesis.server.ts
+++ b/lib/diagnostics/candidat-libre/synthesis.server.ts
@@ -74,6 +74,6 @@ export function buildStaffDiagnosticSynthesis(diagnostic: {
     manualReviewPending,
     flags,
     decisionStatus: manualReviewPending > 0 || flags.some((flag) => flag.severity === 'BLOCKING') ? 'INSUFFICIENT_EVIDENCE_FOR_FINAL_DECISION' : 'READY_FOR_PEDAGOGICAL_COMMITTEE',
-    disclaimer: 'Synthèse technique interne. Elle ne constitue ni une garantie de réussite ni une décision pédagogique définitive.',
+    disclaimer: 'Synthèse technique interne, sans valeur prédictive. Ne remplace pas une décision pédagogique définitive.',
   };
 }

--- a/lib/diagnostics/candidat-libre/synthesis.server.ts
+++ b/lib/diagnostics/candidat-libre/synthesis.server.ts
@@ -1,0 +1,79 @@
+import 'server-only';
+
+type StoredModule = {
+  moduleKey: string;
+  status: string;
+  autoScore?: any;
+  manualScore?: any;
+  submittedAt?: Date | string | null;
+};
+
+function percentage(module?: StoredModule) {
+  const manual = module?.manualScore?.percentage;
+  if (typeof manual === 'number') return manual;
+  const automatic = module?.autoScore?.percentage;
+  return typeof automatic === 'number' ? automatic : null;
+}
+
+function coverage(module?: StoredModule) {
+  const value = module?.autoScore?.coveragePercentage;
+  return typeof value === 'number' ? value : null;
+}
+
+export function buildStaffDiagnosticSynthesis(diagnostic: {
+  modules: StoredModule[];
+  documents: Array<{ status: string; category: string }>;
+  parentSubmittedAt?: Date | string | null;
+}) {
+  const byKey = new Map(diagnostic.modules.map((module) => [module.moduleKey, module]));
+  const moduleScores = Object.fromEntries(
+    [...byKey].map(([key, module]) => [key, {
+      status: module.status,
+      percentage: percentage(module),
+      coveragePercentage: coverage(module),
+      manualReviewPending: module.autoScore?.manualReviewQuestionIds?.length ?? 0,
+    }]),
+  );
+
+  const t0 = percentage(byKey.get('potentiel-t0'));
+  const t1 = percentage(byKey.get('potentiel-t1'));
+  const retention = percentage(byKey.get('retention-transfert'));
+  const flags: Array<{ severity: 'INFO' | 'WATCH' | 'BLOCKING'; code: string; message: string }> = [];
+
+  const french = percentage(byKey.get('francais-academique'));
+  const frenchCoverage = coverage(byKey.get('francais-academique'));
+  if (french !== null && french < 45) flags.push({ severity: 'BLOCKING', code: 'FRENCH_LOW', message: 'Français académique sous le seuil interne de vigilance renforcée.' });
+  if (frenchCoverage !== null && frenchCoverage < 60) flags.push({ severity: 'WATCH', code: 'FRENCH_COVERAGE_LOW', message: 'Couverture du test de français insuffisante pour une conclusion stable.' });
+
+  const specialties = ['mathematiques', 'nsi', 'ses'].map((key) => ({ key, score: percentage(byKey.get(key)), coverage: coverage(byKey.get(key)) }));
+  const viable = specialties.filter((item) => item.score !== null && item.score >= 50 && (item.coverage ?? 0) >= 65);
+  if (viable.length < 2) flags.push({ severity: 'BLOCKING', code: 'SPECIALTIES_NOT_SECURED', message: 'Moins de deux spécialités présentent simultanément un niveau et une couverture internes suffisants.' });
+
+  const autonomy = percentage(byKey.get('autonomie-methodes'));
+  if (autonomy !== null && autonomy < 55) flags.push({ severity: 'WATCH', code: 'AUTONOMY_LOW', message: 'Autonomie déclarée ou observée fragile pour un parcours majoritairement hors établissement.' });
+  if (!diagnostic.parentSubmittedAt) flags.push({ severity: 'BLOCKING', code: 'PARENT_MISSING', message: 'Questionnaire parent non soumis.' });
+  if (diagnostic.documents.some((document) => document.status === 'REJECTED' || document.status === 'NEEDS_REPLACEMENT')) {
+    flags.push({ severity: 'BLOCKING', code: 'DOCUMENTS_INVALID', message: 'Au moins un document est rejeté ou doit être remplacé.' });
+  }
+
+  if (t0 !== null && t1 !== null) {
+    const gain = Math.round((t1 - t0) * 100) / 100;
+    flags.push({ severity: gain >= 15 ? 'INFO' : 'WATCH', code: 'LEARNING_GAIN', message: `Gain immédiat T1−T0 : ${gain >= 0 ? '+' : ''}${gain} points.` });
+  }
+  if (t1 !== null && retention !== null) {
+    const loss = Math.round((retention - t1) * 100) / 100;
+    flags.push({ severity: loss >= -15 ? 'INFO' : 'WATCH', code: 'RETENTION_CHANGE', message: `Évolution rétention−T1 : ${loss >= 0 ? '+' : ''}${loss} points.` });
+  }
+
+  const manualReviewPending = diagnostic.modules.reduce((sum, module) => sum + (module.autoScore?.manualReviewQuestionIds?.length ?? 0), 0);
+  return {
+    generatedAt: new Date().toISOString(),
+    moduleScores,
+    specialties,
+    learningPotential: { t0, t1, retention, immediateGain: t0 !== null && t1 !== null ? Math.round((t1 - t0) * 100) / 100 : null },
+    manualReviewPending,
+    flags,
+    decisionStatus: manualReviewPending > 0 || flags.some((flag) => flag.severity === 'BLOCKING') ? 'INSUFFICIENT_EVIDENCE_FOR_FINAL_DECISION' : 'READY_FOR_PEDAGOGICAL_COMMITTEE',
+    disclaimer: 'Synthèse technique interne. Elle ne constitue ni une garantie de réussite ni une décision pédagogique définitive.',
+  };
+}

--- a/lib/diagnostics/candidat-libre/types.ts
+++ b/lib/diagnostics/candidat-libre/types.ts
@@ -1,0 +1,220 @@
+export const DIAGNOSTIC_KEY = 'BAC_GENERAL_CANDIDAT_INDIVIDUEL_2027' as const;
+export const DIAGNOSTIC_VERSION = '2026.08.05-v1' as const;
+
+export type DiagnosticAudience = 'ELEVE' | 'PARENT';
+
+export type DiagnosticQuestionType =
+  | 'single'
+  | 'multiple'
+  | 'numeric'
+  | 'short'
+  | 'long'
+  | 'scale'
+  | 'acknowledgement'
+  | 'upload'
+  | 'information';
+
+export type DiagnosticModuleKind =
+  | 'questionnaire'
+  | 'academic'
+  | 'oral'
+  | 'documents'
+  | 'learning-potential'
+  | 'review';
+
+export type DiagnosticModuleStatus =
+  | 'LOCKED'
+  | 'AVAILABLE'
+  | 'IN_PROGRESS'
+  | 'SUBMITTED'
+  | 'AUTO_SCORED'
+  | 'NEEDS_REVIEW'
+  | 'REVIEWED';
+
+export type DiagnosticCampaignStatus =
+  | 'DRAFT'
+  | 'ACTIVE'
+  | 'WAITING_PARENT'
+  | 'WAITING_RETENTION'
+  | 'SUBMITTED'
+  | 'IN_REVIEW'
+  | 'REVIEWED'
+  | 'CLOSED'
+  | 'CANCELLED';
+
+export interface DiagnosticOption {
+  id: string;
+  label: string;
+}
+
+export interface DiagnosticUploadRule {
+  category:
+    | 'IDENTITY'
+    | 'CYCLADES'
+    | 'FRENCH_BAC_TRANSCRIPT'
+    | 'TUNISIAN_BAC_TRANSCRIPT'
+    | 'SCHOOL_REPORT'
+    | 'EXAM_ACCOMMODATION'
+    | 'WRITTEN_COPY'
+    | 'ORAL_RECORDING'
+    | 'OTHER';
+  accept: string[];
+  maxFiles: number;
+  maxBytesPerFile: number;
+  required: boolean;
+  help?: string;
+}
+
+export interface DiagnosticQuestion {
+  id: string;
+  type: DiagnosticQuestionType;
+  prompt: string;
+  description?: string;
+  instruction?: string;
+  options?: DiagnosticOption[];
+  min?: number;
+  max?: number;
+  step?: number;
+  leftLabel?: string;
+  rightLabel?: string;
+  placeholder?: string;
+  required?: boolean;
+  allowNotStudied?: boolean;
+  competencies: string[];
+  domains: string[];
+  maxPoints: number;
+  manualReview?: boolean;
+  uploadRule?: DiagnosticUploadRule;
+  wordLimit?: number;
+}
+
+export interface DiagnosticModuleDefinition {
+  key: string;
+  title: string;
+  shortTitle: string;
+  description: string;
+  audience: DiagnosticAudience;
+  kind: DiagnosticModuleKind;
+  estimatedMinutes: number;
+  timed: boolean;
+  prerequisites: string[];
+  unlockDelayHours?: number;
+  instructions: string[];
+  questions: DiagnosticQuestion[];
+  scoreDomains: string[];
+  requiredForSubmission: boolean;
+}
+
+export type DiagnosticAnswerValue =
+  | string
+  | number
+  | boolean
+  | string[]
+  | null;
+
+export interface DiagnosticAnswer {
+  questionId: string;
+  value: DiagnosticAnswerValue;
+  status?: 'ANSWERED' | 'NOT_STUDIED' | 'SKIPPED';
+  confidence?: 0 | 1 | 2 | 3;
+  answeredAt?: string;
+}
+
+export interface DiagnosticModuleDraft {
+  moduleKey: string;
+  answers: Record<string, DiagnosticAnswer>;
+  currentQuestionIndex: number;
+  elapsedMs: number;
+  integrity: {
+    accepted: boolean;
+    focusLossCount: number;
+    fullscreenExitCount: number;
+    copyPasteCount: number;
+    userAgent?: string;
+  };
+}
+
+export interface QuestionScoreEvidence {
+  questionId: string;
+  points: number;
+  maxPoints: number;
+  status: 'CORRECT' | 'PARTIAL' | 'INCORRECT' | 'NOT_STUDIED' | 'MANUAL_REVIEW';
+  domains: string[];
+  competencies: string[];
+  confidence?: number;
+}
+
+export interface DiagnosticAutoScore {
+  points: number;
+  maxPoints: number;
+  percentage: number | null;
+  coveragePercentage: number;
+  domainScores: Record<string, {
+    points: number;
+    maxPoints: number;
+    percentage: number | null;
+  }>;
+  evidence: QuestionScoreEvidence[];
+  manualReviewQuestionIds: string[];
+  confidenceCalibration: {
+    answeredWithConfidence: number;
+    overconfidenceCount: number;
+    underconfidenceCount: number;
+  };
+}
+
+export interface DiagnosticDocumentView {
+  id: string;
+  category: DiagnosticUploadRule['category'];
+  originalName: string;
+  mimeType: string;
+  sizeBytes: number;
+  status: 'UPLOADED' | 'ACCEPTED' | 'REJECTED' | 'NEEDS_REPLACEMENT';
+  reviewNote?: string | null;
+  createdAt: string;
+  downloadUrl?: string;
+}
+
+export interface DiagnosticModuleView {
+  key: string;
+  status: DiagnosticModuleStatus;
+  progress: number;
+  startedAt?: string | null;
+  submittedAt?: string | null;
+  availableAt?: string | null;
+  elapsedMs?: number;
+  autoScore?: DiagnosticAutoScore | null;
+  reviewSummary?: string | null;
+}
+
+export interface DiagnosticCampaignView {
+  id: string;
+  diagnosticKey: string;
+  definitionVersion: string;
+  status: DiagnosticCampaignStatus;
+  targetSession: number;
+  student: {
+    id: string;
+    firstName: string | null;
+    lastName: string | null;
+    email: string;
+    school: string | null;
+    gradeLevel: string;
+  };
+  modules: DiagnosticModuleView[];
+  documents: DiagnosticDocumentView[];
+  completionPercentage: number;
+  studentConsentAt?: string | null;
+  parentConsentAt?: string | null;
+  submittedAt?: string | null;
+  retentionDueAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ModuleSubmissionResponse {
+  success: true;
+  module: DiagnosticModuleView;
+  unlockedModuleKeys: string[];
+  campaignStatus: DiagnosticCampaignStatus;
+}

--- a/lib/diagnostics/candidat-libre/virus-scan.server.ts
+++ b/lib/diagnostics/candidat-libre/virus-scan.server.ts
@@ -1,0 +1,36 @@
+import 'server-only';
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { resolveDiagnosticStoragePath } from './storage.server';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Fail-closed antivirus hook.
+ *
+ * DIAGNOSTIC_AV_MODE=clamdscan  -> execute clamdscan against the private file.
+ * DIAGNOSTIC_AV_MODE=disabled   -> accepted only outside production.
+ */
+export async function scanDiagnosticFile(storageKey: string) {
+  const mode = process.env.DIAGNOSTIC_AV_MODE ?? (process.env.NODE_ENV === 'production' ? 'required' : 'disabled');
+  if (mode === 'disabled') {
+    if (process.env.NODE_ENV === 'production') throw new Error('AV_NOT_CONFIGURED');
+    return { clean: true, engine: 'disabled-development' } as const;
+  }
+  if (mode !== 'clamdscan') throw new Error('AV_NOT_CONFIGURED');
+
+  const absolutePath = resolveDiagnosticStoragePath(storageKey);
+  try {
+    await execFileAsync('clamdscan', ['--no-summary', '--fdpass', absolutePath], {
+      timeout: 45_000,
+      maxBuffer: 64 * 1024,
+      windowsHide: true,
+    });
+    return { clean: true, engine: 'clamdscan' } as const;
+  } catch (error) {
+    const exitCode = typeof error === 'object' && error && 'code' in error ? Number((error as { code?: unknown }).code) : NaN;
+    if (exitCode === 1) throw new Error('MALWARE_DETECTED');
+    throw new Error('AV_SCAN_FAILED');
+  }
+}

--- a/lib/guards.ts
+++ b/lib/guards.ts
@@ -171,8 +171,10 @@ export async function requireCoachAssignedToStudent(
   coachUserId: string,
   studentId: string
 ): Promise<true | NextResponse> {
+  // coachStudentAssignment.coachId references CoachProfile.id, which is distinct
+  // from User.id — resolve through the relation rather than comparing ids directly.
   const assignment = await prisma.coachStudentAssignment.findFirst({
-    where: { coachId: coachUserId, studentId, status: 'ACTIVE' },
+    where: { studentId, status: 'ACTIVE', coach: { userId: coachUserId } },
     select: { id: true },
   });
   if (!assignment) {

--- a/lib/rate-limit/sensitive.ts
+++ b/lib/rate-limit/sensitive.ts
@@ -42,6 +42,13 @@ export const SENSITIVE_RATE_LIMIT_POLICIES = {
   'admin-users-create': { ipPreset: 'expensiveIp', identityPreset: 'expensiveIdentity' },
   'student-credits': { ipPreset: 'readIp', identityPreset: 'readIdentity' },
   'student-sessions': { ipPreset: 'readIp', identityPreset: 'readIdentity' },
+  'candidate-diagnostic-create': { ipPreset: 'writeIp', identityPreset: 'writeIdentity' },
+  'candidate-diagnostic-final-submit': { ipPreset: 'expensiveIp', identityPreset: 'expensiveIdentity' },
+  'candidate-module-draft': { ipPreset: 'writeIp', identityPreset: 'writeIdentity' },
+  'candidate-module-submit': { ipPreset: 'writeIp', identityPreset: 'writeIdentity' },
+  'candidate-parent-draft': { ipPreset: 'writeIp', identityPreset: 'writeIdentity' },
+  'candidate-parent-submit': { ipPreset: 'writeIp', identityPreset: 'writeIdentity' },
+  'candidate-document-upload': { ipPreset: 'writeIp', identityPreset: 'writeIdentity', resourcePreset: 'resourceWrite' },
 } as const satisfies Record<string, SensitivePolicy>
 
 export type SensitiveRateLimitScope = keyof typeof SENSITIVE_RATE_LIMIT_POLICIES

--- a/prisma/migrations/20260807140000_add_candidate_diagnostic/migration.sql
+++ b/prisma/migrations/20260807140000_add_candidate_diagnostic/migration.sql
@@ -1,0 +1,133 @@
+-- PostgreSQL migration. Non appliquée automatiquement.
+-- À tester sur un clone anonymisé de la base avant tout déploiement (voir invariant #1).
+CREATE TYPE "CandidateDiagnosticStatus" AS ENUM (
+  'DRAFT', 'ACTIVE', 'WAITING_PARENT', 'WAITING_RETENTION',
+  'SUBMITTED', 'IN_REVIEW', 'REVIEWED', 'CLOSED', 'CANCELLED'
+);
+CREATE TYPE "CandidateDiagnosticModuleStatus" AS ENUM (
+  'LOCKED', 'AVAILABLE', 'IN_PROGRESS', 'SUBMITTED',
+  'AUTO_SCORED', 'NEEDS_REVIEW', 'REVIEWED'
+);
+CREATE TYPE "CandidateDiagnosticDocumentStatus" AS ENUM (
+  'UPLOADED', 'ACCEPTED', 'REJECTED', 'NEEDS_REPLACEMENT'
+);
+CREATE TYPE "CandidateDiagnosticActorRole" AS ENUM (
+  'ELEVE', 'PARENT', 'COACH', 'ADMIN', 'SYSTEM'
+);
+
+CREATE TABLE "candidate_diagnostics" (
+  "id" TEXT NOT NULL,
+  "diagnosticKey" TEXT NOT NULL,
+  "definitionVersion" TEXT NOT NULL,
+  "targetSession" INTEGER NOT NULL,
+  "status" "CandidateDiagnosticStatus" NOT NULL DEFAULT 'DRAFT',
+  "studentId" TEXT NOT NULL,
+  "createdById" TEXT NOT NULL,
+  "studentConsentAt" TIMESTAMP(3),
+  "parentConsentAt" TIMESTAMP(3),
+  "parentSubmittedAt" TIMESTAMP(3),
+  "retentionDueAt" TIMESTAMP(3),
+  "submittedAt" TIMESTAMP(3),
+  "reviewedAt" TIMESTAMP(3),
+  "closedAt" TIMESTAMP(3),
+  "metadata" JSONB,
+  "synthesis" JSONB,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "candidate_diagnostics_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "candidate_diagnostic_modules" (
+  "id" TEXT NOT NULL,
+  "diagnosticId" TEXT NOT NULL,
+  "moduleKey" TEXT NOT NULL,
+  "audience" TEXT NOT NULL,
+  "status" "CandidateDiagnosticModuleStatus" NOT NULL DEFAULT 'LOCKED',
+  "answers" JSONB,
+  "currentQuestionIndex" INTEGER NOT NULL DEFAULT 0,
+  "elapsedMs" INTEGER NOT NULL DEFAULT 0,
+  "integrity" JSONB,
+  "autoScore" JSONB,
+  "manualScore" JSONB,
+  "reviewSummary" TEXT,
+  "definitionSnapshot" JSONB NOT NULL,
+  "lastMutationId" TEXT,
+  "availableAt" TIMESTAMP(3),
+  "startedAt" TIMESTAMP(3),
+  "submittedAt" TIMESTAMP(3),
+  "reviewedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "candidate_diagnostic_modules_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "candidate_diagnostic_documents" (
+  "id" TEXT NOT NULL,
+  "diagnosticId" TEXT NOT NULL,
+  "uploadedById" TEXT NOT NULL,
+  "category" TEXT NOT NULL,
+  "title" TEXT NOT NULL,
+  "description" TEXT,
+  "originalName" TEXT NOT NULL,
+  "storageKey" TEXT NOT NULL,
+  "mimeType" TEXT NOT NULL,
+  "sizeBytes" INTEGER NOT NULL,
+  "sha256" TEXT NOT NULL,
+  "status" "CandidateDiagnosticDocumentStatus" NOT NULL DEFAULT 'UPLOADED',
+  "reviewNote" TEXT,
+  "reviewedById" TEXT,
+  "reviewedAt" TIMESTAMP(3),
+  "clientMutationId" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "candidate_diagnostic_documents_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "candidate_diagnostic_audit_logs" (
+  "id" TEXT NOT NULL,
+  "diagnosticId" TEXT NOT NULL,
+  "actorId" TEXT,
+  "actorRole" "CandidateDiagnosticActorRole" NOT NULL,
+  "action" TEXT NOT NULL,
+  "entityType" TEXT NOT NULL,
+  "entityId" TEXT,
+  "requestId" TEXT,
+  "ipHash" TEXT,
+  "userAgentHash" TEXT,
+  "details" JSONB,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "candidate_diagnostic_audit_logs_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "candidate_diagnostics_studentId_diagnosticKey_targetSession_key"
+  ON "candidate_diagnostics"("studentId", "diagnosticKey", "targetSession");
+CREATE INDEX "candidate_diagnostics_studentId_status_idx" ON "candidate_diagnostics"("studentId", "status");
+CREATE INDEX "candidate_diagnostics_status_updatedAt_idx" ON "candidate_diagnostics"("status", "updatedAt");
+CREATE UNIQUE INDEX "candidate_diagnostic_modules_diagnosticId_moduleKey_key"
+  ON "candidate_diagnostic_modules"("diagnosticId", "moduleKey");
+CREATE INDEX "candidate_diagnostic_modules_diagnosticId_status_idx"
+  ON "candidate_diagnostic_modules"("diagnosticId", "status");
+CREATE UNIQUE INDEX "candidate_diagnostic_documents_diag_mutation_key"
+  ON "candidate_diagnostic_documents"("diagnosticId", "clientMutationId");
+CREATE INDEX "candidate_diagnostic_documents_diagnosticId_category_idx"
+  ON "candidate_diagnostic_documents"("diagnosticId", "category");
+CREATE INDEX "candidate_diagnostic_documents_sha256_idx" ON "candidate_diagnostic_documents"("sha256");
+CREATE INDEX "candidate_diagnostic_audit_logs_diagnosticId_createdAt_idx"
+  ON "candidate_diagnostic_audit_logs"("diagnosticId", "createdAt");
+CREATE INDEX "candidate_diagnostic_audit_logs_actorId_createdAt_idx"
+  ON "candidate_diagnostic_audit_logs"("actorId", "createdAt");
+
+ALTER TABLE "candidate_diagnostics" ADD CONSTRAINT "candidate_diagnostics_studentId_fkey"
+  FOREIGN KEY ("studentId") REFERENCES "students"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "candidate_diagnostics" ADD CONSTRAINT "candidate_diagnostics_createdById_fkey"
+  FOREIGN KEY ("createdById") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "candidate_diagnostic_modules" ADD CONSTRAINT "candidate_diagnostic_modules_diagnosticId_fkey"
+  FOREIGN KEY ("diagnosticId") REFERENCES "candidate_diagnostics"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "candidate_diagnostic_documents" ADD CONSTRAINT "candidate_diagnostic_documents_diagnosticId_fkey"
+  FOREIGN KEY ("diagnosticId") REFERENCES "candidate_diagnostics"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "candidate_diagnostic_documents" ADD CONSTRAINT "candidate_diagnostic_documents_uploadedById_fkey"
+  FOREIGN KEY ("uploadedById") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "candidate_diagnostic_audit_logs" ADD CONSTRAINT "candidate_diagnostic_audit_logs_diagnosticId_fkey"
+  FOREIGN KEY ("diagnosticId") REFERENCES "candidate_diagnostics"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "candidate_diagnostic_audit_logs" ADD CONSTRAINT "candidate_diagnostic_audit_logs_actorId_fkey"
+  FOREIGN KEY ("actorId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -225,6 +225,11 @@ model User {
   // Canonical bilan reviews performed by this user (ASSISTANTE)
   bilanReportReviews ReportReview[]
 
+  // Diagnostic candidat libre 2027 (feature isolée)
+  createdCandidateDiagnostics          CandidateDiagnostic[]         @relation("CandidateDiagnosticCreatedBy")
+  candidateDiagnosticDocumentsUploaded CandidateDiagnosticDocument[] @relation("CandidateDiagnosticDocumentUploader")
+  candidateDiagnosticAuditLogs         CandidateDiagnosticAuditLog[] @relation("CandidateDiagnosticAuditActor")
+
   // 2FA TOTP (Admin only)
   totpSecret      String? // AES-256-GCM encrypted, format: v1:iv:tag:ciphertext
   totpEnabledAt   DateTime? // non-null = 2FA active (canonical check)
@@ -325,6 +330,9 @@ model Student {
   parentLinks                 ParentStudentLink[]
   canonicalAssessmentAttempts CanonicalAssessmentAttempt[]
   reportArtifacts             ReportArtifact[]
+
+  // Diagnostic candidat libre 2027 (feature isolée, non liée aux bilans/assessments historiques)
+  candidateDiagnostics CandidateDiagnostic[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1648,9 +1656,9 @@ model ReportAudienceArtifact {
 }
 
 model ReportReview {
-  id               String               @id @default(cuid())
+  id               String         @id @default(cuid())
   reportRevisionId String
-  reportRevision   ReportRevision       @relation(fields: [reportRevisionId], references: [id], onDelete: Restrict)
+  reportRevision   ReportRevision @relation(fields: [reportRevisionId], references: [id], onDelete: Restrict)
 
   // Historical reviewer path (COACH, via CoachProfile). Retired for new
   // rows in favor of reviewerId (ASSISTANTE, via User) — exactly one of
@@ -2816,4 +2824,160 @@ model BusinessConfigAudit {
   @@index([namespace, key])
   @@index([changedAt])
   @@map("business_config_audit")
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Diagnostic candidat libre 2027 (bac général, candidat individuel)
+//
+// Feature isolée, non liée aux modèles historiques Assessment/Bilan/Diagnostic.
+// Un CandidateDiagnostic par élève × diagnosticKey × targetSession. Chaque
+// module conserve un snapshot immuable de sa définition au moment de la
+// passation. L'affectation coach réutilise le modèle CoachStudentAssignment
+// existant (lib/guards.ts: requireCoachAssignedToStudent) — pas de modèle
+// d'affectation dédié.
+// ═══════════════════════════════════════════════════════════════════════════
+
+enum CandidateDiagnosticStatus {
+  DRAFT
+  ACTIVE
+  WAITING_PARENT
+  WAITING_RETENTION
+  SUBMITTED
+  IN_REVIEW
+  REVIEWED
+  CLOSED
+  CANCELLED
+}
+
+enum CandidateDiagnosticModuleStatus {
+  LOCKED
+  AVAILABLE
+  IN_PROGRESS
+  SUBMITTED
+  AUTO_SCORED
+  NEEDS_REVIEW
+  REVIEWED
+}
+
+enum CandidateDiagnosticDocumentStatus {
+  UPLOADED
+  ACCEPTED
+  REJECTED
+  NEEDS_REPLACEMENT
+}
+
+enum CandidateDiagnosticActorRole {
+  ELEVE
+  PARENT
+  COACH
+  ADMIN
+  SYSTEM
+}
+
+model CandidateDiagnostic {
+  id                String                        @id @default(cuid())
+  diagnosticKey     String
+  definitionVersion String
+  targetSession     Int
+  status            CandidateDiagnosticStatus     @default(DRAFT)
+  studentId         String
+  student           Student                       @relation(fields: [studentId], references: [id], onDelete: Cascade)
+  createdById       String
+  createdBy         User                          @relation("CandidateDiagnosticCreatedBy", fields: [createdById], references: [id], onDelete: Restrict)
+  studentConsentAt  DateTime?
+  parentConsentAt   DateTime?
+  parentSubmittedAt DateTime?
+  retentionDueAt    DateTime?
+  submittedAt       DateTime?
+  reviewedAt        DateTime?
+  closedAt          DateTime?
+  metadata          Json?
+  synthesis         Json?
+  modules           CandidateDiagnosticModule[]
+  documents         CandidateDiagnosticDocument[]
+  audits            CandidateDiagnosticAuditLog[]
+  createdAt         DateTime                      @default(now())
+  updatedAt         DateTime                      @updatedAt
+
+  @@unique([studentId, diagnosticKey, targetSession])
+  @@index([studentId, status])
+  @@index([status, updatedAt])
+  @@map("candidate_diagnostics")
+}
+
+model CandidateDiagnosticModule {
+  id                   String                          @id @default(cuid())
+  diagnosticId         String
+  diagnostic           CandidateDiagnostic             @relation(fields: [diagnosticId], references: [id], onDelete: Cascade)
+  moduleKey            String
+  audience             String
+  status               CandidateDiagnosticModuleStatus @default(LOCKED)
+  answers              Json?
+  currentQuestionIndex Int                             @default(0)
+  elapsedMs            Int                             @default(0)
+  integrity            Json?
+  autoScore            Json?
+  manualScore          Json?
+  reviewSummary        String?
+  definitionSnapshot   Json
+  lastMutationId       String?
+  availableAt          DateTime?
+  startedAt            DateTime?
+  submittedAt          DateTime?
+  reviewedAt           DateTime?
+  createdAt            DateTime                        @default(now())
+  updatedAt            DateTime                        @updatedAt
+
+  @@unique([diagnosticId, moduleKey])
+  @@index([diagnosticId, status])
+  @@map("candidate_diagnostic_modules")
+}
+
+model CandidateDiagnosticDocument {
+  id               String                            @id @default(cuid())
+  diagnosticId     String
+  diagnostic       CandidateDiagnostic               @relation(fields: [diagnosticId], references: [id], onDelete: Cascade)
+  uploadedById     String
+  uploadedBy       User                              @relation("CandidateDiagnosticDocumentUploader", fields: [uploadedById], references: [id], onDelete: Restrict)
+  category         String
+  title            String
+  description      String?
+  originalName     String
+  storageKey       String
+  mimeType         String
+  sizeBytes        Int
+  sha256           String
+  status           CandidateDiagnosticDocumentStatus @default(UPLOADED)
+  reviewNote       String?
+  reviewedById     String?
+  reviewedAt       DateTime?
+  clientMutationId String
+  createdAt        DateTime                          @default(now())
+  updatedAt        DateTime                          @updatedAt
+
+  @@unique([diagnosticId, clientMutationId], map: "candidate_diagnostic_documents_diag_mutation_key")
+  @@index([diagnosticId, category])
+  @@index([sha256])
+  @@map("candidate_diagnostic_documents")
+}
+
+model CandidateDiagnosticAuditLog {
+  id            String                       @id @default(cuid())
+  diagnosticId  String
+  diagnostic    CandidateDiagnostic          @relation(fields: [diagnosticId], references: [id], onDelete: Cascade)
+  actorId       String?
+  actor         User?                        @relation("CandidateDiagnosticAuditActor", fields: [actorId], references: [id], onDelete: SetNull)
+  actorRole     CandidateDiagnosticActorRole
+  action        String
+  entityType    String
+  entityId      String?
+  requestId     String?
+  ipHash        String?
+  userAgentHash String?
+  details       Json?
+  createdAt     DateTime                     @default(now())
+
+  @@index([diagnosticId, createdAt])
+  @@index([actorId, createdAt])
+  @@map("candidate_diagnostic_audit_logs")
 }


### PR DESCRIPTION
## Résumé

Intègre le lot « Diagnostic candidat individuel 2027 » (16 modules, 266 items) dans `nexus-project_v0` : modèles Prisma isolés `CandidateDiagnostic*`, 8 routes API, composants élève/parent, banque de questions et moteur de scoring `server-only`.

**Le flag produit `CANDIDATE_DIAGNOSTIC_ENABLED` est désactivé et prouvé désactivé** — voir « Preuve que la feature est dark » ci-dessous. Rien n'est déployé, migré en prod, ni provisionné pour de vrais comptes. Cette PR est un checkpoint de revue, pas une mise en production.

Coordination : l'instance A travaille en parallèle sur la PR #98. Les deux branches sont indépendantes ; **séquencer les merges** — #98 d'abord, puis rebase + re-test de migration pour #100 sur le nouveau baseline, jamais deux migrations/déploiements concurrents.

État complet (fait / gaté / décisions attendues) : voir `STATUT-candidat-libre.md` à la racine de la branche.

## Points d'attention pour la revue (priorité)

### 1. Preuve que la feature est dark tant que le flag est OFF — nouveau, à vérifier en priorité
`lib/diagnostics/candidat-libre/feature-flag.ts` introduit un kill switch global (`CANDIDATE_DIAGNOSTIC_ENABLED=true`, désactivé par défaut), câblé en première ligne des 16 points d'entrée (8 fichiers de routes API, 13 handlers + 2 pages). `__tests__/api/diagnostics/candidat-libre/feature-flag-dark.test.ts` (24 tests) prouve que chaque route renvoie 404 **sans appeler `requireAnyRole`/`requireRole`/`guardRateLimitAsync`** — la protection ne dépend d'aucune résolution de rôle, donc aucun rôle (élève, parent, coach, assistante, admin, non-authentifié) ne peut passer, y compris une session qu'une couche d'auth aurait normalement admise en ADMIN.

**Demande au reviewer** : confirmer qu'aucun autre point d'entrée (lien de navigation, menu, middleware) n'expose la feature — vérifié par grep, à recouper.

### 2. Deux tours de correctifs IDOR/RBAC sur la séparation élève/parent/staff — à vérifier en priorité

**Premier tour (Gate 5)** : le GET diagnostic partagé entre portails élève et parent renvoyait `autoScore`/`reviewSummary` (score détaillé par question) de **tous** les modules à **tout** viewer authentifié — un élève voyait le score détaillé du questionnaire confidentiel du parent, et réciproquement.

**Second tour, plus sévère, trouvé lors d'un audit exhaustif volontairement plus large que les deux cas déjà connus** : un parent pouvait **lister et télécharger** les copies écrites (`WRITTEN_COPY`) et l'enregistrement du Grand oral (`ORAL_RECORDING`) de l'enfant — ses productions académiques réelles, pas de simples scores — sans aucun filtre, à la fois via le sérialiseur, la liste des documents et le téléchargement direct par id.

Correction commune : `lib/diagnostics/candidat-libre/serialize.server.ts` prend le rôle du viewer et masque `autoScore`/`reviewSummary` hors audience ; `lib/diagnostics/candidat-libre/access.server.ts` expose `isDocumentVisibleToViewer(category, viewerRole)`, appliqué aux 3 points d'exposition documents. Statut/progression restent visibles partout (nécessaires à l'UX « en attente du parent »).

**Demande explicite au reviewer** : vérifier que ce masquage est **exhaustif** contre `docs/DIAGNOSTIC_CANDIDAT_LIBRE_CROSS_AUDIENCE_AUDIT.md` (matrice champ × audience complète, route par route) — en particulier qu'aucun autre champ ou route partagée n'a été manqué. Les tests (`__tests__/lib/diagnostics/candidat-libre/serialize.test.ts`) verrouillent l'ensemble exact des clés retournées par audience, pas seulement les cas déjà connus.

### 3. Fix du guard `requireCoachAssignedToStudent` (`lib/guards.ts`)
Comparait un `User.id` à `CoachStudentAssignment.coachId`, qui référence en réalité `CoachProfile.id` (espace d'id distinct, confirmé via `app/api/assistante/assignments/route.ts`). Guard mort code en prod avant ce fix (aucun appelant), donc correction sans risque de régression. Résolu via la relation (`coach: { userId }`). Tests : `__tests__/lib/guards.coach-assignment.test.ts`.

### 4. Validateurs magic-bytes audio
Les 4 formats audio du Grand oral n'avaient aucune vérification de signature binaire, seulement le MIME déclaré côté client. Ajoutés dans `lib/diagnostics/candidat-libre/storage.server.ts`. Tests : `__tests__/lib/diagnostics/candidat-libre/storage.test.ts`.

### 5. Nom d'index de migration trop long
Un nom à 64 caractères dépassait la limite Postgres de 63, tronqué silencieusement à la création, causant une désynchronisation permanente avec Prisma. Trouvé en testant la migration sur un Postgres jetable (schéma seul, aucune donnée réelle). Corrigé via `map:` explicite.

## Validation effectuée

- `npm run build` complet : vert, artefact standalone validé (répété après chaque tour de correctifs).
- `tsc --noEmit` sur tout le monorepo : 0 erreur.
- `eslint` sur les fichiers du lot : 0 erreur (warnings `no-explicit-any` préexistants au style du lot).
- Migration testée sur Postgres jetable (`pgvector/pgvector:pg16`, aucune donnée réelle) : idempotente, `migrate status` clean, `migrate diff` sans écart, aucune instruction destructive. **À refaire après rebase sur le baseline post-#98** (pas fait dans cette passe, différé volontairement).
- 75 tests unitaires passants sur le périmètre diagnostic (dont 24 tests flag-off, 12 tests d'audit cross-audience exhaustif, tests des correctifs guard/storage/migration).

## Ouvert — non bloquant pour cette revue de code, bloquant avant tout dossier réel (mineur concerné)

Détail complet dans `STATUT-candidat-libre.md`. Résumé :

- **Merge** : séquencé après #98 → rebase → re-test migration sur nouveau baseline → approbation → merge.
- **Ops/légal** : notice RGPD, politique de rétention, sauvegarde chiffrée des documents, CSP/reverse-proxy, alerting, antivirus testé en conditions réelles.
- **Relecture pédagogique** (`docs/relecture-pedagogique/tronc-commun/`, 218 items prêts sur 14 modules communs) : non couvert = anglais/histoire-géo/LVB/méthodologie (17 items, aucun relecteur du vivier nommé), Grand oral (12 items, dépend des spécialités), 126 items transversaux (rôle de coordination à confirmer), NSI/SES (spécialités à reconfirmer formellement).
- **Provisionnement** (Phase P) : 2 comptes réels par chemin canonique sûr, en toute fin, une fois tout le reste vert.

Décisions produit/pédagogiques attendues du responsable, listées dans `STATUT-candidat-libre.md` : confirmation des 2 spécialités, qui relit les items transversaux, relecteurs pour les items non couverts, et validation explicite du choix « le parent ne voit pas les productions académiques de l'enfant ».

## Test plan

- [ ] Revue de la preuve « flag OFF ⇒ dark » (point 1).
- [ ] Revue de la matrice champ × audience et du filtrage documents (point 2) — exhaustivité à confirmer par un second regard.
- [ ] Revue du fix guard coach (point 3).
- [ ] `npm run test:unit -- __tests__/lib/diagnostics/candidat-libre __tests__/lib/guards.coach-assignment.test.ts __tests__/api/diagnostics/candidat-libre`
- [ ] Après rebase sur main post-#98 : `npx prisma validate` + re-test migration sur clone schéma seul.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
