### PR TITLE
fix(e2e): réparer le pipeline docker-compose.e2e.yml de bout en bout

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -57,9 +57,13 @@ COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/node_modules/.prisma ./.prisma
 COPY --from=builder /app/prisma ./prisma
 
-# Seed script needs these
+# Seed script needs these — tsconfig.json is required for tsx to resolve the
+# "@/..." path alias used throughout scripts/ and lib/ (e.g.
+# scripts/seed-e2e-db.ts imports '@/lib/utils/serialize-error'); without it
+# tsx has no paths mapping and every "@/..." import throws MODULE_NOT_FOUND.
 COPY --from=builder /app/scripts ./scripts
 COPY --from=builder /app/lib ./lib
+COPY --from=builder /app/tsconfig.json ./tsconfig.json
 
 # Entrypoint: migrate → seed → start
 COPY scripts/e2e-entrypoint.sh /app/e2e-entrypoint.sh

--- a/Dockerfile.playwright
+++ b/Dockerfile.playwright
@@ -36,6 +36,11 @@ COPY content ./content
 COPY public ./public
 COPY app/fonts ./app/fonts
 
+# e2e/auth/parent-canonical-report-access.spec.ts imports its fact-sheet
+# fixture from the Jest tree (__tests__/bilans/fixtures) rather than
+# duplicating it under e2e/ — only that one fixture dir is needed here.
+COPY __tests__/bilans/fixtures ./__tests__/bilans/fixtures
+
 # Copy tsconfig for TypeScript resolution
 COPY tsconfig.json ./tsconfig.json
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -585,15 +585,14 @@ async function main() {
       const vectorString = `[${vector.join(',')}]`;
 
       await prisma.$executeRaw`
-        INSERT INTO "pedagogical_contents" (id, title, content, subject, "embedding_vector", "updatedAt", "embedding", "tags")
+        INSERT INTO "pedagogical_contents" (id, title, content, subject, "embedding_vector", "updatedAt", "tags")
         VALUES (
-            ${id}, 
-            ${title}, 
-            ${baseContent.content}, 
-            ${baseContent.subject}::"Subject", 
-            ${vectorString}::vector, 
-            NOW(), 
-            '[]'::jsonb, 
+            ${id},
+            ${title},
+            ${baseContent.content},
+            ${baseContent.subject}::"Subject",
+            ${vectorString}::vector,
+            NOW(),
             '[]'::jsonb
         );
       `;


### PR DESCRIPTION
## Contexte

Découvert en tentant de faire tourner Playwright localement pour la revue de PR #100 : `npm run test:e2e:ephemeral` échouait sur les 123 specs avec la même erreur (`e2e/.credentials.json not found`), qui masquait la vraie cause — `e2e-entrypoint.sh` avale les erreurs de seed en silence (`Seed failed or already seeded, continuing...`) et démarre l'app quand même.

Sans rapport avec le contenu de #100 (feature flag OFF) — cassé pour tout le repo, pas seulement ce lot. PR séparée comme demandé.

## Trois bugs distincts, corrigés séquentiellement (chacun révélé une fois le précédent réglé)

1. **`prisma/seed.ts`** insère une colonne `"embedding"` sur `pedagogical_contents` que la migration `20260421083000_remove_embedding_legacy_column` a supprimée il y a plusieurs mois. Le modèle Prisma ne la déclare plus non plus. Retirée de l'`INSERT`.
2. **`Dockerfile.e2e`** (stage `runner`) ne copiait jamais `tsconfig.json` — `scripts/seed-e2e-db.ts` (exécuté via `tsx`) importe `@/lib/utils/serialize-error` par alias, non résolvable sans le `paths` mapping. `MODULE_NOT_FOUND`.
3. **`Dockerfile.playwright`** ne copie que `__tests__/e2e`, pas tout `__tests__/` — `e2e/auth/parent-canonical-report-access.spec.ts` importe une fixture depuis `__tests__/bilans/fixtures/recipe-fact-sheets`, absente de l'image. Copié uniquement ce dossier de fixture précis.

## Validation effectuée

Rebuild complet + run local (pas seulement lecture de code) :
- ✅ Seed principal (`prisma/seed.ts`) : complet, sans erreur.
- ✅ Seed E2E (`scripts/seed-e2e-db.ts`) : `e2e/.credentials.json` généré.
- ✅ App démarre, healthcheck passe.
- ✅ Playwright se lance et exécute réellement les specs — jamais atteint avant ce correctif.

## Reste ouvert, hors périmètre de ce commit

`e2e/auth/parent-canonical-report-access.spec.ts` a son propre garde qui exige `DATABASE_URL` pointant vers une base `nexus_p0c_parent_test` — aucun job CI ni `docker-compose.e2e.yml` ne la provisionne (`grep -rn "p0c_parent_test"` négatif sur tout le repo). Semble être un spec orphelin d'un job jamais câblé, pas un bug d'infra Docker. À trancher séparément (soit provisionner cette base isolée dans le stack e2e, soit ce spec appartient à un autre job CI à identifier).

## Test plan

- [ ] `docker compose -f docker-compose.e2e.yml up --build --abort-on-container-exit --exit-code-from playwright` (ou `npm run test:e2e:ephemeral`) en local.
- [ ] Vérifier `e2e/.credentials.json` généré et Playwright exécute les specs (au-delà du seul `parent-canonical-report-access.spec.ts`, attendu en échec pour la raison documentée ci-dessus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the e2e `docker-compose.e2e.yml` pipeline so `npm run test:e2e:ephemeral` runs real `Playwright` tests again. Unblocks runs by fixing seed, module resolution, and missing fixtures.

- **Bug Fixes**
  - Removed legacy `"embedding"` column from `prisma/seed.ts` insert to match schema; prevents Postgres 42703.
  - In `Dockerfile.e2e`, copy `tsconfig.json` so `tsx` resolves `@/...` imports used by seed scripts.
  - In `Dockerfile.playwright`, copy `__tests__/bilans/fixtures` needed by `e2e/auth/parent-canonical-report-access.spec.ts`.
  - Note: that spec still expects `DATABASE_URL` for a separate `nexus_p0c_parent_test` DB; to be handled separately.

<sup>Written for commit c84e9c49bc677ba27252422a34a6ebf1f0d8668a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

