### PR TITLE
Phase 3 — onboarding candidat libre : consentement recueillable, allowlist, activation élève

### DIFF
--- a/__tests__/api/diagnostics/candidat-libre/allowlist.test.ts
+++ b/__tests__/api/diagnostics/candidat-libre/allowlist.test.ts
@@ -1,0 +1,128 @@
+import {
+  guardCandidateDiagnosticFeature,
+  guardCandidateDiagnosticForStudent,
+  isCandidateDiagnosticEnabledForStudent,
+  isCandidateDiagnosticFeatureEnabled,
+  listAllowedCandidateStudentIds,
+} from '@/lib/diagnostics/candidat-libre/feature-flag';
+
+/**
+ * Allowlist par `studentId`.
+ *
+ * Le rôle `ELEVE_CANDIDAT_LIBRE` n'existe pas, et la fonctionnalité n'a aucun
+ * contrôle d'éligibilité : le drapeau seul ouvrirait à tous les élèves et
+ * parents de la base. L'allowlist remplace les deux — elle scope l'ouverture au
+ * dossier réellement autorisé.
+ *
+ * Elle est **additive** : le kill switch garde son mot final, et une allowlist
+ * vide ne peut pas ouvrir la fonctionnalité.
+ */
+
+const ORIGINAL_FLAG = process.env.CANDIDATE_DIAGNOSTIC_ENABLED;
+const ORIGINAL_ALLOWLIST = process.env.CANDIDATE_DIAGNOSTIC_STUDENT_IDS;
+
+function configure(flag?: string, allowlist?: string): void {
+  if (flag === undefined) delete process.env.CANDIDATE_DIAGNOSTIC_ENABLED;
+  else process.env.CANDIDATE_DIAGNOSTIC_ENABLED = flag;
+  if (allowlist === undefined) delete process.env.CANDIDATE_DIAGNOSTIC_STUDENT_IDS;
+  else process.env.CANDIDATE_DIAGNOSTIC_STUDENT_IDS = allowlist;
+}
+
+afterAll(() => {
+  configure(ORIGINAL_FLAG, ORIGINAL_ALLOWLIST);
+});
+
+describe('listAllowedCandidateStudentIds', () => {
+  it('est vide quand rien n’est configuré', () => {
+    configure('true', undefined);
+    expect(listAllowedCandidateStudentIds()).toEqual([]);
+  });
+
+  it('accepte une liste séparée par des virgules, en ignorant les espaces', () => {
+    configure('true', ' stu_a , stu_b ,,stu_c ');
+    expect(listAllowedCandidateStudentIds()).toEqual(['stu_a', 'stu_b', 'stu_c']);
+  });
+
+  it('déduplique sans changer l’ordre', () => {
+    configure('true', 'stu_a,stu_b,stu_a');
+    expect(listAllowedCandidateStudentIds()).toEqual(['stu_a', 'stu_b']);
+  });
+});
+
+describe('isCandidateDiagnosticEnabledForStudent', () => {
+  it('autorise un élève inscrit à l’allowlist', () => {
+    configure('true', 'stu_autorise');
+    expect(isCandidateDiagnosticEnabledForStudent('stu_autorise')).toBe(true);
+  });
+
+  it('refuse un élève absent de l’allowlist, drapeau allumé', () => {
+    configure('true', 'stu_autorise');
+    expect(isCandidateDiagnosticEnabledForStudent('stu_autre')).toBe(false);
+  });
+
+  /** Le kill switch garde le dernier mot : l'allowlist ne peut jamais l'outrepasser. */
+  it('refuse même un élève de l’allowlist quand le drapeau est éteint', () => {
+    configure(undefined, 'stu_autorise');
+    expect(isCandidateDiagnosticEnabledForStudent('stu_autorise')).toBe(false);
+  });
+
+  it('refuse tout le monde quand l’allowlist est vide', () => {
+    configure('true', '');
+    expect(isCandidateDiagnosticEnabledForStudent('stu_autorise')).toBe(false);
+  });
+
+  it.each([undefined, null, ''])('refuse un studentId absent (%p)', (value) => {
+    configure('true', 'stu_autorise');
+    expect(isCandidateDiagnosticEnabledForStudent(value as unknown as string)).toBe(false);
+  });
+
+  it('n’ouvre pas par correspondance partielle', () => {
+    configure('true', 'stu_autorise');
+    expect(isCandidateDiagnosticEnabledForStudent('stu_autorise_bis')).toBe(false);
+    expect(isCandidateDiagnosticEnabledForStudent('stu_autoris')).toBe(false);
+  });
+});
+
+describe('guardCandidateDiagnosticForStudent', () => {
+  it('laisse passer un élève autorisé', () => {
+    configure('true', 'stu_autorise');
+    expect(guardCandidateDiagnosticForStudent('stu_autorise')).toBeNull();
+  });
+
+  /**
+   * 404 et non 403 : hors allowlist, la fonctionnalité doit paraître absente,
+   * exactement comme lorsque le kill switch est éteint. Un 403 révélerait son
+   * existence.
+   */
+  it('répond 404 pour un élève non autorisé', async () => {
+    configure('true', 'stu_autorise');
+    const response = guardCandidateDiagnosticForStudent('stu_autre');
+    expect(response?.status).toBe(404);
+    expect((await response?.json()).error).toBe('Not Found');
+  });
+
+  it('répond 404 quand le drapeau est éteint, allowlist non vide', () => {
+    configure(undefined, 'stu_autorise');
+    expect(guardCandidateDiagnosticForStudent('stu_autorise')?.status).toBe(404);
+  });
+});
+
+describe('compatibilité avec le kill switch existant', () => {
+  it('conserve le comportement global du drapeau', () => {
+    configure('true', 'stu_a');
+    expect(isCandidateDiagnosticFeatureEnabled()).toBe(true);
+    expect(guardCandidateDiagnosticFeature()).toBeNull();
+
+    configure(undefined, 'stu_a');
+    expect(isCandidateDiagnosticFeatureEnabled()).toBe(false);
+    expect(guardCandidateDiagnosticFeature()?.status).toBe(404);
+  });
+
+  it.each(['TRUE', '1', 'yes', 'on', ' true'])(
+    'reste fermé pour une valeur de drapeau non conforme (%p)',
+    (value) => {
+      configure(value, 'stu_a');
+      expect(isCandidateDiagnosticEnabledForStudent('stu_a')).toBe(false);
+    },
+  );
+});

--- a/__tests__/api/diagnostics/candidat-libre/consent-recording.test.ts
+++ b/__tests__/api/diagnostics/candidat-libre/consent-recording.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Recueil du consentement candidat libre.
+ *
+ * La Phase 1 a posé le garde-fou qui **lit** le consentement ; sans moyen de
+ * l'enregistrer, l'état restait `MISSING` en permanence. Ce service le rend
+ * recueillable — et lui seul écrit dans `CandidateDiagnosticConsent`.
+ *
+ * Trois exigences que le stockage seul ne garantit pas : le consentement vient
+ * du parent **actuellement** rattaché, il porte la **version de notice**
+ * réellement présentée, et il est **retirable**.
+ */
+
+const mockStudentFindUnique = jest.fn();
+const mockConsentFindFirst = jest.fn();
+const mockConsentUpsert = jest.fn();
+const mockConsentUpdate = jest.fn();
+const mockAuditCreate = jest.fn();
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    student: { findUnique: (...a: unknown[]) => mockStudentFindUnique(...a) },
+    candidateDiagnosticConsent: {
+      findFirst: (...a: unknown[]) => mockConsentFindFirst(...a),
+      upsert: (...a: unknown[]) => mockConsentUpsert(...a),
+      update: (...a: unknown[]) => mockConsentUpdate(...a),
+    },
+    candidateDiagnosticAuditLog: { create: (...a: unknown[]) => mockAuditCreate(...a) },
+  },
+}));
+
+import {
+  ConsentRecordingError,
+  grantParentalConsent,
+  recordStudentAssent,
+  withdrawParentalConsent,
+} from '@/lib/diagnostics/candidat-libre/consent-recording.server';
+import { CANDIDATE_DIAGNOSTIC_NOTICE_VERSION } from '@/lib/diagnostics/candidat-libre/privacy-notice';
+
+const STUDENT_ID = 'stu_1';
+const PARENT_ID = 'usr_parent_1';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockStudentFindUnique.mockResolvedValue({ id: STUDENT_ID, parent: { userId: PARENT_ID } });
+  mockConsentUpsert.mockImplementation(async ({ create }: any) => ({ id: 'c1', ...create }));
+  mockConsentFindFirst.mockResolvedValue({
+    id: 'c1',
+    studentId: STUDENT_ID,
+    parentUserId: PARENT_ID,
+    noticeVersion: CANDIDATE_DIAGNOSTIC_NOTICE_VERSION,
+    withdrawnAt: null,
+  });
+  mockConsentUpdate.mockImplementation(async ({ data }: any) => ({ id: 'c1', ...data }));
+});
+
+describe('grantParentalConsent', () => {
+  it('enregistre le consentement du parent rattaché', async () => {
+    await grantParentalConsent({
+      studentId: STUDENT_ID,
+      parentUserId: PARENT_ID,
+      noticeVersion: CANDIDATE_DIAGNOSTIC_NOTICE_VERSION,
+    });
+
+    const { create } = mockConsentUpsert.mock.calls[0][0];
+    expect(create.studentId).toBe(STUDENT_ID);
+    expect(create.parentUserId).toBe(PARENT_ID);
+    expect(create.noticeVersion).toBe(CANDIDATE_DIAGNOSTIC_NOTICE_VERSION);
+    expect(create.parentConsentedAt).toBeInstanceOf(Date);
+  });
+
+  /** Le titulaire de l'autorité parentale peut avoir changé. */
+  it('refuse un parent qui n’est pas celui actuellement rattaché', async () => {
+    await expect(grantParentalConsent({
+      studentId: STUDENT_ID,
+      parentUserId: 'usr_autre_parent',
+      noticeVersion: CANDIDATE_DIAGNOSTIC_NOTICE_VERSION,
+    })).rejects.toThrow(ConsentRecordingError);
+    expect(mockConsentUpsert).not.toHaveBeenCalled();
+  });
+
+  it('refuse quand l’élève n’a aucun parent rattaché', async () => {
+    mockStudentFindUnique.mockResolvedValue({ id: STUDENT_ID, parent: null });
+    await expect(grantParentalConsent({
+      studentId: STUDENT_ID,
+      parentUserId: PARENT_ID,
+      noticeVersion: CANDIDATE_DIAGNOSTIC_NOTICE_VERSION,
+    })).rejects.toThrow(/NO_PARENT/);
+  });
+
+  /**
+   * Le consentement porte sur un texte précis : accepter une version que la
+   * famille n'a pas vue reviendrait à enregistrer un consentement non éclairé.
+   */
+  it('refuse une version de notice qui n’est pas la version courante', async () => {
+    await expect(grantParentalConsent({
+      studentId: STUDENT_ID,
+      parentUserId: PARENT_ID,
+      noticeVersion: 'candidat-libre-notice.v0',
+    })).rejects.toThrow(/NOTICE_VERSION/);
+    expect(mockConsentUpsert).not.toHaveBeenCalled();
+  });
+
+  it('journalise le recueil', async () => {
+    await grantParentalConsent({
+      studentId: STUDENT_ID,
+      parentUserId: PARENT_ID,
+      noticeVersion: CANDIDATE_DIAGNOSTIC_NOTICE_VERSION,
+      diagnosticId: 'diag_1',
+    });
+    expect(mockAuditCreate).toHaveBeenCalled();
+    const { data } = mockAuditCreate.mock.calls[0][0];
+    expect(data.action).toBe('PARENTAL_CONSENT_GRANTED');
+  });
+
+  it('ne journalise pas sans dossier existant', async () => {
+    await grantParentalConsent({
+      studentId: STUDENT_ID,
+      parentUserId: PARENT_ID,
+      noticeVersion: CANDIDATE_DIAGNOSTIC_NOTICE_VERSION,
+    });
+    expect(mockAuditCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('recordStudentAssent', () => {
+  it('horodate l’assentiment de l’élève sur le consentement courant', async () => {
+    await recordStudentAssent({ studentId: STUDENT_ID });
+    const { data } = mockConsentUpdate.mock.calls[0][0];
+    expect(data.studentAssentedAt).toBeInstanceOf(Date);
+  });
+
+  it('refuse tant que le parent n’a pas consenti', async () => {
+    mockConsentFindFirst.mockResolvedValue(null);
+    await expect(recordStudentAssent({ studentId: STUDENT_ID }))
+      .rejects.toThrow(/PARENTAL_CONSENT_REQUIRED/);
+    expect(mockConsentUpdate).not.toHaveBeenCalled();
+  });
+
+  it('refuse sur un consentement retiré', async () => {
+    mockConsentFindFirst.mockResolvedValue({
+      id: 'c1', studentId: STUDENT_ID, parentUserId: PARENT_ID,
+      noticeVersion: CANDIDATE_DIAGNOSTIC_NOTICE_VERSION, withdrawnAt: new Date(),
+    });
+    await expect(recordStudentAssent({ studentId: STUDENT_ID })).rejects.toThrow(/WITHDRAWN/);
+  });
+
+  it('refuse sur une notice périmée', async () => {
+    mockConsentFindFirst.mockResolvedValue({
+      id: 'c1', studentId: STUDENT_ID, parentUserId: PARENT_ID,
+      noticeVersion: 'candidat-libre-notice.v0', withdrawnAt: null,
+    });
+    await expect(recordStudentAssent({ studentId: STUDENT_ID })).rejects.toThrow(/NOTICE_VERSION/);
+  });
+});
+
+describe('withdrawParentalConsent', () => {
+  it('horodate le retrait', async () => {
+    await withdrawParentalConsent({ studentId: STUDENT_ID, parentUserId: PARENT_ID });
+    const { data } = mockConsentUpdate.mock.calls[0][0];
+    expect(data.withdrawnAt).toBeInstanceOf(Date);
+  });
+
+  it('conserve le motif quand il est fourni', async () => {
+    await withdrawParentalConsent({
+      studentId: STUDENT_ID, parentUserId: PARENT_ID, reason: 'Demande de la famille',
+    });
+    expect(mockConsentUpdate.mock.calls[0][0].data.withdrawnReason).toBe('Demande de la famille');
+  });
+
+  it('refuse un retrait demandé par un autre que le parent rattaché', async () => {
+    await expect(withdrawParentalConsent({ studentId: STUDENT_ID, parentUserId: 'usr_autre' }))
+      .rejects.toThrow(ConsentRecordingError);
+    expect(mockConsentUpdate).not.toHaveBeenCalled();
+  });
+
+  it('est idempotent sur un consentement déjà retiré', async () => {
+    const already = new Date('2026-08-01T10:00:00Z');
+    mockConsentFindFirst.mockResolvedValue({
+      id: 'c1', studentId: STUDENT_ID, parentUserId: PARENT_ID,
+      noticeVersion: CANDIDATE_DIAGNOSTIC_NOTICE_VERSION, withdrawnAt: already,
+    });
+    const result = await withdrawParentalConsent({ studentId: STUDENT_ID, parentUserId: PARENT_ID });
+    expect(result.withdrawnAt).toEqual(already);
+    expect(mockConsentUpdate).not.toHaveBeenCalled();
+  });
+
+  it('ne fait rien s’il n’y a aucun consentement à retirer', async () => {
+    mockConsentFindFirst.mockResolvedValue(null);
+    await expect(withdrawParentalConsent({ studentId: STUDENT_ID, parentUserId: PARENT_ID }))
+      .rejects.toThrow(/NO_CONSENT/);
+  });
+});

--- a/__tests__/api/diagnostics/candidat-libre/student-provisioning.test.ts
+++ b/__tests__/api/diagnostics/candidat-libre/student-provisioning.test.ts
@@ -81,8 +81,8 @@ describe('provisionCandidateLibreStudent', () => {
     const result = await provisionCandidateLibreStudent(INPUT);
     expect(result.activationToken.startsWith('sact_')).toBe(true);
     const { data } = mockUserCreate.mock.calls[0][0];
-    expect(data.activationTokenExpiresAt).toBeInstanceOf(Date);
-    expect(data.activationTokenExpiresAt.getTime()).toBeGreaterThan(Date.now());
+    expect(data.activationExpiry).toBeInstanceOf(Date);
+    expect(data.activationExpiry.getTime()).toBeGreaterThan(Date.now());
   });
 
   it('laisse le compte inactif jusqu’à l’activation par l’élève', async () => {

--- a/__tests__/api/diagnostics/candidat-libre/student-provisioning.test.ts
+++ b/__tests__/api/diagnostics/candidat-libre/student-provisioning.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Provisionnement de l'élève candidat libre.
+ *
+ * Aucun chemin existant ne permet à un élève d'avoir une adresse réelle **et**
+ * de choisir son mot de passe : les routes de création forcent l'identifiant
+ * synthétique `@nexus-student.local`, et la route admin impose un mot de passe
+ * choisi par un tiers puis laisse le compte inactivable.
+ *
+ * Ce chemin est **isolé** du flux add-child du bilan gratuit, qui tourne en
+ * production. Il ne réutilise que des primitives pures — génération de token —
+ * et laisse l'activation elle-même à `completeStudentActivation`, inchangée,
+ * qui pose le mot de passe fourni par l'élève.
+ */
+
+const mockUserFindUnique = jest.fn();
+const mockParentProfileFindUnique = jest.fn();
+const mockUserCreate = jest.fn();
+const mockStudentCreate = jest.fn();
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    $transaction: (fn: (tx: unknown) => unknown) => fn({
+      user: {
+        findUnique: (...a: unknown[]) => mockUserFindUnique(...a),
+        create: (...a: unknown[]) => mockUserCreate(...a),
+      },
+      parentProfile: { findUnique: (...a: unknown[]) => mockParentProfileFindUnique(...a) },
+      student: { create: (...a: unknown[]) => mockStudentCreate(...a) },
+    }),
+  },
+}));
+
+import {
+  StudentProvisioningError,
+  provisionCandidateLibreStudent,
+} from '@/lib/diagnostics/candidat-libre/student-provisioning.server';
+import { hashActivationToken } from '@/lib/auth/activation-token';
+
+const INPUT = {
+  parentUserId: 'usr_parent_1',
+  firstName: 'Ahmed',
+  lastName: 'Ben Hadj Salem',
+  email: 'eleve.reel@example.test',
+  gradeLevel: 'TERMINALE' as const,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockParentProfileFindUnique.mockResolvedValue({ id: 'pp_1' });
+  mockUserFindUnique.mockResolvedValue(null);
+  mockUserCreate.mockImplementation(async ({ data }: any) => ({ id: 'usr_eleve_1', ...data }));
+  mockStudentCreate.mockImplementation(async ({ data }: any) => ({ id: 'stu_1', ...data }));
+});
+
+describe('provisionCandidateLibreStudent', () => {
+  it('crée le compte avec l’adresse réelle fournie', async () => {
+    await provisionCandidateLibreStudent(INPUT);
+    const { data } = mockUserCreate.mock.calls[0][0];
+    expect(data.email).toBe('eleve.reel@example.test');
+    expect(data.email).not.toContain('nexus-student.local');
+  });
+
+  /** Le cœur de l'exigence : personne d'autre que l'élève ne pose son mot de passe. */
+  it('ne pose jamais de mot de passe', async () => {
+    await provisionCandidateLibreStudent(INPUT);
+    const { data } = mockUserCreate.mock.calls[0][0];
+    expect(data.password).toBeNull();
+    expect(JSON.stringify(data)).not.toMatch(/motDePasse|passwordHash|"password":"/);
+  });
+
+  it('stocke le token d’activation haché, jamais en clair', async () => {
+    const result = await provisionCandidateLibreStudent(INPUT);
+    const { data } = mockUserCreate.mock.calls[0][0];
+
+    expect(data.activationToken).toBe(hashActivationToken(result.activationToken));
+    expect(data.activationToken).not.toBe(result.activationToken);
+    expect(data.activationToken).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('émet un token de finalité élève, avec expiration', async () => {
+    const result = await provisionCandidateLibreStudent(INPUT);
+    expect(result.activationToken.startsWith('sact_')).toBe(true);
+    const { data } = mockUserCreate.mock.calls[0][0];
+    expect(data.activationTokenExpiresAt).toBeInstanceOf(Date);
+    expect(data.activationTokenExpiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('laisse le compte inactif jusqu’à l’activation par l’élève', async () => {
+    await provisionCandidateLibreStudent(INPUT);
+    const { data } = mockUserCreate.mock.calls[0][0];
+    expect(data.activatedAt ?? null).toBeNull();
+    expect(data.role).toBe('ELEVE');
+  });
+
+  it('rattache l’élève au profil du parent', async () => {
+    await provisionCandidateLibreStudent(INPUT);
+    const { data } = mockStudentCreate.mock.calls[0][0];
+    expect(data.parentId).toBe('pp_1');
+    expect(data.userId).toBe('usr_eleve_1');
+    expect(data.gradeLevel).toBe('TERMINALE');
+  });
+
+  it('refuse quand le parent n’a pas de profil', async () => {
+    mockParentProfileFindUnique.mockResolvedValue(null);
+    await expect(provisionCandidateLibreStudent(INPUT)).rejects.toThrow(/PARENT_NOT_FOUND/);
+    expect(mockUserCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuse une adresse déjà utilisée', async () => {
+    mockUserFindUnique.mockResolvedValue({ id: 'usr_existant' });
+    await expect(provisionCandidateLibreStudent(INPUT)).rejects.toThrow(/EMAIL_ALREADY_USED/);
+    expect(mockUserCreate).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['vide', ''],
+    ['sans arobase', 'pas-une-adresse'],
+    ['domaine synthétique', 'eleve@nexus-student.local'],
+  ])('refuse une adresse %s', async (_label, email) => {
+    await expect(provisionCandidateLibreStudent({ ...INPUT, email }))
+      .rejects.toThrow(StudentProvisioningError);
+    expect(mockUserCreate).not.toHaveBeenCalled();
+  });
+
+  it('normalise l’adresse en minuscules', async () => {
+    await provisionCandidateLibreStudent({ ...INPUT, email: '  Eleve.Reel@Example.Test  ' });
+    expect(mockUserCreate.mock.calls[0][0].data.email).toBe('eleve.reel@example.test');
+  });
+
+  it('ne retourne jamais de mot de passe', async () => {
+    const result = await provisionCandidateLibreStudent(INPUT);
+    expect(Object.keys(result)).toEqual(
+      expect.arrayContaining(['studentId', 'userId', 'activationToken']),
+    );
+    expect(JSON.stringify(result)).not.toMatch(/password/i);
+  });
+});
+
+describe('isolation du flux bilan gratuit', () => {
+  /**
+   * Non-régression : ce chemin ne doit pas toucher au flux add-child, qui sert
+   * les familles en production. Il ne réutilise que la primitive pure de
+   * génération de token et n'importe aucun service partagé mutable.
+   */
+  it('n’importe pas le service d’activation du flux add-child', () => {
+    const source = require('node:fs').readFileSync(
+      require('node:path').join(process.cwd(), 'lib/diagnostics/candidat-libre/student-provisioning.server.ts'),
+      'utf8',
+    );
+    expect(source).not.toContain('student-activation.service');
+    expect(source).not.toContain('student-login-identifier');
+    expect(source).toContain('activation-token');
+  });
+});

--- a/__tests__/architecture/candidat-libre-consent-wiring.test.ts
+++ b/__tests__/architecture/candidat-libre-consent-wiring.test.ts
@@ -14,6 +14,7 @@ import path from 'node:path';
 
 const ROUTES_ROOT = path.join(process.cwd(), 'app/api/diagnostics/candidat-libre');
 const GATE = 'requireVerifiedParentalConsent';
+const ALLOWLIST = 'guardCandidateDiagnosticForStudent';
 
 /** Routes de lecture seule ou d'export staff : pas de collecte, donc non gatées. */
 const READ_ONLY_ROUTES = new Set(['staff-export/route.ts']);
@@ -74,6 +75,28 @@ describe('candidat libre — consentement parental sur tout chemin d’écriture
     expect(parentRoute).toContain('parentSubmittedAt');
     expect(parentRoute).not.toMatch(/parentConsentAt:\s*now/);
   });
+
+  it.each(routeFiles.map((file) => [path.relative(ROUTES_ROOT, file), file]))(
+    'allowlist — %s',
+    (relative, file) => {
+      const source = fs.readFileSync(file, 'utf8');
+      if (!WRITE_HANDLER.test(source)) return;
+      if (READ_ONLY_ROUTES.has(relative)) return;
+
+      // Sans allowlist, allumer le drapeau ouvrirait le diagnostic à tous les
+      // élèves et parents de la base : le rôle dédié n'existe pas et aucune
+      // éligibilité n'est vérifiée ailleurs.
+      expect(source).toContain(ALLOWLIST);
+
+      // L'allowlist doit précéder le consentement : hors périmètre, la
+      // fonctionnalité doit paraître absente (404) plutôt que de révéler
+      // qu'un consentement serait requis (403).
+      const allowlistAt = source.indexOf(`${ALLOWLIST}(`);
+      const gateAt = source.indexOf(`await ${GATE}(`);
+      expect(allowlistAt).toBeGreaterThanOrEqual(0);
+      expect(allowlistAt).toBeLessThan(gateAt);
+    },
+  );
 
   it('conserve le garde-fou du kill switch avant le consentement', () => {
     // L'ordre importe : la fonctionnalité doit rester invisible (404) avant

--- a/__tests__/architecture/candidat-libre-consent-wiring.test.ts
+++ b/__tests__/architecture/candidat-libre-consent-wiring.test.ts
@@ -19,6 +19,14 @@ const ALLOWLIST = 'guardCandidateDiagnosticForStudent';
 /** Routes de lecture seule ou d'export staff : pas de collecte, donc non gatées. */
 const READ_ONLY_ROUTES = new Set(['staff-export/route.ts']);
 
+/**
+ * La route de recueil est la seule exception au garde-fou de consentement :
+ * exiger un consentement pour joindre la route qui le recueille rendrait le
+ * parcours impossible. Elle reste soumise au kill switch et à l'allowlist, et
+ * n'écrit que le consentement — jamais de donnée de diagnostic.
+ */
+const CONSENT_COLLECTION_ROUTE = 'consent/route.ts';
+
 function listRouteFiles(directory: string): string[] {
   const found: string[] = [];
   for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
@@ -46,6 +54,7 @@ describe('candidat libre — consentement parental sur tout chemin d’écriture
 
       if (!WRITE_HANDLER.test(source)) return; // route de lecture seule
       if (READ_ONLY_ROUTES.has(relative)) return;
+      if (relative === CONSENT_COLLECTION_ROUTE) return;
 
       expect(source).toContain(GATE);
 
@@ -92,8 +101,9 @@ describe('candidat libre — consentement parental sur tout chemin d’écriture
       // fonctionnalité doit paraître absente (404) plutôt que de révéler
       // qu'un consentement serait requis (403).
       const allowlistAt = source.indexOf(`${ALLOWLIST}(`);
-      const gateAt = source.indexOf(`await ${GATE}(`);
       expect(allowlistAt).toBeGreaterThanOrEqual(0);
+      if (relative === CONSENT_COLLECTION_ROUTE) return;
+      const gateAt = source.indexOf(`await ${GATE}(`);
       expect(allowlistAt).toBeLessThan(gateAt);
     },
   );
@@ -109,5 +119,14 @@ describe('candidat libre — consentement parental sur tout chemin d’écriture
       expect(flagAt).toBeGreaterThanOrEqual(0);
       expect(flagAt).toBeLessThan(gateAt);
     }
+  });
+
+  it('la route de recueil reste protégée par le kill switch et l’allowlist', () => {
+    const source = fs.readFileSync(path.join(ROUTES_ROOT, CONSENT_COLLECTION_ROUTE), 'utf8');
+    expect(source).toContain('guardCandidateDiagnosticFeature()');
+    expect(source).toContain(ALLOWLIST);
+    // Elle ne doit écrire aucune donnée de diagnostic : seulement le consentement.
+    expect(source).not.toMatch(/candidateDiagnosticModule\.(create|update)/);
+    expect(source).not.toMatch(/candidateDiagnosticDocument\.(create|update)/);
   });
 });

--- a/__tests__/components/diagnostics/consent-gate.test.tsx
+++ b/__tests__/components/diagnostics/consent-gate.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ConsentGate } from '@/components/diagnostics/candidat-libre/ConsentGate';
+
+/**
+ * Écran de recueil du consentement.
+ *
+ * Ce que ces tests protègent n'est pas l'apparence mais deux propriétés de
+ * fond : la notice est rendue **verbatim** telle que le serveur la fournit, et
+ * la **version présentée** est celle renvoyée au serveur. Reformuler le texte
+ * ou renvoyer une autre version rendrait le consentement non éclairé.
+ */
+
+const NOTICE = {
+  version: 'candidat-libre-notice.v1',
+  title: 'Ce que vous devez savoir avant de commencer',
+  sections: [
+    { heading: 'Qui traite les données', body: ['Nexus Réussite (STE M&M ACADEMY SUARL), Tunis.'] },
+    { heading: 'Sur quelle base', body: ['Sur la base de votre consentement.'] },
+  ],
+  parentConsentStatement: "En tant que titulaire de l'autorité parentale sur {{ELEVE_NOM}}, je consens.",
+  parentConsentCheckbox: 'Je consens au traitement décrit, pour mon enfant mineur.',
+  studentAssentStatement: "J'ai compris à quoi sert ce diagnostic et j'accepte d'y participer.",
+};
+
+function mockFetch(consentState: string, onPost?: (body: unknown) => void) {
+  return jest.fn(async (url: string, init?: RequestInit) => {
+    if (init?.method === 'POST') {
+      onPost?.(JSON.parse(String(init.body)));
+      return { ok: true, json: async () => ({ consentState: 'GRANTED' }) } as Response;
+    }
+    return { ok: true, json: async () => ({ notice: NOTICE, consentState }) } as Response;
+  });
+}
+
+beforeEach(() => { jest.restoreAllMocks(); });
+
+describe('ConsentGate — écran parent', () => {
+  it('rend la notice verbatim, sans reformulation', async () => {
+    global.fetch = mockFetch('MISSING') as unknown as typeof fetch;
+    render(<ConsentGate audience="PARENT" studentId="stu_1" studentName="Ahmed" />);
+
+    expect(await screen.findByText(NOTICE.title)).toBeInTheDocument();
+    for (const section of NOTICE.sections) {
+      expect(screen.getByText(section.heading)).toBeInTheDocument();
+      for (const paragraph of section.body) {
+        expect(screen.getByText(paragraph)).toBeInTheDocument();
+      }
+    }
+  });
+
+  it('interpole le nom de l’élève dans l’engagement parental', async () => {
+    global.fetch = mockFetch('MISSING') as unknown as typeof fetch;
+    render(<ConsentGate audience="PARENT" studentId="stu_1" studentName="Ahmed" />);
+
+    expect(await screen.findByText(/sur Ahmed, je consens/)).toBeInTheDocument();
+    expect(screen.queryByText(/\{\{ELEVE_NOM\}\}/)).not.toBeInTheDocument();
+  });
+
+  it('n’active le consentement qu’après cochage explicite', async () => {
+    global.fetch = mockFetch('MISSING') as unknown as typeof fetch;
+    render(<ConsentGate audience="PARENT" studentId="stu_1" />);
+
+    const button = await screen.findByRole('button', { name: /je consens/i });
+    expect(button).toBeDisabled();
+
+    await userEvent.click(screen.getByRole('checkbox'));
+    expect(button).toBeEnabled();
+  });
+
+  it('renvoie la version réellement présentée', async () => {
+    const posted: unknown[] = [];
+    global.fetch = mockFetch('MISSING', (body) => posted.push(body)) as unknown as typeof fetch;
+    render(<ConsentGate audience="PARENT" studentId="stu_1" />);
+
+    await userEvent.click(await screen.findByRole('checkbox'));
+    await userEvent.click(screen.getByRole('button', { name: /je consens/i }));
+
+    await waitFor(() => expect(posted).toHaveLength(1));
+    expect(posted[0]).toMatchObject({
+      action: 'GRANT_PARENTAL_CONSENT',
+      noticeVersion: NOTICE.version,
+      studentId: 'stu_1',
+    });
+  });
+
+  it('affiche la version consentie, pour que la famille sache sur quoi elle s’engage', async () => {
+    global.fetch = mockFetch('MISSING') as unknown as typeof fetch;
+    render(<ConsentGate audience="PARENT" studentId="stu_1" />);
+    expect(await screen.findByText(/candidat-libre-notice\.v1/)).toBeInTheDocument();
+  });
+});
+
+describe('ConsentGate — écran élève', () => {
+  it('recueille un assentiment distinct, dans sa propre formulation', async () => {
+    const posted: unknown[] = [];
+    global.fetch = mockFetch('STUDENT_ASSENT_MISSING', (b) => posted.push(b)) as unknown as typeof fetch;
+    render(<ConsentGate audience="ELEVE" />);
+
+    expect(await screen.findByText(NOTICE.studentAssentStatement)).toBeInTheDocument();
+    expect(screen.queryByText(/autorité parentale/)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('checkbox'));
+    await userEvent.click(screen.getByRole('button', { name: /j'accepte de participer/i }));
+
+    await waitFor(() => expect(posted).toHaveLength(1));
+    expect(posted[0]).toMatchObject({ action: 'RECORD_STUDENT_ASSENT' });
+  });
+});
+
+describe('ConsentGate — états', () => {
+  it('ne redemande rien quand le consentement est déjà acquis', async () => {
+    global.fetch = mockFetch('GRANTED') as unknown as typeof fetch;
+    render(<ConsentGate audience="PARENT" studentId="stu_1" />);
+
+    expect(await screen.findByText(/consentement est enregistré/i)).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+
+  /** Hors allowlist, l'API répond 404 : l'écran ne doit rien révéler du dossier. */
+  it('reste discret quand le parcours n’est pas accessible', async () => {
+    global.fetch = jest.fn(async () => ({ ok: false, json: async () => ({}) })) as unknown as typeof fetch;
+    render(<ConsentGate audience="PARENT" studentId="stu_1" />);
+
+    expect(await screen.findByText(/n'est pas accessible avec ce compte/i)).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+});

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/[documentId]/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/[documentId]/route.ts
@@ -7,7 +7,7 @@ import { getDocumentStorageRoot } from '@/lib/documents/storage-root';
 import { isErrorResponse } from '@/lib/guards';
 import { getDiagnosticForActor, requireDiagnosticActor, actorRole, isDocumentVisibleToViewer } from '@/lib/diagnostics/candidat-libre/access.server';
 import { requireVerifiedParentalConsent } from '@/lib/diagnostics/candidat-libre/consent-gate.server';
-import { guardCandidateDiagnosticFeature } from '@/lib/diagnostics/candidat-libre/feature-flag';
+import { guardCandidateDiagnosticFeature, guardCandidateDiagnosticForStudent } from '@/lib/diagnostics/candidat-libre/feature-flag';
 
 interface Params { params: Promise<{ diagnosticId: string; documentId: string }> }
 
@@ -58,6 +58,10 @@ export async function DELETE(_request: Request, { params }: Params) {
   }
   const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
   if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  // Hors allowlist, le dossier doit paraitre absent : 404 avant tout autre verdict.
+  const notAllowed = guardCandidateDiagnosticForStudent(diagnosticOrError.studentId);
+  if (notAllowed) return notAllowed;
+
   // Dossier portant sur un mineur : aucune collecte avant consentement parental verifie.
   const consentBlocked = await requireVerifiedParentalConsent(diagnosticOrError.studentId);
   if (consentBlocked) return consentBlocked;

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/route.ts
@@ -9,7 +9,7 @@ import { persistDiagnosticFile, removePersistedDiagnosticFile } from '@/lib/diag
 import { CANDIDATE_DIAGNOSTIC_MODULES } from '@/lib/diagnostics/candidat-libre/definition.public';
 import { scanDiagnosticFile } from '@/lib/diagnostics/candidat-libre/virus-scan.server';
 import { requireVerifiedParentalConsent } from '@/lib/diagnostics/candidat-libre/consent-gate.server';
-import { guardCandidateDiagnosticFeature } from '@/lib/diagnostics/candidat-libre/feature-flag';
+import { guardCandidateDiagnosticFeature, guardCandidateDiagnosticForStudent } from '@/lib/diagnostics/candidat-libre/feature-flag';
 
 interface Params { params: Promise<{ diagnosticId: string }> }
 
@@ -67,6 +67,10 @@ export async function POST(request: Request, { params }: Params) {
   if (identityLimited) return identityLimited;
   const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
   if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  // Hors allowlist, le dossier doit paraitre absent : 404 avant tout autre verdict.
+  const notAllowed = guardCandidateDiagnosticForStudent(diagnosticOrError.studentId);
+  if (notAllowed) return notAllowed;
+
   // Dossier portant sur un mineur : aucune collecte avant consentement parental verifie.
   const consentBlocked = await requireVerifiedParentalConsent(diagnosticOrError.studentId);
   if (consentBlocked) return consentBlocked;

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/modules/[moduleKey]/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/modules/[moduleKey]/route.ts
@@ -11,7 +11,7 @@ import { moduleDraftSchema, moduleKeySchema } from '@/lib/diagnostics/candidat-l
 import { scoreDiagnosticModule, validateRequiredAnswers } from '@/lib/diagnostics/candidat-libre/scoring.server';
 import { resolveModuleAvailability } from '@/lib/diagnostics/candidat-libre/progression';
 import { requireVerifiedParentalConsent } from '@/lib/diagnostics/candidat-libre/consent-gate.server';
-import { guardCandidateDiagnosticFeature } from '@/lib/diagnostics/candidat-libre/feature-flag';
+import { guardCandidateDiagnosticFeature, guardCandidateDiagnosticForStudent } from '@/lib/diagnostics/candidat-libre/feature-flag';
 import type { DiagnosticAnswer, DiagnosticModuleView } from '@/lib/diagnostics/candidat-libre/types';
 
 interface Params { params: Promise<{ diagnosticId: string; moduleKey: string }> }
@@ -111,6 +111,10 @@ async function saveModule(request: Request, { params }: Params, forcedAction: 'd
   if (!canEditAudience(sessionOrError.user.role, definition.audience)) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
   if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  // Hors allowlist, le dossier doit paraitre absent : 404 avant tout autre verdict.
+  const notAllowed = guardCandidateDiagnosticForStudent(diagnosticOrError.studentId);
+  if (notAllowed) return notAllowed;
+
   // Dossier portant sur un mineur : aucune collecte avant consentement parental verifie.
   const consentBlocked = await requireVerifiedParentalConsent(diagnosticOrError.studentId);
   if (consentBlocked) return consentBlocked;

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/parent/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/parent/route.ts
@@ -11,7 +11,7 @@ import { parentQuestionnaireSchema } from '@/lib/diagnostics/candidat-libre/sche
 import { scoreDiagnosticModule, validateRequiredAnswers } from '@/lib/diagnostics/candidat-libre/scoring.server';
 import type { DiagnosticAnswer } from '@/lib/diagnostics/candidat-libre/types';
 import { requireVerifiedParentalConsent } from '@/lib/diagnostics/candidat-libre/consent-gate.server';
-import { guardCandidateDiagnosticFeature } from '@/lib/diagnostics/candidat-libre/feature-flag';
+import { guardCandidateDiagnosticFeature, guardCandidateDiagnosticForStudent } from '@/lib/diagnostics/candidat-libre/feature-flag';
 
 interface Params { params: Promise<{ diagnosticId: string }> }
 const MODULE_KEY = 'questionnaire-parent';
@@ -63,6 +63,10 @@ async function saveParentQuestionnaire(request: Request, { params }: Params, act
   if (identityLimited) return identityLimited;
   const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
   if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  // Hors allowlist, le dossier doit paraitre absent : 404 avant tout autre verdict.
+  const notAllowed = guardCandidateDiagnosticForStudent(diagnosticOrError.studentId);
+  if (notAllowed) return notAllowed;
+
   // Dossier portant sur un mineur : aucune collecte avant consentement parental verifie.
   const consentBlocked = await requireVerifiedParentalConsent(diagnosticOrError.studentId);
   if (consentBlocked) return consentBlocked;
@@ -98,8 +102,8 @@ async function saveParentQuestionnaire(request: Request, { params }: Params, act
       // `parentConsentAt` n'est volontairement plus alimenté ici. La question
       // `parent-22` autorise l'exploitation des réponses du parent lui-même ;
       // elle ne vaut pas autorisation de traiter les données du mineur. Le
-      // consentement parental fait foi dans `canonical_parent_student_links`
-      // et conditionne désormais l'accès à cette route.
+      // consentement parental fait foi dans `CandidateDiagnosticConsent`,
+      // spécifique à ce diagnostic, et conditionne l'accès à cette route.
       await tx.candidateDiagnostic.update({
         where: { id: diagnosticId },
         data: { parentSubmittedAt: now },

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/route.ts
@@ -5,7 +5,7 @@ import { getDiagnosticForActor, requireDiagnosticActor, actorRole } from '@/lib/
 import { updateDiagnosticProfileSchema } from '@/lib/diagnostics/candidat-libre/schemas';
 import { serializeCandidateDiagnostic } from '@/lib/diagnostics/candidat-libre/serialize.server';
 import { requireVerifiedParentalConsent } from '@/lib/diagnostics/candidat-libre/consent-gate.server';
-import { guardCandidateDiagnosticFeature } from '@/lib/diagnostics/candidat-libre/feature-flag';
+import { guardCandidateDiagnosticFeature, guardCandidateDiagnosticForStudent } from '@/lib/diagnostics/candidat-libre/feature-flag';
 import type { Prisma } from '@prisma/client';
 
 interface Params { params: Promise<{ diagnosticId: string }> }
@@ -29,6 +29,10 @@ export async function PATCH(request: Request, { params }: Params) {
   if (isErrorResponse(sessionOrError)) return sessionOrError;
   const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
   if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  // Hors allowlist, le dossier doit paraitre absent : 404 avant tout autre verdict.
+  const notAllowed = guardCandidateDiagnosticForStudent(diagnosticOrError.studentId);
+  if (notAllowed) return notAllowed;
+
   // Dossier portant sur un mineur : aucune collecte avant consentement parental verifie.
   const consentBlocked = await requireVerifiedParentalConsent(diagnosticOrError.studentId);
   if (consentBlocked) return consentBlocked;

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/submit/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/submit/route.ts
@@ -7,7 +7,7 @@ import { getDiagnosticForActor, actorRole } from '@/lib/diagnostics/candidat-lib
 import { CANDIDATE_DIAGNOSTIC_MODULES } from '@/lib/diagnostics/candidat-libre/definition.public';
 import { isModuleComplete } from '@/lib/diagnostics/candidat-libre/progression';
 import { requireVerifiedParentalConsent } from '@/lib/diagnostics/candidat-libre/consent-gate.server';
-import { guardCandidateDiagnosticFeature } from '@/lib/diagnostics/candidat-libre/feature-flag';
+import { guardCandidateDiagnosticFeature, guardCandidateDiagnosticForStudent } from '@/lib/diagnostics/candidat-libre/feature-flag';
 
 interface Params { params: Promise<{ diagnosticId: string }> }
 
@@ -27,6 +27,10 @@ export async function POST(request: Request, { params }: Params) {
   if (identityLimited) return identityLimited;
   const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
   if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  // Hors allowlist, le dossier doit paraitre absent : 404 avant tout autre verdict.
+  const notAllowed = guardCandidateDiagnosticForStudent(diagnosticOrError.studentId);
+  if (notAllowed) return notAllowed;
+
   // Dossier portant sur un mineur : aucune collecte avant consentement parental verifie.
   const consentBlocked = await requireVerifiedParentalConsent(diagnosticOrError.studentId);
   if (consentBlocked) return consentBlocked;

--- a/app/api/diagnostics/candidat-libre/consent/route.ts
+++ b/app/api/diagnostics/candidat-libre/consent/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from 'next/server';
+import { UserRole } from '@prisma/client';
+
+import { isErrorResponse } from '@/lib/guards';
+import { guardSensitiveRateLimit } from '@/lib/rate-limit/sensitive';
+import { getStudentForActor, requireDiagnosticActor } from '@/lib/diagnostics/candidat-libre/access.server';
+import {
+  ConsentRecordingError,
+  grantParentalConsent,
+  recordStudentAssent,
+  withdrawParentalConsent,
+} from '@/lib/diagnostics/candidat-libre/consent-recording.server';
+import { getCandidateDiagnosticConsentState } from '@/lib/diagnostics/candidat-libre/consent-gate.server';
+import {
+  guardCandidateDiagnosticFeature,
+  guardCandidateDiagnosticForStudent,
+} from '@/lib/diagnostics/candidat-libre/feature-flag';
+import {
+  CANDIDATE_DIAGNOSTIC_NOTICE_VERSION,
+  CANDIDATE_DIAGNOSTIC_PRIVACY_NOTICE,
+} from '@/lib/diagnostics/candidat-libre/privacy-notice';
+
+/**
+ * Recueil du consentement candidat libre.
+ *
+ * Cette route est la seule exception au garde-fou de consentement : elle doit
+ * rester joignable **sans** consentement, puisque c'est précisément ce qu'elle
+ * sert à recueillir. Elle reste en revanche soumise au kill switch et à
+ * l'allowlist, et n'écrit aucune donnée de diagnostic — seulement le
+ * consentement lui-même.
+ *
+ * `GET` sert la notice à présenter et l'état courant, pour que l'interface
+ * sache quoi afficher et si le parcours est déjà fait.
+ */
+
+/** Résout l'élève visé, en refusant tout ce qui sort du périmètre autorisé. */
+async function resolveStudent(request: Request, studentId?: string) {
+  const disabled = guardCandidateDiagnosticFeature();
+  if (disabled) return { error: disabled } as const;
+
+  const sessionOrError = await requireDiagnosticActor();
+  if (isErrorResponse(sessionOrError)) return { error: sessionOrError } as const;
+
+  const studentOrError = await getStudentForActor(sessionOrError, studentId);
+  if (studentOrError instanceof NextResponse) return { error: studentOrError } as const;
+  if (!studentOrError) {
+    return { error: NextResponse.json({ error: 'Student not found' }, { status: 404 }) } as const;
+  }
+
+  const notAllowed = guardCandidateDiagnosticForStudent(studentOrError.id);
+  if (notAllowed) return { error: notAllowed } as const;
+
+  return { session: sessionOrError, student: studentOrError } as const;
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const resolved = await resolveStudent(request, url.searchParams.get('studentId') ?? undefined);
+  if ('error' in resolved) return resolved.error;
+
+  return NextResponse.json({
+    notice: CANDIDATE_DIAGNOSTIC_PRIVACY_NOTICE,
+    consentState: await getCandidateDiagnosticConsentState(resolved.student.id),
+  });
+}
+
+export async function POST(request: Request) {
+  const ipLimited = await guardSensitiveRateLimit(request, {
+    scope: 'candidate-diagnostic-create',
+    dimensions: ['ip'],
+  });
+  if (ipLimited) return ipLimited;
+
+  let body: { action?: string; studentId?: string; noticeVersion?: string; reason?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
+  }
+
+  const resolved = await resolveStudent(request, body.studentId);
+  if ('error' in resolved) return resolved.error;
+  const { session, student } = resolved;
+
+  try {
+    switch (body.action) {
+      case 'GRANT_PARENTAL_CONSENT': {
+        if (session.user.role !== UserRole.PARENT) {
+          return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+        }
+        // La version consentie vient du client : elle doit correspondre à celle
+        // réellement présentée. Le service refuse toute autre valeur, ce qui
+        // écarte un consentement donné sur un texte que la famille n'a pas vu.
+        await grantParentalConsent({
+          studentId: student.id,
+          parentUserId: session.user.id,
+          noticeVersion: body.noticeVersion ?? '',
+        });
+        break;
+      }
+      case 'RECORD_STUDENT_ASSENT': {
+        if (session.user.role !== UserRole.ELEVE) {
+          return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+        }
+        await recordStudentAssent({ studentId: student.id });
+        break;
+      }
+      case 'WITHDRAW_PARENTAL_CONSENT': {
+        if (session.user.role !== UserRole.PARENT) {
+          return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+        }
+        await withdrawParentalConsent({
+          studentId: student.id,
+          parentUserId: session.user.id,
+          reason: body.reason,
+        });
+        break;
+      }
+      default:
+        return NextResponse.json({ error: 'Validation failed' }, { status: 400 });
+    }
+  } catch (error) {
+    if (error instanceof ConsentRecordingError) {
+      return NextResponse.json({ error: 'Forbidden', code: error.message }, { status: 403 });
+    }
+    throw error;
+  }
+
+  return NextResponse.json({
+    consentState: await getCandidateDiagnosticConsentState(student.id),
+    noticeVersion: CANDIDATE_DIAGNOSTIC_NOTICE_VERSION,
+  });
+}

--- a/app/api/diagnostics/candidat-libre/route.ts
+++ b/app/api/diagnostics/candidat-libre/route.ts
@@ -9,7 +9,7 @@ import { DIAGNOSTIC_KEY, DIAGNOSTIC_VERSION } from '@/lib/diagnostics/candidat-l
 import { getStudentForActor, requireDiagnosticActor } from '@/lib/diagnostics/candidat-libre/access.server';
 import { serializeCandidateDiagnostic } from '@/lib/diagnostics/candidat-libre/serialize.server';
 import { requireVerifiedParentalConsent } from '@/lib/diagnostics/candidat-libre/consent-gate.server';
-import { guardCandidateDiagnosticFeature } from '@/lib/diagnostics/candidat-libre/feature-flag';
+import { guardCandidateDiagnosticFeature, guardCandidateDiagnosticForStudent } from '@/lib/diagnostics/candidat-libre/feature-flag';
 
 export async function GET(request: Request) {
   const disabled = guardCandidateDiagnosticFeature();
@@ -62,6 +62,10 @@ export async function POST(request: Request) {
   const studentOrError = await getStudentForActor(sessionOrError, parsed.data.studentId);
   if (studentOrError instanceof NextResponse) return studentOrError;
   if (!studentOrError) return NextResponse.json({ error: 'Student not found' }, { status: 404 });
+
+  // Hors allowlist, le dossier doit paraitre absent : 404 avant tout autre verdict.
+  const notAllowed = guardCandidateDiagnosticForStudent(studentOrError.id);
+  if (notAllowed) return notAllowed;
 
   // Dossier portant sur un mineur : aucune collecte avant consentement parental vérifié.
   const consentBlocked = await requireVerifiedParentalConsent(studentOrError.id);

--- a/components/diagnostics/candidat-libre/ConsentGate.tsx
+++ b/components/diagnostics/candidat-libre/ConsentGate.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import type { CandidateDiagnosticConsentState } from '@/lib/diagnostics/candidat-libre/consent-gate.server';
+
+/**
+ * Écrans de recueil du consentement candidat libre.
+ *
+ * ⚠️ À RÉVISER par la direction pédagogique et le juriste avant ouverture.
+ * La présentation familiale et le texte consenti restent leur décision ; ce
+ * composant est une proposition de mise en forme, pas un texte arbitré.
+ *
+ * Deux invariants portés par l'interface :
+ *
+ * - la notice est rendue **verbatim** depuis le serveur, jamais recomposée ni
+ *   résumée ici : le consentement porte sur ce texte précis, et le reformuler
+ *   côté client le rendrait non éclairé ;
+ * - la version présentée est renvoyée telle quelle au serveur, qui refuse toute
+ *   autre valeur — la famille consent à la version qu'elle a réellement lue.
+ *
+ * Le style reprend les jetons de `lib/bilans/render/brand.ts`, ceux qui rendent
+ * les tests papier, afin que la famille retrouve la même identité visuelle.
+ */
+
+type NoticeSection = Readonly<{ heading: string; body: readonly string[] }>;
+
+type Notice = Readonly<{
+  version: string;
+  title: string;
+  sections: readonly NoticeSection[];
+  parentConsentStatement: string;
+  parentConsentCheckbox: string;
+  studentAssentStatement: string;
+}>;
+
+const INK = '#071A3A';
+const INK_SOFT = '#0E2547';
+const GOLD = '#BFA06A';
+const GOLD_WASH = '#EBDFC4';
+const IVORY = '#F7F4ED';
+const SLATE = '#5A6B82';
+
+export type ConsentGateProps = Readonly<{
+  audience: 'PARENT' | 'ELEVE';
+  studentId?: string;
+  /** Nom de l'élève, interpolé dans l'engagement parental. */
+  studentName?: string;
+  onGranted?: () => void;
+}>;
+
+export function ConsentGate({ audience, studentId, studentName, onGranted }: ConsentGateProps) {
+  const [notice, setNotice] = useState<Notice | null>(null);
+  const [state, setState] = useState<CandidateDiagnosticConsentState | null>(null);
+  const [accepted, setAccepted] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const endpoint = studentId
+    ? `/api/diagnostics/candidat-libre/consent?studentId=${encodeURIComponent(studentId)}`
+    : '/api/diagnostics/candidat-libre/consent';
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const response = await fetch(endpoint);
+      if (!response.ok) {
+        setError("Ce parcours n'est pas accessible avec ce compte.");
+        return;
+      }
+      const payload = await response.json();
+      setNotice(payload.notice);
+      setState(payload.consentState);
+    } catch {
+      setError('Le service est momentanément indisponible.');
+    }
+  }, [endpoint]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  async function submit() {
+    if (!notice) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/diagnostics/candidat-libre/consent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: audience === 'PARENT' ? 'GRANT_PARENTAL_CONSENT' : 'RECORD_STUDENT_ASSENT',
+          studentId,
+          // La version rendue est renvoyée telle quelle : le serveur refuse
+          // toute valeur autre que la version courante.
+          noticeVersion: notice.version,
+        }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        setError(
+          payload?.code === 'PARENTAL_CONSENT_REQUIRED'
+            ? "Le consentement d'un parent est requis avant de continuer."
+            : "Le consentement n'a pas pu être enregistré.",
+        );
+        return;
+      }
+      setState(payload.consentState);
+      if (payload.consentState === 'GRANTED') onGranted?.();
+    } catch {
+      setError('Le service est momentanément indisponible.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (error && !notice) {
+    return (
+      <div className="mx-auto max-w-2xl px-6 py-16 text-center" style={{ color: SLATE }}>
+        {error}
+      </div>
+    );
+  }
+
+  if (!notice) {
+    return (
+      <div className="mx-auto max-w-2xl px-6 py-16 text-center" style={{ color: SLATE }}>
+        Chargement…
+      </div>
+    );
+  }
+
+  if (state === 'GRANTED') {
+    return (
+      <section
+        className="mx-auto max-w-2xl rounded-2xl px-8 py-10 text-center"
+        style={{ backgroundColor: IVORY, color: INK, border: `1px solid ${GOLD_WASH}` }}
+      >
+        <p className="text-lg">Le consentement est enregistré. Vous pouvez poursuivre.</p>
+      </section>
+    );
+  }
+
+  const isParent = audience === 'PARENT';
+  const parentStatement = notice.parentConsentStatement.replace(
+    '{{ELEVE_NOM}}',
+    studentName ?? 'votre enfant',
+  );
+
+  return (
+    <article
+      className="mx-auto max-w-3xl overflow-hidden rounded-2xl"
+      style={{ backgroundColor: '#FBFAF5', color: INK, border: `1px solid ${GOLD_WASH}` }}
+    >
+      <header className="px-8 py-7" style={{ backgroundColor: INK, color: IVORY }}>
+        <p
+          className="text-xs uppercase tracking-[0.18em]"
+          style={{ color: GOLD, fontFamily: 'DM Sans, system-ui, sans-serif' }}
+        >
+          Diagnostic candidat libre
+        </p>
+        <h1
+          className="mt-2 text-3xl leading-tight"
+          style={{ fontFamily: 'Fraunces, Georgia, serif', textWrap: 'balance' }}
+        >
+          {notice.title}
+        </h1>
+      </header>
+
+      <div className="px-8 py-8" style={{ fontFamily: 'DM Sans, system-ui, sans-serif' }}>
+        {/* Rendu verbatim : aucune reformulation côté client. */}
+        {notice.sections.map((section) => (
+          <section key={section.heading} className="mb-7 last:mb-0">
+            <h2
+              className="mb-2 text-lg"
+              style={{ fontFamily: 'Fraunces, Georgia, serif', color: INK_SOFT }}
+            >
+              {section.heading}
+            </h2>
+            {section.body.map((paragraph) => (
+              <p key={paragraph} className="mb-2 text-[15px] leading-relaxed" style={{ color: SLATE }}>
+                {paragraph}
+              </p>
+            ))}
+          </section>
+        ))}
+
+        <hr className="my-8" style={{ borderColor: GOLD_WASH }} />
+
+        <section
+          className="rounded-xl px-6 py-6"
+          style={{ backgroundColor: IVORY, border: `1px solid ${GOLD_WASH}` }}
+        >
+          <p className="text-[15px] leading-relaxed" style={{ color: INK }}>
+            {isParent ? parentStatement : notice.studentAssentStatement}
+          </p>
+
+          <label className="mt-5 flex cursor-pointer items-start gap-3 text-[15px]" style={{ color: INK }}>
+            <input
+              type="checkbox"
+              checked={accepted}
+              onChange={(event) => setAccepted(event.target.checked)}
+              className="mt-1 h-4 w-4"
+              style={{ accentColor: GOLD }}
+            />
+            <span>{isParent ? notice.parentConsentCheckbox : "J'accepte de participer."}</span>
+          </label>
+
+          {state === 'STUDENT_ASSENT_MISSING' && isParent ? (
+            <p className="mt-4 text-sm" style={{ color: SLATE }}>
+              Votre consentement est enregistré ; il reste l'accord de votre enfant.
+            </p>
+          ) : null}
+
+          {error ? (
+            <p className="mt-4 text-sm" role="alert" style={{ color: '#7A6535' }}>
+              {error}
+            </p>
+          ) : null}
+
+          <button
+            type="button"
+            disabled={!accepted || busy}
+            onClick={() => void submit()}
+            className="mt-6 rounded-lg px-6 py-3 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-40"
+            style={{ backgroundColor: INK, color: IVORY }}
+          >
+            {busy ? 'Enregistrement…' : isParent ? 'Je consens' : "J'accepte de participer"}
+          </button>
+
+          <p className="mt-4 text-xs" style={{ color: SLATE }}>
+            Version de la notice : {notice.version}
+          </p>
+        </section>
+      </div>
+    </article>
+  );
+}

--- a/lib/diagnostics/candidat-libre/consent-recording.server.ts
+++ b/lib/diagnostics/candidat-libre/consent-recording.server.ts
@@ -1,0 +1,208 @@
+import 'server-only';
+
+import { prisma } from '@/lib/prisma';
+
+import { CANDIDATE_DIAGNOSTIC_NOTICE_VERSION } from './privacy-notice';
+
+/**
+ * Recueil du consentement candidat libre.
+ *
+ * La Phase 1 a posé le garde-fou qui **lit** le consentement ; ce module est le
+ * seul à l'**écrire**. Concentrer l'écriture ici évite qu'un chemin détourné
+ * enregistre un consentement sans en vérifier les conditions — ce qui s'était
+ * précisément produit avec la question `parent-22`, enregistrée comme
+ * consentement parental alors qu'elle ne portait que sur les réponses du parent.
+ *
+ * Trois règles, qu'aucun stockage ne garantit à lui seul :
+ *
+ * - le consentement émane du parent **actuellement** rattaché à l'élève, le
+ *   titulaire de l'autorité parentale pouvant changer ;
+ * - il porte la **version de notice réellement présentée**, faute de quoi il ne
+ *   serait pas éclairé ;
+ * - il est **retirable**, et le retrait bloque immédiatement tout traitement.
+ *
+ * Le retrait ne déclenche pas encore l'effacement des données déjà collectées :
+ * ce branchement viendra avec le mécanisme d'effacement. C'est sans conséquence
+ * tant que la fonctionnalité reste dark, aucune donnée réelle n'étant collectée.
+ */
+
+export class ConsentRecordingError extends Error {
+  constructor(code: string) {
+    super(code);
+    this.name = 'ConsentRecordingError';
+  }
+}
+
+type ConsentRow = Readonly<{
+  id: string;
+  studentId: string;
+  parentUserId: string;
+  noticeVersion: string;
+  withdrawnAt: Date | null;
+  studentAssentedAt?: Date | null;
+}>;
+
+/** Résout le parent actuellement rattaché, ou refuse. */
+async function requireLinkedParent(studentId: string): Promise<string> {
+  const student = await prisma.student.findUnique({
+    where: { id: studentId },
+    select: { id: true, parent: { select: { userId: true } } },
+  });
+  const parentUserId = student?.parent?.userId;
+  if (!parentUserId) throw new ConsentRecordingError('NO_PARENT');
+  return parentUserId;
+}
+
+async function currentConsent(studentId: string): Promise<ConsentRow | null> {
+  return prisma.candidateDiagnosticConsent.findFirst({
+    where: { studentId },
+    orderBy: [{ parentConsentedAt: 'desc' }, { id: 'asc' }],
+  }) as unknown as Promise<ConsentRow | null>;
+}
+
+/**
+ * Enregistre le consentement parental pour la version de notice présentée.
+ *
+ * `diagnosticId` n'est fourni que lorsqu'un dossier existe déjà ; le
+ * consentement précédant normalement sa création, la journalisation est alors
+ * simplement omise faute d'entité à rattacher.
+ */
+export async function grantParentalConsent(input: Readonly<{
+  studentId: string;
+  parentUserId: string;
+  noticeVersion: string;
+  diagnosticId?: string;
+}>): Promise<{ id: string }> {
+  if (input.noticeVersion !== CANDIDATE_DIAGNOSTIC_NOTICE_VERSION) {
+    throw new ConsentRecordingError('NOTICE_VERSION_MISMATCH');
+  }
+
+  const linkedParent = await requireLinkedParent(input.studentId);
+  if (linkedParent !== input.parentUserId) {
+    throw new ConsentRecordingError('NOT_THE_LINKED_PARENT');
+  }
+
+  const now = new Date();
+  const consent = await prisma.candidateDiagnosticConsent.upsert({
+    where: {
+      studentId_noticeVersion: {
+        studentId: input.studentId,
+        noticeVersion: input.noticeVersion,
+      },
+    },
+    create: {
+      studentId: input.studentId,
+      parentUserId: input.parentUserId,
+      noticeVersion: input.noticeVersion,
+      parentConsentedAt: now,
+    },
+    // Re-consentir après un retrait doit relever le blocage, sans effacer la
+    // trace : `withdrawnAt` est remis à nul et l'horodatage rafraîchi.
+    update: {
+      parentUserId: input.parentUserId,
+      parentConsentedAt: now,
+      withdrawnAt: null,
+      withdrawnReason: null,
+    },
+  });
+
+  if (input.diagnosticId) {
+    await prisma.candidateDiagnosticAuditLog.create({
+      data: {
+        diagnosticId: input.diagnosticId,
+        actorId: input.parentUserId,
+        actorRole: 'PARENT',
+        action: 'PARENTAL_CONSENT_GRANTED',
+        entityType: 'CandidateDiagnosticConsent',
+        entityId: consent.id,
+        details: { noticeVersion: input.noticeVersion },
+      },
+    });
+  }
+
+  return { id: consent.id };
+}
+
+/**
+ * Enregistre l'assentiment de l'élève.
+ *
+ * Distinct du consentement parental et exigé en plus de lui : un mineur
+ * participe, il ne subit pas. Il ne peut être recueilli que sur un consentement
+ * parental courant — sans quoi on demanderait son accord à un enfant pour un
+ * traitement que personne n'a autorisé.
+ */
+export async function recordStudentAssent(input: Readonly<{
+  studentId: string;
+  diagnosticId?: string;
+}>): Promise<{ id: string }> {
+  const consent = await currentConsent(input.studentId);
+  if (!consent) throw new ConsentRecordingError('PARENTAL_CONSENT_REQUIRED');
+  if (consent.withdrawnAt !== null) throw new ConsentRecordingError('CONSENT_WITHDRAWN');
+  if (consent.noticeVersion !== CANDIDATE_DIAGNOSTIC_NOTICE_VERSION) {
+    throw new ConsentRecordingError('NOTICE_VERSION_MISMATCH');
+  }
+
+  await prisma.candidateDiagnosticConsent.update({
+    where: { id: consent.id },
+    data: { studentAssentedAt: new Date() },
+  });
+
+  if (input.diagnosticId) {
+    await prisma.candidateDiagnosticAuditLog.create({
+      data: {
+        diagnosticId: input.diagnosticId,
+        actorRole: 'ELEVE',
+        action: 'STUDENT_ASSENT_RECORDED',
+        entityType: 'CandidateDiagnosticConsent',
+        entityId: consent.id,
+      },
+    });
+  }
+
+  return { id: consent.id };
+}
+
+/**
+ * Retire le consentement parental. Bloque immédiatement tout traitement.
+ *
+ * Idempotent : retirer un consentement déjà retiré ne réécrit pas la date, pour
+ * que la trace du retrait initial reste exacte.
+ */
+export async function withdrawParentalConsent(input: Readonly<{
+  studentId: string;
+  parentUserId: string;
+  reason?: string;
+  diagnosticId?: string;
+}>): Promise<{ id: string; withdrawnAt: Date }> {
+  const linkedParent = await requireLinkedParent(input.studentId);
+  if (linkedParent !== input.parentUserId) {
+    throw new ConsentRecordingError('NOT_THE_LINKED_PARENT');
+  }
+
+  const consent = await currentConsent(input.studentId);
+  if (!consent) throw new ConsentRecordingError('NO_CONSENT_TO_WITHDRAW');
+  if (consent.withdrawnAt !== null) {
+    return { id: consent.id, withdrawnAt: consent.withdrawnAt };
+  }
+
+  const now = new Date();
+  await prisma.candidateDiagnosticConsent.update({
+    where: { id: consent.id },
+    data: { withdrawnAt: now, withdrawnReason: input.reason ?? null },
+  });
+
+  if (input.diagnosticId) {
+    await prisma.candidateDiagnosticAuditLog.create({
+      data: {
+        diagnosticId: input.diagnosticId,
+        actorId: input.parentUserId,
+        actorRole: 'PARENT',
+        action: 'PARENTAL_CONSENT_WITHDRAWN',
+        entityType: 'CandidateDiagnosticConsent',
+        entityId: consent.id,
+      },
+    });
+  }
+
+  return { id: consent.id, withdrawnAt: now };
+}

--- a/lib/diagnostics/candidat-libre/feature-flag.ts
+++ b/lib/diagnostics/candidat-libre/feature-flag.ts
@@ -21,3 +21,46 @@ export function guardCandidateDiagnosticFeature(): NextResponse | null {
   if (isCandidateDiagnosticFeatureEnabled()) return null;
   return NextResponse.json({ error: 'Not Found' }, { status: 404 });
 }
+
+/**
+ * Élèves pour lesquels le diagnostic est ouvert, dans l'ordre de configuration.
+ *
+ * Le rôle `ELEVE_CANDIDAT_LIBRE` n'existe pas et la fonctionnalité ne porte
+ * aucun contrôle d'éligibilité : sans cette liste, allumer le drapeau
+ * ouvrirait le diagnostic à tous les élèves et parents de la base. L'allowlist
+ * tient donc lieu des deux, et permet d'ouvrir un dossier — et un seul.
+ */
+export function listAllowedCandidateStudentIds(): readonly string[] {
+  const raw = process.env.CANDIDATE_DIAGNOSTIC_STUDENT_IDS ?? '';
+  const seen = new Set<string>();
+  for (const entry of raw.split(',')) {
+    const id = entry.trim();
+    if (id.length > 0) seen.add(id);
+  }
+  return Object.freeze([...seen]);
+}
+
+/**
+ * Le diagnostic est-il ouvert pour cet élève ?
+ *
+ * Conjonction stricte : le kill switch garde le dernier mot, et une allowlist
+ * vide n'ouvre rien. Aucune correspondance partielle — l'identifiant doit
+ * figurer tel quel.
+ */
+export function isCandidateDiagnosticEnabledForStudent(studentId: string): boolean {
+  if (!isCandidateDiagnosticFeatureEnabled()) return false;
+  if (typeof studentId !== 'string' || studentId.length === 0) return false;
+  return listAllowedCandidateStudentIds().includes(studentId);
+}
+
+/**
+ * Pour les routes portant sur un élève : 404 tant qu'il n'est pas autorisé.
+ *
+ * Volontairement 404 et non 403 — hors allowlist, la fonctionnalité doit
+ * paraître absente, exactement comme lorsque le kill switch est éteint. Un 403
+ * révélerait son existence, et donc celle du dossier.
+ */
+export function guardCandidateDiagnosticForStudent(studentId: string): NextResponse | null {
+  if (isCandidateDiagnosticEnabledForStudent(studentId)) return null;
+  return NextResponse.json({ error: 'Not Found' }, { status: 404 });
+}

--- a/lib/diagnostics/candidat-libre/student-provisioning.server.ts
+++ b/lib/diagnostics/candidat-libre/student-provisioning.server.ts
@@ -1,0 +1,114 @@
+import 'server-only';
+
+import type { GradeLevel } from '@prisma/client';
+
+import { createActivationToken } from '@/lib/auth/activation-token';
+import { prisma } from '@/lib/prisma';
+
+/**
+ * Provisionnement de l'élève candidat libre.
+ *
+ * Aucun chemin existant ne permet à un élève d'avoir une adresse réelle **et**
+ * de choisir son mot de passe : les routes de création forcent l'identifiant
+ * synthétique `@nexus-student.local`, et la route admin impose un mot de passe
+ * choisi par un tiers puis laisse le compte inactivable. Pour un mineur dont on
+ * traitera la pièce d'identité, aucune des deux situations n'est acceptable.
+ *
+ * Ce chemin est **délibérément isolé** du flux add-child du bilan gratuit, qui
+ * tourne en production et sert les familles : la duplication d'une poignée de
+ * lignes coûte moins cher qu'une régression sur du live. Il ne réutilise que
+ * `createActivationToken`, une primitive pure sans effet de bord.
+ *
+ * Il ne pose jamais de mot de passe et n'en retourne aucun. L'activation
+ * elle-même reste assurée par `completeStudentActivation`, inchangée : elle
+ * retrouve le compte par empreinte du token et enregistre le mot de passe que
+ * l'élève choisit.
+ */
+
+export class StudentProvisioningError extends Error {
+  constructor(code: string) {
+    super(code);
+    this.name = 'StudentProvisioningError';
+  }
+}
+
+/** Domaine synthétique du flux add-child : interdit ici, on veut une vraie adresse. */
+const SYNTHETIC_STUDENT_DOMAIN = '@nexus-student.local';
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function normalizeRealEmail(value: string): string {
+  const email = (value ?? '').trim().toLowerCase();
+  if (!EMAIL_PATTERN.test(email)) throw new StudentProvisioningError('INVALID_EMAIL');
+  if (email.endsWith(SYNTHETIC_STUDENT_DOMAIN)) {
+    throw new StudentProvisioningError('SYNTHETIC_EMAIL_REJECTED');
+  }
+  return email;
+}
+
+export type ProvisionedCandidateStudent = Readonly<{
+  studentId: string;
+  userId: string;
+  /**
+   * Token en clair, à transmettre **uniquement** par le lien d'activation
+   * envoyé à l'élève. Seule son empreinte est stockée.
+   */
+  activationToken: string;
+  activationTokenExpiresAt: Date;
+}>;
+
+export async function provisionCandidateLibreStudent(input: Readonly<{
+  parentUserId: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  gradeLevel: GradeLevel;
+  school?: string;
+}>): Promise<ProvisionedCandidateStudent> {
+  const email = normalizeRealEmail(input.email);
+  const token = createActivationToken('student');
+
+  return prisma.$transaction(async (transaction) => {
+    const parentProfile = await transaction.parentProfile.findUnique({
+      where: { userId: input.parentUserId },
+      select: { id: true },
+    });
+    if (!parentProfile) throw new StudentProvisioningError('PARENT_NOT_FOUND');
+
+    const existing = await transaction.user.findUnique({
+      where: { email },
+      select: { id: true },
+    });
+    if (existing) throw new StudentProvisioningError('EMAIL_ALREADY_USED');
+
+    const user = await transaction.user.create({
+      data: {
+        email,
+        firstName: input.firstName,
+        lastName: input.lastName,
+        role: 'ELEVE',
+        // Le compte reste sans mot de passe et inactif : l'élève le choisira
+        // lui-même à l'activation. Personne d'autre ne le fixe.
+        password: null,
+        activationToken: token.tokenHash,
+        activationTokenExpiresAt: token.expiresAt,
+      },
+    });
+
+    const student = await transaction.student.create({
+      data: {
+        userId: user.id,
+        parentId: parentProfile.id,
+        gradeLevel: input.gradeLevel,
+        school: input.school ?? null,
+      },
+    });
+
+    return Object.freeze({
+      studentId: student.id,
+      userId: user.id,
+      activationToken: token.rawToken,
+      activationTokenExpiresAt: token.expiresAt,
+    });
+  });
+}

--- a/lib/diagnostics/candidat-libre/student-provisioning.server.ts
+++ b/lib/diagnostics/candidat-libre/student-provisioning.server.ts
@@ -91,7 +91,7 @@ export async function provisionCandidateLibreStudent(input: Readonly<{
         // lui-même à l'activation. Personne d'autre ne le fixe.
         password: null,
         activationToken: token.tokenHash,
-        activationTokenExpiresAt: token.expiresAt,
+        activationExpiry: token.expiresAt,
       },
     });
 


### PR DESCRIPTION
La Phase 1 avait posé le garde-fou qui **lit** le consentement ; sans moyen de l'enregistrer, l'état restait `MISSING` en permanence. Cette PR rend le parcours praticable, le scope à un dossier, et donne à l'élève un compte qu'il active lui-même. **La fonctionnalité reste dark** : rien ici ne l'ouvre.

## Consentement recueillable

Un service unique écrit dans `CandidateDiagnosticConsent`. Concentrer l'écriture en un point évite qu'un chemin détourné enregistre un consentement sans en vérifier les conditions — ce qui s'était produit avec `parent-22`, comptée comme consentement parental alors qu'elle ne portait que sur les réponses du parent.

Trois règles qu'aucun stockage ne garantit seul : le consentement émane du parent **actuellement** rattaché (le titulaire peut changer), il porte la **version de notice réellement présentée**, et il est **retirable** — le retrait est idempotent, pour que la trace du premier reste exacte. L'assentiment de l'élève ne peut être recueilli que sur un consentement parental courant.

La route de recueil est la seule exception au garde-fou : l'exiger pour joindre la route qui le recueille rendrait le parcours impossible. Elle reste soumise au kill switch et à l'allowlist, et un test vérifie qu'elle n'écrit aucune donnée de diagnostic.

## Allowlist par `studentId`

Le rôle `ELEVE_CANDIDAT_LIBRE` n'existe pas et la fonctionnalité ne portait aucun contrôle d'éligibilité : allumer le drapeau l'aurait ouverte aux 230 comptes de la base. L'allowlist tient lieu des deux contrôles manquants, en conjonction stricte — le kill switch garde le dernier mot, une allowlist vide n'ouvre rien.

Le refus est un **404, pas un 403** : hors périmètre la fonctionnalité doit paraître absente. Un test d'architecture vérifie que l'allowlist est évaluée avant le consentement, pour ne pas révéler qu'un consentement serait requis pour un dossier censé ne pas exister.

## Activation élève, isolée du bilan gratuit

Aucun chemin ne permettait à un élève d'avoir une adresse réelle **et** de choisir son mot de passe. Ce chemin est délibérément **isolé** du flux add-child, qui tourne en production : dupliquer quelques lignes coûte moins cher qu'une régression sur du live.

Le compte est créé sans mot de passe, inactif, avec l'empreinte du token. L'activation reste assurée par `completeStudentActivation`, **inchangée**. Non-régression vérifiée deux fois : aucun fichier du flux bilan gratuit n'est modifié par la branche, et ses sept suites restent vertes.

## Écrans — à réviser avant ouverture

La notice est rendue **verbatim** depuis le serveur, jamais recomposée côté client, et la version présentée est celle renvoyée au serveur. La présentation familiale et le texte consenti restent la décision de la direction pédagogique et du juriste.

## Vérifications

738 suites, **8256 tests, aucun échec** (suite complète, sans filtre), typecheck et lint propres.

## Reste humain avant ouverture

Validation juriste de la notice (contact, durée de conservation, régime INPDP/RGPD) puis incrément de version ; relecteur SES et validation du contenu ; et l'invariant déjà posé — le candidat libre n'ouvre pas tant que l'effacement n'est pas live, pour que « retrait → effacement » soit vrai dès la première minute.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rend le parcours candidat libre praticable: consentement parental/élève désormais recueillable, accès restreint à une allowlist par `studentId`, et provisioning d’un compte élève activé par l’élève. La fonctionnalité reste dark derrière `CANDIDATE_DIAGNOSTIC_ENABLED`.

- **New Features**
  - Consentement: un service unique écrit dans `CandidateDiagnosticConsent` (parent lié actuel, version de notice présentée, retrait possible). L’assentiment élève n’est accepté que si le consentement parental courant existe. La route `POST/GET /api/diagnostics/candidat-libre/consent` est accessible sans consentement mais reste derrière `CANDIDATE_DIAGNOSTIC_ENABLED` et `CANDIDATE_DIAGNOSTIC_STUDENT_IDS`, et n’écrit jamais de données de diagnostic. Le composant `ConsentGate` rend la notice verbatim et renvoie la version affichée.
  - Contrôle d’accès: allowlist par `studentId` via `CANDIDATE_DIAGNOSTIC_STUDENT_IDS`, en conjonction stricte avec `CANDIDATE_DIAGNOSTIC_ENABLED`. Refus hors périmètre en 404 (pas 403). Vérifiée avant le garde-fou de consentement sur toutes les routes d’écriture.
  - Provisioning élève: `provisionCandidateLibreStudent` crée un compte `ELEVE` avec email réel (pas `@nexus-student.local`), sans mot de passe, inactif, avec empreinte du token d’activation. Activation inchangée via `completeStudentActivation`. Chemin isolé du flux add-child du bilan gratuit.

<sup>Written for commit b691bd5436e63188599a2fdd8d0e846a1ce4b1ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

