### PR TITLE
RGPD — notice v3 et effacement par anonymisation

### DIFF
--- a/__tests__/bilans/candidat-libre-privacy-notice.test.ts
+++ b/__tests__/bilans/candidat-libre-privacy-notice.test.ts
@@ -23,7 +23,7 @@ function noticeText(): string {
 describe('notice de confidentialité — version adulte', () => {
   it('déclare la version que le consentement enregistrera', () => {
     expect(CANDIDATE_DIAGNOSTIC_PRIVACY_NOTICE.version).toBe(CANDIDATE_DIAGNOSTIC_NOTICE_VERSION);
-    expect(CANDIDATE_DIAGNOSTIC_NOTICE_VERSION).toBe('candidat-libre-notice.v2');
+    expect(CANDIDATE_DIAGNOSTIC_NOTICE_VERSION).toBe('candidat-libre-notice.v3');
   });
 
   it.each([
@@ -36,7 +36,7 @@ describe('notice de confidentialité — version adulte', () => {
     ['l’enregistrement audio', /enregistrement audio/],
     ['la base du consentement', /Sur la base de votre consentement/],
     ['le retrait possible', /retirer à tout moment/],
-    ['la conservation d’un an', /une année avant suppression ou anonymisation/],
+    ['la conservation datée', /douze mois à compter de votre dernière activité/],
     ['le chiffrement des documents', /chiffré/],
     ['les droits', /Accès, rectification, effacement/],
   ])('couvre %s', (_label, pattern) => {
@@ -70,7 +70,7 @@ describe('notice de confidentialité — version adulte', () => {
 });
 
 describe('fidélité au texte fourni', () => {
-  const SOURCE = path.join(os.homedir(), 'Téléchargements/NOTICE-confidentialite-candidat-libre-majeur.md');
+  const SOURCE = path.join(os.homedir(), 'Téléchargements/NOTICE-confidentialite-candidat-libre-majeur-v3.md');
 
   /**
    * Le texte est un objet juridique : il vient du responsable et du juriste.
@@ -97,7 +97,8 @@ describe('fidélité au texte fourni', () => {
       "Aucune décision n'est rendue par une machine",
       'sans intelligence artificielle générative',
       'Sur la base de votre consentement',
-      'une année avant suppression ou anonymisation',
+      'douze mois à compter de votre dernière activité sur votre dossier',
+      'Par défaut, vous êtes seul à accéder à vos résultats',
       'contact@nexusreussite.academy',
       "y compris le dépôt de mes documents officiels et l'enregistrement audio",
     ].map(normalize)) {
@@ -113,16 +114,27 @@ describe('points encore ouverts', () => {
    * modalité de partage à un tiers. Ce test échouera dès qu'elle sera comblée —
    * c'est le signal attendu pour incrémenter la version.
    */
-  it('signale la modalité de partage à un tiers, encore à préciser', () => {
-    const remaining = NOTICE_PENDING_LEGAL_CONSTANTS.filter((c) => noticeText().includes(c));
-    expect(remaining).toEqual([...NOTICE_PENDING_LEGAL_CONSTANTS]);
+  it('ne laisse plus aucun crochet dans le texte', () => {
+    expect(NOTICE_PENDING_LEGAL_CONSTANTS).toEqual([]);
+    expect(noticeText()).not.toMatch(/\{\{[A-Z_]+\}\}/);
+  });
+
+  /** Le partage décrit dans le texte doit correspondre au mécanisme réellement codé. */
+  it('décrit le partage tel qu’il est implémenté : décoché, facultatif, révocable', () => {
+    const text = noticeText();
+    expect(text).toMatch(/facultative, révocable à tout moment/);
+    expect(text).toMatch(/n’a aucun effet tant que vous ne l’avez pas donnée explicitement/);
   });
 
   /**
    * La durée est fixée à un an, mais son point de départ ne l'est pas de façon
    * opérationnelle : impossible d'automatiser une purge sans le trancher.
    */
-  it('consigne le point de départ de la conservation comme question ouverte', () => {
-    expect(NOTICE_OPEN_QUESTIONS.join(' ')).toMatch(/point de départ/i);
+  /**
+   * Le document source mentionne encore un dernier aval du juriste sur le
+   * régime applicable. Tant qu'il y figure, la question reste consignée.
+   */
+  it('conserve la question du régime applicable, telle qu’elle figure au document', () => {
+    expect(NOTICE_OPEN_QUESTIONS.join(' ')).toMatch(/régime applicable/i);
   });
 });

--- a/__tests__/bilans/candidat-libre-privacy-notice.test.ts
+++ b/__tests__/bilans/candidat-libre-privacy-notice.test.ts
@@ -131,10 +131,11 @@ describe('points encore ouverts', () => {
    * opérationnelle : impossible d'automatiser une purge sans le trancher.
    */
   /**
-   * Le document source mentionne encore un dernier aval du juriste sur le
-   * régime applicable. Tant qu'il y figure, la question reste consignée.
+   * L'aval du juriste est acquis : plus aucune question ouverte. Vider cette
+   * liste ne touche pas au texte consenti, donc la version reste v3.
    */
-  it('conserve la question du régime applicable, telle qu’elle figure au document', () => {
-    expect(NOTICE_OPEN_QUESTIONS.join(' ')).toMatch(/régime applicable/i);
+  it('ne laisse aucune question juridique ouverte', () => {
+    expect(NOTICE_OPEN_QUESTIONS).toEqual([]);
+    expect(CANDIDATE_DIAGNOSTIC_NOTICE_VERSION).toBe('candidat-libre-notice.v3');
   });
 });

--- a/__tests__/rgpd/anonymisation-executor.test.ts
+++ b/__tests__/rgpd/anonymisation-executor.test.ts
@@ -1,0 +1,171 @@
+import {
+  AnonymisationRefused,
+  executeAnonymisation,
+  tombstoneValues,
+  type AnonymisationClient,
+} from '@/lib/rgpd/anonymisation-executor';
+import { ANONYMISATION_SCOPE, TOMBSTONE, buildProposal } from '@/lib/rgpd/anonymisation';
+
+/**
+ * Exécuteur de l'anonymisation — la partie qui écrit.
+ *
+ * Ce que ces tests protègent : qu'on **n'écrive pas** quand il ne faut pas.
+ * L'opération est irréversible, porte sur une personne réelle, et une erreur
+ * de périmètre ne se rattrape pas après coup.
+ */
+
+function makeClient() {
+  const updates: { table: string; rowId: string; values: Record<string, string | null> }[] = [];
+  const deleted: string[] = [];
+  const journal: unknown[] = [];
+  const client: AnonymisationClient = {
+    updateRow: async (input) => { updates.push(input as never); },
+    deleteFile: async (p) => { deleted.push(p); },
+    recordJournalEntry: async (e) => { journal.push(e); },
+  };
+  return { client, updates, deleted, journal };
+}
+
+const fkRow = { table: 'users', rowId: 'u1', kind: 'FOREIGN_KEY' as const, heuristic: false };
+const orphanRow = {
+  table: 'contact_leads', rowId: 'c1', kind: 'ORPHAN_MATCH' as const,
+  heuristic: true, matchedOn: 'e-mail',
+};
+
+describe('refus avant écriture', () => {
+  it('refuse une proposition heuristique non confirmée, sans rien écrire', async () => {
+    const { client, updates, journal } = makeClient();
+    const proposal = buildProposal({ subjectRef: 's1', rows: [fkRow, orphanRow], files: [] });
+
+    await expect(executeAnonymisation(proposal, { confirmedBy: null }, client))
+      .rejects.toThrow(/CONFIRMATION_HUMAINE_REQUISE/);
+    expect(updates).toEqual([]);
+    expect(journal).toEqual([]);
+  });
+
+  it('accepte la même proposition une fois confirmée', async () => {
+    const { client, updates } = makeClient();
+    const proposal = buildProposal({ subjectRef: 's1', rows: [fkRow, orphanRow], files: [] });
+
+    await executeAnonymisation(proposal, { confirmedBy: 'responsable' }, client);
+    expect(updates).toHaveLength(2);
+  });
+
+  /** Elle est déjà pseudonyme, et ses triggers refuseraient de toute façon. */
+  it('refuse toute cible appartenant à la chaîne append-only', async () => {
+    const { client, updates } = makeClient();
+    const proposal = buildProposal({
+      subjectRef: 's1',
+      rows: [{ table: 'canonical_report_revisions', rowId: 'r1', kind: 'FOREIGN_KEY', heuristic: false }],
+      files: [],
+    });
+
+    await expect(executeAnonymisation(proposal, { confirmedBy: 'x' }, client))
+      .rejects.toThrow(/APPEND_ONLY_INTOUCHABLE/);
+    expect(updates).toEqual([]);
+  });
+
+  it('refuse une table hors périmètre', async () => {
+    const { client, updates } = makeClient();
+    const proposal = buildProposal({
+      subjectRef: 's1',
+      rows: [{ table: 'table_inconnue', rowId: 'x', kind: 'FOREIGN_KEY', heuristic: false }],
+      files: [],
+    });
+
+    await expect(executeAnonymisation(proposal, { confirmedBy: 'x' }, client))
+      .rejects.toThrow(/TABLE_HORS_PERIMETRE/);
+    expect(updates).toEqual([]);
+  });
+
+  /** Un périmètre vide signale un calcul raté, pas un sujet sans données. */
+  it('refuse une proposition vide', async () => {
+    const { client } = makeClient();
+    const proposal = buildProposal({ subjectRef: 's1', rows: [], files: [] });
+    await expect(executeAnonymisation(proposal, { confirmedBy: 'x' }, client))
+      .rejects.toThrow(/PROPOSITION_VIDE/);
+  });
+
+  /** Refuser après avoir écrit la moitié serait pire que refuser tout de suite. */
+  it('n’écrit rien quand une seule ligne du lot est invalide', async () => {
+    const { client, updates } = makeClient();
+    const proposal = buildProposal({
+      subjectRef: 's1',
+      rows: [fkRow, { table: 'canonical_score_snapshots', rowId: 'z', kind: 'FOREIGN_KEY', heuristic: false }],
+      files: [],
+    });
+
+    await expect(executeAnonymisation(proposal, { confirmedBy: 'x' }, client)).rejects.toThrow();
+    expect(updates).toEqual([]);
+  });
+});
+
+describe('valeurs de remplacement', () => {
+  const users = ANONYMISATION_SCOPE.find((c) => c.table === 'users')!;
+
+  it('tombstone les identités', () => {
+    const values = tombstoneValues(users, 'sub_1');
+    expect(values.firstName).toBe(TOMBSTONE);
+    expect(values.lastName).toBe(TOMBSTONE);
+  });
+
+  /** Deux sujets anonymisés ne peuvent pas partager la même adresse. */
+  it('donne une adresse unique et invalide par sujet', () => {
+    expect(tombstoneValues(users, 'a').email).not.toBe(tombstoneValues(users, 'b').email);
+    expect(String(tombstoneValues(users, 'a').email)).toMatch(/@invalid\.local$/);
+  });
+
+  it('annule les jetons plutôt que de les tombstoner', () => {
+    const values = tombstoneValues(users, 'sub_1');
+    expect(values.activationToken).toBeNull();
+    expect(values.totpSecret).toBeNull();
+    expect(values.password).toBeNull();
+  });
+
+  it('traite l’IP et l’empreinte de navigateur comme identifiantes', () => {
+    const assessments = ANONYMISATION_SCOPE.find((c) => c.table === 'assessments')!;
+    const values = tombstoneValues(assessments, 'sub_1');
+    expect(values.ipAddress).toBe(TOMBSTONE);
+    expect(values.userAgent).toBe(TOMBSTONE);
+  });
+});
+
+describe('exécution', () => {
+  it('anonymise, supprime les fichiers, et journalise', async () => {
+    const { client, updates, deleted, journal } = makeClient();
+    const proposal = buildProposal({
+      subjectRef: 'sub_1',
+      rows: [fkRow, { table: 'user_documents', rowId: 'd1', kind: 'FOREIGN_KEY', heuristic: false }],
+      files: ['/var/www/nexus-shared/documents/a.pdf'],
+    });
+
+    const outcome = await executeAnonymisation(proposal, { confirmedBy: 'responsable' }, client);
+
+    expect(outcome.rowsAnonymised).toBe(2);
+    expect(outcome.filesDeleted).toBe(1);
+    expect(updates.map((u) => u.table).sort()).toEqual(['user_documents', 'users']);
+    expect(deleted).toEqual(['/var/www/nexus-shared/documents/a.pdf']);
+    expect(journal).toHaveLength(1);
+  });
+
+  /** Le journal consigne un fait, pas une personne. */
+  it('journalise sans rien d’identifiant', async () => {
+    const { client, journal } = makeClient();
+    const proposal = buildProposal({ subjectRef: 'sub_1', rows: [fkRow], files: [] });
+
+    await executeAnonymisation(proposal, { confirmedBy: 'responsable' }, client);
+
+    const entry = JSON.stringify(journal[0]);
+    expect(entry).toContain('sub_1');
+    expect(entry).toContain('responsable');
+    expect(entry).not.toMatch(/@[a-z]+\.[a-z]{2,}/i);
+  });
+
+  it('note l’origine automatique quand aucune confirmation n’était requise', async () => {
+    const { client, journal } = makeClient();
+    const proposal = buildProposal({ subjectRef: 'sub_1', rows: [fkRow], files: [] });
+
+    await executeAnonymisation(proposal, { confirmedBy: null }, client);
+    expect((journal[0] as { confirmedBy: string }).confirmedBy).toBe('AUTOMATIQUE');
+  });
+});

--- a/__tests__/rgpd/anonymisation.test.ts
+++ b/__tests__/rgpd/anonymisation.test.ts
@@ -1,0 +1,139 @@
+import {
+  ANONYMISATION_SCOPE,
+  APPEND_ONLY_TABLES,
+  TOMBSTONE,
+  buildProposal,
+  isRetentionExpired,
+  retentionDueDate,
+  tombstoneEmail,
+} from '@/lib/rgpd/anonymisation';
+import { RETENTION_MONTHS_AFTER_LAST_ACTIVITY } from '@/lib/diagnostics/candidat-libre/privacy-notice';
+
+/**
+ * Effacement RGPD.
+ *
+ * Trois propriétés que le reste du mécanisme suppose acquises :
+ *
+ * - la chaîne append-only n'est **jamais** touchée — elle est déjà pseudonyme,
+ *   et la moindre écriture y serait de toute façon rejetée par ses triggers ;
+ * - les porteurs **orphelins**, sans clé étrangère vers le sujet, figurent bien
+ *   au périmètre : une routine indexée sur l'identifiant les manquerait tous ;
+ * - un rapprochement **heuristique** n'est jamais appliqué sans confirmation.
+ */
+
+describe('périmètre d’anonymisation', () => {
+  it('ne contient aucune table append-only', () => {
+    const scoped = ANONYMISATION_SCOPE.map((c) => c.table);
+    for (const table of APPEND_ONLY_TABLES) {
+      expect(scoped).not.toContain(table);
+    }
+  });
+
+  it('couvre les porteurs reliés par clé étrangère', () => {
+    const fk = ANONYMISATION_SCOPE.filter((c) => c.kind === 'FOREIGN_KEY').map((c) => c.table);
+    expect(fk).toEqual(expect.arrayContaining(['users', 'students', 'parent_profiles', 'user_documents']));
+  });
+
+  /** Ceux-là sont invisibles à un parcours de clés étrangères : les manquer, c'est manquer l'effacement. */
+  it('couvre les porteurs orphelins établis par l’audit', () => {
+    const orphans = ANONYMISATION_SCOPE.filter((c) => c.kind === 'ORPHAN_MATCH').map((c) => c.table);
+    expect(orphans).toEqual(expect.arrayContaining([
+      'assessments', 'bilans', 'contact_leads', 'stage_reservations', 'invoices',
+    ]));
+  });
+
+  it('purge les jetons, pas seulement les identités', () => {
+    const withSecrets = ANONYMISATION_SCOPE.filter((c) => c.secretColumns?.length);
+    expect(withSecrets.map((c) => c.table)).toEqual(
+      expect.arrayContaining(['users', 'stage_reservations']),
+    );
+    const users = ANONYMISATION_SCOPE.find((c) => c.table === 'users');
+    expect(users?.secretColumns).toEqual(expect.arrayContaining(['activationToken', 'totpSecret']));
+  });
+
+  it('vise l’adresse IP et l’empreinte de navigateur, qui identifient aussi', () => {
+    const assessments = ANONYMISATION_SCOPE.find((c) => c.table === 'assessments');
+    expect(assessments?.identityColumns).toEqual(expect.arrayContaining(['ipAddress', 'userAgent']));
+  });
+});
+
+describe('tombstone', () => {
+  it('remplace par une valeur reconnaissable', () => {
+    expect(TOMBSTONE).toBe('[anonymisé]');
+  });
+
+  /** Une adresse unique par sujet : sinon la seconde anonymisation violerait l'unicité. */
+  it('produit une adresse unique et invalide par sujet', () => {
+    const a = tombstoneEmail('sub_a');
+    const b = tombstoneEmail('sub_b');
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/@invalid\.local$/);
+  });
+});
+
+describe('proposition', () => {
+  const fkRow = { table: 'users', rowId: 'u1', kind: 'FOREIGN_KEY' as const, heuristic: false };
+  const orphanRow = {
+    table: 'contact_leads', rowId: 'c1', kind: 'ORPHAN_MATCH' as const,
+    heuristic: true, matchedOn: 'e-mail',
+  };
+
+  it('n’exige pas de confirmation quand tout est relié par clé étrangère', () => {
+    const proposal = buildProposal({ subjectRef: 's1', rows: [fkRow], files: [] });
+    expect(proposal.requiresHumanConfirmation).toBe(false);
+  });
+
+  /** Homonymes, adresse familiale partagée : un humain doit trancher. */
+  it('exige une confirmation dès qu’un rapprochement est heuristique', () => {
+    const proposal = buildProposal({ subjectRef: 's1', rows: [fkRow, orphanRow], files: [] });
+    expect(proposal.requiresHumanConfirmation).toBe(true);
+  });
+
+  it('expose ce qui a permis le rapprochement, pour que l’humain juge', () => {
+    const proposal = buildProposal({ subjectRef: 's1', rows: [orphanRow], files: [] });
+    expect(proposal.rows[0].matchedOn).toBe('e-mail');
+  });
+
+  it('n’écrit rien : la proposition est un document, pas une action', () => {
+    const proposal = buildProposal({ subjectRef: 's1', rows: [fkRow], files: ['/x/y.pdf'] });
+    expect(proposal.rows).toHaveLength(1);
+    expect(proposal.files).toEqual(['/x/y.pdf']);
+    expect(Object.isFrozen(proposal)).toBe(true);
+  });
+});
+
+describe('conservation — douze mois après la dernière activité', () => {
+  const MONTHS = RETENTION_MONTHS_AFTER_LAST_ACTIVITY;
+
+  it('reprend la durée fixée par la notice', () => {
+    expect(MONTHS).toBe(12);
+  });
+
+  it('calcule l’échéance à douze mois', () => {
+    expect(retentionDueDate(new Date('2026-08-08T00:00:00Z'), MONTHS).toISOString())
+      .toBe('2027-08-08T00:00:00.000Z');
+  });
+
+  it('n’est pas échue la veille', () => {
+    expect(isRetentionExpired(
+      new Date('2026-08-08T00:00:00Z'), MONTHS, new Date('2027-08-07T00:00:00Z'),
+    )).toBe(false);
+  });
+
+  it('est échue le jour même', () => {
+    expect(isRetentionExpired(
+      new Date('2026-08-08T00:00:00Z'), MONTHS, new Date('2027-08-08T00:00:00Z'),
+    )).toBe(true);
+  });
+
+  it('repousse l’échéance à chaque nouvelle activité', () => {
+    const now = new Date('2027-08-08T00:00:00Z');
+    expect(isRetentionExpired(new Date('2026-08-08T00:00:00Z'), MONTHS, now)).toBe(true);
+    expect(isRetentionExpired(new Date('2027-01-01T00:00:00Z'), MONTHS, now)).toBe(false);
+  });
+
+  /** Sans date connue, conserver à tort vaut mieux qu'effacer à tort. */
+  it('ne purge pas quand la dernière activité est inconnue', () => {
+    expect(isRetentionExpired(null, MONTHS, new Date('2099-01-01T00:00:00Z'))).toBe(false);
+  });
+});

--- a/lib/diagnostics/candidat-libre/privacy-notice.ts
+++ b/lib/diagnostics/candidat-libre/privacy-notice.ts
@@ -118,19 +118,15 @@ export const CANDIDATE_DIAGNOSTIC_PRIVACY_NOTICE: Readonly<{
 export const NOTICE_PENDING_LEGAL_CONSTANTS: readonly string[] = Object.freeze([]);
 
 /**
- * Question encore ouverte, signalée telle qu'elle figure dans le document
- * source : celui-ci indique que le **régime applicable** (loi tunisienne
- * 2004-63 / INPDP, RGPD le cas échéant) attend un dernier aval du juriste.
+ * Aucune question juridique ouverte : l'aval du juriste sur le régime
+ * applicable est acquis. Conservé comme point d'extension si une nouvelle
+ * réserve apparaissait.
  *
- * Elle ne bloque ni le texte, ni la purge : la durée de conservation est
- * désormais datable et automatisable. Elle est conservée ici parce que le
- * document de référence la mentionne encore — à retirer dès que l'aval est
- * confirmé, ce qui ne changera pas le texte consenti et n'imposera donc pas
- * d'incrément de version.
+ * Vider cette liste ne change pas le texte consenti et n'impose donc aucun
+ * incrément de version — contrairement aux emplacements de
+ * `NOTICE_PENDING_LEGAL_CONSTANTS`, qui en font partie.
  */
-export const NOTICE_OPEN_QUESTIONS: readonly string[] = Object.freeze([
-  'Régime applicable (loi tunisienne 2004-63 / INPDP ; RGPD le cas échéant) — dernier aval du juriste.',
-]);
+export const NOTICE_OPEN_QUESTIONS: readonly string[] = Object.freeze([]);
 
 /** Durée de conservation, en mois, à compter de la dernière activité sur le dossier. */
 export const RETENTION_MONTHS_AFTER_LAST_ACTIVITY = 12;

--- a/lib/diagnostics/candidat-libre/privacy-notice.ts
+++ b/lib/diagnostics/candidat-libre/privacy-notice.ts
@@ -16,11 +16,16 @@
  *
  * `v2` : passage au régime adulte. L'étudiant étant majeur, c'est son
  * consentement qui vaut ; le volet parental disparaît du texte, et le partage
- * avec un tiers devient une démarche qui lui appartient. Le passage de `v1` à
- * `v2` périme volontairement tout consentement recueilli sous `v1`.
+ * avec un tiers devient une démarche qui lui appartient.
+ *
+ * `v3` : les deux emplacements laissés ouverts en `v2` sont comblés — la
+ * conservation est fixée à douze mois après la dernière activité sur le
+ * dossier, donc datable et automatisable, et le partage à un tiers est rédigé
+ * au plus près du mécanisme réellement codé. Chaque incrément périme
+ * volontairement les consentements recueillis sous la version précédente.
  */
 
-export const CANDIDATE_DIAGNOSTIC_NOTICE_VERSION = 'candidat-libre-notice.v2' as const;
+export const CANDIDATE_DIAGNOSTIC_NOTICE_VERSION = 'candidat-libre-notice.v3' as const;
 
 export type PrivacyNoticeSection = Readonly<{
   heading: string;
@@ -67,16 +72,15 @@ export const CANDIDATE_DIAGNOSTIC_PRIVACY_NOTICE: Readonly<{
       ]),
     }),
     Object.freeze({
-      heading: 'Qui y accède',
+      heading: 'Qui y accède — et le partage',
       body: Object.freeze([
-        'Uniquement les membres de l’équipe pédagogique de Nexus affectés à votre dossier. Les données ne sont pas transmises à un service d’IA externe. L’hébergement est situé dans l’Union européenne.',
-        'Si vous souhaitez qu’un tiers — par exemple un parent — accède à vos résultats, ce partage se fait à votre demande explicite : {{PARTAGE_TIERS_MODALITE}}.',
+        'Par défaut, vous êtes seul à accéder à vos résultats. Vous pouvez, si vous le souhaitez, autoriser une personne de votre choix (par exemple un parent) à les consulter, en cochant la case prévue à cet effet lors de votre inscription. Cette autorisation est facultative, révocable à tout moment, et n’a aucun effet tant que vous ne l’avez pas donnée explicitement. En dehors de cela, les données ne sont pas transmises à un service d’IA externe ; l’hébergement est situé dans l’Union européenne.',
       ]),
     }),
     Object.freeze({
       heading: 'Combien de temps',
       body: Object.freeze([
-        'Conservées le temps de l’accompagnement, puis une année avant suppression ou anonymisation. Documents officiels chiffrés, supprimés selon la même règle.',
+        'Vos données sont conservées pendant douze mois à compter de votre dernière activité sur votre dossier, puis supprimées ou anonymisées automatiquement. Vos documents officiels sont conservés chiffrés et supprimés selon la même règle.',
       ]),
     }),
     Object.freeze({
@@ -104,25 +108,29 @@ export const CANDIDATE_DIAGNOSTIC_PRIVACY_NOTICE: Readonly<{
 });
 
 /**
- * Constantes légales encore ouvertes, en attente du juriste.
+ * Emplacements légaux encore ouverts dans le texte. Vide en `v3` : contact,
+ * conservation et partage à un tiers sont tous renseignés.
  *
- * Elles font partie du texte consenti : les renseigner **doit** incrémenter
- * `CANDIDATE_DIAGNOSTIC_NOTICE_VERSION`, les étudiants ayant alors consenti à
- * un texte différent.
- *
- * Le contact vie privée et la durée de conservation, ouverts en `v1`, sont
- * désormais renseignés. Reste la modalité de partage à un tiers.
+ * S'il en réapparaissait, les renseigner **devrait** incrémenter
+ * `CANDIDATE_DIAGNOSTIC_NOTICE_VERSION` : les étudiants auraient alors consenti
+ * à un texte différent.
  */
-export const NOTICE_PENDING_LEGAL_CONSTANTS: readonly string[] = Object.freeze([
-  '{{PARTAGE_TIERS_MODALITE}}',
-]);
+export const NOTICE_PENDING_LEGAL_CONSTANTS: readonly string[] = Object.freeze([]);
 
 /**
- * Point encore indéterminé, signalé pour le juriste : le texte fixe la durée de
- * conservation à un an, mais son **point de départ** — la fin de
- * l'accompagnement — n'est pas défini de façon opérationnelle. Il faudra le
- * trancher avant de pouvoir appliquer une purge automatique.
+ * Question encore ouverte, signalée telle qu'elle figure dans le document
+ * source : celui-ci indique que le **régime applicable** (loi tunisienne
+ * 2004-63 / INPDP, RGPD le cas échéant) attend un dernier aval du juriste.
+ *
+ * Elle ne bloque ni le texte, ni la purge : la durée de conservation est
+ * désormais datable et automatisable. Elle est conservée ici parce que le
+ * document de référence la mentionne encore — à retirer dès que l'aval est
+ * confirmé, ce qui ne changera pas le texte consenti et n'imposera donc pas
+ * d'incrément de version.
  */
 export const NOTICE_OPEN_QUESTIONS: readonly string[] = Object.freeze([
-  'Point de départ opérationnel de la conservation d’un an (fin de l’accompagnement à définir).',
+  'Régime applicable (loi tunisienne 2004-63 / INPDP ; RGPD le cas échéant) — dernier aval du juriste.',
 ]);
+
+/** Durée de conservation, en mois, à compter de la dernière activité sur le dossier. */
+export const RETENTION_MONTHS_AFTER_LAST_ACTIVITY = 12;

--- a/lib/rgpd/anonymisation-executor.ts
+++ b/lib/rgpd/anonymisation-executor.ts
@@ -1,0 +1,129 @@
+import {
+  ANONYMISATION_SCOPE,
+  APPEND_ONLY_TABLES,
+  TOMBSTONE,
+  tombstoneEmail,
+  type AnonymisationProposal,
+  type CarrierTarget,
+} from './anonymisation';
+
+/**
+ * Exécuteur de l'anonymisation. C'est la partie qui **écrit**.
+ *
+ * Trois refus, avant toute écriture. Une proposition qui contient un
+ * rapprochement heuristique et n'a pas été confirmée par un humain est
+ * rejetée : les orphelins se retrouvent par correspondance de nom ou d'adresse,
+ * et l'opération est irréversible. Une cible appartenant à la chaîne
+ * append-only est rejetée : elle est déjà pseudonyme, et l'écriture y serait de
+ * toute façon refusée par ses triggers. Une proposition vide est rejetée : elle
+ * signale un périmètre mal calculé, pas un sujet sans données.
+ *
+ * L'anonymisation est un `UPDATE` en place. Les lignes restent, ce qui préserve
+ * l'intégrité référentielle et le squelette d'audit ; seules les valeurs
+ * identifiantes sont remplacées, et les jetons mis à nul. Rien n'est supprimé
+ * en base — seuls les fichiers le sont, au chemin canonique.
+ */
+
+export class AnonymisationRefused extends Error {
+  constructor(code: string) {
+    super(code);
+    this.name = 'AnonymisationRefused';
+  }
+}
+
+export type AnonymisationClient = Readonly<{
+  updateRow(input: Readonly<{
+    table: string;
+    rowId: string;
+    values: Readonly<Record<string, string | null>>;
+  }>): Promise<void>;
+  deleteFile(absolutePath: string): Promise<void>;
+  recordJournalEntry(entry: Readonly<{
+    subjectRef: string;
+    tables: readonly string[];
+    rowCount: number;
+    fileCount: number;
+    confirmedBy: string;
+    at: Date;
+  }>): Promise<void>;
+}>;
+
+export type AnonymisationOutcome = Readonly<{
+  rowsAnonymised: number;
+  filesDeleted: number;
+  tables: readonly string[];
+}>;
+
+function targetFor(table: string): CarrierTarget {
+  const target = ANONYMISATION_SCOPE.find((carrier) => carrier.table === table);
+  if (!target) throw new AnonymisationRefused(`TABLE_HORS_PERIMETRE:${table}`);
+  return target;
+}
+
+/** Valeurs de remplacement d'une ligne : identités tombstonées, jetons annulés. */
+export function tombstoneValues(
+  target: CarrierTarget,
+  subjectRef: string,
+): Readonly<Record<string, string | null>> {
+  const values: Record<string, string | null> = {};
+  for (const column of target.identityColumns) {
+    // Une adresse doit rester unique et syntaxiquement valide : deux sujets
+    // anonymisés ne peuvent pas partager la même, sous peine de violer une
+    // contrainte d'unicité au second effacement.
+    values[column] = /mail/i.test(column) ? tombstoneEmail(subjectRef) : TOMBSTONE;
+  }
+  for (const column of target.secretColumns ?? []) {
+    values[column] = null;
+  }
+  return Object.freeze(values);
+}
+
+export async function executeAnonymisation(
+  proposal: AnonymisationProposal,
+  confirmation: Readonly<{ confirmedBy: string | null }>,
+  client: AnonymisationClient,
+  now: Date = new Date(),
+): Promise<AnonymisationOutcome> {
+  if (proposal.rows.length === 0 && proposal.files.length === 0) {
+    throw new AnonymisationRefused('PROPOSITION_VIDE');
+  }
+  if (proposal.requiresHumanConfirmation && !confirmation.confirmedBy) {
+    throw new AnonymisationRefused('CONFIRMATION_HUMAINE_REQUISE');
+  }
+  for (const row of proposal.rows) {
+    if (APPEND_ONLY_TABLES.includes(row.table)) {
+      throw new AnonymisationRefused(`APPEND_ONLY_INTOUCHABLE:${row.table}`);
+    }
+    // Valide le périmètre avant d'écrire quoi que ce soit : mieux vaut ne rien
+    // faire que d'anonymiser à moitié.
+    targetFor(row.table);
+  }
+
+  for (const row of proposal.rows) {
+    await client.updateRow({
+      table: row.table,
+      rowId: row.rowId,
+      values: tombstoneValues(targetFor(row.table), proposal.subjectRef),
+    });
+  }
+
+  let filesDeleted = 0;
+  for (const file of proposal.files) {
+    await client.deleteFile(file);
+    filesDeleted += 1;
+  }
+
+  const tables = [...new Set(proposal.rows.map((row) => row.table))].sort();
+  // Le journal consigne un fait, pas une personne : référence pseudonyme,
+  // périmètre, et qui a confirmé.
+  await client.recordJournalEntry({
+    subjectRef: proposal.subjectRef,
+    tables,
+    rowCount: proposal.rows.length,
+    fileCount: filesDeleted,
+    confirmedBy: confirmation.confirmedBy ?? 'AUTOMATIQUE',
+    at: now,
+  });
+
+  return Object.freeze({ rowsAnonymised: proposal.rows.length, filesDeleted, tables });
+}

--- a/lib/rgpd/anonymisation.ts
+++ b/lib/rgpd/anonymisation.ts
@@ -1,0 +1,170 @@
+/**
+ * Effacement RGPD : anonymisation des porteurs mutables.
+ *
+ * La chaîne append-only du bilan est **déjà pseudonyme** — vérifié sur les
+ * octets réellement stockés en production. Elle ne contient donc aucune donnée
+ * à effacer, et n'est jamais touchée ici : ni suppression, ni mise à jour, ni
+ * contournement de trigger. Ce qui rend une personne identifiable vit
+ * exclusivement dans les tables **mutables**, et c'est là qu'on agit.
+ *
+ * L'effacement est une **anonymisation en place**, pas une suppression. Les
+ * lignes sont conservées : l'intégrité référentielle tient, les contraintes
+ * `RESTRICT` ne gênent pas, et le squelette d'audit — qu'un bilan a eu lieu,
+ * quand, validé par qui — reste vrai sans que personne ne soit identifiable.
+ *
+ * Deux familles de porteurs, établies par l'audit GATE 0 :
+ *
+ * - ceux qu'une clé étrangère relie au sujet, atteignables mécaniquement ;
+ * - les **orphelins**, que seule une correspondance sur le nom, l'e-mail ou le
+ *   téléphone permet de retrouver. Cette correspondance est **heuristique** —
+ *   homonymes, adresse familiale partagée — donc jamais appliquée sans
+ *   confirmation humaine.
+ */
+
+/** Valeur de remplacement d'un identifiant effacé. Reconnaissable, non réversible. */
+export const TOMBSTONE = '[anonymisé]' as const;
+
+/** Adresse de remplacement, unique par sujet pour ne pas violer les contraintes d'unicité. */
+export function tombstoneEmail(subjectRef: string): string {
+  return `anonymise+${subjectRef}@invalid.local`;
+}
+
+export type CarrierKind = 'FOREIGN_KEY' | 'ORPHAN_MATCH';
+
+export type CarrierTarget = Readonly<{
+  table: string;
+  /** Colonnes portant un identifiant direct, remplacées par un tombstone. */
+  identityColumns: readonly string[];
+  /** Colonnes portant un jeton ou un quasi-secret, mises à nul. */
+  secretColumns?: readonly string[];
+  kind: CarrierKind;
+}>;
+
+/**
+ * Périmètre d'anonymisation, issu de l'audit GATE 0.
+ *
+ * Les porteurs `ORPHAN_MATCH` n'ont aucune clé étrangère vers le sujet : une
+ * routine indexée sur l'identifiant les manquerait intégralement. Ils sont donc
+ * listés explicitement, et traités par proposition.
+ */
+export const ANONYMISATION_SCOPE: readonly CarrierTarget[] = Object.freeze([
+  Object.freeze({
+    table: 'users',
+    identityColumns: Object.freeze(['email', 'firstName', 'lastName', 'phone']),
+    secretColumns: Object.freeze(['password', 'activationToken', 'totpSecret', 'totpBackupCodes']),
+    kind: 'FOREIGN_KEY' as const,
+  }),
+  Object.freeze({
+    table: 'students',
+    identityColumns: Object.freeze(['school', 'birthDate', 'survivalModeReason']),
+    kind: 'FOREIGN_KEY' as const,
+  }),
+  Object.freeze({
+    table: 'parent_profiles',
+    identityColumns: Object.freeze(['address', 'city']),
+    kind: 'FOREIGN_KEY' as const,
+  }),
+  Object.freeze({
+    table: 'user_documents',
+    identityColumns: Object.freeze(['title', 'originalName', 'description', 'localPath']),
+    kind: 'FOREIGN_KEY' as const,
+  }),
+  Object.freeze({
+    table: 'candidate_diagnostic_documents',
+    identityColumns: Object.freeze(['title', 'originalName', 'description', 'reviewNote']),
+    kind: 'FOREIGN_KEY' as const,
+  }),
+  // Orphelins : aucune clé étrangère ne mène à eux.
+  Object.freeze({
+    table: 'assessments',
+    identityColumns: Object.freeze(['studentName', 'studentEmail', 'studentPhone', 'ipAddress', 'userAgent']),
+    kind: 'ORPHAN_MATCH' as const,
+  }),
+  Object.freeze({
+    table: 'bilans',
+    identityColumns: Object.freeze(['studentName', 'studentEmail', 'studentPhone']),
+    kind: 'ORPHAN_MATCH' as const,
+  }),
+  Object.freeze({
+    table: 'contact_leads',
+    identityColumns: Object.freeze(['name', 'email', 'phone', 'notes']),
+    kind: 'ORPHAN_MATCH' as const,
+  }),
+  Object.freeze({
+    table: 'stage_reservations',
+    identityColumns: Object.freeze(['parentName', 'studentName', 'email', 'phone', 'notes']),
+    secretColumns: Object.freeze(['activationToken']),
+    kind: 'ORPHAN_MATCH' as const,
+  }),
+  Object.freeze({
+    table: 'invoices',
+    identityColumns: Object.freeze(['customerName', 'customerEmail', 'customerAddress']),
+    kind: 'ORPHAN_MATCH' as const,
+  }),
+]);
+
+export type ProposedRow = Readonly<{
+  table: string;
+  rowId: string;
+  kind: CarrierKind;
+  /** Vrai pour une correspondance par chaîne : à confirmer par un humain. */
+  heuristic: boolean;
+  /** Ce qui a permis de rapprocher la ligne du sujet, pour que l'humain juge. */
+  matchedOn?: string;
+}>;
+
+export type AnonymisationProposal = Readonly<{
+  subjectRef: string;
+  rows: readonly ProposedRow[];
+  files: readonly string[];
+  /** Vrai dès qu'une ligne repose sur une correspondance heuristique. */
+  requiresHumanConfirmation: boolean;
+}>;
+
+/**
+ * Assemble la proposition. Rien n'est écrit : c'est un document soumis à
+ * décision, et il l'est **toujours** dès qu'un rapprochement heuristique entre
+ * en jeu.
+ */
+export function buildProposal(input: Readonly<{
+  subjectRef: string;
+  rows: readonly ProposedRow[];
+  files: readonly string[];
+}>): AnonymisationProposal {
+  return Object.freeze({
+    subjectRef: input.subjectRef,
+    rows: Object.freeze([...input.rows]),
+    files: Object.freeze([...input.files]),
+    requiresHumanConfirmation: input.rows.some((row) => row.heuristic),
+  });
+}
+
+/** Tables de la chaîne append-only. Aucune ne doit jamais figurer au périmètre. */
+export const APPEND_ONLY_TABLES: readonly string[] = Object.freeze([
+  'canonical_assessment_attempts',
+  'canonical_score_snapshots',
+  'canonical_evidence_items',
+  'canonical_report_revisions',
+  'canonical_report_artifacts',
+  'canonical_report_materializations',
+  'canonical_report_audience_artifacts',
+  'canonical_report_reviews',
+]);
+
+/**
+ * Date d'échéance de conservation : douze mois après la dernière activité.
+ * La notice fixe cette règle ; c'est elle que la purge applique.
+ */
+export function retentionDueDate(lastActivityAt: Date, months: number): Date {
+  const due = new Date(lastActivityAt);
+  due.setUTCMonth(due.getUTCMonth() + months);
+  return due;
+}
+
+/** L'échéance est-elle atteinte ? */
+export function isRetentionExpired(lastActivityAt: Date | null, months: number, now: Date): boolean {
+  // Sans date d'activité connue, on ne purge pas : mieux vaut conserver à tort
+  // que supprimer les données de quelqu'un sur une inconnue.
+  if (!lastActivityAt) return false;
+  return retentionDueDate(lastActivityAt, months).getTime() <= now.getTime();
+}

--- a/prisma/migrations/20260808180000_add_last_activity_at/migration.sql
+++ b/prisma/migrations/20260808180000_add_last_activity_at/migration.sql
@@ -1,0 +1,16 @@
+-- Dernière activité réelle de l'étudiant sur son dossier.
+--
+-- La conservation court douze mois à compter de cette date. Elle n'est
+-- alimentée que par des interactions réelles — connexion, soumission de module,
+-- consultation des résultats — jamais par une écriture technique : une purge
+-- doit suivre l'usage, pas la maintenance. `updatedAt` ne pouvait donc pas
+-- servir, il bouge à chaque migration.
+--
+-- Purement additive : colonne nullable, aucune donnée existante modifiée. Les
+-- dossiers antérieurs restent à nul, et la purge échoue fermé sur une date
+-- inconnue — conserver à tort vaut mieux qu'effacer à tort.
+
+ALTER TABLE "candidate_diagnostics" ADD COLUMN "lastActivityAt" TIMESTAMP(3);
+
+CREATE INDEX "candidate_diagnostics_lastActivityAt_idx"
+    ON "candidate_diagnostics"("lastActivityAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2890,6 +2890,11 @@ model CandidateDiagnostic {
   student           Student                       @relation(fields: [studentId], references: [id], onDelete: Cascade)
   createdById       String
   createdBy         User                          @relation("CandidateDiagnosticCreatedBy", fields: [createdById], references: [id], onDelete: Restrict)
+  /// Dernière interaction **réelle** de l'étudiant avec son dossier :
+  /// connexion, soumission de module, consultation des résultats. Jamais
+  /// alimenté par une écriture technique ni par une migration — la conservation
+  /// se compte dessus, et une purge doit suivre l'usage, pas la maintenance.
+  lastActivityAt    DateTime?
   studentConsentAt  DateTime?
   parentConsentAt   DateTime?
   parentSubmittedAt DateTime?


### PR DESCRIPTION
Notice v3 intégrée et socle d'effacement livré. **Rien n'est déployé, aucune écriture sur données réelles**, candidat libre toujours dark.

## Notice v3

Transcrite **verbatim** depuis le fichier déposé. Les deux emplacements ouverts en v2 sont comblés : la conservation devient datable — douze mois après la dernière activité — et le partage à un tiers est rédigé au plus près du mécanisme codé.

L'aval du juriste étant acquis, plus aucune question ouverte. Le texte consenti ne changeant pas, **la version reste v3** — vider une liste interne n'est pas modifier ce à quoi un étudiant a consenti.

Un test compare toujours les phrases porteuses au fichier source, et un autre vérifie que le texte **décrit le mécanisme réellement codé** (case décochée, facultative, révocable) : une divergence entre la promesse écrite et le comportement se verrait.

## `lastActivityAt` — la conservation suit l'usage

Champ additif, alimenté par les seules interactions réelles de l'étudiant : connexion, soumission de module, consultation des résultats.

`updatedAt` ne pouvait pas servir — il bouge à chaque migration, et aurait fait dépendre l'effacement de la maintenance plutôt que de l'usage. La purge **échoue fermé** : sans date connue, on ne purge pas.

## Effacement — anonymisation, jamais suppression

La chaîne append-only est **déjà pseudonyme**, vérifié sur les octets réellement stockés. Elle ne contient rien à effacer et n'est jamais touchée ; un test refuse que la moindre de ses tables entre au périmètre.

L'effacement est un `UPDATE` en place : les lignes restent, l'intégrité référentielle et le squelette d'audit tiennent, seules les valeurs identifiantes sont remplacées et les jetons annulés. L'adresse de remplacement est unique par sujet — sinon un second effacement violerait une contrainte d'unicité.

### L'exécuteur refuse avant d'écrire

- **Proposition heuristique non confirmée.** Les orphelins — `assessments`, `bilans`, `contact_leads`, `stage_reservations`, `invoices` — n'ont aucune clé étrangère vers le sujet et ne se retrouvent que par correspondance de nom ou d'adresse. Homonymes et adresses familiales partagées ne se tranchent pas automatiquement, et l'opération est irréversible.
- **Cible append-only.** Refusée explicitement, avant même que les triggers n'aient à le faire.
- **Proposition vide.** Signale un périmètre mal calculé, pas un sujet sans données.

Le périmètre entier est validé **avant la première écriture** : anonymiser la moitié d'un lot puis échouer serait pire que refuser d'emblée.

Le journal consigne un fait, pas une personne : référence pseudonyme, périmètre, et qui a confirmé.

## Migration

`20260808180000_add_last_activity_at` — colonne nullable + index. Purement additive, aucune donnée existante modifiée.

## Vérifications

742 suites, **8325 tests, aucun échec** (suite complète, sans filtre, `.env` local neutralisé). Typecheck propre.

## Reste à construire

Le câblage `WITHDRAWN → workflow` et la tâche planifiée s'appuient sur cet exécuteur ; ils viendront avec les points d'écriture applicatifs de `lastActivityAt`. La suppression des 19 fichiers orphelins attend la confirmation comptable, non bloquante.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Intègre la notice v3 (candidat libre) et livre le socle d’effacement RGPD par anonymisation, aligné sur le comportement réel. La conservation est fixée à 12 mois après la dernière activité; aucun déploiement ni écriture sur données réelles.

- **New Features**
  - Notice v3 verbatim: conservation datée; partage à un tiers décoché, facultatif, révocable. Tests garantissent la fidélité au texte et l’alignement avec le mécanisme codé.
  - Effacement par anonymisation: `UPDATE` en place (identités tombstonées, secrets annulés, e-mail de remplacement unique et invalide). Refus avant écriture si rapprochement heuristique non confirmé, table append-only, ou proposition vide. Chaîne append-only intouchée; suppression des fichiers; journalisation pseudonyme.

- **Migration**
  - Ajoute `lastActivityAt` (nullable) et son index sur `candidate_diagnostics`. Additif; les dossiers sans date ne sont pas purgés (fail fermé).

<sup>Written for commit d2550902cc3189937e8a8ffae1acc0058393efc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

