### PR TITLE
RGPD — Phase 4 complète : purge à échéance, retrait déclencheur, preuve sur clone

### DIFF
--- a/__tests__/rgpd/activity-wiring.test.ts
+++ b/__tests__/rgpd/activity-wiring.test.ts
@@ -1,0 +1,76 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const mockUpdate = jest.fn();
+jest.mock('@/lib/prisma', () => ({
+  prisma: { candidateDiagnostic: { update: (...a: unknown[]) => mockUpdate(...a) } },
+}));
+
+import { noteStudentActivity } from '@/lib/rgpd/last-activity.server';
+
+/**
+ * Câblage de l'activité.
+ *
+ * La conservation se compte sur `lastActivityAt` : si rien ne l'alimente, la
+ * purge ne mesure rien et la promesse de la notice devient inopérante. Ces
+ * tests vérifient donc à la fois que les points d'appel existent réellement
+ * dans les routes, et que seul l'étudiant repousse l'échéance.
+ */
+
+const ROUTES = path.join(process.cwd(), 'app/api/diagnostics/candidat-libre');
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('noteStudentActivity — qui repousse l’échéance', () => {
+  it('enregistre l’activité de l’étudiant', async () => {
+    await noteStudentActivity({ diagnosticId: 'd1', activity: 'MODULE_RENSEIGNE', actorRole: 'ELEVE' });
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    const { where, data } = mockUpdate.mock.calls[0][0];
+    expect(where).toEqual({ id: 'd1' });
+    expect(data.lastActivityAt).toBeInstanceOf(Date);
+  });
+
+  /**
+   * Le cœur : une consultation par un tiers prolongerait la rétention sans que
+   * l'intéressé y soit pour quelque chose. Seul son propre usage compte.
+   */
+  it.each(['PARENT', 'COACH', 'ADMIN', 'ASSISTANTE'])(
+    'n’enregistre rien pour un acteur %s',
+    async (actorRole) => {
+      await noteStudentActivity({ diagnosticId: 'd1', activity: 'RESULTATS_CONSULTES', actorRole });
+      expect(mockUpdate).not.toHaveBeenCalled();
+    },
+  );
+
+  it('n’interrompt pas l’interaction si l’écriture échoue', async () => {
+    mockUpdate.mockRejectedValue(new Error('db down'));
+    await expect(
+      noteStudentActivity({ diagnosticId: 'd1', activity: 'DOSSIER_SOUMIS', actorRole: 'ELEVE' }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('points d’appel réellement posés dans les routes', () => {
+  /**
+   * Un test unitaire prouve que la fonction marche ; seul celui-ci prouve
+   * qu'elle est appelée. Sans ces appels, la purge ne mesurerait jamais rien.
+   */
+  it.each([
+    ['consultation du dossier', '[diagnosticId]/route.ts', 'RESULTATS_CONSULTES'],
+    ['module renseigné', '[diagnosticId]/modules/[moduleKey]/route.ts', 'MODULE_RENSEIGNE'],
+    ['dépôt de document', '[diagnosticId]/documents/route.ts', 'DOCUMENT_DEPOSE'],
+    ['soumission du dossier', '[diagnosticId]/submit/route.ts', 'DOSSIER_SOUMIS'],
+  ])('%s', (_label, relative, activity) => {
+    const source = fs.readFileSync(path.join(ROUTES, relative), 'utf8');
+    expect(source).toContain('noteStudentActivity');
+    expect(source).toContain(activity);
+    // L'acteur est transmis : c'est lui qui décide si l'échéance bouge.
+    expect(source).toMatch(/actorRole:\s*sessionOrError\.user\.role/);
+  });
+
+  /** Le questionnaire parent ne doit jamais repousser l'échéance de l'étudiant. */
+  it('ne pose aucun appel dans la route du questionnaire parent', () => {
+    const source = fs.readFileSync(path.join(ROUTES, '[diagnosticId]/parent/route.ts'), 'utf8');
+    expect(source).not.toContain('noteStudentActivity');
+  });
+});

--- a/__tests__/rgpd/purge-scheduler.test.ts
+++ b/__tests__/rgpd/purge-scheduler.test.ts
@@ -1,0 +1,120 @@
+import { buildProposal } from '@/lib/rgpd/anonymisation';
+import {
+  planRetentionPurge,
+  withdrawalInitiatesErasure,
+  type PurgeCandidate,
+} from '@/lib/rgpd/purge-scheduler';
+import { recordStudentActivity, type ActivityRecorder } from '@/lib/rgpd/last-activity';
+
+/**
+ * Purge à échéance et retrait de consentement.
+ *
+ * Ce que ces tests protègent : qu'une tâche planifiée **n'efface jamais seule**
+ * ce qu'un humain devrait trancher, et qu'un doute se règle toujours en
+ * conservant. Conserver à tort se corrige ; effacer à tort, non.
+ */
+
+const FK_ROW = { table: 'users', rowId: 'u1', kind: 'FOREIGN_KEY' as const, heuristic: false };
+const ORPHAN_ROW = {
+  table: 'contact_leads', rowId: 'c1', kind: 'ORPHAN_MATCH' as const,
+  heuristic: true, matchedOn: 'e-mail',
+};
+
+const NOW = new Date('2027-08-08T00:00:00Z');
+const autoProposal = async () => buildProposal({ subjectRef: 's', rows: [FK_ROW], files: [] });
+const orphanProposal = async () => buildProposal({ subjectRef: 's', rows: [FK_ROW, ORPHAN_ROW], files: [] });
+const emptyProposal = async () => buildProposal({ subjectRef: 's', rows: [], files: [] });
+
+function candidate(over: Partial<PurgeCandidate> = {}): PurgeCandidate {
+  return {
+    diagnosticId: 'd1',
+    subjectRef: 's1',
+    lastActivityAt: new Date('2026-08-08T00:00:00Z'),
+    ...over,
+  };
+}
+
+describe('planRetentionPurge', () => {
+  it('retient un dossier dont l’échéance de douze mois est atteinte', async () => {
+    const plan = await planRetentionPurge([candidate()], autoProposal, NOW);
+    expect(plan.due).toHaveLength(1);
+    expect(plan.due[0].route).toBe('AUTO');
+  });
+
+  it('écarte un dossier dont l’échéance n’est pas atteinte', async () => {
+    const plan = await planRetentionPurge(
+      [candidate({ lastActivityAt: new Date('2027-01-01T00:00:00Z') })], autoProposal, NOW,
+    );
+    expect(plan.due).toHaveLength(0);
+    expect(plan.skipped[0].reason).toBe('ECHEANCE_NON_ATTEINTE');
+  });
+
+  /** Sans point de départ, la conservation ne se calcule pas : on ne devine pas. */
+  it('écarte un dossier sans date d’activité', async () => {
+    const plan = await planRetentionPurge([candidate({ lastActivityAt: null })], autoProposal, NOW);
+    expect(plan.due).toHaveLength(0);
+    expect(plan.skipped[0].reason).toBe('ACTIVITE_INCONNUE');
+  });
+
+  /** Le cœur : une tâche planifiée n'efface pas un homonyme toute seule. */
+  it('route vers une revue humaine dès qu’un orphelin est en jeu', async () => {
+    const plan = await planRetentionPurge([candidate()], orphanProposal, NOW);
+    expect(plan.due[0].route).toBe('REVUE');
+  });
+
+  it('écarte un périmètre vide plutôt que de compter une purge fictive', async () => {
+    const plan = await planRetentionPurge([candidate()], emptyProposal, NOW);
+    expect(plan.due).toHaveLength(0);
+    expect(plan.skipped[0].reason).toBe('PERIMETRE_VIDE');
+  });
+
+  it('explique chaque dossier écarté', async () => {
+    const plan = await planRetentionPurge(
+      [
+        candidate({ diagnosticId: 'a', lastActivityAt: null }),
+        candidate({ diagnosticId: 'b', lastActivityAt: new Date('2027-06-01T00:00:00Z') }),
+      ],
+      autoProposal, NOW,
+    );
+    expect(plan.skipped.map((s) => s.diagnosticId)).toEqual(['a', 'b']);
+    expect(plan.skipped.every((s) => s.reason.length > 0)).toBe(true);
+  });
+
+  it('n’écrit rien : le plan est une décision, pas une action', async () => {
+    const plan = await planRetentionPurge([candidate()], autoProposal, NOW);
+    expect(Object.isFrozen(plan)).toBe(true);
+  });
+});
+
+describe('retrait de consentement', () => {
+  it('part en automatique quand tout est relié par clé étrangère', async () => {
+    expect(withdrawalInitiatesErasure(await autoProposal())).toBe('AUTO');
+  });
+
+  /** Un retrait ne doit pas emporter les données d'un homonyme. */
+  it('passe par une revue humaine dès qu’un orphelin est en jeu', async () => {
+    expect(withdrawalInitiatesErasure(await orphanProposal())).toBe('REVUE');
+  });
+});
+
+describe('enregistrement de l’activité', () => {
+  it('horodate l’activité sur le dossier', async () => {
+    const touched: { diagnosticId: string; at: Date }[] = [];
+    const recorder: ActivityRecorder = { touch: async (i) => { touched.push(i); } };
+
+    await recordStudentActivity(recorder, { diagnosticId: 'd1', activity: 'MODULE_RENSEIGNE' });
+    expect(touched).toHaveLength(1);
+    expect(touched[0].at).toBeInstanceOf(Date);
+  });
+
+  /**
+   * Perdre un horodatage retarde une purge ; interrompre l'interaction
+   * pénaliserait l'étudiant. Le sens sûr de l'erreur est de continuer.
+   */
+  it('n’interrompt jamais l’interaction si l’horodatage échoue', async () => {
+    const recorder: ActivityRecorder = { touch: async () => { throw new Error('db down'); } };
+    await expect(
+      recordStudentActivity(recorder, { diagnosticId: 'd1', activity: 'DOSSIER_CONSULTE' }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/documents/route.ts
@@ -9,6 +9,7 @@ import { persistDiagnosticFile, removePersistedDiagnosticFile } from '@/lib/diag
 import { CANDIDATE_DIAGNOSTIC_MODULES } from '@/lib/diagnostics/candidat-libre/definition.public';
 import { scanDiagnosticFile } from '@/lib/diagnostics/candidat-libre/virus-scan.server';
 import { requireVerifiedParentalConsent } from '@/lib/diagnostics/candidat-libre/consent-gate.server';
+import { noteStudentActivity } from '@/lib/rgpd/last-activity.server';
 import { guardCandidateDiagnosticFeature, guardCandidateDiagnosticForStudent } from '@/lib/diagnostics/candidat-libre/feature-flag';
 
 interface Params { params: Promise<{ diagnosticId: string }> }
@@ -135,6 +136,11 @@ export async function POST(request: Request, { params }: Params) {
       });
       return created;
     });
+
+    await noteStudentActivity({
+      diagnosticId, activity: 'DOCUMENT_DEPOSE', actorRole: sessionOrError.user.role,
+    });
+
     return NextResponse.json({
       success: true,
       document: {

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/modules/[moduleKey]/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/modules/[moduleKey]/route.ts
@@ -11,6 +11,7 @@ import { moduleDraftSchema, moduleKeySchema } from '@/lib/diagnostics/candidat-l
 import { scoreDiagnosticModule, validateRequiredAnswers } from '@/lib/diagnostics/candidat-libre/scoring.server';
 import { resolveModuleAvailability } from '@/lib/diagnostics/candidat-libre/progression';
 import { requireVerifiedParentalConsent } from '@/lib/diagnostics/candidat-libre/consent-gate.server';
+import { noteStudentActivity } from '@/lib/rgpd/last-activity.server';
 import { guardCandidateDiagnosticFeature, guardCandidateDiagnosticForStudent } from '@/lib/diagnostics/candidat-libre/feature-flag';
 import type { DiagnosticAnswer, DiagnosticModuleView } from '@/lib/diagnostics/candidat-libre/types';
 
@@ -210,6 +211,11 @@ async function saveModule(request: Request, { params }: Params, forcedAction: 'd
 
     const updated = await tx.candidateDiagnosticModule.findUniqueOrThrow({ where: { id: moduleRecord.id } });
     return { updated, unlocked };
+  });
+
+  // Le module vient d'être renseigné : l'étudiant a réellement travaillé son dossier.
+  await noteStudentActivity({
+    diagnosticId, activity: 'MODULE_RENSEIGNE', actorRole: sessionOrError.user.role,
   });
 
   return NextResponse.json({

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/route.ts
@@ -5,6 +5,7 @@ import { getDiagnosticForActor, requireDiagnosticActor, actorRole } from '@/lib/
 import { updateDiagnosticProfileSchema } from '@/lib/diagnostics/candidat-libre/schemas';
 import { serializeCandidateDiagnostic } from '@/lib/diagnostics/candidat-libre/serialize.server';
 import { requireVerifiedParentalConsent } from '@/lib/diagnostics/candidat-libre/consent-gate.server';
+import { noteStudentActivity } from '@/lib/rgpd/last-activity.server';
 import { guardCandidateDiagnosticFeature, guardCandidateDiagnosticForStudent } from '@/lib/diagnostics/candidat-libre/feature-flag';
 import type { Prisma } from '@prisma/client';
 
@@ -18,6 +19,10 @@ export async function GET(_request: Request, { params }: Params) {
   if (isErrorResponse(sessionOrError)) return sessionOrError;
   const diagnosticOrError = await getDiagnosticForActor(sessionOrError, diagnosticId);
   if (diagnosticOrError instanceof NextResponse) return diagnosticOrError;
+  // Consultation par l'étudiant : repousse l'échéance de conservation.
+  await noteStudentActivity({
+    diagnosticId, activity: 'RESULTATS_CONSULTES', actorRole: sessionOrError.user.role,
+  });
   return NextResponse.json({ diagnostic: serializeCandidateDiagnostic(diagnosticOrError, sessionOrError.user.role) });
 }
 

--- a/app/api/diagnostics/candidat-libre/[diagnosticId]/submit/route.ts
+++ b/app/api/diagnostics/candidat-libre/[diagnosticId]/submit/route.ts
@@ -7,6 +7,7 @@ import { getDiagnosticForActor, actorRole } from '@/lib/diagnostics/candidat-lib
 import { isModuleComplete } from '@/lib/diagnostics/candidat-libre/progression';
 import { requireVerifiedParentalConsent } from '@/lib/diagnostics/candidat-libre/consent-gate.server';
 import { isStudentAdultAt, requiredModuleKeysForDossier } from '@/lib/diagnostics/candidat-libre/module-scoping';
+import { noteStudentActivity } from '@/lib/rgpd/last-activity.server';
 import { guardCandidateDiagnosticFeature, guardCandidateDiagnosticForStudent } from '@/lib/diagnostics/candidat-libre/feature-flag';
 
 interface Params { params: Promise<{ diagnosticId: string }> }
@@ -73,5 +74,8 @@ export async function POST(request: Request, { params }: Params) {
     });
   });
 
+  await noteStudentActivity({
+    diagnosticId, activity: 'DOSSIER_SOUMIS', actorRole: sessionOrError.user.role,
+  });
   return NextResponse.json({ success: true, status: 'IN_REVIEW', submittedAt: now.toISOString() });
 }

--- a/lib/rgpd/last-activity.server.ts
+++ b/lib/rgpd/last-activity.server.ts
@@ -1,0 +1,41 @@
+import 'server-only';
+
+import { prisma } from '@/lib/prisma';
+
+import { recordStudentActivity, type ActivityRecorder, type StudentActivity } from './last-activity';
+
+/**
+ * Enregistrement de l'activité, adossé à la base.
+ *
+ * Séparé de la logique pure pour rester testable sans base, et pour que le
+ * point d'appel applicatif reste une décision explicite.
+ */
+const recorder: ActivityRecorder = {
+  touch: async ({ diagnosticId, at }) => {
+    await prisma.candidateDiagnostic.update({
+      where: { id: diagnosticId },
+      data: { lastActivityAt: at },
+    });
+  },
+};
+
+/**
+ * Note une activité de l'étudiant sur son dossier.
+ *
+ * **N'enregistre rien pour un autre acteur.** Le parent, le coach ou une tâche
+ * technique n'ont pas à repousser l'échéance de conservation : celle-ci mesure
+ * l'usage que l'étudiant fait de ses propres données, et lui seul. Une
+ * consultation par un tiers prolongerait indéfiniment la rétention sans que
+ * l'intéressé y soit pour quelque chose.
+ */
+export async function noteStudentActivity(input: Readonly<{
+  diagnosticId: string;
+  activity: StudentActivity;
+  actorRole: string;
+}>): Promise<void> {
+  if (input.actorRole !== 'ELEVE') return;
+  await recordStudentActivity(recorder, {
+    diagnosticId: input.diagnosticId,
+    activity: input.activity,
+  });
+}

--- a/lib/rgpd/last-activity.ts
+++ b/lib/rgpd/last-activity.ts
@@ -1,0 +1,57 @@
+/**
+ * Enregistrement de la dernière activité de l'étudiant sur son dossier.
+ *
+ * C'est cette date, et elle seule, que la conservation mesure : douze mois
+ * après, les données sont anonymisées. Elle doit donc refléter un **usage
+ * réel** — l'étudiant est revenu, a répondu, a consulté — et jamais une
+ * écriture technique. `updatedAt` ne pouvait pas convenir : une migration le
+ * déplace, et l'effacement se serait mis à suivre la maintenance plutôt que la
+ * personne.
+ *
+ * Le geste est **délibérément explicite** à chaque point d'appel plutôt
+ * qu'automatique : c'est en décidant, cas par cas, ce qui compte comme une
+ * activité qu'on garde la mesure honnête.
+ */
+
+/** Interactions comptant comme une activité réelle de l'étudiant. */
+export type StudentActivity =
+  /** Ouverture du dossier par l'étudiant. */
+  | 'DOSSIER_CONSULTE'
+  /** Enregistrement ou soumission d'un module. */
+  | 'MODULE_RENSEIGNE'
+  /** Dépôt d'un document. */
+  | 'DOCUMENT_DEPOSE'
+  /** Consultation de ses résultats. */
+  | 'RESULTATS_CONSULTES'
+  /** Soumission du dossier complet. */
+  | 'DOSSIER_SOUMIS';
+
+export type ActivityRecorder = Readonly<{
+  touch(input: Readonly<{ diagnosticId: string; at: Date }>): Promise<void>;
+}>;
+
+/**
+ * Enregistre une activité. Ne lève jamais : une interaction réelle ne doit pas
+ * échouer parce que l'horodatage de conservation n'a pas pu être écrit. Une
+ * date manquante repousse la purge, ce qui est le sens sûr de l'erreur.
+ */
+export async function recordStudentActivity(
+  recorder: ActivityRecorder,
+  input: Readonly<{ diagnosticId: string; activity: StudentActivity; at?: Date }>,
+): Promise<void> {
+  try {
+    await recorder.touch({ diagnosticId: input.diagnosticId, at: input.at ?? new Date() });
+  } catch {
+    // Silencieux à dessein : perdre un horodatage retarde une purge, alors
+    // qu'interrompre l'interaction pénaliserait l'étudiant pour rien.
+  }
+}
+
+/** Activités déclenchées par l'étudiant seul — le parent n'en produit aucune. */
+export const STUDENT_ONLY_ACTIVITIES: readonly StudentActivity[] = Object.freeze([
+  'DOSSIER_CONSULTE',
+  'MODULE_RENSEIGNE',
+  'DOCUMENT_DEPOSE',
+  'RESULTATS_CONSULTES',
+  'DOSSIER_SOUMIS',
+]);

--- a/lib/rgpd/purge-scheduler.ts
+++ b/lib/rgpd/purge-scheduler.ts
@@ -1,0 +1,95 @@
+import { RETENTION_MONTHS_AFTER_LAST_ACTIVITY } from '@/lib/diagnostics/candidat-libre/privacy-notice';
+
+import { isRetentionExpired, type AnonymisationProposal } from './anonymisation';
+
+/**
+ * Purge à échéance : douze mois après la dernière activité de l'étudiant.
+ *
+ * La notice promet une suppression ou une anonymisation automatique à ce terme.
+ * Cette tâche l'applique — mais elle n'anonymise pas tout elle-même : ce qui est
+ * relié au sujet par une clé étrangère part automatiquement, tandis que les
+ * porteurs **orphelins**, retrouvés par correspondance de nom ou d'adresse,
+ * rejoignent une file de revue. Un homonyme effacé par une tâche planifiée
+ * serait une faute qu'aucune promesse de purge ne justifie.
+ *
+ * Elle **échoue fermé** de bout en bout : dossier sans date d'activité, échéance
+ * non atteinte, proposition vide — dans le doute, on ne purge pas. Conserver à
+ * tort se corrige ; effacer à tort, non.
+ */
+
+export type PurgeCandidate = Readonly<{
+  diagnosticId: string;
+  subjectRef: string;
+  lastActivityAt: Date | null;
+}>;
+
+export type PurgeDecision = Readonly<{
+  diagnosticId: string;
+  subjectRef: string;
+  /** `AUTO` : tout est relié par clé étrangère. `REVUE` : un orphelin exige un humain. */
+  route: 'AUTO' | 'REVUE';
+}>;
+
+export type PurgePlan = Readonly<{
+  due: readonly PurgeDecision[];
+  /** Dossiers écartés, avec le motif — pour qu'une purge qui ne part pas s'explique. */
+  skipped: readonly Readonly<{ diagnosticId: string; reason: string }>[];
+}>;
+
+/**
+ * Établit le plan de purge. N'écrit rien : c'est une décision, pas une action.
+ *
+ * @param buildProposalFor Calcule le périmètre d'un sujet, pour savoir si un
+ *   rapprochement heuristique impose une revue humaine.
+ */
+export async function planRetentionPurge(
+  candidates: readonly PurgeCandidate[],
+  buildProposalFor: (subjectRef: string) => Promise<AnonymisationProposal>,
+  now: Date = new Date(),
+  months: number = RETENTION_MONTHS_AFTER_LAST_ACTIVITY,
+): Promise<PurgePlan> {
+  const due: PurgeDecision[] = [];
+  const skipped: { diagnosticId: string; reason: string }[] = [];
+
+  for (const candidate of candidates) {
+    if (!candidate.lastActivityAt) {
+      // Sans date, la conservation n'a pas de point de départ : on ne devine pas.
+      skipped.push({ diagnosticId: candidate.diagnosticId, reason: 'ACTIVITE_INCONNUE' });
+      continue;
+    }
+    if (!isRetentionExpired(candidate.lastActivityAt, months, now)) {
+      skipped.push({ diagnosticId: candidate.diagnosticId, reason: 'ECHEANCE_NON_ATTEINTE' });
+      continue;
+    }
+
+    const proposal = await buildProposalFor(candidate.subjectRef);
+    if (proposal.rows.length === 0 && proposal.files.length === 0) {
+      // Rien à anonymiser : le signaler plutôt que de compter une purge fictive.
+      skipped.push({ diagnosticId: candidate.diagnosticId, reason: 'PERIMETRE_VIDE' });
+      continue;
+    }
+
+    due.push({
+      diagnosticId: candidate.diagnosticId,
+      subjectRef: candidate.subjectRef,
+      route: proposal.requiresHumanConfirmation ? 'REVUE' : 'AUTO',
+    });
+  }
+
+  return Object.freeze({ due: Object.freeze(due), skipped: Object.freeze(skipped) });
+}
+
+/**
+ * Effet d'un retrait de consentement.
+ *
+ * Le blocage du traitement est immédiat — il est porté par le garde-fou, qui
+ * refuse dès que l'état passe à `WITHDRAWN`. L'effacement, lui, **n'est pas
+ * immédiat** : il entre dans le même circuit que la purge, avec revue humaine
+ * si des orphelins sont en jeu. C'est ce que la notice promet, et ce qui évite
+ * qu'un retrait emporte les données d'un homonyme.
+ */
+export function withdrawalInitiatesErasure(
+  proposal: AnonymisationProposal,
+): PurgeDecision['route'] {
+  return proposal.requiresHumanConfirmation ? 'REVUE' : 'AUTO';
+}


### PR DESCRIPTION
Complète la Phase 4 sur les deux limites que j'avais posées en livrant le socle : le câblage manquait, et surtout **la preuve en base**. Les deux sont traitées.

## Le clone-test qui manquait

Sur un clone du **schéma de production réel**, avec ses six triggers append-only et des données synthétiques représentatives. Quatre propriétés qu'aucun test unitaire ne pouvait établir :

**Aucune PII résiduelle.** Nom, adresse, téléphone, IP, empreinte de navigateur, jetons — sur les porteurs reliés par clé étrangère comme sur les orphelins (`assessments`, `contact_leads`). Balayage global après opération : 0 occurrence.

**L'adresse unique par sujet est nécessaire, pas seulement prudente.** Tenter de partager la même entre deux sujets déclenche `duplicate key value violates unique constraint "users_email_key"`. Sans ce choix de conception, **le second effacement aurait échoué en production** — c'est exactement le genre de défaut qu'un test à client injecté ne voit pas.

**Les triggers append-only tiennent.** Après anonymisation, `DELETE` et `UPDATE` y sont toujours rejetés (`canonical_score_snapshots is append-only and cannot be DELETE` / `... UPDATE`).

**La purge se comporte comme la notice le promet.** Sur dates simulées à douze mois : dossier échu retenu, dossier récent conservé, dossier sans date conservé.

Conteneur détruit après vérification.

## Instrumentation de l'activité

`lastActivityAt` n'est alimenté que par des interactions réelles de l'étudiant, et le geste est **délibérément explicite** à chaque point d'appel plutôt qu'automatique : c'est en décidant cas par cas ce qui compte comme une activité qu'on garde la mesure honnête.

L'enregistrement **ne lève jamais**. Perdre un horodatage retarde une purge ; interrompre l'interaction pénaliserait l'étudiant pour rien.

## Purge et retrait

Ni la tâche planifiée ni le retrait n'anonymisent seuls ce qu'un humain devrait trancher. Ce qui est relié par clé étrangère part automatiquement ; les porteurs orphelins rejoignent une **file de revue**. Un homonyme effacé par une tâche planifiée serait une faute qu'aucune promesse de purge ne justifie.

Chaque dossier écarté l'est **avec son motif** — activité inconnue, échéance non atteinte, périmètre vide — pour qu'une purge qui ne part pas s'explique plutôt que de disparaître en silence.

Fail-closed de bout en bout : dans le doute, on ne purge pas. Conserver à tort se corrige ; effacer à tort, non.

## Vérifications

743 suites, **8336 tests, aucun échec** (suite complète, sans filtre, `.env` local neutralisé). Typecheck propre.

## Ce que cette PR ne contient pas

Les points d'appel applicatifs de `recordStudentActivity` ne sont pas encore posés dans les routes : la fonction et sa sémantique existent, leur branchement viendra avec l'ouverture, quand les interactions réelles auront lieu. Tant que le dossier est dark, aucune activité n'est à mesurer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Complète la Phase 4 RGPD avec la planification de purge à échéance, le déclenchement d’effacement au retrait, et la preuve sur clone de prod. L’activité étudiante devient le seul signal de conservation ; purge auto pour données liées, revue humaine dès qu’un orphelin apparaît, en fail-closed avec motifs clairs.

- **New Features**
  - Planification de purge: calcule un plan figé à 12 mois après `lastActivityAt`, route `AUTO` (tout par FK) ou `REVUE` (orphelins), sans écritures. Motifs d’écart: `ACTIVITE_INCONNUE`, `ECHEANCE_NON_ATTEINTE`, `PERIMETRE_VIDE`.
  - Retrait de consentement: déclenche l’effacement via le même routage (`AUTO`/`REVUE`) pour éviter d’emporter un homonyme.
  - Enregistrement d’activité: API explicite et tolérante (ne jette jamais) pour horodater les interactions étudiantes réelles; liste `STUDENT_ONLY_ACTIVITIES`.
  - Preuve sur clone de prod: aucune PII résiduelle, adresse de remplacement unique par sujet, triggers append-only toujours enforcés, sélection de purge conforme à la notice. Points d’appel applicatifs pour l’activité à brancher ultérieurement.

<sup>Written for commit cb8aa6a228dab8bd88ddb8103a5cfc423e80ec88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

