### PR TITLE
Bilan diagnostic — rendre le chemin trouvable et l'ajout d'enfants fluide

### DIFF
--- a/__tests__/app/bilan-gratuit-parcours-diagnostic.test.ts
+++ b/__tests__/app/bilan-gratuit-parcours-diagnostic.test.ts
@@ -1,0 +1,71 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Chemin public vers le bilan diagnostic.
+ *
+ * Constat à l'origine : la plomberie était complète — le formulaire crée le
+ * compte parent, le compte élève et envoie un lien d'activation qui ouvre le
+ * diagnostic — mais le discours disait d'attendre. Le parent était invité à
+ * patienter « sous 24h » alors que tout était déjà en place pour commencer.
+ *
+ * Ces tests portent sur ce que la page **promet**, parce que c'est là qu'était
+ * le défaut. Ils ne vérifient pas une mise en forme : ils vérifient qu'on ne
+ * redit pas au parent d'attendre, et qu'on ne casse pas la reprise de contact
+ * qui alimente les leads.
+ */
+
+const ROOT = process.cwd();
+const CONFIRMATION = fs.readFileSync(
+  path.join(ROOT, 'app/bilan-gratuit/confirmation/page.tsx'), 'utf8',
+);
+const FORM = fs.readFileSync(
+  path.join(ROOT, 'app/bilan-gratuit/BilanStrategiqueClient.tsx'), 'utf8',
+);
+const API = fs.readFileSync(path.join(ROOT, 'app/api/bilan-gratuit/route.ts'), 'utf8');
+
+describe('le formulaire ouvre réellement le diagnostic', () => {
+  /** Si cela cessait d'être vrai, tout le discours ci-dessous deviendrait mensonger. */
+  it('crée bien le compte parent, le compte élève et l’activation', () => {
+    expect(API).toMatch(/user\.create/);
+    expect(API).toMatch(/student\.create/);
+    expect(API).toMatch(/activationToken/);
+  });
+
+  it('annonce ce qu’il fait, plutôt qu’une demande de rappel', () => {
+    expect(FORM).toContain('lancer le bilan diagnostic');
+    expect(FORM).not.toContain('Demander mon bilan stratégique gratuit');
+  });
+});
+
+describe('la confirmation dit au parent qu’il peut commencer', () => {
+  it('n’annonce plus une attente de 24 h avant analyse', () => {
+    expect(CONFIRMATION).not.toMatch(/Sous 24h/);
+    expect(CONFIRMATION).not.toMatch(/prépare votre bilan personnalisé/);
+  });
+
+  it('explique à quoi sert le lien reçu', () => {
+    expect(CONFIRMATION).toMatch(/lien d’activation/);
+    expect(CONFIRMATION).toMatch(/mot de passe/);
+    expect(CONFIRMATION).toMatch(/bilan diagnostic en ligne/);
+  });
+
+  it('indique que l’enfant peut passer son bilan sans attendre', () => {
+    expect(CONFIRMATION).toMatch(/sans attendre/);
+  });
+});
+
+describe('non-régression du lead-gen', () => {
+  /** Le formulaire alimente aussi les leads : le rappel conseiller doit subsister. */
+  it('conserve la création de lead', () => {
+    expect(API).toMatch(/contactLead\.create/);
+  });
+
+  it('continue d’annoncer une reprise de contact par un conseiller', () => {
+    expect(CONFIRMATION).toMatch(/conseiller/i);
+  });
+
+  it('conserve le point d’entrée public du formulaire', () => {
+    expect(fs.existsSync(path.join(ROOT, 'app/bilan-gratuit/page.tsx'))).toBe(true);
+  });
+});

--- a/__tests__/components/dashboard/parent/add-child-dialog.test.tsx
+++ b/__tests__/components/dashboard/parent/add-child-dialog.test.tsx
@@ -1,6 +1,26 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
+/**
+ * Radix Select n'expose pas de `combobox` sous jsdom (il dépend d'API pointeur
+ * absentes). On le remplace par un `select` natif : ces tests portent sur le
+ * panneau de succès et la répétabilité, pas sur le composant de sélection.
+ */
+jest.mock('@/components/ui/select', () => ({
+  Select: ({ value, onValueChange, children }: any) => (
+    <select aria-label="Niveau" value={value ?? ''} onChange={(e) => onValueChange?.(e.target.value)}>
+      <option value="">--</option>
+      {['Seconde', 'Première', 'Terminale'].map((g) => <option key={g} value={g}>{g}</option>)}
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: () => null,
+  SelectItem: () => null,
+}));
+
 import AddChildDialog from '@/app/dashboard/parent/add-child-dialog';
 
 describe('AddChildDialog', () => {
@@ -13,5 +33,47 @@ describe('AddChildDialog', () => {
   test('stays closed by default when no controlled open prop is given', () => {
     render(<AddChildDialog onChildAdded={jest.fn()} />);
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  /**
+   * Le lien d'activation partait dans un `window.alert()` : URL nue,
+   * incopiable, sans explication. Le parent doit pouvoir le lire, le copier,
+   * et comprendre à quoi il sert.
+   */
+  it('affiche le lien d’activation avec un libellé explicite après ajout', async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ activation: { activationUrl: 'https://exemple.test/activer/abc' } }),
+    })) as unknown as typeof fetch;
+
+    render(<AddChildDialog onChildAdded={() => {}} open onOpenChange={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText(/^Prénom/), { target: { value: 'Ahmed' } });
+    fireEvent.change(screen.getByLabelText(/^Nom/), { target: { value: 'Test' } });
+    await userEvent.selectOptions(screen.getByLabelText('Niveau'), 'Terminale');
+    await userEvent.click(screen.getByRole('button', { name: /Ajouter l'Enfant/i }));
+
+    expect(await screen.findByText(/Ahmed peut maintenant passer son bilan/i)).toBeInTheDocument();
+    expect(screen.getByDisplayValue('https://exemple.test/activer/abc')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Copier/i })).toBeInTheDocument();
+  });
+
+  /** Ajouter un second enfant ne doit pas obliger à rouvrir la boîte. */
+  it('permet d’enchaîner sur un autre enfant sans quitter l’écran', async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: true, json: async () => ({ activation: { activationUrl: 'https://exemple.test/a' } }),
+    })) as unknown as typeof fetch;
+
+    render(<AddChildDialog onChildAdded={() => {}} open onOpenChange={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText(/^Prénom/), { target: { value: 'Ahmed' } });
+    fireEvent.change(screen.getByLabelText(/^Nom/), { target: { value: 'Test' } });
+    await userEvent.selectOptions(screen.getByLabelText('Niveau'), 'Terminale');
+    await userEvent.click(screen.getByRole('button', { name: /Ajouter l'Enfant/i }));
+
+    await userEvent.click(await screen.findByRole('button', { name: /Ajouter un autre enfant/i }));
+
+    // Le formulaire revient, vide, sans avoir fermé la boîte.
+    expect(await screen.findByLabelText(/^Prénom/)).toHaveValue('');
   });
 });

--- a/__tests__/lib/bilan-gratuit-form.test.tsx
+++ b/__tests__/lib/bilan-gratuit-form.test.tsx
@@ -111,7 +111,7 @@ describe('BilanGratuitPage', () => {
     fireEvent.change(screen.getByLabelText('Classe'), { target: { value: 'terminale' } });
     await user.click(screen.getByLabelText('Mathématiques'));
     await user.click(screen.getByRole('checkbox', { name: /j.*accepte/i }));
-    await user.click(screen.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }));
+    await user.click(screen.getByRole('button', { name: /lancer le bilan diagnostic/i }));
 
     await waitFor(() => {
       const request = mockFetch.mock.calls[0]?.[1];
@@ -150,7 +150,7 @@ describe('BilanGratuitPage', () => {
 
     await user.click(screen.getByLabelText('Mathématiques'));
     await user.click(screen.getByRole('checkbox', { name: /j.*accepte/i }));
-    await user.click(screen.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }));
+    await user.click(screen.getByRole('button', { name: /lancer le bilan diagnostic/i }));
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith(

--- a/app/bilan-gratuit/BilanStrategiqueClient.tsx
+++ b/app/bilan-gratuit/BilanStrategiqueClient.tsx
@@ -402,7 +402,7 @@ export function BilanStrategiqueClient({
                     aria-describedby="bilan-submit-status"
                     className="lux-cta-reserve rounded-lg px-6 py-3.5 text-sm font-semibold disabled:opacity-60"
                   >
-                    {isSubmitting ? 'Envoi...' : 'Demander mon bilan stratégique gratuit'}
+                    {isSubmitting ? 'Création de votre espace…' : 'Créer mon espace et lancer le bilan diagnostic'}
                   </button>
                   <span id="bilan-submit-status" className="sr-only" role="status" aria-live="polite">
                     {isSubmitting ? 'Envoi de la demande en cours' : ''}

--- a/app/bilan-gratuit/confirmation/page.tsx
+++ b/app/bilan-gratuit/confirmation/page.tsx
@@ -31,9 +31,10 @@ export default function ConfirmationPage() {
               <div className="mx-auto inline-flex h-12 w-12 items-center justify-center rounded-full bg-lux-gold/12">
                 <Clock className="h-6 w-6 text-lux-gold" aria-hidden="true" />
               </div>
-              <h2 className="mt-4 text-xl font-fraunces text-lux-ink">Sous 24h</h2>
+              <h2 className="mt-4 text-xl font-fraunces text-lux-ink">Dès maintenant</h2>
               <p className="mt-2 text-sm text-lux-slate">
-                Notre équipe analyse votre profil et prépare votre bilan personnalisé.
+                Votre espace est déjà créé. Activez-le depuis l’email reçu : votre enfant pourra
+                passer son bilan diagnostic sans attendre.
               </p>
             </CardContent>
           </Card>
@@ -73,8 +74,13 @@ export default function ConfirmationPage() {
                 <h2 className="text-2xl font-fraunces text-lux-ink">Vérifiez votre boîte email</h2>
               </div>
               <p className="mt-4 text-sm leading-6 text-lux-slate">
-                Un email de confirmation a été envoyé avec les prochaines étapes de prise en charge.
-                Si vous ne le trouvez pas, pensez à vérifier vos spams.
+                Vous venez de recevoir un <strong>lien d’activation</strong>. Il vous permet de choisir
+                votre mot de passe, puis d’ajouter votre enfant depuis votre espace : un lien
+                personnel lui sera alors remis pour passer son bilan diagnostic en ligne.
+                Si vous ne trouvez pas cet email, pensez à vérifier vos spams.
+              </p>
+              <p className="mt-3 text-sm leading-6 text-lux-slate">
+                Un conseiller vous recontacte par ailleurs pour échanger sur les résultats.
               </p>
               <div className="mt-8 flex flex-col gap-3 sm:flex-row">
                 <Link href="/offres" className="lux-cta-reserve rounded-lg px-6 py-3.5 text-sm font-semibold">

--- a/app/dashboard/parent/add-child-dialog.tsx
+++ b/app/dashboard/parent/add-child-dialog.tsx
@@ -6,7 +6,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Loader2, Plus, User } from "lucide-react";
+import { Check, Copy, Loader2, Plus, User } from "lucide-react";
 
 interface AddChildDialogProps {
   onChildAdded: () => void;
@@ -30,6 +30,14 @@ export default function AddChildDialog({ onChildAdded, open: controlledOpen, onO
     grade: "",
     school: ""
   });
+  /**
+   * Enfant qui vient d'être ajouté. Tant qu'il est là, on affiche son lien
+   * d'activation plutôt que le formulaire : le parent doit pouvoir le lire,
+   * le copier et comprendre à quoi il sert — une URL jetée dans une alerte
+   * navigateur ne remplissait aucune de ces trois conditions.
+   */
+  const [justAdded, setJustAdded] = useState<{ firstName: string; activationUrl: string | null } | null>(null);
+  const [copied, setCopied] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -52,13 +60,13 @@ export default function AddChildDialog({ onChildAdded, open: controlledOpen, onO
       const responseData = await response.json().catch(() => null);
 
       if (response.ok) {
-        const activationUrl = responseData?.activation?.activationUrl;
-        alert(
-          activationUrl
-            ? `Enfant ajouté avec succès. Transmettez ce lien d'activation uniquement à l'élève concerné : ${activationUrl}`
-            : "Enfant ajouté avec succès!"
-        );
-        setOpen(false);
+        // La boîte reste ouverte : le parent doit voir le lien, et peut
+        // enchaîner sur un autre enfant sans rouvrir quoi que ce soit.
+        setJustAdded({
+          firstName: formData.firstName,
+          activationUrl: responseData?.activation?.activationUrl ?? null,
+        });
+        setCopied(false);
         setFormData({
           firstName: "",
           lastName: "",
@@ -98,6 +106,53 @@ export default function AddChildDialog({ onChildAdded, open: controlledOpen, onO
             Un lien d'activation élève sera généré après la création.
           </p>
         </DialogHeader>
+        {justAdded ? (
+          <div className="space-y-4">
+            <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4">
+              <p className="font-medium text-emerald-200">
+                {`${justAdded.firstName} peut maintenant passer son bilan.`}
+              </p>
+              <p className="mt-1 text-sm text-neutral-300">
+                Transmettez-lui ce lien : il choisira son mot de passe, puis accédera à son bilan
+                diagnostic. Ce lien est personnel et ne doit être communiqué qu'à lui.
+              </p>
+            </div>
+
+            {justAdded.activationUrl ? (
+              <div className="space-y-2">
+                <Label className="text-neutral-200">{`Lien d'activation de ${justAdded.firstName}`}</Label>
+                <div className="flex gap-2">
+                  <Input readOnly value={justAdded.activationUrl} className="font-mono text-xs" />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      void navigator.clipboard?.writeText(justAdded.activationUrl ?? '');
+                      setCopied(true);
+                    }}
+                  >
+                    {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                    <span className="ml-2">{copied ? 'Copié' : 'Copier'}</span>
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-neutral-400">
+                Le lien d'activation sera disponible depuis la fiche de l'enfant.
+              </p>
+            )}
+
+            <div className="flex gap-2 pt-2">
+              <Button type="button" variant="outline" className="flex-1" onClick={() => setJustAdded(null)}>
+                <Plus className="mr-2 h-4 w-4" />
+                Ajouter un autre enfant
+              </Button>
+              <Button type="button" className="flex-1" onClick={() => { setJustAdded(null); setOpen(false); }}>
+                Terminer
+              </Button>
+            </div>
+          </div>
+        ) : (
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
@@ -180,6 +235,7 @@ export default function AddChildDialog({ onChildAdded, open: controlledOpen, onO
             </Button>
           </div>
         </form>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/docs/handoff/saisie-papier-bilan.md
+++ b/docs/handoff/saisie-papier-bilan.md
@@ -1,0 +1,89 @@
+# Handoff — saisie papier des bilans (session dédiée)
+
+Point de reprise pour le seul développement restant du chantier « bilan
+accessible ». Écrit le 8 août 2026, après livraison du chemin public (PR #109).
+
+Le contexte : des élèves ont déjà passé le bilan **sur papier**. Leurs copies
+sont récupérées. Il faut pouvoir en saisir les réponses côté staff, sans les
+faire repasser, et obtenir le même bilan qu'une passation en ligne.
+
+## À réutiliser — ne rien reconstruire
+
+Tout le moteur existe et tourne en production. Le travail consiste à ajouter une
+**entrée de saisie**, pas un second pipeline.
+
+| Élément | Emplacement |
+|---|---|
+| Création d'un attempt | `createCanonicalAttempt` — `lib/bilans/passation/pilot-protocol.ts` |
+| Enregistrement des réponses | `PATCH /api/bilans/attempts/[id]/answers` (`{revision, answers[]}`) |
+| Soumission | `POST /api/bilans/attempts/[id]/submit` (`{revision}`) |
+| Scoring déterministe | worker `SCORE_ATTEMPT` → `SCORED` → `REPORT_PENDING_REVIEW`, automatique |
+| Picker de matière | `components/bilans/CanonicalAssessmentStart.tsx`, packs filtrés sur `student.gradeLevel` |
+| Écran de passation | `components/bilans/CanonicalAssessmentRunner.tsx` |
+| Validation et publication | `validateAndPublishReportAction` — `app/dashboard/assistante/bilans/actions.ts` |
+| Activation parent | `lib/auth/parent-activation.ts` — mot de passe choisi par le parent |
+| Ajout d'enfant | `app/dashboard/parent/add-child-dialog.tsx` + `POST /api/parent/children` |
+
+Les réponses sont de la forme `{ itemId, optionId, confidence }`, la confiance
+allant de 1 à 4. Les items d'un pack se lisent dans
+`data/bilans/banks/<slug>.json`, sous `questionnaire.items[]`.
+
+## Spécification
+
+**Rôle** : assistante ou admin uniquement. Rien de cette interface ne doit être
+atteignable par un parent ou un élève.
+
+**Parcours**
+
+1. Créer ou sélectionner le parent — adresse réelle, **activation en attente** :
+   il posera son mot de passe lui-même, personne ne le fixe à sa place.
+2. Ajouter le ou les enfants (prénom, niveau).
+3. Choisir la matière — même picker, filtré sur le niveau — ce qui sélectionne
+   le pack validé.
+4. **Écran de saisie** : les items du pack, dans l'ordre. Par item, la réponse
+   lue sur la copie (A/B/C/D) et, **si l'élève l'a cochée**, sa certitude (1-4).
+   La certitude est **optionnelle** : beaucoup de copies papier ne la portent
+   pas, et il ne faut surtout pas en inventer une.
+5. Valider → attempt de provenance `SAISIE_PAPIER`, avec le saisisseur et la
+   date dans l'audit pseudonyme → scoring déterministe → bilan plancher.
+6. Validation assistante → publication, par le flux existant.
+
+**Provenance.** C'est le point sur lequel il ne faut rien céder. Une saisie
+papier doit être identifiable comme telle, pour toujours. Une passation en
+ligne est faite par l'élève depuis sa session ; une saisie est faite par un
+membre du staff qui recopie. Les deux produisent un bilan légitime, mais ce ne
+sont pas les mêmes faits, et les confondre reviendrait à maquiller l'origine
+d'une donnée.
+
+## Le test qui compte
+
+**Les mêmes réponses doivent produire le même score, en ligne et par saisie.**
+S'il existe un écart, c'est que la saisie a introduit un chemin de calcul
+parallèle — exactement ce qu'il faut éviter.
+
+Écrire ce test en premier : un jeu de réponses connu, passé par les deux
+chemins, et comparer les scores et profils obtenus.
+
+Les autres cas à couvrir : provenance et saisisseur enregistrés ; certitude
+absente gérée sans être inventée ; saisie inaccessible aux rôles non staff ;
+non-régression de la passation en ligne.
+
+## Points d'accroche
+
+L'écran de saisie a sa place dans le tableau de bord assistante, à côté de la
+revue des bilans (`app/dashboard/assistante/bilans/`). La route de saisie peut
+suivre la forme des routes canoniques existantes sous `app/api/bilans/`.
+
+La provenance demande un champ additif sur `canonical_assessment_attempts`.
+**Attention** : cette table est protégée par des triggers append-only. Ajouter
+une colonne est possible — c'est du DDL, pas une mutation de ligne — mais la
+valeur devra être posée **à la création** de l'attempt, jamais par un `UPDATE`
+ultérieur, qui serait rejeté.
+
+## Ce qui a été livré avant ce handoff
+
+- PR #109 : chemin public, lien d'activation lisible, ajout d'enfants répétable.
+- Le diagnostic lui-même était déjà live : 17 packs validés, scoring
+  déterministe, rapport plancher, validation assistante, dashboard parent.
+- 138 items du candidat libre validés par les relecteurs, enregistrement prêt
+  mais non appliqué (attend une fenêtre).

--- a/e2e/auth/bilan-golden-path.spec.ts
+++ b/e2e/auth/bilan-golden-path.spec.ts
@@ -77,7 +77,7 @@ test.describe('Golden-path — bilan de bout en bout (rapport LLM stubbé)', () 
     await page.locator('label').filter({ hasText: 'Mathématiques' }).getByRole('checkbox').click();
     await page.locator('#objectives').fill('Prouver le golden-path bilan de bout en bout.');
     await page.locator('label').filter({ hasText: /J.accepte d.être contacté/ }).getByRole('checkbox').click();
-    await page.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }).click();
+    await page.getByRole('button', { name: /lancer le bilan diagnostic/i }).click();
     await expect(page).toHaveURL(/\/bilan-gratuit\/confirmation/);
 
     const parent = await prisma.user.findUniqueOrThrow({

--- a/e2e/auth/bilan-worker-autonomous.spec.ts
+++ b/e2e/auth/bilan-worker-autonomous.spec.ts
@@ -95,7 +95,7 @@ test.describe('GATE A — posture prod (worker ON, sans clé OpenRouter)', () =>
     await page.locator('label').filter({ hasText: 'Mathématiques' }).getByRole('checkbox').click();
     await page.locator('#objectives').fill('Prouver la posture worker-ON sans clé OpenRouter.');
     await page.locator('label').filter({ hasText: /J.accepte d.être contacté/ }).getByRole('checkbox').click();
-    await page.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }).click();
+    await page.getByRole('button', { name: /lancer le bilan diagnostic/i }).click();
     await expect(page).toHaveURL(/\/bilan-gratuit\/confirmation/);
 
     const parent = await prisma.user.findUniqueOrThrow({

--- a/e2e/auth/canonical-attempt-level-guard.spec.ts
+++ b/e2e/auth/canonical-attempt-level-guard.spec.ts
@@ -64,7 +64,7 @@ test.describe('P0-B Student level to pack guard', () => {
       await page.locator('label').filter({ hasText: 'Mathématiques' }).getByRole('checkbox').click();
       await page.locator('#objectives').fill('Prouver la garde générique niveau élève vers pack.');
       await page.locator('label').filter({ hasText: /J.accepte d.être contacté/ }).getByRole('checkbox').click();
-      await page.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }).click();
+      await page.getByRole('button', { name: /lancer le bilan diagnostic/i }).click();
       await expect(page).toHaveURL(/\/bilan-gratuit\/confirmation/);
 
       const parent = await prisma.user.findUniqueOrThrow({

--- a/e2e/auth/forms-validation.contract.spec.ts
+++ b/e2e/auth/forms-validation.contract.spec.ts
@@ -48,7 +48,7 @@ test.describe('Bilan Gratuit - Validation formulaire multi-etapes', () => {
     await page.locator('#parentEmail').fill('pasunemail');
     // Fill enough required fields to trigger validation
     await page.locator('#parentFirstName').fill('T');
-    await page.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }).click();
+    await page.getByRole('button', { name: /lancer le bilan diagnostic/i }).click();
     await expect(page.getByText(/invalide/i).first()).toBeVisible();
   });
 
@@ -63,7 +63,7 @@ test.describe('Bilan Gratuit - Validation formulaire multi-etapes', () => {
     await page.goto('/bilan-gratuit');
     await fillBilanForm(page);
 
-    const submit = page.getByRole('button', { name: /demander mon bilan stratégique gratuit/i });
+    const submit = page.getByRole('button', { name: /lancer le bilan diagnostic/i });
     await submit.dblclick();
     await page.waitForTimeout(400);
 
@@ -78,7 +78,7 @@ test.describe('Bilan Gratuit - Validation formulaire multi-etapes', () => {
 
     await page.goto('/bilan-gratuit');
     await fillBilanForm(page);
-    await page.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }).click();
+    await page.getByRole('button', { name: /lancer le bilan diagnostic/i }).click();
 
     await expect(page).toHaveURL(/\/bilan-gratuit\/confirmation/);
   });

--- a/e2e/auth/initial-student-activation.spec.ts
+++ b/e2e/auth/initial-student-activation.spec.ts
@@ -64,7 +64,7 @@ test.describe('P0 initial student identity', () => {
       await page.locator('label').filter({ hasText: 'Mathématiques' }).getByRole('checkbox').click();
       await page.locator('#objectives').fill('Vérifier le parcours utilisateur réel sans donnée personnelle.');
       await page.locator('label').filter({ hasText: /J.accepte d.être contacté/ }).getByRole('checkbox').click();
-      await page.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }).click();
+      await page.getByRole('button', { name: /lancer le bilan diagnostic/i }).click();
       await expect(page).toHaveURL(/\/bilan-gratuit\/confirmation/);
 
       const parent = await prisma.user.findUniqueOrThrow({

--- a/e2e/auth/parent-canonical-report-access.spec.ts
+++ b/e2e/auth/parent-canonical-report-access.spec.ts
@@ -218,7 +218,7 @@ test.describe('P0-C — consultation Parent sécurisée', () => {
     await page.locator('label').filter({ hasText: 'Mathématiques' }).getByRole('checkbox').click();
     await page.locator('#objectives').fill('Prouver la consultation Parent sans fuite inter-audiences.');
     await page.locator('label').filter({ hasText: /J.accepte d.être contacté/ }).getByRole('checkbox').click();
-    await page.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }).click();
+    await page.getByRole('button', { name: /lancer le bilan diagnostic/i }).click();
     await expect(page).toHaveURL(/\/bilan-gratuit\/confirmation/);
 
     const parent = await prisma.user.findUniqueOrThrow({

--- a/e2e/auth/parent-email-onboarding.spec.ts
+++ b/e2e/auth/parent-email-onboarding.spec.ts
@@ -165,7 +165,7 @@ test.describe('P0-D Parent onboarding without direct database bootstrap', () => 
 
     await page.goto('/bilan-gratuit')
     const signupForm = page.locator('form').filter({
-      has: page.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }),
+      has: page.getByRole('button', { name: /lancer le bilan diagnostic/i }),
     })
     await signupForm.getByRole('textbox', { name: 'Prénom du parent' }).fill('Parent')
     await signupForm.getByRole('textbox', { name: 'Nom du parent', exact: true }).fill('Synthétique')
@@ -177,7 +177,7 @@ test.describe('P0-D Parent onboarding without direct database bootstrap', () => 
     await signupForm.getByRole('checkbox', { name: 'Mathématiques' }).check()
     await signupForm.getByRole('textbox', { name: 'Besoin principal' }).fill('Prouver le parcours Parent sans bootstrap direct en base.')
     await signupForm.getByRole('checkbox', { name: /j’accepte d’être contacté/i }).check()
-    await signupForm.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }).click()
+    await signupForm.getByRole('button', { name: /lancer le bilan diagnostic/i }).click()
     await expect(page).toHaveURL(/\/bilan-gratuit\/confirmation/)
 
     const parentBeforeActivation = await prisma.user.findUniqueOrThrow({ where: { email: parentEmail } })

--- a/e2e/auth/pending-parent-lifecycle.spec.ts
+++ b/e2e/auth/pending-parent-lifecycle.spec.ts
@@ -55,7 +55,7 @@ async function waitForActivationUrls(recipient: string, expected: number): Promi
 async function submitPublicSignup(page: import('@playwright/test').Page, email: string) {
   await page.goto('/bilan-gratuit')
   const form = page.locator('form').filter({
-    has: page.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }),
+    has: page.getByRole('button', { name: /lancer le bilan diagnostic/i }),
   })
   await form.getByRole('textbox', { name: 'Prénom du parent' }).fill('Parent')
   await form.getByRole('textbox', { name: 'Nom du parent', exact: true }).fill('Lifecycle')
@@ -67,7 +67,7 @@ async function submitPublicSignup(page: import('@playwright/test').Page, email: 
   await form.getByRole('checkbox', { name: 'Mathématiques' }).check()
   await form.getByRole('textbox', { name: 'Besoin principal' }).fill('Preuve synthétique du cycle PENDING.')
   await form.getByRole('checkbox', { name: /j’accepte d’être contacté/i }).check()
-  await form.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }).click()
+  await form.getByRole('button', { name: /lancer le bilan diagnostic/i }).click()
   await expect(page).toHaveURL(/\/bilan-gratuit\/confirmation/)
 }
 

--- a/e2e/auth/public-front-go-live.spec.ts
+++ b/e2e/auth/public-front-go-live.spec.ts
@@ -10,7 +10,7 @@ const PUBLIC_PAGES: PublicPageCase[] = [
   { url: '/', h1: /préparer le bac français avec méthode, suivi et exigence/i, cta: /bilan gratuit|offres|trouver ma formule/i },
   { url: '/offres', h1: /offres\s*&\s*tarifs/i, cta: /réserver ma place|trouver ma formule|whatsapp/i },
   { url: '/recommandation', h1: /trouver ma formule|diagnostic/i, cta: /demander un bilan gratuit|offres|whatsapp/i },
-  { url: '/bilan-gratuit', h1: /bilan stratégique gratuit/i, cta: /demander mon bilan stratégique gratuit|whatsapp|voir les offres/i },
+  { url: '/bilan-gratuit', h1: /bilan stratégique gratuit/i, cta: /lancer le bilan diagnostic|whatsapp|voir les offres/i },
   { url: '/stages', h1: /viser\.\s*atteindre\.\s*dépasser/i, cta: /pré-inscription|demander un bilan|whatsapp/i },
   { url: '/plateforme-aria', h1: /aria/i, cta: /demander un bilan|voir les offres/i },
   { url: '/accompagnement-scolaire', h1: /accompagnement scolaire|progresser avec méthode/i, cta: /demander un bilan gratuit|whatsapp|voir les offres/i },
@@ -314,7 +314,7 @@ test.describe('Public front go-live smoke', () => {
       });
     });
 
-    await page.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }).click();
+    await page.getByRole('button', { name: /lancer le bilan diagnostic/i }).click();
     await expect(page).toHaveURL(/\/bilan-gratuit\/confirmation$/);
     await expect(page.getByRole('heading', { name: /demande de bilan a bien été enregistrée/i })).toBeVisible();
   });
@@ -355,7 +355,7 @@ test.describe('Public front go-live smoke', () => {
       });
     });
 
-    await page.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }).click();
+    await page.getByRole('button', { name: /lancer le bilan diagnostic/i }).click();
     await expect(page.getByText(/bot detected|erreur/i).first()).toBeVisible();
 
     await page.unroute('**/api/bilan-gratuit');
@@ -379,7 +379,7 @@ test.describe('Public front go-live smoke', () => {
     await page.locator('#objectives').fill('Preparer une remise a niveau avant la rentree.');
     await page.locator('#difficulties').fill("Besoin d'un echange pedagogique pour clarifier les priorites.");
     await page.locator('label').filter({ hasText: /accepte|consent/i }).first().click();
-    await page.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }).click();
+    await page.getByRole('button', { name: /lancer le bilan diagnostic/i }).click();
     await expect(page.getByText(/server error|erreur/i).first()).toBeVisible();
   });
 

--- a/e2e/auth/session-revocation.spec.ts
+++ b/e2e/auth/session-revocation.spec.ts
@@ -87,7 +87,7 @@ test.describe('S1 versioned JWT revocation', () => {
 
     await page.goto('/bilan-gratuit')
     const form = page.locator('form').filter({
-      has: page.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }),
+      has: page.getByRole('button', { name: /lancer le bilan diagnostic/i }),
     })
     await form.getByRole('textbox', { name: 'Prénom du parent' }).fill('Parent')
     await form.getByRole('textbox', { name: 'Nom du parent', exact: true }).fill('Session')
@@ -99,7 +99,7 @@ test.describe('S1 versioned JWT revocation', () => {
     await form.getByRole('checkbox', { name: 'Mathématiques' }).check()
     await form.getByRole('textbox', { name: 'Besoin principal' }).fill('Test synthétique de révocation de session.')
     await form.getByRole('checkbox', { name: /j’accepte d’être contacté/i }).check()
-    await form.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }).click()
+    await form.getByRole('button', { name: /lancer le bilan diagnostic/i }).click()
 
     const url = await activationUrl(parentEmail)
     await page.goto(url)

--- a/e2e/pre-rentree-2026.spec.ts
+++ b/e2e/pre-rentree-2026.spec.ts
@@ -228,7 +228,7 @@ test.describe('Landing Pré-rentrée 2026', () => {
 
     const requestPromise = page.waitForRequest((request) => request.url().endsWith('/api/bilan-gratuit'));
     await page.route('**/api/bilan-gratuit', (route) => route.abort());
-    await page.getByRole('button', { name: /demander mon bilan stratégique gratuit/i }).click();
+    await page.getByRole('button', { name: /lancer le bilan diagnostic/i }).click();
     const request = await requestPromise;
     const payload = request.postDataJSON() as {
       campaignContext: { packCode: string; level: string; subjectIds: string[] } | null;

--- a/e2e/real/pages/04-bilan-gratuit.spec.ts
+++ b/e2e/real/pages/04-bilan-gratuit.spec.ts
@@ -49,7 +49,7 @@ test.describe('REAL — Bilan Gratuit (/bilan-gratuit)', () => {
   });
 
   test('Validation empêche soumission vide', async ({ page }) => {
-    const submitBtn = page.getByRole('button', { name: /demander mon bilan stratégique gratuit/i });
+    const submitBtn = page.getByRole('button', { name: /lancer le bilan diagnostic/i });
     await submitBtn.click();
     await expect(page.locator('text=Email invalide')).toBeVisible({ timeout: 5000 });
     await expect(page.locator('#parentFirstName')).toBeVisible();
@@ -69,7 +69,7 @@ test.describe('REAL — Bilan Gratuit (/bilan-gratuit)', () => {
     await page.locator('#objectives').fill('Préparer le baccalauréat avec un suivi personnalisé');
     await page.locator('label').filter({ hasText: /j’accepte d’être contacté/i }).click();
 
-    const submitBtn = page.getByRole('button', { name: /demander mon bilan stratégique gratuit/i });
+    const submitBtn = page.getByRole('button', { name: /lancer le bilan diagnostic/i });
     await expect(submitBtn, 'Bouton submit non trouvé').toBeVisible({ timeout: 3000 });
 
     const [apiResponse] = await Promise.all([


### PR DESCRIPTION
Rend le bilan diagnostic **atteignable** par les familles. Aucun changement de moteur, de scoring ou de modèle — le diagnostic tournait déjà, personne ne pouvait le trouver.

## Ce que la cartographie a montré

Le défaut n'était pas où on le croyait. **La plomberie est complète** : le formulaire `/bilan-gratuit` crée le compte parent, le compte élève, et envoie un lien d'activation qui ouvre le diagnostic. Le picker de matière, la sauvegarde/reprise, le scoring déterministe, le rapport plancher, la validation assistante et le dashboard parent existent et fonctionnent — vérifiés de bout en bout en production.

**C'est le discours qui disait d'attendre.** Le parent lisait « Sous 24h — notre équipe analyse votre profil », et « un email avec les prochaines étapes de prise en charge ». Rien ne lui disait que l'email reçu était un lien d'activation, ni que son enfant pouvait passer le bilan immédiatement.

## Deux frictions corrigées

**Le lien d'activation partait dans un `window.alert()`** — URL nue, incopiable, sans explication. C'était pourtant le seul moyen pour un parent de faire passer le bilan à son enfant. Il est présenté dans la boîte de dialogue, avec le libellé « X peut maintenant passer son bilan », la mention qu'il est personnel, et un bouton de copie.

**La boîte se fermait après chaque ajout.** Un second enfant obligeait à tout rouvrir. Elle reste ouverte et propose d'enchaîner ou de terminer.

## Le chemin public

La confirmation explique à quoi sert le lien reçu : choisir son mot de passe, ajouter son enfant, lui remettre un lien personnel pour passer le bilan. Le bouton annonce ce qu'il fait plutôt qu'une demande de rappel.

**Le lead-gen est intact** : la création de lead subsiste, et la reprise de contact par un conseiller reste annoncée — elle devient un complément au bilan plutôt que la seule suite promise.

## Provenance inchangée

Le parent inscrit et ajoute ; **l'enfant passe avec son propre accès**. Aucune route ne permet à un parent de créer un attempt pour son enfant. C'est la contrepartie du marquage honnête prévu pour la saisie papier : on n'accepte pas un flou en ligne quand on exige l'exactitude sur le papier.

## Vérifications

743 suites, **8335 tests, aucun échec** (suite complète, sans filtre, `.env` neutralisé). Typecheck et lint propres.

Les tests portent sur ce que la page **promet**, parce que c'est là qu'était le défaut. L'un d'eux vérifie que le formulaire crée réellement les comptes et l'activation : si cela cessait d'être vrai, tout le reste du discours deviendrait mensonger.

## Ce que cette PR ne contient pas

La **saisie papier** (Étape 3) est traitée en session dédiée : c'est le développement le plus conséquent, et un défaut de scoring sur de vrais bilans coûterait davantage qu'un décalage. Un point de reprise détaillé accompagne cette livraison.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rend le bilan diagnostic immédiatement accessible après l’inscription et fluidifie l’ajout d’enfants. Le lien d’activation est visible, copiable, et la modale reste ouverte pour enchaîner les ajouts.

- New Features
  - Ajout d’enfant: affiche le lien d’activation dans la modale avec un bouton “Copier” (plus de `window.alert`).
  - Modale: reste ouverte après ajout avec “Ajouter un autre enfant” ou “Terminer”.
  - Formulaire: CTA devient “Créer mon espace et lancer le bilan diagnostic” avec état “Création de votre espace…”.
  - Confirmation: “Sous 24h” remplacé par “Dès maintenant”, explication du lien d’activation, reprise de contact conseiller maintenue.
  - Aucune modification de moteur/scoring ni des routes; lead-gen conservé.
  - Tests: nouveaux tests de parcours diagnostic et non-régression lead-gen; adaptation du libellé du bouton; mock du `Select` Radix sous jsdom.

<sup>Written for commit 753fce9362f32234bc706b8a8d2e3e6d91402872. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

