### PR TITLE
Résorber le drift de schéma du candidat libre, sans migration

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2913,6 +2913,9 @@ model CandidateDiagnostic {
   @@unique([studentId, diagnosticKey, targetSession])
   @@index([studentId, status])
   @@index([status, updatedAt])
+  /// Créé par la migration `20260808180000` : la purge de conservation
+  /// balaie les dossiers par date de dernière activité.
+  @@index([lastActivityAt])
   @@map("candidate_diagnostics")
 }
 
@@ -2978,6 +2981,14 @@ model CandidateDiagnosticConsent {
   /// Consentement parental. N'est plus requis pour un étudiant majeur ; ne
   /// subsiste que pour les dossiers ouverts sur un mineur.
   parentConsentedAt DateTime?
+
+  /// Champ historique de la version mineur, où l'assentiment de l'élève
+  /// complétait le consentement parental. Le passage au régime adulte l'a
+  /// remplacé par `studentConsentedAt`, mais la colonne existe en base et
+  /// n'est pas supprimée : la déclarer ici évite un écart de schéma qu'un
+  /// futur `migrate dev` proposerait de « réconcilier » par un DROP.
+  /// Plus aucun code ne la lit ni ne l'écrit.
+  studentAssentedAt DateTime?
 
   /// Autorisation, donnée par l'étudiant, que le parent consulte ses résultats.
   /// **Nul par défaut** : le parent ne voit rien tant que l'étudiant n'a pas


### PR DESCRIPTION
Deux écarts entre `schema.prisma` et la base, **introduits par mes propres migrations**, détectés au clone-test de la fenêtre de déploiement. Correction de schéma uniquement : **aucune migration générée**, l'état de la base reste exactement celui que le clone-test avait validé.

## Les deux écarts

**Index `lastActivityAt` non déclaré.** La migration `20260808180000` le crée en SQL, mais le schéma ne le déclarait pas. Prisma ignorait son existence.

**Colonne `studentAssentedAt` orpheline.** Elle datait de la version mineur, où l'assentiment de l'élève complétait le consentement parental. Le passage au régime adulte l'a remplacée par `studentConsentedAt` et retirée du schéma — sans migration de suppression. La colonne subsiste donc en base, et existe déjà en production (table vide, vérifié).

Elle est **re-déclarée et documentée comme historique** plutôt que supprimée : elle est nullable, aucun code ne la lit, et un `DROP` toucherait une table du dossier candidat libre qu'on s'apprête à ouvrir.

## Pourquoi corriger avant de déployer

Aucun risque au runtime dans les deux cas — le déploiement aurait été sûr. Le risque était **différé** : un futur `migrate dev` aurait vu l'écart et proposé de « réconcilier », c'est-à-dire de supprimer la colonne, sur une table qui ne sera plus vide une fois la fonctionnalité ouverte. C'est le genre de dette qui se paie au pire moment.

## Vérification

**Re-clone-test** sur le schéma de production exact, avec les trois migrations rejouées : `migrate status` sur « Database schema is up to date! », et **drift nul** hormis deux écarts environnementaux préexistants — extensions `btree_gist`/`plpgsql`, index `eam_progress` — qui ne viennent pas de ces migrations et ne sont pas touchés. Conteneur détruit.

743 suites, **8335 tests, aucun échec** (suite complète, sans filtre). Typecheck propre.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligne `schema.prisma` avec la base pour résorber le drift du dossier candidat libre, sans créer de migration. Évite qu’un futur `migrate dev` tente de supprimer une colonne historique.

- **Bug Fixes**
  - Ajoute `@@index([lastActivityAt])` à `CandidateDiagnostic` pour refléter l’index créé par `20260808180000`.
  - Re-déclare `studentAssentedAt` dans `CandidateDiagnosticConsent` comme champ historique nullable, non utilisé, pour prévenir un DROP automatique.

<sup>Written for commit 2862d5e8927602dcd6f79af6e7f7624b584e5c8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

