### PR TITLE
fix(bilans): neutraliser la fausse passation express des saisies papier

### DIFF
--- a/__tests__/bilans/passation-presentation.test.ts
+++ b/__tests__/bilans/passation-presentation.test.ts
@@ -1,0 +1,55 @@
+import { ENTRY_RECIPE_FACT_SHEETS } from './fixtures/recipe-fact-sheets';
+
+import {
+  PAPER_ENTRY_DURATION_MEASUREMENT,
+  prepareReportPassationPresentation,
+} from '@/lib/bilans/render/passation-presentation';
+import { buildDeterministicReports } from '@/lib/bilans/render/report';
+import { validateDeterministicReports } from '@/lib/bilans/worker/structural-validation';
+
+const rawExpressFactSheet = Object.freeze({
+  ...ENTRY_RECIPE_FACT_SHEETS[0],
+  flags: Object.freeze([
+    ...ENTRY_RECIPE_FACT_SHEETS[0].flags.filter((flag) => flag !== 'PASSATION_EXPRESS'),
+    'PASSATION_EXPRESS' as const,
+  ]),
+});
+
+describe('Présentation de la durée de passation dans le rapport', () => {
+  test('une saisie papier ne porte jamais PASSATION_EXPRESS dans sa vue de rapport', () => {
+    const presentation = prepareReportPassationPresentation(rawExpressFactSheet, 'SAISIE_PAPIER');
+
+    expect(rawExpressFactSheet.flags).toContain('PASSATION_EXPRESS');
+    expect(presentation.factSheet.flags).not.toContain('PASSATION_EXPRESS');
+    expect(presentation.durationMeasurement).toBe(PAPER_ENTRY_DURATION_MEASUREMENT);
+  });
+
+  test('une passation en ligne réellement express conserve son drapeau', () => {
+    const presentation = prepareReportPassationPresentation(rawExpressFactSheet, 'EN_LIGNE');
+
+    expect(presentation.factSheet.flags).toContain('PASSATION_EXPRESS');
+    expect(presentation.durationMeasurement).toBeUndefined();
+  });
+
+  test('la projection de rapport ne modifie jamais le snapshot brut', () => {
+    const before = JSON.stringify(rawExpressFactSheet);
+
+    prepareReportPassationPresentation(rawExpressFactSheet, 'SAISIE_PAPIER');
+
+    expect(JSON.stringify(rawExpressFactSheet)).toBe(before);
+  });
+
+  test('la validation structurelle accepte le marqueur contrôlé', () => {
+    const presentation = prepareReportPassationPresentation(rawExpressFactSheet, 'SAISIE_PAPIER');
+    const reports = buildDeterministicReports(presentation.factSheet, {
+      displayName: rawExpressFactSheet.student.alias,
+      level: rawExpressFactSheet.student.level,
+      subject: 'MATHS',
+      date: '2026-08-08',
+      stageLabel: 'Stage de pré-rentrée — Mathématiques',
+      durationMeasurement: presentation.durationMeasurement,
+    });
+
+    expect(() => validateDeterministicReports(presentation.factSheet, reports)).not.toThrow();
+  });
+});

--- a/__tests__/bilans/render-html.test.ts
+++ b/__tests__/bilans/render-html.test.ts
@@ -1,6 +1,10 @@
 import { ENTRY_RECIPE_FACT_SHEETS } from './fixtures/recipe-fact-sheets';
 
 import { renderDeterministicBilanHtml } from '@/lib/bilans/render/html';
+import {
+  PAPER_ENTRY_DURATION_MEASUREMENT,
+  PAPER_ENTRY_DURATION_NOTICE,
+} from '@/lib/bilans/render/passation-presentation';
 import type { RenderIdentity } from '@/lib/bilans/render/render-identity';
 
 const identity: RenderIdentity = {
@@ -71,5 +75,16 @@ describe('A90.2 deterministic HTML reports', () => {
 
     expect(html).toContain('Tableau des aptitudes');
     expect(html).not.toContain('score de maîtrise');
+  });
+
+  it('affiche une mention neutre pour la durée non mesurée d’une saisie papier', () => {
+    const paperHtml = renderDeterministicBilanHtml(ENTRY_RECIPE_FACT_SHEETS[0], 'PARENTS', {
+      ...identity,
+      durationMeasurement: PAPER_ENTRY_DURATION_MEASUREMENT,
+    });
+    const onlineHtml = renderDeterministicBilanHtml(ENTRY_RECIPE_FACT_SHEETS[0], 'PARENTS', identity);
+
+    expect(paperHtml).toContain(PAPER_ENTRY_DURATION_NOTICE);
+    expect(onlineHtml).not.toContain(PAPER_ENTRY_DURATION_NOTICE);
   });
 });

--- a/__tests__/bilans/render-identity-pseudonymity.test.ts
+++ b/__tests__/bilans/render-identity-pseudonymity.test.ts
@@ -51,6 +51,13 @@ describe('assertPseudonymousRenderIdentity — pseudonymity of the immutable cha
       .toThrow('RENDER_IDENTITY_INVALID:stageLabel');
   });
 
+  it('rejects any uncontrolled duration marker', () => {
+    expect(() => assertPseudonymousRenderIdentity({
+      ...VALID,
+      durationMeasurement: 'MEASURED' as never,
+    })).toThrow('RENDER_IDENTITY_INVALID:durationMeasurement');
+  });
+
   it('matches the alias format enforced upstream by buildFactSheet', () => {
     // buildFactSheet (lib/bilans/facts/fact-sheet.ts) rejects any alias that is
     // not /^ELEVE_[A-Z]+$/. The render boundary must not be laxer than the

--- a/__tests__/bilans/report-materialization.test.ts
+++ b/__tests__/bilans/report-materialization.test.ts
@@ -1,10 +1,15 @@
 import {
   audienceArtifactChecksum,
+  parseReportRenderContext,
   prepareCoachPreview,
   prepareReportMaterialization,
   storedAudienceArtifactIsIntact,
 } from '@/lib/bilans/core/report-materialization';
 import { renderDeterministicBilanHtml } from '@/lib/bilans/render/html';
+import {
+  PAPER_ENTRY_DURATION_MEASUREMENT,
+  PAPER_ENTRY_DURATION_NOTICE,
+} from '@/lib/bilans/render/passation-presentation';
 import { BILAN_PDF_ENGINE_VERSION } from '@/lib/bilans/render/pdf';
 import type { RenderIdentity } from '@/lib/bilans/render/render-identity';
 import { ENTRY_RECIPE_FACT_SHEETS } from '@/__tests__/bilans/fixtures/recipe-fact-sheets';
@@ -66,5 +71,31 @@ describe('A90.3 report materialization preparation', () => {
     expect(preview.official).toBe(false);
     expect(preview.label).toContain('NON OFFICIELLE');
     expect(preview.audiences).toHaveLength(3);
+  });
+
+  test('reprojects the raw snapshot before materializing a paper-entry report', () => {
+    const rawExpressFactSheet = {
+      ...factSheet,
+      flags: [...factSheet.flags, 'PASSATION_EXPRESS' as const],
+    };
+    const context = parseReportRenderContext(rawExpressFactSheet, {
+      NEXUS: {
+        identity: { ...identity, durationMeasurement: PAPER_ENTRY_DURATION_MEASUREMENT },
+      },
+    });
+
+    expect(rawExpressFactSheet.flags).toContain('PASSATION_EXPRESS');
+    expect(context.factSheet.flags).not.toContain('PASSATION_EXPRESS');
+  });
+
+  test('materializes the neutral paper-entry notice for all audiences', async () => {
+    const paperIdentity = { ...identity, durationMeasurement: PAPER_ENTRY_DURATION_MEASUREMENT };
+    const prepared = await prepareReportMaterialization(
+      { factSheet, identity: paperIdentity },
+      readyRenderer,
+    );
+
+    expect(prepared.audiences).toHaveLength(3);
+    expect(prepared.audiences.every(({ html }) => html.includes(PAPER_ENTRY_DURATION_NOTICE))).toBe(true);
   });
 });

--- a/__tests__/integration/bilans-saisie-papier.real.test.ts
+++ b/__tests__/integration/bilans-saisie-papier.real.test.ts
@@ -21,8 +21,15 @@ import { createGetAttemptHandler } from '@/lib/bilans/api/get-attempt';
 import { createPaperEntryHandler } from '@/lib/bilans/api/paper-entry';
 import { createPatchAnswersHandler } from '@/lib/bilans/api/patch-answers';
 import { createSubmitAttemptHandler } from '@/lib/bilans/api/submit-attempt';
+import type { FactSheet } from '@/lib/bilans/facts/fact-sheet';
+import { BilanLlmConfigError } from '@/lib/bilans/llm/config';
 import { prisma } from '@/lib/prisma';
 import { processScoreAttemptJob } from '@/lib/bilans/worker/score-job';
+import { processGenerateReportJob } from '@/lib/bilans/worker/generate-report-job';
+import {
+  PAPER_ENTRY_DURATION_MEASUREMENT,
+  prepareReportPassationPresentation,
+} from '@/lib/bilans/render/passation-presentation';
 
 import {
   CANONICAL_WORKER_ENABLED_PACK,
@@ -132,6 +139,16 @@ describe('Saisie papier — parité et provenance sur PostgreSQL réel', () => {
     return prisma.scoreSnapshot.findUniqueOrThrow({ where: { assessmentAttemptId: attemptId } });
   }
 
+  async function generateReport(attemptId: string) {
+    const job = await prisma.jobOutbox.findUniqueOrThrow({
+      where: { idempotencyKey: `${attemptId}.generate-report` },
+    });
+    return processGenerateReportJob(job.id, {
+      ...workerDependencies,
+      buildTransport: () => { throw new BilanLlmConfigError('OPENROUTER_API_KEY_MISSING'); },
+    });
+  }
+
   beforeAll(async () => {
     const parentUser = await prisma.user.create({
       data: { email: `${PREFIX}parent@example.test`, role: 'PARENT' },
@@ -193,22 +210,39 @@ describe('Saisie papier — parité et provenance sur PostgreSQL réel', () => {
     ));
     expect(comparable(paper.result)).toBe(comparable(online.result));
 
-    const facts = paper.result as unknown as {
-      globalScore: number;
-      calibrationIndex: number | null;
-      flags: readonly string[];
-    };
-    expect(facts.globalScore).toBeGreaterThan(0);
-    expect(facts.globalScore).toBeLessThan(100);
+    const paperFacts = paper.result as unknown as FactSheet;
+    const onlineFacts = online.result as unknown as FactSheet;
+    expect(paperFacts.globalScore).toBeGreaterThan(0);
+    expect(paperFacts.globalScore).toBeLessThan(100);
     // Le volet métacognition est bien porté par la copie papier.
-    expect(facts.calibrationIndex).not.toBeNull();
+    expect(paperFacts.calibrationIndex).not.toBeNull();
 
-    // LIMITE CONNUE, documentée dans paper-entry.ts : la durée de composition
-    // n'est pas sur la copie, donc le moteur en déduit une durée nulle et
-    // lève PASSATION_EXPRESS sur tout bilan saisi. Le test l'énonce plutôt
-    // que de le taire — si un jour ce drapeau est arbitré, il échouera ici, à
-    // l'endroit exact où il faut le reconsidérer.
-    expect(facts.flags).toContain('PASSATION_EXPRESS');
+    // Le snapshot brut reste strictement identique entre les deux chemins :
+    // le moteur n'apprend rien de la provenance. La vue de rapport, elle,
+    // neutralise le faux signal papier tout en conservant le vrai signal en
+    // ligne et en portant un marqueur de durée non mesurée.
+    expect(paperFacts.flags).toContain('PASSATION_EXPRESS');
+    expect(onlineFacts.flags).toContain('PASSATION_EXPRESS');
+    const paperPresentation = prepareReportPassationPresentation(paperFacts, 'SAISIE_PAPIER');
+    const onlinePresentation = prepareReportPassationPresentation(onlineFacts, 'EN_LIGNE');
+    expect(paperPresentation.factSheet.flags).not.toContain('PASSATION_EXPRESS');
+    expect(paperPresentation.durationMeasurement).toBe(PAPER_ENTRY_DURATION_MEASUREMENT);
+    expect(onlinePresentation.factSheet.flags).toContain('PASSATION_EXPRESS');
+    expect(onlinePresentation.durationMeasurement).toBeUndefined();
+
+    await Promise.all([generateReport(paperAttemptId), generateReport(onlineAttemptId)]);
+    const [paperRevision, onlineRevision] = await Promise.all([
+      prisma.reportRevision.findUniqueOrThrow({ where: { scoreSnapshotId: paper.id } }),
+      prisma.reportRevision.findUniqueOrThrow({ where: { scoreSnapshotId: online.id } }),
+    ]);
+    const paperIdentity = (paperRevision.content as {
+      NEXUS: { identity: { durationMeasurement?: string } };
+    }).NEXUS.identity;
+    const onlineIdentity = (onlineRevision.content as {
+      NEXUS: { identity: { durationMeasurement?: string } };
+    }).NEXUS.identity;
+    expect(paperIdentity.durationMeasurement).toBe(PAPER_ENTRY_DURATION_MEASUREMENT);
+    expect(onlineIdentity.durationMeasurement).toBeUndefined();
 
     const attempts = await prisma.canonicalAssessmentAttempt.findMany({
       where: { id: { in: [onlineAttemptId, paperAttemptId] } },

--- a/docs/handoff/saisie-papier-bilan.md
+++ b/docs/handoff/saisie-papier-bilan.md
@@ -105,9 +105,9 @@ L'adaptateur a été élargi pour laisser passer `null`. La passation en ligne n
 peut pas produire ce cas — sa validation d'entrée impose la certitude — donc
 rien n'y change.
 
-### Deux limites connues, à arbitrer
+### Accès ADMIN : question ouverte de périmètre
 
-**ADMIN n'ouvre pas l'écran.** Le garde et la route d'API acceptent
+Le garde et la route d'API acceptent
 `ASSISTANTE` et `ADMIN`. Mais `middleware.ts` renvoie tout ADMIN de
 `/dashboard/assistante/*` vers `/dashboard/admin` : en pratique l'écran n'est
 ouvrable que par une assistante, un ADMIN ne passant que par l'API. C'est une
@@ -115,16 +115,18 @@ convention de plateforme partagée par toutes les pages assistante ; la lever se
 déciderait pour l'ensemble du tableau de bord, pas au détour de cette
 fonctionnalité.
 
-**PASSATION_EXPRESS.**
+### Durée de passation des copies papier
 
 La durée de composition ne figure pas sur une copie. `startedAt` et
 `submittedAt` d'un attempt saisi valent donc l'instant de la saisie, le moteur
-en déduit une durée nulle, et **le drapeau `PASSATION_EXPRESS` est levé sur
-tout bilan saisi**. Le score, les profils et la calibration n'en dépendent pas ;
-seul ce drapeau est trompeur. Le corriger supposerait soit d'inventer une
-durée, soit de faire entrer la provenance dans le moteur de faits — les deux
-étaient exclus. Le comportement est épinglé par un test (`bilans-saisie-papier.real.test.ts`)
-pour qu'un arbitrage futur échoue à l'endroit exact où il faut reconsidérer.
+en déduit une durée nulle et le snapshot brut porte `PASSATION_EXPRESS`. Ce
+snapshot reste inchangé afin de conserver un moteur unique et la parité avec le
+chemin en ligne. À la frontière de présentation/validation du rapport,
+`lib/bilans/render/passation-presentation.ts` retire ce faux signal pour la
+seule provenance `SAISIE_PAPIER` et affiche la mention neutre : « Durée non
+mesurée — saisie papier. » Une passation en ligne réellement express conserve
+son drapeau. La projection et la parité sont verrouillées par les tests unitaires
+et PostgreSQL réel.
 
 ## Ce qui a été livré avant ce handoff
 

--- a/lib/bilans/api/paper-entry.ts
+++ b/lib/bilans/api/paper-entry.ts
@@ -189,14 +189,12 @@ async function writePaperAttempt(
       // passation. Il est soumis immédiatement, dans cette transaction, et
       // n'est donc jamais reprenable comme un brouillon en ligne.
       //
-      // LIMITE CONNUE : la durée réelle de composition n'est pas sur la copie.
-      // `startedAt` et `submittedAt` valent donc l'instant de la saisie, et le
-      // moteur en déduit une durée nulle, ce qui lève le drapeau
-      // PASSATION_EXPRESS sur tout bilan saisi. Le score, les profils et la
-      // calibration n'en dépendent pas ; seul ce drapeau est trompeur. Le
-      // corriger supposerait soit d'inventer une durée, soit de faire entrer
-      // la provenance dans le moteur de faits — les deux sont exclus. À
-      // arbitrer avec le responsable, hors de ce périmètre.
+      // La durée réelle de composition n'est pas sur la copie. `startedAt` et
+      // `submittedAt` valent donc l'instant de la saisie : le snapshot brut
+      // reste strictement produit par le moteur commun, sans durée inventée ni
+      // branche de scoring liée à la provenance. La vue de rapport neutralise
+      // ensuite le faux PASSATION_EXPRESS et indique « durée non mesurée —
+      // saisie papier » (render/passation-presentation.ts).
       startedAt: input.now,
       expiresAt: input.now,
       subject: resolvePrismaSubject(enabled.pack.subject),

--- a/lib/bilans/core/report-materialization.ts
+++ b/lib/bilans/core/report-materialization.ts
@@ -10,6 +10,7 @@ import {
   type RenderIdentity,
 } from '../render/render-identity';
 import { renderDeterministicBilanHtml } from '../render/html';
+import { applyReportPassationPresentation } from '../render/passation-presentation';
 import {
   assertPublicRenderedArtifact,
   audienceArtifactChecksum,
@@ -83,9 +84,10 @@ function parseIdentity(content: unknown): RenderIdentity {
 }
 
 export function parseReportRenderContext(scoreResult: unknown, reportContent: unknown): ReportRenderContext {
+  const identity = parseIdentity(reportContent);
   return Object.freeze({
-    factSheet: parseFactSheet(scoreResult),
-    identity: parseIdentity(reportContent),
+    factSheet: applyReportPassationPresentation(parseFactSheet(scoreResult), identity.durationMeasurement),
+    identity,
   });
 }
 

--- a/lib/bilans/render/html.ts
+++ b/lib/bilans/render/html.ts
@@ -5,6 +5,10 @@ import {
 } from '../catalog/subjects';
 import { BILAN_PRINT_BRAND, bilanPrintTokenCss } from './brand';
 import { buildDeterministicReport } from './report';
+import {
+  PAPER_ENTRY_DURATION_MEASUREMENT,
+  PAPER_ENTRY_DURATION_NOTICE,
+} from './passation-presentation';
 import type { RenderIdentity } from './render-identity';
 import type { ReportAudience } from './profile-copy';
 import { bilanPackLevelLabel } from './stage-label';
@@ -65,10 +69,13 @@ function list(items: readonly string[], className = ''): string {
 }
 
 function header(identity: RenderIdentity, audience: ReportAudience): string {
+  const durationNotice = identity.durationMeasurement === PAPER_ENTRY_DURATION_MEASUREMENT
+    ? `<p class="passation-note" style="margin:1.5mm 0 0;color:var(--color-lux-slate);font-size:9pt">${escapeHtml(PAPER_ENTRY_DURATION_NOTICE)}</p>`
+    : '';
   return `<header class="report-header">
     <img class="brand-logo" src="${BILAN_PRINT_BRAND.logos.header}" alt="Nexus Réussite">
     <div class="identity"><p class="eyebrow">Bilan ${escapeHtml(audience)}</p><h1>${escapeHtml(identity.stageLabel)}</h1>
-    <p><strong>${escapeHtml(identity.displayName)}</strong> · ${escapeHtml(bilanPackLevelLabel(identity.level))} · ${escapeHtml(bilanPackSubjectLabel(identity.subject))} · ${escapeHtml(identity.date)}</p></div>
+    <p><strong>${escapeHtml(identity.displayName)}</strong> · ${escapeHtml(bilanPackLevelLabel(identity.level))} · ${escapeHtml(bilanPackSubjectLabel(identity.subject))} · ${escapeHtml(identity.date)}</p>${durationNotice}</div>
   </header>`;
 }
 

--- a/lib/bilans/render/passation-presentation.ts
+++ b/lib/bilans/render/passation-presentation.ts
@@ -1,0 +1,45 @@
+import type { CanonicalAttemptProvenance } from '@prisma/client';
+
+import type { FactSheet } from '../facts/fact-sheet';
+
+export const PAPER_ENTRY_DURATION_MEASUREMENT = 'NOT_MEASURED_PAPER_ENTRY' as const;
+export const PAPER_ENTRY_DURATION_NOTICE = 'Durée non mesurée — saisie papier.' as const;
+
+export type ReportDurationMeasurement = typeof PAPER_ENTRY_DURATION_MEASUREMENT;
+
+export type ReportPassationPresentation = Readonly<{
+  factSheet: FactSheet;
+  durationMeasurement?: ReportDurationMeasurement;
+}>;
+
+/**
+ * Removes the misleading duration flag from a report view, never from the
+ * append-only scoring snapshot. The marker is persisted with the report
+ * identity so later HTML/PDF materialization can rebuild the same view.
+ */
+export function applyReportPassationPresentation(
+  factSheet: FactSheet,
+  durationMeasurement?: ReportDurationMeasurement,
+): FactSheet {
+  if (durationMeasurement !== PAPER_ENTRY_DURATION_MEASUREMENT) return factSheet;
+  return Object.freeze({
+    ...factSheet,
+    flags: Object.freeze(factSheet.flags.filter((flag) => flag !== 'PASSATION_EXPRESS')),
+  });
+}
+
+/**
+ * Presentation-only decision. Provenance deliberately stays out of the facts
+ * engine: an online attempt retains every computed flag, while a paper entry
+ * gets a duration-not-measured marker and a projected report fact sheet.
+ */
+export function prepareReportPassationPresentation(
+  factSheet: FactSheet,
+  provenance: CanonicalAttemptProvenance,
+): ReportPassationPresentation {
+  if (provenance !== 'SAISIE_PAPIER') return Object.freeze({ factSheet });
+  return Object.freeze({
+    factSheet: applyReportPassationPresentation(factSheet, PAPER_ENTRY_DURATION_MEASUREMENT),
+    durationMeasurement: PAPER_ENTRY_DURATION_MEASUREMENT,
+  });
+}

--- a/lib/bilans/render/render-identity.ts
+++ b/lib/bilans/render/render-identity.ts
@@ -1,5 +1,9 @@
 import type { FactSheet } from '../facts/fact-sheet';
 import type { BilanPackSubject } from '../catalog/subjects';
+import {
+  PAPER_ENTRY_DURATION_MEASUREMENT,
+  type ReportDurationMeasurement,
+} from './passation-presentation';
 
 export const RENDER_IDENTITY_VERSION = 'render-identity.v1' as const;
 
@@ -9,6 +13,7 @@ export type RenderIdentity = Readonly<{
   subject: BilanPackSubject;
   date: string;
   stageLabel: string;
+  durationMeasurement?: ReportDurationMeasurement;
 }>;
 
 /**
@@ -19,6 +24,12 @@ export type RenderIdentity = Readonly<{
 const PSEUDONYMOUS_DISPLAY_NAME = /^ELEVE_[A-Z]+$/;
 
 export function assertRenderIdentity(identity: RenderIdentity): RenderIdentity {
+  if (
+    identity.durationMeasurement !== undefined
+    && identity.durationMeasurement !== PAPER_ENTRY_DURATION_MEASUREMENT
+  ) {
+    throw new Error('RENDER_IDENTITY_INVALID:durationMeasurement');
+  }
   for (const [field, value] of Object.entries(identity)) {
     if (typeof value !== 'string' || value.trim().length === 0) {
       throw new Error(`RENDER_IDENTITY_INVALID:${field}`);

--- a/lib/bilans/worker/generate-report-job.ts
+++ b/lib/bilans/worker/generate-report-job.ts
@@ -10,6 +10,7 @@ import { OpenRouterBilanTransport } from '../llm/openrouter-transport';
 import { sha256Canonical } from '../local-first/hash';
 import { createPseudonymizedFactSheet } from '../local-first/contracts';
 import { buildLlmReports } from '../render/llm-report';
+import { prepareReportPassationPresentation } from '../render/passation-presentation';
 import type { RenderIdentity } from '../render/render-identity';
 import { buildDeterministicReports, type DeterministicBilanReportBundle } from '../render/report';
 import { buildPreRentreeStageLabel } from '../render/stage-label';
@@ -205,18 +206,29 @@ async function claimJob(
     },
   });
 
-  const factSheet = snapshot.result as unknown as FactSheet;
+  const rawFactSheet = snapshot.result as unknown as FactSheet;
+  const presentation = prepareReportPassationPresentation(rawFactSheet, attempt.provenance);
   const identity: RenderIdentity = Object.freeze({
-    displayName: factSheet.student.alias,
+    displayName: rawFactSheet.student.alias,
     level: enabled.pack.level,
     subject: enabled.pack.subject,
     date: attempt.submittedAt.toISOString().slice(0, 10),
     stageLabel: buildPreRentreeStageLabel(enabled.pack.level, enabled.pack.subject),
+    ...(presentation.durationMeasurement === undefined
+      ? {}
+      : { durationMeasurement: presentation.durationMeasurement }),
   });
 
   return {
     replayed: false,
-    claim: { attemptId: attempt.id, studentId: attempt.studentId, scoreSnapshotId: snapshot.id, factSheet, identity, enabled },
+    claim: {
+      attemptId: attempt.id,
+      studentId: attempt.studentId,
+      scoreSnapshotId: snapshot.id,
+      factSheet: presentation.factSheet,
+      identity,
+      enabled,
+    },
   };
 }
 

--- a/lib/bilans/worker/structural-validation.ts
+++ b/lib/bilans/worker/structural-validation.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { BILAN_PACK_SUBJECTS } from '../catalog/subjects';
 import type { FactSheet } from '../facts/fact-sheet';
 import { BILAN_REPORT_TEMPLATE_VERSION, type DeterministicBilanReportBundle } from '../render/report';
+import { PAPER_ENTRY_DURATION_MEASUREMENT } from '../render/passation-presentation';
 
 const technicalProfileSchema = z.enum([
   'NON_TRAITE',
@@ -26,6 +27,7 @@ const identitySchema = z.object({
   subject: z.enum(BILAN_PACK_SUBJECTS),
   date: z.string().trim().min(1),
   stageLabel: z.string().trim().min(1),
+  durationMeasurement: z.literal(PAPER_ENTRY_DURATION_MEASUREMENT).optional(),
 }).strict();
 
 const narrativeSchema = z.object({


### PR DESCRIPTION
## Dépendance

PR empilée sur #111 (`feat/saisie-papier-bilan`) afin de garder un diff ciblé. Elle devra être retargetée vers `main` après la fusion de #111.

## Cause racine

Une copie papier ne fournit aucune durée de composition. La saisie crée donc un attempt soumis immédiatement ; le snapshot brut du moteur porte `PASSATION_EXPRESS`, alors qu'il s'agit d'une absence de mesure et non d'une passation express.

## Correctif

- conserve le moteur commun et le snapshot append-only inchangés ;
- projette le FactSheet à la frontière de génération/matérialisation du rapport pour la seule provenance `SAISIE_PAPIER` ;
- retire `PASSATION_EXPRESS` de la vue de rapport et persiste le marqueur contrôlé `NOT_MEASURED_PAPER_ENTRY` ;
- affiche « Durée non mesurée — saisie papier. » dans les rapports ;
- conserve `PASSATION_EXPRESS` pour une passation en ligne réellement express ;
- documente que l'accès ADMIN reste une question globale du dashboard, sans modification de `middleware.ts`.

## Vérifications

- Suite unitaire locale complète sans filtre : 748 suites, 8407 tests, 7 snapshots — OK
- Intégration PostgreSQL réelle locale, partitions CI : 30 suites, 198 tests — OK
- `npm run lint` — OK (warnings préexistants uniquement)
- `npm run typecheck` — OK
- `npm run build` — OK
- [CI Pipeline complète](https://github.com/cyranoaladin/nexus-project_v0/actions/runs/31280388674) sur le SHA `57a836a22` : tous les jobs et `CI Success` verts
- GitGuardian — OK
- `git diff --check` — OK
- moteur de scoring, middleware, migrations et candidat libre : aucun changement

La base a été temporairement pointée vers `main`, puis la PR rouverte, uniquement pour déclencher le workflow qui filtre ses événements sur cette base. Elle a ensuite été restaurée sur #111 pour conserver le petit diff de revue. Aucun workflow ni contrôle n'a été modifié ou neutralisé.

Aucun déploiement, aucune fusion.