### PR TITLE
Bilan de pré-rentrée : rendre le parcours trouvable et guidé

### DIFF
--- a/.github/workflows/pre-rentree-documents.yml
+++ b/.github/workflows/pre-rentree-documents.yml
@@ -40,6 +40,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
+      NODE_OPTIONS: "--max-old-space-size=4096"
       SOURCE_DATE_EPOCH: "1784505600"
       PYTHONDONTWRITEBYTECODE: "1"
       PRE_RENTREE_REPOSITORY_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/__tests__/api/student.activate.lifecycle-security.test.ts
+++ b/__tests__/api/student.activate.lifecycle-security.test.ts
@@ -60,7 +60,10 @@ describe('student activation token lifecycle security', () => {
 
     const result = await completeStudentActivation('act_valid_token', 'securePass123');
 
-    expect(result.success).toBe(true);
+    expect(result).toEqual({
+      success: true,
+      redirectUrl: '/auth/signin?activated=true&callbackUrl=%2Fbilan-gratuit%2Fassessment',
+    });
     expect(prisma.user.updateMany).toHaveBeenCalledWith({
       where: expect.objectContaining({
         id: 'user-1',

--- a/__tests__/bilans/saisie-papier-page-access.test.tsx
+++ b/__tests__/bilans/saisie-papier-page-access.test.tsx
@@ -1,0 +1,39 @@
+import '@testing-library/jest-dom';
+
+import { render, screen } from '@testing-library/react';
+
+const mockNotFound = jest.fn(() => {
+  throw new Error('NEXT_NOT_FOUND');
+});
+
+jest.mock('next/navigation', () => ({
+  notFound: () => mockNotFound(),
+  useRouter: () => ({ replace: jest.fn(), refresh: jest.fn() }),
+}));
+
+import { auth } from '@/auth';
+import SaisiePapierPage from '@/app/dashboard/assistante/bilans/saisie-papier/page';
+import { prisma } from '@/lib/prisma';
+
+const params = Promise.resolve({});
+
+describe('Écran assistante de saisie papier', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (prisma.student.findMany as jest.Mock).mockResolvedValue([]);
+  });
+
+  it.each(['PARENT', 'ELEVE'])('reste invisible au rôle %s', async (role) => {
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'user-1', role } });
+    await expect(SaisiePapierPage({ searchParams: params })).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(prisma.student.findMany).not.toHaveBeenCalled();
+  });
+
+  it('affiche le fil guidé à une assistante', async () => {
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'staff-1', role: 'ASSISTANTE' } });
+    render(await SaisiePapierPage({ searchParams: params }));
+
+    expect(screen.getByRole('heading', { name: 'Saisir un bilan passé sur copie' })).toBeInTheDocument();
+    expect(screen.getByRole('list', { name: 'Progression de la saisie papier' })).toBeInTheDocument();
+  });
+});

--- a/__tests__/bilans/saisie-papier-workflow.test.tsx
+++ b/__tests__/bilans/saisie-papier-workflow.test.tsx
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { PaperEntryGrid } from '@/components/bilans/PaperEntryGrid';
+import { PaperEntryWorkflowSteps } from '@/components/bilans/PaperEntryWorkflowSteps';
+
+describe('Fil guidé de saisie papier', () => {
+  it('affiche les cinq étapes et l’étape courante', () => {
+    render(<PaperEntryWorkflowSteps currentStep={3} />);
+
+    expect(screen.getByRole('list', { name: 'Progression de la saisie papier' })).toBeInTheDocument();
+    for (const label of [
+      'Créer ou sélectionner le foyer',
+      'Ajouter ou sélectionner l’enfant',
+      'Choisir la matière',
+      'Saisir les réponses',
+      'Valider',
+    ]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+    expect(screen.getByText('Choisir la matière').closest('li')).toHaveAttribute('aria-current', 'step');
+  });
+
+  it('rend l’état de saisie visible et nomme explicitement la validation', () => {
+    render(
+      <PaperEntryGrid
+        studentId="student-1"
+        studentName="Élève Test"
+        packSlug="entree-seconde-maths-v1"
+        packTitle="Entrée en Seconde · Mathématiques"
+        items={[{
+          id: 'q1',
+          position: 1,
+          prompt: 'Question test',
+          options: [{ id: 'A', label: 'Réponse A' }],
+        }]}
+      />,
+    );
+
+    expect(screen.getByText('0 réponse sur 1 saisie')).toBeInTheDocument();
+    const radios = screen.getAllByRole('radio');
+    fireEvent.click(radios[0]);
+    fireEvent.click(radios[4]);
+    expect(screen.getByText('1 réponse sur 1 saisie')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Valider la saisie papier' })).toBeEnabled();
+  });
+});

--- a/__tests__/components/HomePage.test.tsx
+++ b/__tests__/components/HomePage.test.tsx
@@ -10,7 +10,14 @@ describe('HomePage', () => {
     expect(screen.getAllByAltText('Nexus Réussite').length).toBeGreaterThan(0);
     expect(screen.getByRole('heading', { name: /préparer le bac français avec méthode, suivi et exigence/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /trouvez la formule adaptée à votre enfant/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /demander un bilan gratuit/i })).toHaveAttribute('href', '/bilan-gratuit');
+    expect(screen.getByRole('link', { name: 'Passer le bilan de pré-rentrée' })).toHaveAttribute(
+      'href',
+      '/bilan-gratuit?parcours=diagnostic#demande-bilan',
+    );
+    expect(screen.getByRole('link', { name: 'Être rappelé par un conseiller' })).toHaveAttribute(
+      'href',
+      '/bilan-gratuit?parcours=conseiller#rappel-conseiller',
+    );
   });
 
   it('exports homepage metadata', () => {

--- a/__tests__/components/dashboard/eleve/PreRentreeAssessmentCard.test.tsx
+++ b/__tests__/components/dashboard/eleve/PreRentreeAssessmentCard.test.tsx
@@ -1,0 +1,17 @@
+import '@testing-library/jest-dom';
+
+import { render, screen } from '@testing-library/react';
+
+import { PreRentreeAssessmentCard } from '@/components/dashboard/eleve/PreRentreeAssessmentCard';
+
+describe('PreRentreeAssessmentCard', () => {
+  it('mène directement de l’espace élève à la sélection de matière', () => {
+    render(<PreRentreeAssessmentCard />);
+
+    expect(screen.getByRole('link', { name: 'Passer le bilan de pré-rentrée' })).toHaveAttribute(
+      'href',
+      '/bilan-gratuit/assessment',
+    );
+    expect(screen.getByText(/choisis d’abord la matière/i)).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/dashboard/parent/BilanGratuitBanner.test.tsx
+++ b/__tests__/components/dashboard/parent/BilanGratuitBanner.test.tsx
@@ -28,7 +28,7 @@ describe('BilanGratuitBanner', () => {
     const onGoToChildren = jest.fn();
     render(<BilanGratuitBanner onGoToChildren={onGoToChildren} />);
 
-    const cta = await screen.findByRole('button', { name: /faire le bilan/i });
+    const cta = await screen.findByRole('button', { name: /ajouter votre enfant/i });
     // The whole point of this fix: an already-authenticated parent must be
     // routed to their own "Ajouter un Enfant" flow, never back to the
     // anonymous public /bilan-gratuit registration form (dead end for an
@@ -37,5 +37,13 @@ describe('BilanGratuitBanner', () => {
 
     await userEvent.click(cta);
     expect(onGoToChildren).toHaveBeenCalledTimes(1);
+  });
+
+  test('guide vers le lien existant sans proposer de créer un doublon', async () => {
+    mockFetchStatus({ completed: false, dismissed: false });
+    render(<BilanGratuitBanner hasChildren onGoToChildren={jest.fn()} />);
+
+    expect(await screen.findByRole('button', { name: /voir le lien de votre enfant/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /ajouter votre enfant/i })).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/dashboard/parent/ChildCard.activation.test.tsx
+++ b/__tests__/components/dashboard/parent/ChildCard.activation.test.tsx
@@ -35,6 +35,9 @@ describe('ChildCard initial student activation', () => {
       expect.objectContaining({ method: 'POST' }),
     ));
     expect(await screen.findByText(child.email)).toBeInTheDocument();
+    expect(screen.getByText("Remettez ce lien à votre enfant pour qu'il passe son bilan.")).toBeInTheDocument();
+    expect(screen.getByDisplayValue('http://localhost/auth/activate?token=act_raw_once')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copier le lien' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /ouvrir l.activation/i })).toHaveAttribute(
       'href',
       'http://localhost/auth/activate?token=act_raw_once',

--- a/__tests__/components/dashboard/parent/DashboardParent.guidance.test.tsx
+++ b/__tests__/components/dashboard/parent/DashboardParent.guidance.test.tsx
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+jest.mock('next-auth/react', () => {
+  const session = {
+    data: { user: { role: 'PARENT', firstName: 'Parent', lastName: 'Test' } },
+    status: 'authenticated',
+  };
+  return {
+    signOut: jest.fn(),
+    useSession: () => session,
+  };
+});
+
+jest.mock('next/navigation', () => {
+  const router = { push: jest.fn() };
+  return { useRouter: () => router };
+});
+
+jest.mock('@/components/dashboard/BilanGratuitBanner', () => ({
+  BilanGratuitBanner: () => <div>Bannière bilan</div>,
+}));
+
+jest.mock('@/app/dashboard/parent/add-child-dialog', () => ({
+  __esModule: true,
+  default: ({ onChildAdded }: { onChildAdded: () => void }) => (
+    <button type="button" onClick={onChildAdded}>Simuler l’ajout réussi</button>
+  ),
+}));
+
+import DashboardParent from '@/app/dashboard/parent/page';
+
+describe('DashboardParent — guidage après ajout', () => {
+  it('conserve l’écran et la boîte de succès pendant le rafraîchissement des enfants', async () => {
+    let resolveRefresh!: (response: Response) => void;
+    const pendingRefresh = new Promise<Response>((resolve) => { resolveRefresh = resolve; });
+
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ children: [] }) } as Response)
+      .mockReturnValueOnce(pendingRefresh) as unknown as typeof fetch;
+
+    render(<DashboardParent />);
+
+    await screen.findByRole('heading', { name: /Mes Enfants/ });
+    await userEvent.click(screen.getByRole('button', { name: 'Simuler l’ajout réussi' }));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+
+    expect(screen.getByText('Espace Famille')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Mes Enfants/ })).toBeInTheDocument();
+
+    await act(async () => {
+      resolveRefresh({ ok: true, json: async () => ({ children: [] }) } as Response);
+      await pendingRefresh;
+    });
+  });
+});

--- a/__tests__/components/dashboard/parent/ParentChildrenEmptyState.test.tsx
+++ b/__tests__/components/dashboard/parent/ParentChildrenEmptyState.test.tsx
@@ -1,0 +1,17 @@
+import '@testing-library/jest-dom';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ParentChildrenEmptyState } from '@/components/dashboard/parent/ParentChildrenEmptyState';
+
+describe('ParentChildrenEmptyState', () => {
+  it('guide sans étape muette vers l’ajout du premier enfant', async () => {
+    const onAddChild = jest.fn();
+    render(<ParentChildrenEmptyState onAddChild={onAddChild} />);
+
+    expect(screen.getByText(/ajoutez votre enfant, puis remettez-lui son lien personnel/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Ajouter votre enfant' }));
+    expect(onAddChild).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/components/dashboard/parent/add-child-dialog.test.tsx
+++ b/__tests__/components/dashboard/parent/add-child-dialog.test.tsx
@@ -54,6 +54,7 @@ describe('AddChildDialog', () => {
     await userEvent.click(screen.getByRole('button', { name: /Ajouter l'Enfant/i }));
 
     expect(await screen.findByText(/Ahmed peut maintenant passer son bilan/i)).toBeInTheDocument();
+    expect(screen.getByText("Remettez ce lien à votre enfant pour qu'il passe son bilan.")).toBeInTheDocument();
     expect(screen.getByDisplayValue('https://exemple.test/activer/abc')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Copier/i })).toBeInTheDocument();
   });

--- a/__tests__/components/pre-rentree-2026-director-page.test.tsx
+++ b/__tests__/components/pre-rentree-2026-director-page.test.tsx
@@ -32,10 +32,17 @@ describe('Pré-rentrée 2026 director landing contract', () => {
     expect(container.textContent).not.toMatch(/quatre documents personnalisés/i);
   });
 
-  it('keeps the public funnel at information request until a validated proposal', () => {
+  it('keeps reservation informational while distinguishing assessment and adviser callback', () => {
     const { container } = render(<PreRentree2026Page />);
     expect(screen.getAllByText(/WhatsApp|Écrire sur WhatsApp/i).length).toBeGreaterThan(0);
-    expect(container.querySelector('a[href*="/bilan-gratuit"]')).toBeNull();
+    expect(screen.getByRole('link', { name: 'Passer le bilan de pré-rentrée' })).toHaveAttribute(
+      'href',
+      '/bilan-gratuit?parcours=diagnostic#demande-bilan',
+    );
+    expect(screen.getByRole('link', { name: 'Être rappelé par un conseiller' })).toHaveAttribute(
+      'href',
+      '/bilan-gratuit?parcours=conseiller#rappel-conseiller',
+    );
     expect(container.textContent).toMatch(/demander une information|demande d'information/i);
     expect(container.textContent).toMatch(/sans paiement|aucun paiement/i);
   });

--- a/__tests__/homepage/landing-invariants.test.ts
+++ b/__tests__/homepage/landing-invariants.test.ts
@@ -15,6 +15,7 @@ const root = join(__dirname, '..', '..');
 
 describe('Landing page business invariants', () => {
   const homeClient = readFileSync(join(root, 'app/HomePageClient.tsx'), 'utf8');
+  const diagnosticCtas = readFileSync(join(root, 'components/marketing/PreRentreeDiagnosticCtas.tsx'), 'utf8');
   const heroSection = readFileSync(join(root, 'components/premium/HeroSection.tsx'), 'utf8');
   const spotlightPath = join(root, 'components/marketing/PreRentreeCampaignSpotlight.tsx');
 
@@ -46,8 +47,10 @@ describe('Landing page business invariants', () => {
     expect(faqMatches?.length ?? 0).toBeGreaterThanOrEqual(5);
   });
 
-  test('home CTA section links to /bilan-gratuit', () => {
-    expect(homeClient).toContain('href="/bilan-gratuit"');
+  test('home CTA section distinguishes online assessment and adviser callback', () => {
+    expect(homeClient).toContain('<PreRentreeDiagnosticCtas');
+    expect(diagnosticCtas).toContain('/bilan-gratuit?parcours=diagnostic#demande-bilan');
+    expect(diagnosticCtas).toContain('/bilan-gratuit?parcours=conseiller#rappel-conseiller');
   });
 
   test('home uses canonical repères (not hardcoded prices)', () => {

--- a/__tests__/marketing/pre-rentree-diagnostic-guidance.test.tsx
+++ b/__tests__/marketing/pre-rentree-diagnostic-guidance.test.tsx
@@ -1,0 +1,37 @@
+import '@testing-library/jest-dom';
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { render, screen } from '@testing-library/react';
+
+import { PreRentreeDiagnosticCtas } from '@/components/marketing/PreRentreeDiagnosticCtas';
+
+const root = process.cwd();
+
+describe('CTA publics du bilan de pré-rentrée', () => {
+  it('distingue la passation en ligne du rappel conseiller', () => {
+    render(<PreRentreeDiagnosticCtas />);
+
+    expect(screen.getByRole('link', { name: 'Passer le bilan de pré-rentrée' })).toHaveAttribute(
+      'href',
+      '/bilan-gratuit?parcours=diagnostic#demande-bilan',
+    );
+    expect(screen.getByRole('link', { name: 'Être rappelé par un conseiller' })).toHaveAttribute(
+      'href',
+      '/bilan-gratuit?parcours=conseiller#rappel-conseiller',
+    );
+  });
+
+  it.each([
+    'app/HomePageClient.tsx',
+    'app/stages/pre-rentree-2026/page.tsx',
+  ])('est rendu sur la surface publique %s', (file) => {
+    expect(readFileSync(join(root, file), 'utf8')).toContain('<PreRentreeDiagnosticCtas');
+  });
+
+  it('ancre séparément le formulaire diagnostic et le rappel conseiller', () => {
+    const source = readFileSync(join(root, 'app/bilan-gratuit/BilanStrategiqueClient.tsx'), 'utf8');
+    expect(source).toContain('id="demande-bilan"');
+    expect(source).toContain('id="rappel-conseiller"');
+  });
+});

--- a/app/HomePageClient.tsx
+++ b/app/HomePageClient.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/components/marketing/acadomia-inspired';
 import { buildWhatsAppUrl } from '@/lib/whatsapp';
 import { PreRentreeCampaignSpotlight } from '@/components/marketing/PreRentreeCampaignSpotlight';
+import { PreRentreeDiagnosticCtas } from '@/components/marketing/PreRentreeDiagnosticCtas';
 import type { PreRentreeHomepageSpotlightDTO } from '@/lib/campaigns/pre-rentree-2026/homepage-spotlight';
 
 // ── Router par niveau (near hero) ──
@@ -265,7 +266,7 @@ export function HomePageClient({ campaign }: { campaign?: PreRentreeHomepageSpot
       <FAQAccordion items={faqItems} className="bg-lux-paper" />
 
       {/* 9. CTA bilan gratuit (bg-lux-ink) */}
-      <section className="bg-lux-ink px-4 py-14 md:py-20 md:px-6" aria-label="Demander un bilan gratuit">
+      <section className="bg-lux-ink px-4 py-14 md:py-20 md:px-6" aria-label="Choisir entre bilan en ligne et rappel conseiller">
         <div className="mx-auto max-w-2xl text-center">
           <span className="lux-eyebrow text-lux-gold-wash">Commencer</span>
           <h2 className="mt-3 text-2xl md:text-3xl font-fraunces font-light text-lux-ivory">
@@ -278,14 +279,8 @@ export function HomePageClient({ campaign }: { campaign?: PreRentreeHomepageSpot
           <p className="mt-3 text-sm text-lux-on-dark-subtle">
             Sans engagement · Réponse sous 24 h ouvrées
           </p>
-          <div className="mt-8 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
-            <Link
-              href="/bilan-gratuit"
-              className="lux-cta-reserve rounded-lg px-8 py-3.5 text-sm font-semibold"
-            >
-              Demander un bilan gratuit
-              <ArrowRight className="ml-2 h-4 w-4" />
-            </Link>
+          <div className="mt-8 flex flex-col items-center gap-4">
+            <PreRentreeDiagnosticCtas className="justify-center" />
             <a
               href={buildWhatsAppUrl()}
               target="_blank"
@@ -293,7 +288,7 @@ export function HomePageClient({ campaign }: { campaign?: PreRentreeHomepageSpot
               className="inline-flex items-center gap-2 text-sm font-medium text-lux-gold-wash hover:underline min-h-[44px]"
             >
               <WhatsAppLogo className="h-4 w-4" style={{ color: WHATSAPP_BRAND_GREEN }} />
-              Nous écrire sur WhatsApp
+              Une question ? Nous écrire sur WhatsApp
             </a>
           </div>
         </div>

--- a/app/bilan-gratuit/BilanStrategiqueClient.tsx
+++ b/app/bilan-gratuit/BilanStrategiqueClient.tsx
@@ -189,7 +189,7 @@ export function BilanStrategiqueClient({
 
       <section className="bg-lux-paper px-4 py-14 md:px-6">
         <div className="mx-auto grid max-w-6xl gap-6 lg:grid-cols-[1.15fr_0.85fr]">
-          <Card className="border-lux-line bg-lux-white text-lux-ink lux-shadow">
+          <Card id="demande-bilan" className="scroll-mt-24 border-lux-line bg-lux-white text-lux-ink lux-shadow">
             <CardContent className="p-6 sm:p-8">
               <form onSubmit={onSubmit} noValidate className="space-y-8" aria-busy={isSubmitting}>
                 {prefill && (
@@ -419,7 +419,9 @@ export function BilanStrategiqueClient({
           </Card>
 
           <div className="space-y-6">
-            <ConseillerCard />
+            <div id="rappel-conseiller" className="scroll-mt-24">
+              <ConseillerCard />
+            </div>
 
             <Card className="border-lux-line bg-lux-white text-lux-ink lux-shadow">
               <CardContent className="p-6">

--- a/app/dashboard/assistante/bilans/saisie-papier/page.tsx
+++ b/app/dashboard/assistante/bilans/saisie-papier/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 
 import { auth } from '@/auth';
 import { PaperEntryGrid } from '@/components/bilans/PaperEntryGrid';
+import { PaperEntryWorkflowSteps } from '@/components/bilans/PaperEntryWorkflowSteps';
 import { listEnabledPacks } from '@/lib/bilans/api/pack-access';
 import { bilanPackSubjectLabel } from '@/lib/bilans/catalog/subjects';
 import { bilanPackLevelLabel } from '@/lib/bilans/render/stage-label';
@@ -110,6 +111,8 @@ export default async function SaisiePapierPage({
           </Link>
         </header>
 
+        <PaperEntryWorkflowSteps currentStep={chosenPack !== null ? 4 : selected !== null ? 3 : 1} />
+
         {chosenPack !== null && selected !== null ? (
           <>
             <Link
@@ -128,9 +131,9 @@ export default async function SaisiePapierPage({
           </>
         ) : selected !== null ? (
           <section className="mt-8 rounded-3xl border border-white/10 bg-white/[0.06] p-6">
-            <h2 className="text-lg font-semibold text-white">
-              {studentName} · {bilanPackLevelLabel(selected.gradeLevel)}
-            </h2>
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-amber-300">Étape 3</p>
+            <h2 className="mt-2 text-lg font-semibold text-white">Choisir la matière</h2>
+            <p className="mt-1 text-sm text-slate-300">{studentName} · {bilanPackLevelLabel(selected.gradeLevel)}</p>
             <p className="mt-1 text-sm text-slate-400">Choisissez la matière de la copie.</p>
             {packsForStudent.length === 0 ? (
               <p className="mt-5 rounded-2xl border border-amber-300/30 bg-amber-300/5 p-5 text-sm text-amber-100">
@@ -143,9 +146,10 @@ export default async function SaisiePapierPage({
                   <Link
                     key={pack.slug}
                     href={`/dashboard/assistante/bilans/saisie-papier?studentId=${encodeURIComponent(selected.id)}&packSlug=${encodeURIComponent(pack.slug)}`}
-                    className="block rounded-2xl bg-slate-900 px-5 py-4 font-semibold text-white ring-1 ring-white/10"
+                    className="flex items-center justify-between gap-4 rounded-2xl bg-slate-900 px-5 py-4 font-semibold text-white ring-1 ring-white/10"
                   >
-                    {packLabel(pack.level, pack.subject)}
+                    <span>{packLabel(pack.level, pack.subject)}</span>
+                    <span className="text-sm text-amber-200">Choisir cette matière →</span>
                   </Link>
                 ))}
               </div>
@@ -157,7 +161,8 @@ export default async function SaisiePapierPage({
         ) : (
           <>
             <section className="mt-8 rounded-3xl border border-white/10 bg-white/[0.06] p-6">
-              <h2 className="text-lg font-semibold text-white">1. Choisir l’élève</h2>
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-amber-300">Étapes 1 et 2</p>
+              <h2 className="mt-2 text-lg font-semibold text-white">Sélectionner le foyer et l’enfant</h2>
               <form method="GET" className="mt-4 flex flex-wrap gap-3">
                 <input
                   type="search"
@@ -177,17 +182,22 @@ export default async function SaisiePapierPage({
                 <ul className="mt-5 divide-y divide-white/10">
                   {students.map((student) => (
                     <li key={student.id}>
-                      <Link
-                        href={`/dashboard/assistante/bilans/saisie-papier?studentId=${encodeURIComponent(student.id)}`}
-                        className="flex flex-wrap items-baseline justify-between gap-2 py-3 text-sm"
-                      >
-                        <span className="font-semibold text-white">
-                          {`${student.user.firstName ?? ''} ${student.user.lastName ?? ''}`.trim() || 'Élève'}
-                        </span>
-                        <span className="text-slate-400">
-                          {bilanPackLevelLabel(student.gradeLevel)} · {student.parent?.user.email ?? '—'}
-                        </span>
-                      </Link>
+                      <div className="flex flex-wrap items-center justify-between gap-3 py-3 text-sm">
+                        <div>
+                          <span className="font-semibold text-white">
+                            {`${student.user.firstName ?? ''} ${student.user.lastName ?? ''}`.trim() || 'Élève'}
+                          </span>
+                          <span className="ml-3 text-slate-400">
+                            {bilanPackLevelLabel(student.gradeLevel)} · {student.parent?.user.email ?? '—'}
+                          </span>
+                        </div>
+                        <Link
+                          href={`/dashboard/assistante/bilans/saisie-papier?studentId=${encodeURIComponent(student.id)}`}
+                          className="rounded-xl border border-amber-300 px-4 py-2 font-semibold text-amber-100"
+                        >
+                          Choisir cet enfant
+                        </Link>
+                      </div>
                     </li>
                   ))}
                 </ul>
@@ -195,7 +205,8 @@ export default async function SaisiePapierPage({
             </section>
 
             <section className="mt-6 rounded-3xl border border-white/10 bg-white/[0.06] p-6">
-              <h2 className="text-lg font-semibold text-white">2. Ou créer le foyer</h2>
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-amber-300">Étapes 1 et 2</p>
+              <h2 className="mt-2 text-lg font-semibold text-white">Créer le foyer et ajouter l’enfant</h2>
               <p className="mt-1 max-w-3xl text-sm leading-6 text-slate-400">
                 Le parent reçoit un lien d’activation et choisit lui-même son mot de passe. Personne ne le fixe à sa
                 place.

--- a/app/dashboard/eleve/page.tsx
+++ b/app/dashboard/eleve/page.tsx
@@ -23,6 +23,7 @@ import { EafStageQuestionnaireCard } from "@/components/dashboard/eleve/EafStage
 import { EAMCockpitSummary } from "@/components/dashboard/eleve/EAMCockpitSummary";
 import { MathsPremiereStageQuestionnaireCard } from "@/components/dashboard/eleve/MathsPremiereStageQuestionnaireCard";
 import { NsiCockpitCard } from "@/components/dashboard/eleve/NsiCockpitCard";
+import { PreRentreeAssessmentCard } from "@/components/dashboard/eleve/PreRentreeAssessmentCard";
 import { SurvivalDashboard } from "@/components/dashboard/eleve/survival";
 import { StageEntryCard } from "@/components/stage-eam-stmg/StageEntryCard";
 import { AriaWidget } from "@/components/ui/aria-widget";
@@ -245,6 +246,7 @@ export default function DashboardEleve() {
           <DashboardPilotage role="ELEVE" trajectoryData={dashboardData?.trajectory}>
             {dashboardData && (
               <div className="space-y-6">
+                <PreRentreeAssessmentCard />
                 {/* Rubriques Navigation */}
                 <div className="mb-6 -mx-4 sm:mx-0">
                   <div className="flex gap-1.5 sm:gap-2 p-1 bg-white/5 border-y sm:border border-white/10 sm:rounded-xl overflow-x-auto scrollbar-none px-4 sm:px-1">

--- a/app/dashboard/parent/add-child-dialog.tsx
+++ b/app/dashboard/parent/add-child-dialog.tsx
@@ -38,16 +38,18 @@ export default function AddChildDialog({ onChildAdded, open: controlledOpen, onO
    */
   const [justAdded, setJustAdded] = useState<{ firstName: string; activationUrl: string | null } | null>(null);
   const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
     if (!formData.firstName || !formData.lastName || !formData.grade) {
-      alert("Veuillez remplir tous les champs obligatoires");
+      setError("Veuillez remplir tous les champs obligatoires.");
       return;
     }
 
     setLoading(true);
+    setError(null);
     try {
       const response = await fetch('/api/parent/children', {
         method: 'POST',
@@ -75,10 +77,10 @@ export default function AddChildDialog({ onChildAdded, open: controlledOpen, onO
         });
         onChildAdded();
       } else {
-        alert(`Erreur: ${responseData?.error ?? "Impossible d'ajouter l'enfant"}`);
+        setError(responseData?.error ?? "Impossible d'ajouter l'enfant.");
       }
     } catch {
-      alert('Une erreur est survenue lors de l\'ajout de l\'enfant');
+      setError("Une erreur est survenue lors de l'ajout de l'enfant. Réessayez.");
     } finally {
       setLoading(false);
     }
@@ -113,8 +115,11 @@ export default function AddChildDialog({ onChildAdded, open: controlledOpen, onO
                 {`${justAdded.firstName} peut maintenant passer son bilan.`}
               </p>
               <p className="mt-1 text-sm text-neutral-300">
-                Transmettez-lui ce lien : il choisira son mot de passe, puis accédera à son bilan
-                diagnostic. Ce lien est personnel et ne doit être communiqué qu'à lui.
+                Remettez ce lien à votre enfant pour qu'il passe son bilan.
+              </p>
+              <p className="mt-1 text-sm text-neutral-300">
+                Il choisira son mot de passe avant d’accéder au diagnostic. Ce lien est personnel et ne doit être
+                communiqué qu’à lui.
               </p>
             </div>
 
@@ -234,6 +239,11 @@ export default function AddChildDialog({ onChildAdded, open: controlledOpen, onO
               Annuler
             </Button>
           </div>
+          {error !== null && (
+            <p role="alert" className="rounded-lg border border-rose-500/30 bg-rose-500/10 p-3 text-sm text-rose-200">
+              {error}
+            </p>
+          )}
         </form>
         )}
       </DialogContent>

--- a/app/dashboard/parent/page.tsx
+++ b/app/dashboard/parent/page.tsx
@@ -10,6 +10,7 @@ import { Card,CardContent,CardHeader,CardTitle } from "@/components/ui/card";
 
 import { AlertsConsolidated } from "@/components/dashboard/parent/AlertsConsolidated";
 import { ChildCard,type ParentDashboardChild } from "@/components/dashboard/parent/ChildCard";
+import { ParentChildrenEmptyState } from "@/components/dashboard/parent/ParentChildrenEmptyState";
 import { BilanGratuitBanner } from "@/components/dashboard/BilanGratuitBanner";
 import AddChildDialog from "./add-child-dialog";
 
@@ -26,10 +27,13 @@ export default function DashboardParent() {
   const [activeRubrique, setActiveRubrique] = useState<'enfants' | 'facturation' | 'alertes'>('enfants');
   const [addChildOpen, setAddChildOpen] = useState(false);
 
-  const refreshDashboardData = useCallback(async () => {
+  const refreshDashboardData = useCallback(async (options: { silent?: boolean } = {}) => {
+    const silent = options.silent === true;
     try {
-      setLoading(true)
-      setError(null)
+      if (!silent) {
+        setLoading(true)
+        setError(null)
+      }
 
       const response = await fetch('/api/parent/dashboard')
 
@@ -40,9 +44,9 @@ export default function DashboardParent() {
       const data = await response.json()
       setDashboardData(data)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred')
+      if (!silent) setError(err instanceof Error ? err.message : 'An error occurred')
     } finally {
-      setLoading(false)
+      if (!silent) setLoading(false)
     }
   }, [])
 
@@ -54,7 +58,7 @@ export default function DashboardParent() {
       return
     }
 
-    refreshDashboardData()
+    void refreshDashboardData()
   }, [session, status, router, refreshDashboardData])
 
   if (status === "loading" || loading) {
@@ -71,7 +75,7 @@ export default function DashboardParent() {
         <div className="text-center">
           <AlertCircle className="w-8 h-8 mx-auto mb-4 text-rose-300" />
           <p className="text-rose-200 mb-4">{error}</p>
-          <Button onClick={refreshDashboardData} className="btn-primary">Réessayer</Button>
+          <Button onClick={() => { void refreshDashboardData(); }} className="btn-primary">Réessayer</Button>
         </div>
       </div>
     )
@@ -110,7 +114,13 @@ export default function DashboardParent() {
       {/* Main Content */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="space-y-6">
-          <BilanGratuitBanner onGoToChildren={() => { setActiveRubrique('enfants'); setAddChildOpen(true); }} />
+          <BilanGratuitBanner
+            hasChildren={(dashboardData?.children.length ?? 0) > 0}
+            onGoToChildren={() => {
+              setActiveRubrique('enfants');
+              if ((dashboardData?.children.length ?? 0) === 0) setAddChildOpen(true);
+            }}
+          />
 
           {/* Rubriques Switcher */}
           <div className="flex flex-wrap gap-2 p-1 bg-white/5 border border-white/10 rounded-xl">
@@ -144,14 +154,22 @@ export default function DashboardParent() {
                     {dashboardData?.children.length || 0}
                   </Badge>
                 </h2>
-                <AddChildDialog onChildAdded={refreshDashboardData} open={addChildOpen} onOpenChange={setAddChildOpen} />
+                <AddChildDialog
+                  onChildAdded={() => { void refreshDashboardData({ silent: true }); }}
+                  open={addChildOpen}
+                  onOpenChange={setAddChildOpen}
+                />
               </div>
 
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                {dashboardData?.children.map((child) => (
-                  <ChildCard key={child.id} child={child} />
-                ))}
-              </div>
+              {(dashboardData?.children.length ?? 0) === 0 ? (
+                <ParentChildrenEmptyState onAddChild={() => setAddChildOpen(true)} />
+              ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  {dashboardData?.children.map((child) => (
+                    <ChildCard key={child.id} child={child} />
+                  ))}
+                </div>
+              )}
             </div>
           )}
 

--- a/app/stages/pre-rentree-2026/page.tsx
+++ b/app/stages/pre-rentree-2026/page.tsx
@@ -8,6 +8,7 @@ import { CanonicalOfferCatalogue } from '@/components/pre-rentree-2026/Canonical
 import { CampaignExperienceProvider } from '@/components/pre-rentree-2026/CampaignExperienceContext';
 import { ProgramsSection } from '@/components/pre-rentree-2026/ProgramsSection';
 import { ScheduleSection } from '@/components/pre-rentree-2026/ScheduleSection';
+import { PreRentreeDiagnosticCtas } from '@/components/marketing/PreRentreeDiagnosticCtas';
 import { buildWhatsAppUrl } from '@/lib/whatsapp';
 import { getPreRentreePublicSurfaceDTO } from '@/lib/campaigns/pre-rentree-2026/public-surface';
 import { getPreRentreeReleaseGate } from '@/lib/campaigns/pre-rentree-2026/release-gate';
@@ -111,6 +112,7 @@ export default function PreRentree2026Page() {
             <a href={whatsappUrl} target="_blank" rel="noopener noreferrer" className="inline-flex min-h-11 items-center justify-center rounded-lg border border-lux-line/50 px-6 py-3 text-center text-sm font-semibold text-lux-on-dark">Échanger sur WhatsApp</a>
             <a href={dto.contact.phoneHref} className="inline-flex min-h-11 items-center justify-center rounded-lg border border-lux-line/50 px-6 py-3 text-sm font-semibold text-lux-on-dark">Appeler le {dto.contact.phoneDisplay}</a>
           </div>
+          <PreRentreeDiagnosticCtas className="mt-5" />
         </div>
       </section>
 

--- a/components/bilans/PaperEntryGrid.tsx
+++ b/components/bilans/PaperEntryGrid.tsx
@@ -62,6 +62,9 @@ export function PaperEntryGrid({
     [items, confidences],
   );
   const complete = missingOption.length === 0 && untouchedConfidence.length === 0;
+  const completedItems = items.filter((item) => (
+    options[item.id] !== undefined && confidences[item.id] !== undefined
+  )).length;
 
   async function submit() {
     if (!complete || submitting) return;
@@ -97,6 +100,10 @@ export function PaperEntryGrid({
         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-300">Copie à saisir</p>
         <h2 className="mt-2 text-xl font-semibold text-white">{studentName}</h2>
         <p className="mt-1 text-sm text-slate-400">{packTitle}</p>
+        <p role="status" className="mt-3 text-sm font-semibold text-amber-200">
+          {completedItems} {items.length === 1 ? 'réponse' : 'réponses'} sur {items.length}{' '}
+          {items.length === 1 ? 'saisie' : 'saisies'}
+        </p>
         <p className="mt-4 max-w-3xl text-sm leading-6 text-slate-300">
           Reportez, pour chaque question, la réponse entourée sur la copie et la certitude cochée par l’élève.
           Si une case de certitude manque sur la copie, choisissez «&nbsp;Absente de la copie&nbsp;» :
@@ -217,7 +224,7 @@ export function PaperEntryGrid({
           onClick={() => void submit()}
           className="mt-3 w-full rounded-xl bg-amber-400 px-4 py-3 font-semibold text-slate-950 disabled:cursor-not-allowed disabled:opacity-40"
         >
-          {submitting ? 'Enregistrement…' : 'Enregistrer la copie et lancer le bilan'}
+          {submitting ? 'Validation…' : 'Valider la saisie papier'}
         </button>
         <p className="mt-3 text-xs text-slate-400">
           La saisie est enregistrée comme telle&nbsp;: provenance «&nbsp;saisie papier&nbsp;», avec votre identifiant et

--- a/components/bilans/PaperEntryWorkflowSteps.tsx
+++ b/components/bilans/PaperEntryWorkflowSteps.tsx
@@ -1,0 +1,40 @@
+const STEPS = [
+  'Créer ou sélectionner le foyer',
+  'Ajouter ou sélectionner l’enfant',
+  'Choisir la matière',
+  'Saisir les réponses',
+  'Valider',
+] as const;
+
+export function PaperEntryWorkflowSteps({ currentStep }: Readonly<{ currentStep: 1 | 2 | 3 | 4 | 5 }>) {
+  return (
+    <nav className="mt-8" aria-label="Étapes de la saisie papier">
+      <ol
+        className="grid gap-2 sm:grid-cols-2 lg:grid-cols-5"
+        aria-label="Progression de la saisie papier"
+      >
+        {STEPS.map((label, index) => {
+          const number = (index + 1) as 1 | 2 | 3 | 4 | 5;
+          const current = number === currentStep;
+          const complete = number < currentStep;
+          return (
+            <li
+              key={label}
+              aria-current={current ? 'step' : undefined}
+              className={`rounded-xl border px-3 py-3 text-sm ${
+                current
+                  ? 'border-amber-300 bg-amber-300/15 text-amber-100'
+                  : complete
+                    ? 'border-emerald-300/30 bg-emerald-300/10 text-emerald-100'
+                    : 'border-white/10 bg-white/[0.04] text-slate-400'
+              }`}
+            >
+              <span className="mr-2 font-mono text-xs" aria-hidden="true">{number}</span>
+              <span className="font-semibold">{label}</span>
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/components/dashboard/BilanGratuitBanner.tsx
+++ b/components/dashboard/BilanGratuitBanner.tsx
@@ -5,10 +5,11 @@ import { Button } from "@/components/ui/button";
 import { ClipboardCheck, X } from "lucide-react";
 
 type BilanGratuitBannerProps = {
+  hasChildren?: boolean;
   /**
    * The banner only ever renders for an authenticated parent (it reads
-   * /api/bilan-gratuit/status, which requires a session) -- so "Faire le
-   * bilan" must send them to their own "Ajouter un Enfant" flow, never to
+   * /api/bilan-gratuit/status, which requires a session) -- so its CTA must
+   * send them to their own children flow, never to
    * the public /bilan-gratuit registration form, which assumes an
    * anonymous visitor and silently no-ops on an already-registered email.
    */
@@ -21,7 +22,7 @@ type BilanGratuitBannerProps = {
  *
  * Dismiss state is persisted in DB via /api/bilan-gratuit/status and /dismiss.
  */
-export function BilanGratuitBanner({ onGoToChildren }: BilanGratuitBannerProps) {
+export function BilanGratuitBanner({ hasChildren = false, onGoToChildren }: BilanGratuitBannerProps) {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
@@ -63,7 +64,7 @@ export function BilanGratuitBanner({ onGoToChildren }: BilanGratuitBannerProps) 
       </div>
       <div className="flex items-center gap-2 ml-8 sm:ml-0 flex-shrink-0">
         <Button size="sm" className="text-xs sm:text-sm" onClick={onGoToChildren}>
-          Faire le bilan
+          {hasChildren ? 'Voir le lien de votre enfant' : 'Ajouter votre enfant'}
         </Button>
         <Button
           variant="ghost"

--- a/components/dashboard/eleve/PreRentreeAssessmentCard.tsx
+++ b/components/dashboard/eleve/PreRentreeAssessmentCard.tsx
@@ -1,0 +1,29 @@
+import { ArrowRight, ClipboardCheck } from 'lucide-react';
+import Link from 'next/link';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+
+export function PreRentreeAssessmentCard() {
+  return (
+    <Card className="border-brand-accent/30 bg-gradient-to-r from-brand-accent/15 to-surface-card shadow-premium">
+      <CardContent className="flex flex-col gap-4 p-5 sm:flex-row sm:items-center sm:justify-between sm:p-6">
+        <div className="flex items-start gap-3">
+          <ClipboardCheck className="mt-0.5 h-6 w-6 shrink-0 text-brand-accent" aria-hidden="true" />
+          <div>
+            <h2 className="text-lg font-bold text-white">Bilan de pré-rentrée</h2>
+            <p className="mt-1 text-sm leading-6 text-neutral-300">
+              Choisis d’abord la matière, puis réponds au questionnaire à ton rythme.
+            </p>
+          </div>
+        </div>
+        <Link href="/bilan-gratuit/assessment" className="shrink-0">
+          <Button className="w-full bg-brand-accent text-surface-darker sm:w-auto">
+            Passer le bilan de pré-rentrée
+            <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+          </Button>
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/dashboard/parent/ChildCard.tsx
+++ b/components/dashboard/parent/ChildCard.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Card,CardContent,CardHeader,CardTitle } from "@/components/ui/card";
-import { AlertTriangle,ArrowRight,Calendar,KeyRound,Loader2,User } from "lucide-react";
+import { AlertTriangle,ArrowRight,Calendar,Check,Copy,KeyRound,Loader2,User } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 
@@ -46,6 +47,7 @@ export function ChildCard({ child }: ChildCardProps) {
     expiresAt: string;
     loginIdentifier: string;
   }>(null);
+  const [copied, setCopied] = useState(false);
 
   const issueActivation = async () => {
     setActivationLoading(true);
@@ -59,6 +61,7 @@ export function ChildCard({ child }: ChildCardProps) {
       const body = await response.json() as { activation?: typeof activation };
       if (!body.activation) throw new Error('ACTIVATION_UNAVAILABLE');
       setActivation(body.activation);
+      setCopied(false);
     } catch {
       setActivation(null);
       setActivationError(true);
@@ -142,6 +145,23 @@ export function ChildCard({ child }: ChildCardProps) {
             {activation ? (
               <div className="space-y-2 rounded-md bg-black/20 p-3 text-xs text-neutral-200">
                 <p>Identifiant de connexion : <span className="font-semibold text-white">{activation.loginIdentifier}</span></p>
+                <p>Remettez ce lien à votre enfant pour qu'il passe son bilan.</p>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <Input readOnly value={activation.activationUrl} className="h-9 min-w-0 font-mono text-xs" />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    aria-label="Copier le lien"
+                    onClick={() => {
+                      void navigator.clipboard?.writeText(activation.activationUrl);
+                      setCopied(true);
+                    }}
+                  >
+                    {copied ? <Check className="mr-2 h-4 w-4" aria-hidden="true" /> : <Copy className="mr-2 h-4 w-4" aria-hidden="true" />}
+                    {copied ? 'Copié' : 'Copier'}
+                  </Button>
+                </div>
                 <a
                   href={activation.activationUrl}
                   className="inline-flex font-semibold text-brand-accent underline underline-offset-4"

--- a/components/dashboard/parent/ParentChildrenEmptyState.tsx
+++ b/components/dashboard/parent/ParentChildrenEmptyState.tsx
@@ -1,0 +1,19 @@
+import { Plus, Users } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+
+export function ParentChildrenEmptyState({ onAddChild }: Readonly<{ onAddChild: () => void }>) {
+  return (
+    <section className="rounded-2xl border border-brand-accent/30 bg-brand-accent/10 p-6 text-center">
+      <Users className="mx-auto h-9 w-9 text-brand-accent" aria-hidden="true" />
+      <h3 className="mt-3 text-lg font-semibold text-white">Commencez le bilan de votre enfant</h3>
+      <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-neutral-300">
+        Ajoutez votre enfant, puis remettez-lui son lien personnel pour qu’il active son compte et passe son bilan.
+      </p>
+      <Button type="button" className="mt-5 bg-brand-accent text-surface-darker" onClick={onAddChild}>
+        <Plus className="mr-2 h-4 w-4" aria-hidden="true" />
+        Ajouter votre enfant
+      </Button>
+    </section>
+  );
+}

--- a/components/marketing/PreRentreeDiagnosticCtas.tsx
+++ b/components/marketing/PreRentreeDiagnosticCtas.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+import { ArrowRight, Phone } from 'lucide-react';
+
+const DIAGNOSTIC_PATH = '/bilan-gratuit?parcours=diagnostic#demande-bilan';
+const ADVISER_PATH = '/bilan-gratuit?parcours=conseiller#rappel-conseiller';
+
+export function PreRentreeDiagnosticCtas({ className = '' }: Readonly<{ className?: string }>) {
+  return (
+    <div className={`flex flex-col items-stretch gap-3 sm:flex-row sm:items-center ${className}`.trim()}>
+      <Link
+        href={DIAGNOSTIC_PATH}
+        className="lux-cta-reserve inline-flex min-h-11 items-center justify-center rounded-lg px-6 py-3 text-center text-sm font-semibold"
+      >
+        Passer le bilan de pré-rentrée
+        <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+      </Link>
+      <Link
+        href={ADVISER_PATH}
+        className="inline-flex min-h-11 items-center justify-center rounded-lg border border-lux-gold/60 px-6 py-3 text-center text-sm font-semibold text-lux-gold-wash transition-colors hover:bg-lux-gold/10"
+      >
+        <Phone className="mr-2 h-4 w-4" aria-hidden="true" />
+        Être rappelé par un conseiller
+      </Link>
+    </div>
+  );
+}

--- a/docs/audits/2026-08-09-bilan-pre-rentree-trouvabilite-guidage.md
+++ b/docs/audits/2026-08-09-bilan-pre-rentree-trouvabilite-guidage.md
@@ -59,6 +59,7 @@ Audit demandé avant correction, sans déploiement, depuis `origin/main` après 
 - `npm run lint`, `npm run typecheck` et `npm run check:e2e-syntax` sont verts. Le lint ne remonte que les avertissements candidat libre préexistants, hors périmètre et non modifiés.
 - `npm run build` est vert avec environnement local synthétique, LLM désactivé et candidat libre désactivé : 91 pages générées, traces valides, artefact standalone valide et aucun fichier runtime résiduel.
 - Playwright local réel sur PostgreSQL E2E jetable : public desktop/mobile, parent sans enfant, ajout enfant, activation élève, sélection de matière, accès refusé parent/élève et workflow assistante. Aucune erreur navigateur.
+- Le workflow documentaire a reproduit l'OOM V8 déjà observé sur `main` après #111 et #112 pendant `tsc --noEmit`, après 160 tests Python et 404 tests pré-rentrée verts. Son heap Node passe de la limite par défaut de 2 Go à 4 Go; aucun contrôle n'est désactivé ou allégé.
 
 ## Résultats
 

--- a/docs/audits/2026-08-09-bilan-pre-rentree-trouvabilite-guidage.md
+++ b/docs/audits/2026-08-09-bilan-pre-rentree-trouvabilite-guidage.md
@@ -1,0 +1,88 @@
+# Bilan de pré-rentrée — trouvabilité et guidage
+
+## Date
+
+9 août 2026
+
+## Contexte
+
+Audit demandé avant correction, sans déploiement, depuis `origin/main` après les PR #111, #112 et #113. Le candidat libre reste dark et le LLM reste désactivé.
+
+## Problèmes observés
+
+### Pages publiques
+
+- `https://nexusreussite.academy/` répond 200. Le CTA « Demander un bilan gratuit » de `app/HomePageClient.tsx` mène à `/bilan-gratuit`; aucun CTA visible ne nomme le bilan de pré-rentrée ni la passation en ligne.
+- `https://nexusreussite.academy/stages/pre-rentree-2026` répond 200. Les CTA de `app/stages/pre-rentree-2026/page.tsx` mènent au planning, à WhatsApp ou au téléphone; aucun ne mène au diagnostic.
+- Le bouton global « Bilan gratuit » mène à `https://nexusreussite.academy/bilan-gratuit`.
+- `/bilan-gratuit` juxtapose deux intentions dans un vocabulaire ambigu : le formulaire principal crée un espace parent et un premier enfant, tandis que `ConseillerCard` est un formulaire de rappel commercial.
+
+### Parcours parent et élève
+
+- `app/dashboard/parent/page.tsx` expose le bouton générique « Ajouter un Enfant », mais aucun état vide guidé « Ajouter votre enfant ».
+- `app/dashboard/parent/add-child-dialog.tsx` conserve le lien après création, permet de le copier et d'ajouter plusieurs enfants. La consigne explicite demandée n'est toutefois pas présente mot pour mot.
+- `components/dashboard/parent/ChildCard.tsx` permet de régénérer un lien, mais ce lien n'est pas copiable depuis une visite ultérieure et n'est pas accompagné de la consigne de remise à l'enfant.
+- Après activation et connexion, un élève arrive sur `/dashboard/eleve`. La sélection de matière existe à `/bilan-gratuit/assessment`, puis la passation canonique s'enchaîne, mais le dashboard élève ne contient aucun lien vers cette route.
+- La vérification navigateur après la première correction a mis au jour un défaut d'intégration de #109 : après un ajout réussi, `refreshDashboardData()` repassait tout le dashboard en chargement. La boîte de dialogue était démontée et le lien d'activation disparaissait avant d'être lu, alors que son test isolé restait vert.
+
+### Saisie papier assistante
+
+- `app/dashboard/assistante/bilans/saisie-papier/page.tsx` permet de rechercher/sélectionner un élève ou de créer un foyer, puis de choisir un pack.
+- `app/dashboard/assistante/bilans/saisie-papier/family-form.tsx` crée un foyer et un ou plusieurs enfants; les erreurs sont affichées dans la page.
+- `components/bilans/PaperEntryGrid.tsx` indique les réponses et certitudes manquantes, mais l'écran n'affiche pas un fil commun en cinq étapes. Le libellé final « Enregistrer la copie et lancer le bilan » ne distingue pas clairement la validation de la saisie du traitement ultérieur du rapport.
+- La route et l'API sont fermées aux rôles parent, élève et coach. Le garde accepte `ASSISTANTE` et `ADMIN`; la convention globale du middleware ADMIN reste inchangée.
+- `lib/bilans/api/paper-entry.ts` pose `SAISIE_PAPIER`, le saisisseur et la date directement à l'INSERT. Le scoring canonique n'a pas besoin d'être modifié.
+
+## Décisions prises
+
+- Afficher côte à côte « Passer le bilan de pré-rentrée » et « Être rappelé par un conseiller » sur l'accueil et la page de stage.
+- Faire pointer le premier CTA sur le formulaire de création d'espace (`/bilan-gratuit?parcours=diagnostic#demande-bilan`) et le second sur le formulaire de rappel déjà présent (`/bilan-gratuit?parcours=conseiller#rappel-conseiller`).
+- Ajouter un état vide parent explicite, conserver le parcours multi-enfants de #109 et rendre le lien d'activation copiable également depuis la fiche enfant.
+- Après activation élève, conserver l'étape de connexion mais lui fournir un retour sûr vers `/bilan-gratuit/assessment`; ajouter aussi un accès durable depuis le dashboard élève.
+- Ajouter un fil assistante en cinq étapes sans modifier le moteur, l'API de scoring, le middleware ADMIN ni les surfaces candidat libre.
+
+## Fichiers modifiés
+
+- CTA publics et ancres : `components/marketing/PreRentreeDiagnosticCtas.tsx`, `app/HomePageClient.tsx`, `app/stages/pre-rentree-2026/page.tsx`, `app/bilan-gratuit/BilanStrategiqueClient.tsx`.
+- Guidage parent : `components/dashboard/BilanGratuitBanner.tsx`, `components/dashboard/parent/ParentChildrenEmptyState.tsx`, `components/dashboard/parent/ChildCard.tsx`, `app/dashboard/parent/page.tsx`, `app/dashboard/parent/add-child-dialog.tsx`.
+- Guidage élève : `lib/services/student-activation.service.ts`, `components/dashboard/eleve/PreRentreeAssessmentCard.tsx`, `app/dashboard/eleve/page.tsx`.
+- Saisie assistante : `components/bilans/PaperEntryWorkflowSteps.tsx`, `components/bilans/PaperEntryGrid.tsx`, `app/dashboard/assistante/bilans/saisie-papier/page.tsx`.
+- Contrats et tests : fichiers correspondants sous `__tests__/` et scénarios publics sous `e2e/`.
+
+## Tests exécutés
+
+- Audit Playwright production desktop et mobile de `/`, `/stages/pre-rentree-2026` et `/bilan-gratuit`.
+- Baseline Jest complète : 747 suites vertes; une suite préexistante dépendait de `NEXTAUTH_URL`. La même suite est verte avec `NEXTAUTH_URL=http://localhost:3000`, sans charger de `.env`.
+- Cycle TDD ciblé : les nouveaux contrats CTA, parent, élève, assistante et contrôle d'accès ont d'abord échoué, puis sont passés après implémentation.
+- Test d'intégration parent ajouté après la découverte navigateur : il prouve que l'écran et la boîte de succès restent montés pendant le rafraîchissement silencieux.
+- Suite Jest complète finale sans filtre : 754 suites, 8 420 tests et 7 snapshots verts après le correctif d'intégration.
+- `npm run lint`, `npm run typecheck` et `npm run check:e2e-syntax` sont verts. Le lint ne remonte que les avertissements candidat libre préexistants, hors périmètre et non modifiés.
+- `npm run build` est vert avec environnement local synthétique, LLM désactivé et candidat libre désactivé : 91 pages générées, traces valides, artefact standalone valide et aucun fichier runtime résiduel.
+- Playwright local réel sur PostgreSQL E2E jetable : public desktop/mobile, parent sans enfant, ajout enfant, activation élève, sélection de matière, accès refusé parent/élève et workflow assistante. Aucune erreur navigateur.
+
+## Résultats
+
+- `/` et `/stages/pre-rentree-2026` affichent côte à côte les CTA distincts. Le diagnostic cible `/bilan-gratuit?parcours=diagnostic#demande-bilan`; le rappel cible `/bilan-gratuit?parcours=conseiller#rappel-conseiller`. Les deux formulaires existants restent présents et répondent 200.
+- L'état parent vide explique l'enchaînement et expose « Ajouter votre enfant ». Après ajout, le lien personnel reste visible pendant le rafraîchissement, est copiable, porte la consigne exacte et laisse « Ajouter un autre enfant » disponible.
+- L'activation élève redirige vers la connexion avec `callbackUrl=/bilan-gratuit/assessment`. La sélection `2de · Mathématiques` est ensuite visible; un accès durable existe aussi dans le dashboard élève.
+- L'écran assistante affiche les cinq étapes, les boutons « Choisir cet enfant » et « Choisir cette matière », le compteur de réponses et « Valider la saisie papier ».
+- Le navigateur confirme que parent et élève ne restent jamais sur `/dashboard/assistante/bilans/saisie-papier`. Les tests serveur verrouillent aussi le `notFound()` hors staff.
+- La provenance `SAISIE_PAPIER` reste posée à l'INSERT par `lib/bilans/api/paper-entry.ts`; le moteur de scoring n'est pas modifié.
+
+### Captures locales
+
+- CTA accueil : `/tmp/nexus-pr-guidage-captures/home-cta-desktop.png` et `/tmp/nexus-pr-guidage-captures/home-mobile.png`.
+- CTA stage : `/tmp/nexus-pr-guidage-captures/stages-cta-desktop.png` et `/tmp/nexus-pr-guidage-captures/stages-pre-rentree-mobile.png`.
+- Guidage parent : `/tmp/nexus-pr-guidage-captures/parent-empty-guidance-desktop.png` et `/tmp/nexus-pr-guidage-captures/parent-child-activation-link-desktop.png`.
+- Sélection élève : `/tmp/nexus-pr-guidage-captures/student-assessment-selection-desktop.png`.
+- Saisie assistante : `/tmp/nexus-pr-guidage-captures/assistante-paper-workflow-step-1-desktop.png`, `assistante-paper-workflow-step-3-desktop.png` et `assistante-paper-workflow-step-4-desktop.png` dans le même dossier.
+- Relevés : `/tmp/nexus-pr-guidage-captures/public-verification.json` et `/tmp/nexus-pr-guidage-captures/authenticated-verification.json`.
+
+## Risques restants
+
+- La convention globale qui redirige les ADMIN hors de `/dashboard/assistante/*` reste une question de périmètre dashboard.
+- Le libellé global « Bilan gratuit » continue de désigner la page mixte `/bilan-gratuit`; sur les deux surfaces demandées, l'ambiguïté est levée par les deux libellés explicites. Une éventuelle harmonisation de toute la navigation relève d'un chantier éditorial global.
+
+## Rollback
+
+PR applicative sans migration : revert du commit de la PR. Aucun déploiement n'est réalisé dans cette mission.

--- a/docs/superpowers/plans/2026-08-09-bilan-pre-rentree-guidage.md
+++ b/docs/superpowers/plans/2026-08-09-bilan-pre-rentree-guidage.md
@@ -1,0 +1,9 @@
+# Plan d'implémentation — bilan de pré-rentrée
+
+1. Écrire les tests de contrat des deux CTA publics, de leurs destinations et de leur présence sur les deux pages.
+2. Écrire les tests de guidage parent : état vide, consigne exacte, lien copiable et répétabilité multi-enfants.
+3. Écrire les tests du retour d'activation élève vers la sélection de matière et de l'accès durable depuis son dashboard.
+4. Écrire les tests du fil assistante, de l'état de saisie et du libellé final, tout en conservant les tests d'accès et de provenance.
+5. Implémenter les composants et adaptations minimales jusqu'à rendre ces tests verts.
+6. Exécuter les tests ciblés, la suite Jest complète sans filtre, lint, typecheck et build avec environnement local neutralisé.
+7. Vérifier le rendu réel desktop/mobile avec Playwright, produire les captures, relire le diff, puis publier une PR sans merge ni déploiement.

--- a/e2e/auth/nexus-premium-final.spec.ts
+++ b/e2e/auth/nexus-premium-final.spec.ts
@@ -12,7 +12,8 @@ test.describe('Nexus premium final — contenu et parcours publics', () => {
       'Cellule Cyclades',
       'Repères tarifaires',
       'TND',
-      'Demander un bilan gratuit',
+      'Passer le bilan de pré-rentrée',
+      'Être rappelé par un conseiller',
     ]) {
       await expect(body).toContainText(text);
     }

--- a/e2e/premium-home.spec.ts
+++ b/e2e/premium-home.spec.ts
@@ -59,13 +59,15 @@ test.describe('Premium Home Journey', () => {
         await expect(pricingCard).toBeVisible({ timeout: 10000 });
     });
 
-    test('CTA bilan gratuit is accessible', async ({ page }) => {
-        const ctaSection = page.locator('section[aria-label="Demander un bilan gratuit"]');
+    test('CTA bilan de pré-rentrée et rappel conseiller sont distincts', async ({ page }) => {
+        const ctaSection = page.locator('section[aria-label="Choisir entre bilan en ligne et rappel conseiller"]');
         await ctaSection.scrollIntoViewIfNeeded();
         await expect(ctaSection).toBeInViewport({ timeout: 5000 });
 
-        const ctaLink = ctaSection.getByRole('link', { name: /bilan gratuit/i });
-        await expect(ctaLink).toBeVisible({ timeout: 10000 });
-        await expect(ctaLink).toHaveAttribute('href', '/bilan-gratuit');
+        const assessmentLink = ctaSection.getByRole('link', { name: 'Passer le bilan de pré-rentrée' });
+        const adviserLink = ctaSection.getByRole('link', { name: 'Être rappelé par un conseiller' });
+        await expect(assessmentLink).toBeVisible({ timeout: 10000 });
+        await expect(assessmentLink).toHaveAttribute('href', '/bilan-gratuit?parcours=diagnostic#demande-bilan');
+        await expect(adviserLink).toHaveAttribute('href', '/bilan-gratuit?parcours=conseiller#rappel-conseiller');
     });
 });

--- a/lib/services/student-activation.service.ts
+++ b/lib/services/student-activation.service.ts
@@ -429,7 +429,9 @@ export async function completeStudentActivation(
 
     return {
       success: true,
-      redirectUrl: '/auth/signin?activated=true',
+      redirectUrl: purpose === 'student'
+        ? '/auth/signin?activated=true&callbackUrl=%2Fbilan-gratuit%2Fassessment'
+        : '/auth/signin?activated=true',
     };
   }
 


### PR DESCRIPTION
## Contexte

L'audit production a confirmé trois ruptures de guidage : aucun CTA explicite vers la passation sur l'accueil et la page de pré-rentrée, un parcours parent peu guidé après activation, et une saisie papier fonctionnelle mais sans fil commun.

## Corrections

- ajoute les CTA distincts « Passer le bilan de pré-rentrée » et « Être rappelé par un conseiller » sur `/` et `/stages/pre-rentree-2026` ;
- conserve les deux formulaires de `/bilan-gratuit` et les cible par des ancres explicites ;
- guide le parent vers « Ajouter votre enfant », maintient la boîte de succès pendant le rafraîchissement, rend le lien copiable avec la consigne de remise, et conserve l'ajout multi-enfants ;
- renvoie l'élève activé vers la sélection de matière après connexion et ajoute un accès durable depuis son dashboard ;
- ajoute le fil en cinq étapes, l'état d'avancement et des boutons explicites à la saisie papier ;
- documente l'audit complet dans `docs/audits/2026-08-09-bilan-pre-rentree-trouvabilite-guidage.md`.

## Invariants

- aucune modification du scoring, du middleware ADMIN ou du candidat libre ;
- provenance `SAISIE_PAPIER` toujours posée à l'INSERT ;
- écran de saisie papier toujours inaccessible aux rôles parent et élève ;
- aucun déploiement, aucune migration ; LLM off et candidat libre dark pendant les vérifications.

## Vérifications

- `npm run lint` ✅ (avertissements candidat libre préexistants uniquement)
- `npm run typecheck` ✅
- `npm run check:e2e-syntax` ✅
- `npm run test -- --runInBand` ✅ — 754 suites, 8 420 tests, 7 snapshots
- `npm run build` ✅ — 91 pages, traces propres, artefact standalone valide, aucun résidu runtime
- audit Playwright production desktop/mobile puis vérification locale réelle sur PostgreSQL jetable ✅

Approbation demandée à @abenrhouma. Je ne merge pas cette PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rend le parcours “bilan de pré‑rentrée” trouvable et guidé de bout en bout. Ajoute des CTA explicites, un fil de saisie papier en 5 étapes, et un accès direct à la sélection de matière pour l’élève.

- **New Features**
  - Ajout des CTA “Passer le bilan de pré‑rentrée” et “Être rappelé par un conseiller” sur / et /stages/pre-rentree-2026, pointant vers des ancres dédiées sur /bilan-gratuit (diagnostic et rappel).
  - Parcours parent guidé: état vide clair, bannière orientée vers “Ajouter votre enfant”, lien d’activation copiable avec consigne, ajout multi‑enfants conservé.
  - Élève: après activation, connexion avec retour vers /bilan-gratuit/assessment et carte d’accès direct dans le dashboard.
  - Assistante (saisie papier): fil en 5 étapes, boutons explicites, compteur de réponses saisis et bouton final “Valider la saisie papier”.
  - Documentation d’audit et plan ajoutés sous docs/.

- **Bug Fixes**
  - Le rafraîchissement des enfants est silencieux après ajout: l’écran reste visible et la boîte de succès ne disparaît plus.
  - Contrôle d’accès renforcé: la page de saisie papier reste inaccessible aux rôles parent et élève; pas de changement pour assistante.
  - Libellés et états accessibles clarifiés (étape courante, compteur, CTA bannière parent).
  - Invariants conservés: pas de changement de scoring, middleware ADMIN intact, provenance SAISIE_PAPIER posée à l’INSERT, aucune migration.

<sup>Written for commit 3d20ce1588e26bf13956f46d21cd6f085744fe1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

