### PR TITLE
infra: align production Docker image with Node 22

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -4,17 +4,17 @@
 # Multi-stage build pour optimiser la taille de l'image
 
 # Stage 1: Dependencies
-FROM node:20-alpine AS deps
+FROM node:22.23.1-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Copier les fichiers de dépendances
-COPY package.json package-lock.json ./
+COPY package.json package-lock.json .npmrc ./
 # Install ALL dependencies (devDependencies needed for build stage)
 RUN npm ci --frozen-lockfile
 
 # Stage 2: Builder
-FROM node:20-alpine AS builder
+FROM node:22.23.1-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS builder
 WORKDIR /app
 
 # Copier les dépendances depuis l'étape précédente
@@ -41,7 +41,7 @@ WORKDIR /app
 COPY prisma ./prisma
 
 # Stage 3: Runner
-FROM node:20-alpine AS runner
+FROM node:22.23.1-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -12,6 +12,8 @@ WORKDIR /app
 COPY package.json package-lock.json .npmrc ./
 # Install ALL dependencies (devDependencies needed for build stage)
 RUN npm ci --frozen-lockfile
+ARG NPM_VERSION=10.9.8
+RUN test "$(npm --version)" = "$NPM_VERSION"
 
 # Stage 2: Builder
 FROM node:22.23.1-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS builder
@@ -34,6 +36,8 @@ ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 # Build de l'application Next.js
 RUN RELEASE_SHA="$RELEASE_SHA" npm run build
+ARG NPM_VERSION=10.9.8
+RUN test "$(npm --version)" = "$NPM_VERSION"
 
 # Stage 2.5: Migrator (includes full Prisma CLI dependency graph)
 FROM deps AS migrator
@@ -72,6 +76,8 @@ COPY --from=builder /app/node_modules/pdfkit/js/data ./node_modules/pdfkit/js/da
 # Créer les dossiers nécessaires
 RUN mkdir -p /app/uploads /app/logs
 RUN chown -R nextjs:nodejs /app/uploads /app/logs
+ARG NPM_VERSION=10.9.8
+RUN test "$(npm --version)" = "$NPM_VERSION"
 
 USER nextjs
 

--- a/__tests__/config/deploy-contract.test.ts
+++ b/__tests__/config/deploy-contract.test.ts
@@ -61,6 +61,20 @@ describe('production deployment contract', () => {
     expect(verifier).toContain('validate-npm-tree.js');
   });
 
+  it('keeps every Dockerfile.prod stage on the pinned Node 22 production base', () => {
+    const dockerfile = read('Dockerfile.prod');
+    const pinnedBase = 'node:22.23.1-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2';
+    const productionStages = dockerfile.match(/^FROM .* AS (deps|builder|runner)$/gm) ?? [];
+
+    expect(productionStages).toEqual([
+      `FROM ${pinnedBase} AS deps`,
+      `FROM ${pinnedBase} AS builder`,
+      `FROM ${pinnedBase} AS runner`,
+    ]);
+    expect(dockerfile).toContain('COPY package.json package-lock.json .npmrc ./');
+    expect(dockerfile).not.toMatch(/^FROM node:20(?:-|:)/m);
+  });
+
   it('keeps public deployment helpers fail-closed and free of topology', () => {
     for (const scriptPath of [
       'scripts/deploy-git-pull.sh',

--- a/__tests__/config/deploy-contract.test.ts
+++ b/__tests__/config/deploy-contract.test.ts
@@ -71,6 +71,8 @@ describe('production deployment contract', () => {
       `FROM ${pinnedBase} AS builder`,
       `FROM ${pinnedBase} AS runner`,
     ]);
+    expect(dockerfile.match(/ARG NPM_VERSION=10\.9\.8/g)).toHaveLength(3);
+    expect(dockerfile.match(/RUN test "\$\(npm --version\)" = "\$NPM_VERSION"/g)).toHaveLength(3);
     expect(dockerfile).toContain('COPY package.json package-lock.json .npmrc ./');
     expect(dockerfile).not.toMatch(/^FROM node:20(?:-|:)/m);
   });

--- a/docs/audits/2026-08-10-node22-network-migration-prerequisite-phase-b.md
+++ b/docs/audits/2026-08-10-node22-network-migration-prerequisite-phase-b.md
@@ -1,4 +1,4 @@
-# Préalable #116 — réseau `nexus_admin` sur clone et canary Node 22
+# Préalable #116 — qualification réseau et canary Node 22
 
 ## Date
 
@@ -6,167 +6,147 @@
 
 ## Contexte
 
-La branche `agent/node22-migration-prerequisite` part de `origin/main` au commit
-`7e9033eff1d81b4a848bc789aeec1101575810d8` (merge de la PR #116). Le périmètre
-autorisé est limité à un clone PostgreSQL jetable et à des images/canary locaux.
-La rotation du rôle de production, le HBA de production, le launcher PM2, la
-release active et la migration #116 en production sont explicitement hors
-périmètre.
+La branche dédiée part du merge de la PR #116. Le périmètre autorisé est
+limité à un clone PostgreSQL jetable et à des images/canary locaux. La rotation
+du rôle administrateur de migration, la politique d'authentification réseau, le
+launcher de processus, la release active et la migration #116 en production
+sont explicitement hors périmètre.
 
 ## Problèmes observés
 
 - `Dockerfile.prod` utilisait `node:20-alpine`, alors que `package.json` exige
   Node `>=22.13.0` et que la CI est alignée sur Node 22.23.1.
-- Le rôle `nexus_admin` de production fonctionne par le socket local autorisé
-  par le HBA, mais le credential réseau historique n'est plus synchronisé avec
-  la base réelle. Le HBA réseau impose déjà SCRAM ; il n'a pas besoin d'être
-  élargi.
-- La migration `20260809090000_deferred_parent_email` contient deux `ALTER
-  TABLE`, un `UPDATE` de backfill et un `CREATE INDEX`. Elle nécessite donc un
-  rôle de migration capable d'altérer le schéma. L'accès local peut servir de
-  secours opératoire, mais ne valide pas le chemin réseau du migrateur.
+- Le chemin d'administration local de la base fonctionne, mais le credential
+  historique ne permet plus l'authentification par le réseau interne prévu pour
+  le migrateur. La politique réseau impose déjà SCRAM et ne doit pas être
+  élargie.
+- La migration `20260809090000_deferred_parent_email` contient des changements
+  de schéma et un backfill. Elle nécessite donc un rôle de migration autorisé à
+  altérer le schéma ; une connexion locale ne prouve pas le chemin réseau du
+  migrateur.
 
 ## Décisions prises
 
 - Les stages `deps`, `builder` et `runner` utilisent tous l'image exacte
   `node:22.23.1-alpine` verrouillée par digest.
-- Les trois stages vérifient au build `npm 10.9.8`. Le build échoue si la version
-  fournie par l'image dérive.
-- `.npmrc` est copié dans `deps` avec `package.json` et `package-lock.json` avant
-  `npm ci`.
-- Aucun secret de migration n'est versionné. Les credentials et secrets canary
-  ont été générés dans un répertoire temporaire mode 0700, avec fichiers mode
-  0600, puis écrasés et supprimés.
+- Les trois stages vérifient au build `npm 10.9.8`. Le build échoue si la
+  version fournie par l'image dérive.
+- `.npmrc` est copié dans `deps` avec `package.json` et `package-lock.json`
+  avant `npm ci`.
+- Aucun secret de migration n'est versionné. Les credentials et secrets du
+  clone ont été conservés dans un stockage temporaire protégé, puis détruits.
 
 ## Preuves du clone PostgreSQL 15
 
 Source du clone :
 
-- dump production `--schema-only --format=custom --no-owner --no-privileges` ;
-- dump `--data-only` limité à `public._prisma_migrations` ;
-- zéro entrée `TABLE DATA` dans le dump de schéma ;
-- clone obtenu : 85 tables publiques, 69 migrations enregistrées, zéro ligne
-  métier avant migration ;
-- aucune publication de port PostgreSQL sur l'hôte.
+- export production limité au schéma, sans propriétaires ni privilèges ;
+- registre technique des migrations copié séparément ;
+- aucune donnée métier copiée ;
+- clone PostgreSQL 15 sans exposition réseau publique.
 
 Authentification réseau du rôle éphémère :
 
-- mot de passe aléatoire hexadécimal de 64 caractères, jamais affiché ;
-- verifier du rôle : SCRAM ;
-- règle HBA du bridge : `host all all all scram-sha-256` ;
-- connexion depuis un second conteneur du bridge :
-  `nexus_admin|client_address_present|nexus_prod` ;
-- PostgreSQL clone : 15.15, même version majeure que la production PostgreSQL
-  15.
+- credential fort généré exclusivement pour le clone, jamais affiché ;
+- verifier SCRAM confirmé ;
+- connexion réussie depuis le réseau Docker interne isolé ;
+- rôle et base attendus confirmés sans consigner leurs identifiants.
 
 Migration #116 :
 
-- avant : `users.email` `NOT NULL`, aucune colonne `phoneNormalized`, exactement
-  une migration en attente (`20260809090000_deferred_parent_email`) ;
+- avant : `users.email` non nullable, aucune colonne `phoneNormalized` et une
+  seule migration en attente ;
 - premier `prisma migrate deploy` : migration appliquée avec succès par le
-  bridge SCRAM ;
-- après : `users.email` nullable, `phoneNormalized` de type `text` nullable,
-  index `users_phoneNormalized_idx` présent ;
-- l'index unique existant `users_email_key` reste présent. PostgreSQL conserve
-  ainsi l'unicité des valeurs non nulles et autorise plusieurs `NULL` ;
-- second `prisma migrate deploy` : `No pending migrations to apply` ;
-- une seule ligne terminée dans `_prisma_migrations` pour #116.
+  chemin réseau SCRAM ;
+- après : `users.email` nullable, `phoneNormalized` nullable et index de
+  recherche présent ;
+- l'index unique existant sur l'e-mail reste présent. PostgreSQL conserve ainsi
+  l'unicité des valeurs non nulles et autorise plusieurs `NULL` ;
+- second `prisma migrate deploy` : aucune migration en attente ;
+- une seule exécution terminée pour #116 dans le registre Prisma.
 
 Invariants append-only et scoring :
 
-- 12 tables `canonical_*`, zéro ligne avant migration, zéro ligne après
-  migration et après canary ;
-- `canonical_job_outbox` et `canonical_notification_outbox` restent à zéro ;
-- le dump de schéma canonique normalisé des marqueurs aléatoires
-  `\\restrict`/`\\unrestrict` est strictement identique avant/après :
-  `f0f9e98d45d4e7ef8655ff7b9eb2a4d94a32ba2160904a793ad43df2515f1306` ;
-- aucun fichier de scoring, append-only ou candidat libre n'est modifié dans la
-  branche.
+- aucune ligne métier avant migration, après migration ou après canary ;
+- les outbox Canonical restent vides ;
+- le schéma Canonical normalisé est strictement identique avant et après ;
+- aucun fichier de scoring, append-only ou candidat libre n'est modifié dans
+  la branche.
 
 ## Preuves des images et du canary Node 22
 
 Images construites :
 
-- target `migrator` : Node 22.23.1, npm 10.9.8, Prisma 6.19.3,
-  `linux-musl-openssl-3.0.x` ;
-- target `runner` : Node 22.23.1, npm 10.9.8, `linux x64` ;
-- build Next.js 15.5.21 réussi, Prisma Client généré, typecheck de build réussi,
+- target `migrator` : Node 22.23.1, npm 10.9.8, Prisma 6.19.3 et moteur natif
+  Alpine ;
+- target `runner` : Node 22.23.1, npm 10.9.8, Linux x64 ;
+- build Next.js 15 réussi, Prisma Client généré, typecheck de build réussi,
   traces et artefact standalone validés ;
-- les contrôles npm explicites ont ensuite été exécutés avec succès dans les
-  trois stages sur le commit technique `0efd4e8d83138558f3a9b0f86071c66b6303dc91`.
+- les contrôles npm explicites ont réussi dans les trois stages.
 
-Canary local isolé sur `127.0.0.1:31022`, connecté au clone :
+Canary local isolé, connecté au clone :
 
-- `/api/health` : HTTP 200 et requête Prisma réussie ;
-- authentification réelle Chromium d'un compte ADMIN synthétique : page de
-  connexion 200, session NextAuth 200, rôle ADMIN, redirection
-  `/dashboard/admin`, API dashboard 200, aucune erreur de page ;
-- Prisma natif : connexion à `nexus_prod` avec le rôle du clone ;
-- Sharp : PNG 2×2 généré et relu, 95 octets ;
-- PDFKit : document `%PDF` généré, 1268 octets ;
-- logs : aucun `FATAL`, `Unhandled`, envoi SMTP, génération LLM ou drain worker.
+- endpoint de santé : HTTP 200 et requête Prisma réussie ;
+- authentification réelle Chromium d'un compte ADMIN synthétique : connexion,
+  session et API staff réussies, sans erreur de page ;
+- Prisma natif : connexion avec le rôle et la base du clone ;
+- Sharp : image PNG générée et relue ;
+- PDFKit : document PDF non vide généré ;
+- logs : aucun échec Prisma natif, envoi SMTP, génération LLM ou drain worker.
 
-Les garde-fous canary étaient `MAIL_DISABLED=true`,
-`EMAIL_OUTBOX_WORKER_ENABLED=false`, `BILAN_WORKER_ENABLED=false`,
-`LLM_MODE=off` et `NPC_LLM_MODE=off`. L'instrumentation refuse volontairement
-un worker e-mail désactivé lorsque `NODE_ENV=production`. Pour respecter le
-contrat « workers off » sans modifier le produit, le canary a utilisé le garde
-existant `NEXT_PHASE=phase-production-build`, qui évite l'instrumentation de
-démarrage. Le serveur, NextAuth, Prisma, Sharp et PDFKit ont bien tourné avec
-`NODE_ENV=production`. Cette exception de test doit rester explicite : elle ne
-remplace pas un smoke de release avec la politique workers de production.
+SMTP, les workers et les chemins LLM étaient désactivés. L'instrumentation
+refuse volontairement un worker e-mail désactivé dans le mode de production.
+Le canary a donc utilisé le garde de build existant pour ne pas démarrer cette
+instrumentation, sans modifier le produit. Le serveur, NextAuth, Prisma, Sharp
+et PDFKit ont bien tourné dans le mode de production. Cette exception de test
+reste explicite : elle ne remplace pas un smoke de release avec la politique
+workers de production.
 
 ## Destruction et état de production
 
 Après les preuves :
 
-- conteneurs PostgreSQL, Redis et runner supprimés ;
-- réseau bridge dédié supprimé ;
-- images de test taguées supprimées ;
-- port 31022 fermé ;
-- dumps, mots de passe, hash synthétique et fichier env écrasés puis supprimés.
+- conteneurs du clone, du cache et du runner supprimés ;
+- réseau Docker interne dédié supprimé ;
+- images de qualification supprimées ;
+- endpoint local isolé fermé ;
+- exports, credentials et fichiers temporaires détruits.
 
 Constat final production, en lecture seule :
 
-- PM2 `nexus-prod` : PID `706275`, inchangé ;
-- release active :
-  `1d0f202e0-main-bilans-rendu-20260809T201748Z` ;
-- runtime launcher : `/usr/bin/node` v20.20.0, inchangé ;
-- probe HTTP local `/` : 200 ;
-- migration #116 terminée : 0 ligne ;
-- `users.email` reste `NOT NULL` et `phoneNormalized` reste absente ;
-- HBA non modifié, SHA-256 final
-  `85c57882d53ed4fd928e9250e4aedad83266b84bffdadf51254ed2deca077d55`.
+- processus et release active inchangés ;
+- runtime Node inchangé ;
+- sonde HTTP réussie ;
+- migration #116 non appliquée ;
+- `users.email` reste non nullable et `phoneNormalized` reste absente ;
+- politique d'authentification réseau inchangée.
 
 ## Mécanisme proposé pour la rotation production
 
 À exécuter seulement après un second feu vert, par le responsable habilité :
 
-1. Générer hors dépôt une valeur hexadécimale aléatoire d'au moins 256 bits et
-   la déposer depuis le gestionnaire de secrets dans un fichier staging
-   root-only, par exemple `/etc/nexus/nexus-migrator.env.next` (0600, répertoire
-   0700). Le fichier contient uniquement la `DATABASE_URL` du migrateur ; aucun
-   secret ne passe dans Git, les logs ou l'historique shell.
-2. Vérifier sans changement que les règles host restent limitées au réseau
-   Docker attendu et en `scram-sha-256`. Ne pas ajouter de CIDR large et ne pas
-   modifier l'authentification locale au cours de cette rotation.
-3. Ouvrir une session locale contrôlée :
-   `docker exec -it nexus-postgres-db psql -U nexus_admin -d postgres`, puis
-   exécuter `\\password nexus_admin`. Cette commande demande le secret dans le
-   TTY et évite de le placer dans une ligne de commande ou un SQL journalisé.
-4. Depuis une image migrator approuvée attachée au bridge de production,
-   utiliser le fichier staging comme `--env-file` et exécuter d'abord
-   `prisma migrate status`/une requête sans écriture. Attester le rôle, la base,
-   une adresse client réseau et le succès SCRAM, sans afficher l'URL.
-5. Si le test échoue, conserver l'accès local, corriger immédiatement le mot de
-   passe via `\\password` et recommencer ; ne modifier ni HBA ni privilèges pour
-   contourner l'échec.
-6. Quand le bridge est prouvé, remplacer atomiquement le fichier root-only
-   actif par le staging, supprimer toute copie transitoire et conserver
-   uniquement l'empreinte/date de rotation dans le journal opératoire.
-7. Faire un nouveau clone/dry-run si l'image ou les migrations ont changé depuis
-   ce rapport. L'application de #116 en production et la bascule Node 22/PM2
-   restent deux actions séparées, chacune avec son feu vert et son rollback.
+1. Générer hors dépôt un secret fort depuis le gestionnaire de secrets et le
+   déposer dans un emplacement staging protégé, sans valeur dans Git, les logs
+   ou l'historique shell.
+2. Vérifier sans changement que les règles réseau restent limitées au réseau
+   interne attendu et imposent SCRAM. Ne pas élargir la plage autorisée ni
+   modifier l'authentification locale pendant cette rotation.
+3. Depuis une session locale interactive et contrôlée, remplacer le mot de
+   passe du rôle administrateur de migration sans le placer dans une commande
+   ou une requête journalisée.
+4. Depuis l'image migrator approuvée attachée au réseau interne, utiliser le
+   secret staging pour une requête d'identité en lecture seule et un contrôle
+   d'état Prisma. Attester le rôle, la base et le succès SCRAM sans afficher de
+   chaîne de connexion.
+5. Si le test échoue, conserver l'accès local et resynchroniser le credential ;
+   ne modifier ni la politique réseau ni les privilèges pour contourner
+   l'échec.
+6. Quand le chemin réseau est prouvé, promouvoir atomiquement le secret
+   staging, supprimer toute copie transitoire et ne conserver que la date et
+   l'empreinte de rotation dans le journal opératoire.
+7. Refaire un clone/dry-run si l'image ou les migrations ont changé depuis ce
+   rapport. L'application de #116 et la bascule Node 22 restent deux actions
+   séparées, chacune avec son feu vert et son rollback.
 
 ## Fichiers modifiés
 
@@ -181,13 +161,13 @@ Constat final production, en lecture seule :
 - test de contrat ciblé observé rouge sous Node 20 / sans garde npm, puis vert ;
 - builds Docker targets `migrator` et `runner` ;
 - migrations réseau sur clone, deux passages ;
-- canary HTTP, Prisma, auth Chromium, Sharp et PDFKit ;
+- canary HTTP, Prisma, authentification Chromium, Sharp et PDFKit ;
 - quality gates complets consignés dans le rapport de PR.
 
 ## Risques restants
 
-- La production reste volontairement sur Node 20.20.0 : modifier le Dockerfile
-  n'aligne pas le launcher PM2, qui invoque encore `/usr/bin/node`.
+- La production reste volontairement sur son runtime Node actuel : modifier le
+  Dockerfile n'aligne pas le launcher de processus existant.
 - Le credential réseau de production reste volontairement périmé jusqu'au
   second feu vert.
 - #116 reste volontairement non appliquée en production.

--- a/docs/audits/2026-08-10-node22-network-migration-prerequisite-phase-b.md
+++ b/docs/audits/2026-08-10-node22-network-migration-prerequisite-phase-b.md
@@ -1,0 +1,202 @@
+# Préalable #116 — réseau `nexus_admin` sur clone et canary Node 22
+
+## Date
+
+2026-08-10 (Africa/Tunis)
+
+## Contexte
+
+La branche `agent/node22-migration-prerequisite` part de `origin/main` au commit
+`7e9033eff1d81b4a848bc789aeec1101575810d8` (merge de la PR #116). Le périmètre
+autorisé est limité à un clone PostgreSQL jetable et à des images/canary locaux.
+La rotation du rôle de production, le HBA de production, le launcher PM2, la
+release active et la migration #116 en production sont explicitement hors
+périmètre.
+
+## Problèmes observés
+
+- `Dockerfile.prod` utilisait `node:20-alpine`, alors que `package.json` exige
+  Node `>=22.13.0` et que la CI est alignée sur Node 22.23.1.
+- Le rôle `nexus_admin` de production fonctionne par le socket local autorisé
+  par le HBA, mais le credential réseau historique n'est plus synchronisé avec
+  la base réelle. Le HBA réseau impose déjà SCRAM ; il n'a pas besoin d'être
+  élargi.
+- La migration `20260809090000_deferred_parent_email` contient deux `ALTER
+  TABLE`, un `UPDATE` de backfill et un `CREATE INDEX`. Elle nécessite donc un
+  rôle de migration capable d'altérer le schéma. L'accès local peut servir de
+  secours opératoire, mais ne valide pas le chemin réseau du migrateur.
+
+## Décisions prises
+
+- Les stages `deps`, `builder` et `runner` utilisent tous l'image exacte
+  `node:22.23.1-alpine` verrouillée par digest.
+- Les trois stages vérifient au build `npm 10.9.8`. Le build échoue si la version
+  fournie par l'image dérive.
+- `.npmrc` est copié dans `deps` avec `package.json` et `package-lock.json` avant
+  `npm ci`.
+- Aucun secret de migration n'est versionné. Les credentials et secrets canary
+  ont été générés dans un répertoire temporaire mode 0700, avec fichiers mode
+  0600, puis écrasés et supprimés.
+
+## Preuves du clone PostgreSQL 15
+
+Source du clone :
+
+- dump production `--schema-only --format=custom --no-owner --no-privileges` ;
+- dump `--data-only` limité à `public._prisma_migrations` ;
+- zéro entrée `TABLE DATA` dans le dump de schéma ;
+- clone obtenu : 85 tables publiques, 69 migrations enregistrées, zéro ligne
+  métier avant migration ;
+- aucune publication de port PostgreSQL sur l'hôte.
+
+Authentification réseau du rôle éphémère :
+
+- mot de passe aléatoire hexadécimal de 64 caractères, jamais affiché ;
+- verifier du rôle : SCRAM ;
+- règle HBA du bridge : `host all all all scram-sha-256` ;
+- connexion depuis un second conteneur du bridge :
+  `nexus_admin|client_address_present|nexus_prod` ;
+- PostgreSQL clone : 15.15, même version majeure que la production PostgreSQL
+  15.
+
+Migration #116 :
+
+- avant : `users.email` `NOT NULL`, aucune colonne `phoneNormalized`, exactement
+  une migration en attente (`20260809090000_deferred_parent_email`) ;
+- premier `prisma migrate deploy` : migration appliquée avec succès par le
+  bridge SCRAM ;
+- après : `users.email` nullable, `phoneNormalized` de type `text` nullable,
+  index `users_phoneNormalized_idx` présent ;
+- l'index unique existant `users_email_key` reste présent. PostgreSQL conserve
+  ainsi l'unicité des valeurs non nulles et autorise plusieurs `NULL` ;
+- second `prisma migrate deploy` : `No pending migrations to apply` ;
+- une seule ligne terminée dans `_prisma_migrations` pour #116.
+
+Invariants append-only et scoring :
+
+- 12 tables `canonical_*`, zéro ligne avant migration, zéro ligne après
+  migration et après canary ;
+- `canonical_job_outbox` et `canonical_notification_outbox` restent à zéro ;
+- le dump de schéma canonique normalisé des marqueurs aléatoires
+  `\\restrict`/`\\unrestrict` est strictement identique avant/après :
+  `f0f9e98d45d4e7ef8655ff7b9eb2a4d94a32ba2160904a793ad43df2515f1306` ;
+- aucun fichier de scoring, append-only ou candidat libre n'est modifié dans la
+  branche.
+
+## Preuves des images et du canary Node 22
+
+Images construites :
+
+- target `migrator` : Node 22.23.1, npm 10.9.8, Prisma 6.19.3,
+  `linux-musl-openssl-3.0.x` ;
+- target `runner` : Node 22.23.1, npm 10.9.8, `linux x64` ;
+- build Next.js 15.5.21 réussi, Prisma Client généré, typecheck de build réussi,
+  traces et artefact standalone validés ;
+- les contrôles npm explicites ont ensuite été exécutés avec succès dans les
+  trois stages sur le commit technique `0efd4e8d83138558f3a9b0f86071c66b6303dc91`.
+
+Canary local isolé sur `127.0.0.1:31022`, connecté au clone :
+
+- `/api/health` : HTTP 200 et requête Prisma réussie ;
+- authentification réelle Chromium d'un compte ADMIN synthétique : page de
+  connexion 200, session NextAuth 200, rôle ADMIN, redirection
+  `/dashboard/admin`, API dashboard 200, aucune erreur de page ;
+- Prisma natif : connexion à `nexus_prod` avec le rôle du clone ;
+- Sharp : PNG 2×2 généré et relu, 95 octets ;
+- PDFKit : document `%PDF` généré, 1268 octets ;
+- logs : aucun `FATAL`, `Unhandled`, envoi SMTP, génération LLM ou drain worker.
+
+Les garde-fous canary étaient `MAIL_DISABLED=true`,
+`EMAIL_OUTBOX_WORKER_ENABLED=false`, `BILAN_WORKER_ENABLED=false`,
+`LLM_MODE=off` et `NPC_LLM_MODE=off`. L'instrumentation refuse volontairement
+un worker e-mail désactivé lorsque `NODE_ENV=production`. Pour respecter le
+contrat « workers off » sans modifier le produit, le canary a utilisé le garde
+existant `NEXT_PHASE=phase-production-build`, qui évite l'instrumentation de
+démarrage. Le serveur, NextAuth, Prisma, Sharp et PDFKit ont bien tourné avec
+`NODE_ENV=production`. Cette exception de test doit rester explicite : elle ne
+remplace pas un smoke de release avec la politique workers de production.
+
+## Destruction et état de production
+
+Après les preuves :
+
+- conteneurs PostgreSQL, Redis et runner supprimés ;
+- réseau bridge dédié supprimé ;
+- images de test taguées supprimées ;
+- port 31022 fermé ;
+- dumps, mots de passe, hash synthétique et fichier env écrasés puis supprimés.
+
+Constat final production, en lecture seule :
+
+- PM2 `nexus-prod` : PID `706275`, inchangé ;
+- release active :
+  `1d0f202e0-main-bilans-rendu-20260809T201748Z` ;
+- runtime launcher : `/usr/bin/node` v20.20.0, inchangé ;
+- probe HTTP local `/` : 200 ;
+- migration #116 terminée : 0 ligne ;
+- `users.email` reste `NOT NULL` et `phoneNormalized` reste absente ;
+- HBA non modifié, SHA-256 final
+  `85c57882d53ed4fd928e9250e4aedad83266b84bffdadf51254ed2deca077d55`.
+
+## Mécanisme proposé pour la rotation production
+
+À exécuter seulement après un second feu vert, par le responsable habilité :
+
+1. Générer hors dépôt une valeur hexadécimale aléatoire d'au moins 256 bits et
+   la déposer depuis le gestionnaire de secrets dans un fichier staging
+   root-only, par exemple `/etc/nexus/nexus-migrator.env.next` (0600, répertoire
+   0700). Le fichier contient uniquement la `DATABASE_URL` du migrateur ; aucun
+   secret ne passe dans Git, les logs ou l'historique shell.
+2. Vérifier sans changement que les règles host restent limitées au réseau
+   Docker attendu et en `scram-sha-256`. Ne pas ajouter de CIDR large et ne pas
+   modifier l'authentification locale au cours de cette rotation.
+3. Ouvrir une session locale contrôlée :
+   `docker exec -it nexus-postgres-db psql -U nexus_admin -d postgres`, puis
+   exécuter `\\password nexus_admin`. Cette commande demande le secret dans le
+   TTY et évite de le placer dans une ligne de commande ou un SQL journalisé.
+4. Depuis une image migrator approuvée attachée au bridge de production,
+   utiliser le fichier staging comme `--env-file` et exécuter d'abord
+   `prisma migrate status`/une requête sans écriture. Attester le rôle, la base,
+   une adresse client réseau et le succès SCRAM, sans afficher l'URL.
+5. Si le test échoue, conserver l'accès local, corriger immédiatement le mot de
+   passe via `\\password` et recommencer ; ne modifier ni HBA ni privilèges pour
+   contourner l'échec.
+6. Quand le bridge est prouvé, remplacer atomiquement le fichier root-only
+   actif par le staging, supprimer toute copie transitoire et conserver
+   uniquement l'empreinte/date de rotation dans le journal opératoire.
+7. Faire un nouveau clone/dry-run si l'image ou les migrations ont changé depuis
+   ce rapport. L'application de #116 en production et la bascule Node 22/PM2
+   restent deux actions séparées, chacune avec son feu vert et son rollback.
+
+## Fichiers modifiés
+
+- `Dockerfile.prod`
+- `__tests__/config/deploy-contract.test.ts`
+- `docs/superpowers/specs/2026-08-10-node22-migration-prerequisite-design.md`
+- `docs/superpowers/plans/2026-08-10-node22-migration-prerequisite.md`
+- `docs/audits/2026-08-10-node22-network-migration-prerequisite-phase-b.md`
+
+## Tests exécutés
+
+- test de contrat ciblé observé rouge sous Node 20 / sans garde npm, puis vert ;
+- builds Docker targets `migrator` et `runner` ;
+- migrations réseau sur clone, deux passages ;
+- canary HTTP, Prisma, auth Chromium, Sharp et PDFKit ;
+- quality gates complets consignés dans le rapport de PR.
+
+## Risques restants
+
+- La production reste volontairement sur Node 20.20.0 : modifier le Dockerfile
+  n'aligne pas le launcher PM2, qui invoque encore `/usr/bin/node`.
+- Le credential réseau de production reste volontairement périmé jusqu'au
+  second feu vert.
+- #116 reste volontairement non appliquée en production.
+- Un smoke avec l'instrumentation complète et les workers configurés comme en
+  production sera requis avant toute bascule réelle.
+
+## Rollback
+
+La branche ne change que le contrat d'image et ses tests/documentation. Le
+rollback versionné consiste à revenir au Dockerfile précédent. Aucun rollback
+de données n'est nécessaire : le clone et le canary ont été détruits, et la
+production n'a subi aucune mutation.

--- a/docs/superpowers/plans/2026-08-10-node22-migration-prerequisite.md
+++ b/docs/superpowers/plans/2026-08-10-node22-migration-prerequisite.md
@@ -197,4 +197,3 @@ Require no Prisma engine, native module, SMTP, worker or LLM error.
 - [ ] **Step 4: Push the dedicated branch**
 - [ ] **Step 5: Open a draft PR to `main` and request `abenrhouma`**
 - [ ] **Step 6: Report and stop before any production credential rotation**
-

--- a/docs/superpowers/plans/2026-08-10-node22-migration-prerequisite.md
+++ b/docs/superpowers/plans/2026-08-10-node22-migration-prerequisite.md
@@ -136,7 +136,7 @@ pre-migration values.
 
 - [ ] **Step 1: Start isolated Redis and seed synthetic auth data**
 
-Create only a synthetic parent account in the clone with a known temporary
+Create only a synthetic ADMIN account in the clone with a known temporary
 password. Do not copy production users.
 
 - [ ] **Step 2: Start runner on a loopback-only port**
@@ -178,7 +178,7 @@ Require no Prisma engine, native module, SMTP, worker or LLM error.
 ### Task 7: Record the audit evidence
 
 **Files:**
-- Create: `docs/audits/2026-08-10-node22-migration-prerequisite.md`
+- Create: `docs/audits/2026-08-10-node22-network-migration-prerequisite-phase-b.md`
 
 - [ ] **Step 1: Document root causes and versioned changes**
 - [ ] **Step 2: Document clone/canary commands in redacted form and results**

--- a/docs/superpowers/plans/2026-08-10-node22-migration-prerequisite.md
+++ b/docs/superpowers/plans/2026-08-10-node22-migration-prerequisite.md
@@ -1,0 +1,200 @@
+# Node 22 and Network Migration Prerequisite Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align the production Docker build with Node 22 and prove the #116 migration and application runtime on an isolated SCRAM-authenticated clone without changing production.
+
+**Architecture:** The committed change is deliberately limited to `Dockerfile.prod`, its deployment contract, and an evidence report. Operational verification uses a schema-only PostgreSQL 15 clone plus Prisma registry metadata, a dedicated Docker bridge, temporary credentials and an isolated Node 22 runner canary.
+
+**Tech Stack:** Docker/BuildKit, Node 22.23.1 Alpine, npm 10.9.8, Next.js 15 standalone, Prisma 6.19.3, PostgreSQL 15/pgvector, Redis 7, Jest.
+
+---
+
+## Chunk 1: Versioned alignment
+
+### Task 1: Lock `Dockerfile.prod` to Node 22
+
+**Files:**
+- Modify: `__tests__/config/deploy-contract.test.ts`
+- Modify: `Dockerfile.prod`
+
+- [ ] **Step 1: Write the failing deployment contract**
+
+Require exactly three occurrences of the canonical pinned image, require
+`COPY package.json package-lock.json .npmrc ./`, and reject `node:20`.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `npx --yes npm@10.9.8 test -- --runInBand __tests__/config/deploy-contract.test.ts`
+
+Expected: FAIL because `Dockerfile.prod` still contains three Node 20 bases and
+does not copy `.npmrc`.
+
+- [ ] **Step 3: Apply the minimal Dockerfile change**
+
+Use the exact Node 22.23.1 Alpine digest already present in `Dockerfile`,
+`Dockerfile.e2e` and `Dockerfile.dependencies` for `deps`, `builder` and
+`runner`. Add `.npmrc` only to the dependency-stage copy.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run the command from Step 2.
+
+Expected: all deployment-contract tests pass.
+
+- [ ] **Step 5: Commit**
+
+Commit only the test and `Dockerfile.prod`.
+
+### Task 2: Build and inspect both production targets
+
+**Files:**
+- Verify: `Dockerfile.prod`
+
+- [ ] **Step 1: Build the `migrator` target**
+
+Build with an explicit local evidence tag and no production environment.
+
+- [ ] **Step 2: Verify migrator runtime versions**
+
+Run `node --version`, `npm --version` and Prisma CLI version inside the image.
+
+Expected: Node 22.23.1, npm 10.9.8, Prisma 6.19.3.
+
+- [ ] **Step 3: Build the `runner` target**
+
+Use the exact branch commit as `RELEASE_SHA`; neutralize build-time outbound
+providers and keep candidate libre disabled.
+
+- [ ] **Step 4: Verify runner runtime versions**
+
+Expected: Node 22.23.1 and npm 10.9.8.
+
+## Chunk 2: Ephemeral PostgreSQL and canary proof
+
+### Task 3: Create the schema-only production clone
+
+**Files:**
+- Temporary only: protected directory outside the repository
+
+- [ ] **Step 1: Capture production baseline read-only**
+
+Record active release, PM2 PID, health and absence of migration #116.
+
+- [ ] **Step 2: Stream a schema-only custom dump**
+
+Use production's local PostgreSQL socket with `pg_dump --schema-only
+--no-owner --no-privileges`. Separately dump only `_prisma_migrations` data.
+
+- [ ] **Step 3: Create isolated Docker resources**
+
+Create a dedicated bridge, a `pgvector/pgvector:pg15` container backed by
+`tmpfs`, and a 32-byte random hexadecimal `nexus_admin` password stored mode
+600 outside Git.
+
+- [ ] **Step 4: Restore schema and registry metadata**
+
+Restore with `--no-owner --no-privileges`, keeping all business tables empty.
+
+- [ ] **Step 5: Record Canonical invariants before migration**
+
+Hash the schema of `canonical_*` relations and count all append-only/scoring
+rows.
+
+### Task 4: Prove network Prisma migration
+
+**Files:**
+- Verify: `prisma/migrations/20260809090000_deferred_parent_email/migration.sql`
+
+- [ ] **Step 1: Prove SCRAM network authentication**
+
+Run `SELECT current_user, inet_client_addr() IS NOT NULL` from the migrator
+container using the clone's Docker DNS name.
+
+- [ ] **Step 2: Run first `prisma migrate deploy`**
+
+Expected: only `20260809090000_deferred_parent_email` is applied.
+
+- [ ] **Step 3: Verify resulting schema**
+
+Assert nullable `users.email`, nullable `users.phoneNormalized`, preserved
+`users_email_key`, and present `users_phoneNormalized_idx`.
+
+- [ ] **Step 4: Run second `prisma migrate deploy`**
+
+Expected: no pending migrations.
+
+- [ ] **Step 5: Recheck invariants**
+
+Canonical schema hash and all append-only/scoring counts must equal the
+pre-migration values.
+
+### Task 5: Run the isolated Node 22 canary
+
+**Files:**
+- Temporary only: canary environment outside the repository
+
+- [ ] **Step 1: Start isolated Redis and seed synthetic auth data**
+
+Create only a synthetic parent account in the clone with a known temporary
+password. Do not copy production users.
+
+- [ ] **Step 2: Start runner on a loopback-only port**
+
+Use clone PostgreSQL/Redis, random auth/rate-limit secrets, disabled SMTP,
+disabled workers, disabled LLM and temporary storage.
+
+- [ ] **Step 3: Verify HTTP and Prisma**
+
+Require `/api/health` 200 and a DB-backed request without server errors.
+
+- [ ] **Step 4: Verify Credentials authentication**
+
+Obtain a CSRF token, submit the synthetic credentials, retain the session
+cookie and require an authenticated parent route response.
+
+- [ ] **Step 5: Verify Sharp and PDFKit**
+
+Load both native/runtime libraries inside the runner, create in-memory output,
+and require non-empty buffers without writing documents.
+
+- [ ] **Step 6: Capture canary logs**
+
+Require no Prisma engine, native module, SMTP, worker or LLM error.
+
+### Task 6: Destroy all ephemeral resources
+
+**Files:**
+- Temporary only
+
+- [ ] **Step 1: Stop and remove canary, Redis and PostgreSQL containers**
+- [ ] **Step 2: Remove the dedicated network and evidence images**
+- [ ] **Step 3: Remove dump, registry and credential files**
+- [ ] **Step 4: Prove zero residual container, network, listener and file**
+- [ ] **Step 5: Recheck production baseline unchanged**
+
+## Chunk 3: Evidence and publication
+
+### Task 7: Record the audit evidence
+
+**Files:**
+- Create: `docs/audits/2026-08-10-node22-migration-prerequisite.md`
+
+- [ ] **Step 1: Document root causes and versioned changes**
+- [ ] **Step 2: Document clone/canary commands in redacted form and results**
+- [ ] **Step 3: Document the proposed production rotation mechanism**
+- [ ] **Step 4: State all prohibited production actions remained unperformed**
+- [ ] **Step 5: Commit the report**
+
+### Task 8: Run final verification and publish the PR
+
+**Files:**
+- Verify all changed files
+
+- [ ] **Step 1: Run focused test, full unit suite, lint and typecheck**
+- [ ] **Step 2: Run `git diff --check` and inspect the complete diff**
+- [ ] **Step 3: Confirm branch is clean and based on `main` after #116**
+- [ ] **Step 4: Push the dedicated branch**
+- [ ] **Step 5: Open a draft PR to `main` and request `abenrhouma`**
+- [ ] **Step 6: Report and stop before any production credential rotation**
+

--- a/docs/superpowers/plans/2026-08-10-node22-migration-prerequisite.md
+++ b/docs/superpowers/plans/2026-08-10-node22-migration-prerequisite.md
@@ -4,7 +4,7 @@
 
 **Goal:** Align the production Docker build with Node 22 and prove the #116 migration and application runtime on an isolated SCRAM-authenticated clone without changing production.
 
-**Architecture:** The committed change is deliberately limited to `Dockerfile.prod`, its deployment contract, and an evidence report. Operational verification uses a schema-only PostgreSQL 15 clone plus Prisma registry metadata, a dedicated Docker bridge, temporary credentials and an isolated Node 22 runner canary.
+**Architecture:** The committed change is deliberately limited to `Dockerfile.prod`, its deployment contract, and an evidence report. Operational verification uses a schema-only PostgreSQL 15 clone plus Prisma registry metadata, an isolated internal network, temporary secrets and a Node 22 runner canary.
 
 **Tech Stack:** Docker/BuildKit, Node 22.23.1 Alpine, npm 10.9.8, Next.js 15 standalone, Prisma 6.19.3, PostgreSQL 15/pgvector, Redis 7, Jest.
 
@@ -79,18 +79,19 @@ Expected: Node 22.23.1 and npm 10.9.8.
 
 - [ ] **Step 1: Capture production baseline read-only**
 
-Record active release, PM2 PID, health and absence of migration #116.
+Record runtime identity, health and absence of migration #116 without
+persisting infrastructure identifiers.
 
 - [ ] **Step 2: Stream a schema-only custom dump**
 
-Use production's local PostgreSQL socket with `pg_dump --schema-only
---no-owner --no-privileges`. Separately dump only `_prisma_migrations` data.
+Use the read-only administration channel to export the schema without owners or
+privileges. Export the Prisma migration registry separately.
 
 - [ ] **Step 3: Create isolated Docker resources**
 
-Create a dedicated bridge, a `pgvector/pgvector:pg15` container backed by
-`tmpfs`, and a 32-byte random hexadecimal `nexus_admin` password stored mode
-600 outside Git.
+Create an isolated internal network, an ephemeral PostgreSQL 15 clone and a
+strong random credential for the migration administrator, stored securely
+outside Git.
 
 - [ ] **Step 4: Restore schema and registry metadata**
 
@@ -108,8 +109,8 @@ rows.
 
 - [ ] **Step 1: Prove SCRAM network authentication**
 
-Run `SELECT current_user, inet_client_addr() IS NOT NULL` from the migrator
-container using the clone's Docker DNS name.
+Prove from the migrator that the expected role and database are reached through
+the clone's internal network, without recording their identifiers.
 
 - [ ] **Step 2: Run first `prisma migrate deploy`**
 
@@ -139,7 +140,7 @@ pre-migration values.
 Create only a synthetic ADMIN account in the clone with a known temporary
 password. Do not copy production users.
 
-- [ ] **Step 2: Start runner on a loopback-only port**
+- [ ] **Step 2: Start runner on an isolated local endpoint**
 
 Use clone PostgreSQL/Redis, random auth/rate-limit secrets, disabled SMTP,
 disabled workers, disabled LLM and temporary storage.
@@ -151,7 +152,7 @@ Require `/api/health` 200 and a DB-backed request without server errors.
 - [ ] **Step 4: Verify Credentials authentication**
 
 Obtain a CSRF token, submit the synthetic credentials, retain the session
-cookie and require an authenticated parent route response.
+cookie and require an authenticated staff route response.
 
 - [ ] **Step 5: Verify Sharp and PDFKit**
 
@@ -170,7 +171,7 @@ Require no Prisma engine, native module, SMTP, worker or LLM error.
 - [ ] **Step 1: Stop and remove canary, Redis and PostgreSQL containers**
 - [ ] **Step 2: Remove the dedicated network and evidence images**
 - [ ] **Step 3: Remove dump, registry and credential files**
-- [ ] **Step 4: Prove zero residual container, network, listener and file**
+- [ ] **Step 4: Prove zero residual container, network, endpoint and file**
 - [ ] **Step 5: Recheck production baseline unchanged**
 
 ## Chunk 3: Evidence and publication

--- a/docs/superpowers/specs/2026-08-10-node22-migration-prerequisite-design.md
+++ b/docs/superpowers/specs/2026-08-10-node22-migration-prerequisite-design.md
@@ -81,4 +81,3 @@ restera bloquée derrière un second feu vert explicite.
 - Migration réseau et idempotence prouvées sur clone.
 - Canary complet vert, puis environnement jetable absent.
 - PR ouverte vers `main`, revue demandée à `abenrhouma`.
-

--- a/docs/superpowers/specs/2026-08-10-node22-migration-prerequisite-design.md
+++ b/docs/superpowers/specs/2026-08-10-node22-migration-prerequisite-design.md
@@ -1,0 +1,84 @@
+# Préalable Node 22 et migrations réseau — conception
+
+## Date
+
+10 août 2026.
+
+## Contexte
+
+La PR #116 est fusionnée mais ne doit pas être déployée avant deux preuves :
+`Dockerfile.prod` doit respecter le contrat Node 22 du dépôt, et une migration
+Prisma avec un rôle `nexus_admin` doit fonctionner par SCRAM sur un réseau
+Docker. La production reste strictement inchangée pendant cette phase.
+
+## Périmètre versionné
+
+- Remplacer les trois bases `node:20-alpine` de `Dockerfile.prod` par l'image
+  déjà canonique et épinglée du dépôt : Node 22.23.1 Alpine, digest immuable.
+- Copier `.npmrc` avec `package.json` et `package-lock.json` dans le stage
+  `deps`, afin que `engine-strict=true` soit réellement appliqué.
+- Étendre `__tests__/config/deploy-contract.test.ts` pour verrouiller les trois
+  stages, le digest, la copie de `.npmrc` et l'absence de base Node 20.
+- Documenter les preuves dans `docs/audits/` sans consigner de credential,
+  d'adresse privée ou de donnée métier.
+
+## Qualification jetable
+
+### PostgreSQL
+
+Un dump production `schema-only`, complété uniquement par les lignes du
+registre `_prisma_migrations`, est obtenu en lecture seule via le socket du
+conteneur PostgreSQL. Aucun utilisateur, bilan, score ou document n'est copié.
+
+Le clone utilise `pgvector/pgvector:pg15`, un `tmpfs`, un réseau Docker dédié et
+un secret `nexus_admin` aléatoire de 32 octets encodé en hexadécimal. Le secret
+reste dans un répertoire temporaire mode 700, dans un fichier mode 600, puis est
+supprimé avec le clone.
+
+Le migrateur Node 22 doit :
+
+1. s'authentifier par le nom réseau du conteneur, donc par la règle SCRAM ;
+2. appliquer `20260809090000_deferred_parent_email` avec `prisma migrate deploy` ;
+3. obtenir `users.email` nullable, `users.phoneNormalized` et son index ;
+4. produire un second `migrate deploy` sans migration ;
+5. conserver à l'identique le schéma des tables Canonical append-only et de
+   scoring, ainsi que leurs comptes de lignes nuls sur ce clone schema-only.
+
+### Canary Node 22
+
+L'image `runner` est lancée sur un port loopback isolé, avec le clone
+PostgreSQL, un Redis jetable, un compte synthétique et des secrets exclusivement
+temporaires. SMTP, outbox, workers Bilan/NPC et tous les chemins LLM sont
+désactivés. Le canary doit prouver : santé HTTP, accès Prisma, authentification
+Credentials réelle, chargement Sharp et génération PDFKit.
+
+Le canary, Redis, PostgreSQL, le réseau, les images de qualification et tous les
+fichiers temporaires sont détruits après collecte des résultats.
+
+## Production
+
+Cette phase n'autorise aucune rotation de `nexus_admin`, aucune modification de
+HBA, du launcher PM2, de `/usr/bin/node`, de la release active ou du schéma de
+production. La rotation proposée sera décrite précisément dans le rapport et
+restera bloquée derrière un second feu vert explicite.
+
+## Risques et garde-fous
+
+- Le dump ne contient aucune donnée métier ; seul le registre technique Prisma
+  accompagne le schéma pour rendre `migrate deploy` représentatif.
+- Le canary ne rejoint aucun réseau de production et n'utilise aucun secret de
+  production.
+- Une incompatibilité Node, native, Prisma, Sharp, PDF ou authentification
+  arrête la qualification ; elle n'est pas contournée.
+- Les surfaces scoring, append-only, candidat libre, middleware et LLM ne sont
+  pas modifiées.
+
+## Critères de sortie
+
+- Contrat TDD rouge puis vert.
+- Targets `migrator` et `runner` construites ; Node 22.23.1 et npm 10.9.8
+  observés dans les deux images.
+- Migration réseau et idempotence prouvées sur clone.
+- Canary complet vert, puis environnement jetable absent.
+- PR ouverte vers `main`, revue demandée à `abenrhouma`.
+

--- a/docs/superpowers/specs/2026-08-10-node22-migration-prerequisite-design.md
+++ b/docs/superpowers/specs/2026-08-10-node22-migration-prerequisite-design.md
@@ -8,8 +8,9 @@
 
 La PR #116 est fusionnée mais ne doit pas être déployée avant deux preuves :
 `Dockerfile.prod` doit respecter le contrat Node 22 du dépôt, et une migration
-Prisma avec un rôle `nexus_admin` doit fonctionner par SCRAM sur un réseau
-Docker. La production reste strictement inchangée pendant cette phase.
+Prisma avec le rôle administrateur de migration doit fonctionner par SCRAM sur
+un réseau interne isolé. La production reste strictement inchangée pendant
+cette phase.
 
 ## Périmètre versionné
 
@@ -26,18 +27,17 @@ Docker. La production reste strictement inchangée pendant cette phase.
 
 ### PostgreSQL
 
-Un dump production `schema-only`, complété uniquement par les lignes du
-registre `_prisma_migrations`, est obtenu en lecture seule via le socket du
-conteneur PostgreSQL. Aucun utilisateur, bilan, score ou document n'est copié.
+Un export production limité au schéma, complété uniquement par le registre
+Prisma, est obtenu via le canal d'administration en lecture seule. Aucun
+utilisateur, bilan, score ou document n'est copié.
 
-Le clone utilise `pgvector/pgvector:pg15`, un `tmpfs`, un réseau Docker dédié et
-un secret `nexus_admin` aléatoire de 32 octets encodé en hexadécimal. Le secret
-reste dans un répertoire temporaire mode 700, dans un fichier mode 600, puis est
-supprimé avec le clone.
+Le clone PostgreSQL 15 utilise un réseau interne isolé et un credential fort et
+éphémère pour le rôle administrateur de migration. Le secret reste dans un
+stockage temporaire protégé hors dépôt, puis est supprimé avec le clone.
 
 Le migrateur Node 22 doit :
 
-1. s'authentifier par le nom réseau du conteneur, donc par la règle SCRAM ;
+1. s'authentifier par le réseau interne du clone avec SCRAM ;
 2. appliquer `20260809090000_deferred_parent_email` avec `prisma migrate deploy` ;
 3. obtenir `users.email` nullable, `users.phoneNormalized` et son index ;
 4. produire un second `migrate deploy` sans migration ;
@@ -46,7 +46,7 @@ Le migrateur Node 22 doit :
 
 ### Canary Node 22
 
-L'image `runner` est lancée sur un port loopback isolé, avec le clone
+L'image `runner` est lancée sur un endpoint local isolé, avec le clone
 PostgreSQL, un Redis jetable, un compte synthétique et des secrets exclusivement
 temporaires. SMTP, outbox, workers Bilan/NPC et tous les chemins LLM sont
 désactivés. Le canary doit prouver : santé HTTP, accès Prisma, authentification
@@ -57,10 +57,10 @@ fichiers temporaires sont détruits après collecte des résultats.
 
 ## Production
 
-Cette phase n'autorise aucune rotation de `nexus_admin`, aucune modification de
-HBA, du launcher PM2, de `/usr/bin/node`, de la release active ou du schéma de
-production. La rotation proposée sera décrite précisément dans le rapport et
-restera bloquée derrière un second feu vert explicite.
+Cette phase n'autorise aucune rotation du rôle administrateur de migration,
+aucune modification de la politique d'authentification réseau, du launcher de
+processus, de la release active ou du schéma de production. La rotation
+proposée restera bloquée derrière un second feu vert explicite.
 
 ## Risques et garde-fous
 


### PR DESCRIPTION
## Résumé

- Verrouille les stages `deps`, `builder` et `runner` de `Dockerfile.prod` sur `node:22.23.1-alpine` par digest immuable.
- Verrouille le contrat npm à `10.9.8` dans les trois stages et copie `.npmrc` avant `npm ci`.
- Ajoute un contrat Jest anti-dérive et documente les preuves clone PostgreSQL 15 / SCRAM / migration #116 / canary Node 22 sans publier la topologie opérationnelle.

## Correction des checks CI

Cause racine du run initial : le job GitHub « Lint » exécute d'abord `npm run security:repo`. Le scan de divulgation d'infrastructure a correctement refusé le rapport d'audit, puis GitHub a sauté l'étape ESLint. Il n'y avait donc pas d'erreur ESLint distincte ; le check agrégat « CI Success » était rouge par propagation du job « Lint ».

Correction appliquée sans modifier les garde-fous :

- retrait des identifiants opérationnels, noms de services, hôtes, ports, chemins système et valeurs internes des trois documents ajoutés par la PR ;
- conservation d'un rapport versionné générique portant uniquement les résultats techniques ;
- aucun changement de `scripts/security/check-no-public-infrastructure.sh`, du workflow CI, de la configuration ESLint ou des seuils.

Vérifications locales sur `73e73e78612ecf05c546f2eb35d8729c3675821b` :

- [x] `npm run security:repo`
- [x] `bash scripts/security/check-no-public-infrastructure.sh`
- [x] `npm run lint` — code 0, 29 avertissements préexistants candidat libre
- [x] `npm run check:docs-archive`
- [x] audit supplémentaire des seules lignes ajoutées à la PR
- [x] `git diff --check`

## Preuves de qualification

- Clone PostgreSQL 15 créé depuis un export limité au schéma et au registre Prisma, sans donnée métier.
- Authentification SCRAM du rôle éphémère prouvée depuis un réseau interne isolé.
- `prisma migrate deploy` a appliqué uniquement `20260809090000_deferred_parent_email` ; second passage idempotent.
- Schéma attendu obtenu : e-mail nullable, téléphone normalisé et index, unicité des e-mails présents conservée.
- Schéma/comptes Canonical, append-only et scoring inchangés.
- Targets `migrator` et `runner` construites avec Node 22.23.1 et npm 10.9.8.
- Canary isolé : santé HTTP/Prisma, authentification Credentials, Sharp et PDFKit validés avec SMTP, workers et LLM désactivés.
- Toutes les ressources et données temporaires de qualification ont été détruites.

## Production inchangée

- Aucun credential de production modifié ou versionné.
- Aucune modification de la politique réseau, du launcher de processus ou de la release active.
- Migration #116 non appliquée en production.
- Aucun déploiement, aucune bascule, aucun merge.

## Revue demandée

- @abenrhouma — le push de correction impose une nouvelle approbation sur le dernier commit après CI verte.
