### PR TITLE
ops: formalize canonical release pointer

### DIFF
--- a/DEPLOY_RUNBOOK.md
+++ b/DEPLOY_RUNBOOK.md
@@ -32,3 +32,34 @@ PRE_DEPLOY_HEALTH_GREEN=true
 Les preuves restent hors Git. Leur intake schema-validé ne fournit que des
 booléens, références redacted et empreintes. Toute dérive du SHA ou du runbook
 invalide le GO.
+
+## Contrat générique du pointeur de release
+
+Le runbook privé désigne un unique `<CANONICAL_POINTER>` mutable. Le pointeur
+historique `<COMPAT_ALIAS>` doit être un lien symbolique vers ce pointeur
+canonique, jamais un second lien direct vers une release. Une bascule atomique
+ne modifie donc que `<CANONICAL_POINTER>`.
+
+Après la bascule et **avant le reload**, exécuter le garde public en lui
+fournissant les valeurs du runbook privé :
+
+```bash
+scripts/release/verify-release-pointers.sh \
+  --canonical <CANONICAL_POINTER> \
+  --alias <COMPAT_ALIAS> \
+  --release-root <RELEASE_ROOT> \
+  --expected-release <NEW_RELEASE>
+```
+
+Un échec arrête la procédure avant toute action sur le processus. Exécuter
+**après le reload** exactement le même garde, puis vérifier que le pointeur
+canonique, les métadonnées du gestionnaire de processus et `/proc` désignent
+tous `<NEW_RELEASE>`.
+
+Le garde ne modifie rien. Il refuse notamment un alias direct même si les deux
+pointeurs résolvent temporairement vers la même release : deux liens directs
+resteraient indépendamment mutables et pourraient diverger plus tard.
+
+La politique de conservation associée est documentée dans
+`docs/runbooks/release-retention-policy.md`. Toute liste exacte de releases et
+tout chemin concret restent dans le runbook privé root-only.

--- a/__tests__/config/deploy-contract.test.ts
+++ b/__tests__/config/deploy-contract.test.ts
@@ -77,6 +77,34 @@ describe('production deployment contract', () => {
     expect(dockerfile).not.toMatch(/^FROM node:20(?:-|:)/m);
   });
 
+  it('documents the canonical pointer guard before and after process reload', () => {
+    const runbook = read('DEPLOY_RUNBOOK.md');
+
+    expect(runbook).toContain('scripts/release/verify-release-pointers.sh');
+    expect(runbook).toContain('--canonical <CANONICAL_POINTER>');
+    expect(runbook).toContain('--alias <COMPAT_ALIAS>');
+    expect(runbook).toContain('--release-root <RELEASE_ROOT>');
+    expect(runbook).toContain('--expected-release <NEW_RELEASE>');
+    expect(runbook).toContain('avant le reload');
+    expect(runbook).toContain('après le reload');
+  });
+
+  it('keeps release retention fail-closed around runtime data and distinct SHAs', () => {
+    const policyPath = path.join(rootDir, 'docs', 'runbooks', 'release-retention-policy.md');
+    expect(fs.existsSync(policyPath)).toBe(true);
+    const policy = fs.readFileSync(policyPath, 'utf8');
+
+    expect(policy).toContain('deux derniers SHA distincts');
+    expect(policy).toContain('ne compte pas comme rollback');
+    expect(policy).toContain('donnée runtime non répliquée');
+    expect(policy).toContain('feu vert humain explicite');
+    expect(policy).toContain('blocage permanent');
+    expect(policy).toContain('ne lève jamais');
+    expect(policy).toContain('<CANONICAL_POINTER>');
+    expect(policy).toContain('<COMPAT_ALIAS>');
+    expect(policy).toContain('<RELEASE_ROOT>');
+  });
+
   it('keeps public deployment helpers fail-closed and free of topology', () => {
     for (const scriptPath of [
       'scripts/deploy-git-pull.sh',

--- a/__tests__/scripts/verify-release-pointers.test.ts
+++ b/__tests__/scripts/verify-release-pointers.test.ts
@@ -1,0 +1,206 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const guardPath = path.join(repoRoot, 'scripts', 'release', 'verify-release-pointers.sh');
+
+type Fixture = Readonly<{
+  root: string;
+  releaseRoot: string;
+  release: string;
+  canonical: string;
+  alias: string;
+}>;
+
+function createFixture(): Fixture {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nexus-release-pointers-'));
+  const releaseRoot = path.join(root, 'releases');
+  const release = path.join(releaseRoot, 'abc123-release');
+  const canonical = path.join(root, 'app-current');
+  const alias = path.join(releaseRoot, 'current');
+
+  fs.mkdirSync(path.join(release, '.next', 'standalone'), { recursive: true });
+  fs.writeFileSync(path.join(release, '.next', 'standalone', 'server.js'), 'server');
+  fs.symlinkSync(release, canonical);
+  fs.symlinkSync(canonical, alias);
+
+  return { root, releaseRoot, release, canonical, alias };
+}
+
+function runGuard(fixture: Fixture, extraArguments: readonly string[] = []) {
+  return spawnSync(
+    'bash',
+    [
+      guardPath,
+      '--canonical', fixture.canonical,
+      '--alias', fixture.alias,
+      '--release-root', fixture.releaseRoot,
+      ...extraArguments,
+    ],
+    { encoding: 'utf8' },
+  );
+}
+
+function runGuardArguments(arguments_: readonly string[]) {
+  return spawnSync('bash', [guardPath, ...arguments_], { encoding: 'utf8' });
+}
+
+describe('release pointer guard', () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  function fixture() {
+    const created = createFixture();
+    roots.push(created.root);
+    return created;
+  }
+
+  it('accepts a compatibility alias chained to the canonical pointer', () => {
+    const current = fixture();
+
+    const result = runGuard(current, ['--expected-release', current.release]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Release pointer guard passed');
+  });
+
+  it('rejects two independently mutable pointers even when they currently resolve together', () => {
+    const current = fixture();
+    fs.unlinkSync(current.alias);
+    fs.symlinkSync(current.release, current.alias);
+
+    const result = runGuard(current);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('ALIAS_NOT_CHAINED');
+  });
+
+  it('rejects pointers resolving to different releases', () => {
+    const current = fixture();
+    const otherRelease = path.join(current.releaseRoot, 'def456-release');
+    fs.mkdirSync(path.join(otherRelease, '.next', 'standalone'), { recursive: true });
+    fs.writeFileSync(path.join(otherRelease, '.next', 'standalone', 'server.js'), 'server');
+    fs.unlinkSync(current.alias);
+    fs.symlinkSync(otherRelease, current.alias);
+
+    const result = runGuard(current);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('POINTER_DIVERGENCE');
+  });
+
+  it('rejects a dangling canonical pointer', () => {
+    const current = fixture();
+    fs.unlinkSync(current.canonical);
+    fs.symlinkSync(path.join(current.releaseRoot, 'missing'), current.canonical);
+
+    const result = runGuard(current);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('CANONICAL_DANGLING');
+  });
+
+  it('rejects a release outside the declared release root', () => {
+    const current = fixture();
+    const outside = path.join(current.root, 'outside-release');
+    fs.mkdirSync(path.join(outside, '.next', 'standalone'), { recursive: true });
+    fs.writeFileSync(path.join(outside, '.next', 'standalone', 'server.js'), 'server');
+    fs.unlinkSync(current.canonical);
+    fs.symlinkSync(outside, current.canonical);
+
+    const result = runGuard(current);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('RELEASE_OUTSIDE_ROOT');
+  });
+
+  it('rejects a release missing the standalone entry point', () => {
+    const current = fixture();
+    fs.unlinkSync(path.join(current.release, '.next', 'standalone', 'server.js'));
+
+    const result = runGuard(current);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('STANDALONE_ENTRYPOINT_MISSING');
+  });
+
+  it('rejects a resolved release that differs from the expected release', () => {
+    const current = fixture();
+    const unexpected = path.join(current.releaseRoot, 'unexpected-release');
+
+    const result = runGuard(current, ['--expected-release', unexpected]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('EXPECTED_RELEASE_MISMATCH');
+  });
+
+  it('rejects unknown and incomplete arguments', () => {
+    const current = fixture();
+
+    const unknown = runGuard(current, ['--unsupported']);
+    const incomplete = runGuard(current, ['--expected-release']);
+
+    expect(unknown.status).not.toBe(0);
+    expect(unknown.stderr).toContain('UNKNOWN_ARGUMENT');
+    expect(incomplete.status).not.toBe(0);
+    expect(incomplete.stderr).toContain('MISSING_ARGUMENT_VALUE');
+  });
+
+  it('rejects missing required and relative path arguments', () => {
+    const current = fixture();
+
+    const missing = runGuardArguments([
+      '--canonical', current.canonical,
+      '--alias', current.alias,
+    ]);
+    const relative = runGuardArguments([
+      '--canonical', 'relative/current',
+      '--alias', current.alias,
+      '--release-root', current.releaseRoot,
+    ]);
+
+    expect(missing.status).not.toBe(0);
+    expect(missing.stderr).toContain('REQUIRED_ARGUMENT_MISSING');
+    expect(relative.status).not.toBe(0);
+    expect(relative.stderr).toContain('PATH_NOT_ABSOLUTE');
+  });
+
+  it('rejects a canonical pointer that is not a symlink', () => {
+    const current = fixture();
+    fs.unlinkSync(current.canonical);
+    fs.writeFileSync(current.canonical, current.release);
+
+    const result = runGuard(current);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('CANONICAL_NOT_SYMLINK');
+  });
+
+  it('rejects a dangling compatibility alias', () => {
+    const current = fixture();
+    fs.unlinkSync(current.alias);
+    fs.symlinkSync(path.join(current.releaseRoot, 'missing-alias-target'), current.alias);
+
+    const result = runGuard(current);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('ALIAS_DANGLING');
+  });
+
+  it('rejects a missing release root', () => {
+    const current = fixture();
+    const result = runGuardArguments([
+      '--canonical', current.canonical,
+      '--alias', current.alias,
+      '--release-root', path.join(current.root, 'missing-release-root'),
+    ]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('RELEASE_ROOT_MISSING');
+  });
+});

--- a/docs/runbooks/release-retention-policy.md
+++ b/docs/runbooks/release-retention-policy.md
@@ -1,0 +1,62 @@
+# Politique de rétention des releases
+
+## Portée
+
+Cette politique décrit le contrat public sans exposer la topologie réelle. Les
+valeurs `<CANONICAL_POINTER>`, `<COMPAT_ALIAS>` et `<RELEASE_ROOT>` sont
+renseignées uniquement dans le runbook privé.
+
+Aucune suppression n'est automatique. Un inventaire n'est qu'une proposition
+jusqu'au feu vert humain explicite portant sur une liste exacte.
+
+## Releases à conserver
+
+Conserver systématiquement :
+
+- la release active résolue par `<CANONICAL_POINTER>` ;
+- les deux derniers SHA distincts antérieurs compatibles avec la version Node
+  de production supportée ;
+- toute release couverte par un blocage juridique, comptable ou opérationnel ;
+- toute release contenant une donnée runtime non répliquée dans un stockage
+  durable vérifié.
+
+Une reconstruction supplémentaire du même SHA ne compte pas comme rollback.
+Elle peut devenir candidate à la suppression après preuve d'identité des
+artefacts et vérification qu'elle ne contient aucune donnée runtime.
+
+Une copie durable protège la donnée, mais ne lève jamais un blocage permanent
+prononcé pour une release. Seule une décision humaine explicite peut faire
+évoluer un blocage non permanent ; un blocage permanent reste hors de toute
+liste de suppression.
+
+## Garde avant toute proposition de suppression
+
+Pour chaque candidate, produire et faire relire les preuves suivantes :
+
+1. elle n'est la cible ni de `<CANONICAL_POINTER>`, ni de `<COMPAT_ALIAS>` ;
+2. aucun processus en cours ni configuration persistée ne la référence ;
+3. le scan des racines de documents, factures, uploads et rapports ne trouve
+   aucune donnée runtime non répliquée ;
+4. les chemins enregistrés en base ne la référencent pas ;
+5. toute donnée découverte possède une copie durable relue, une empreinte et
+   une décision métier explicite ;
+6. la liste nominative, l'espace estimé et le rollback conservé reçoivent un
+   feu vert humain explicite.
+
+Un seul contrôle rouge bloque la release concernée. Il est interdit de déplacer
+ou de supprimer le fichier problématique pour faire artificiellement passer le
+scan.
+
+## Séquence de nettoyage autorisée ultérieurement
+
+Après validation humaine seulement :
+
+1. refaire l'inventaire et le garde de pointeurs immédiatement avant l'action ;
+2. comparer la liste recalculée à la liste approuvée ;
+3. arrêter si un chemin, un SHA, une référence ou un compteur diffère ;
+4. supprimer uniquement les répertoires explicitement approuvés ;
+5. mesurer l'espace réellement récupéré et refaire les contrôles de santé.
+
+La divergence entre une racine de documents configurée et un répertoire
+historique contenant des fichiers relève d'un chantier distinct. Elle ne doit
+jamais être corrigée implicitement pendant un nettoyage de releases.

--- a/docs/superpowers/plans/2026-08-11-release-pointer-retention.md
+++ b/docs/superpowers/plans/2026-08-11-release-pointer-retention.md
@@ -1,0 +1,112 @@
+# Canonical Release Pointer and Retention Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make one release pointer canonical, keep the compatibility alias synchronized by construction, and document a safe retention policy without deleting releases.
+
+**Architecture:** A generic read-only shell guard validates a canonical symlink and a chained compatibility alias using caller-provided paths. Public documentation uses placeholders; exact topology, inventory and evidence are written to a private root-only runbook on the server.
+
+**Tech Stack:** Bash, Jest/TypeScript, GitHub Actions repository gates, PM2 production topology.
+
+---
+
+## Chunk 1: Versioned pointer contract
+
+### Task 1: Test-drive the generic pointer guard
+
+**Files:**
+- Create: `__tests__/scripts/verify-release-pointers.test.ts`
+- Create: `scripts/release/verify-release-pointers.sh`
+
+- [ ] **Step 1: Write failing tests**
+
+Cover a valid chained alias plus failures for a direct alias, divergent target,
+dangling pointer, target outside the release root and missing standalone entry
+point. Execute the real shell script against temporary directories.
+
+- [ ] **Step 2: Run the test and confirm RED**
+
+Run: `npm test -- __tests__/scripts/verify-release-pointers.test.ts --runInBand`
+
+Expected: FAIL because the guard does not exist.
+
+- [ ] **Step 3: Implement the minimal guard**
+
+Accept `--canonical`, `--alias`, `--release-root` and optional
+`--expected-release`. Reject unknown or missing arguments, validate raw and
+resolved symlink topology, containment and the standalone server entry point.
+
+- [ ] **Step 4: Run the test and confirm GREEN**
+
+Run: `npm test -- __tests__/scripts/verify-release-pointers.test.ts --runInBand`
+
+Expected: all pointer scenarios pass.
+
+### Task 2: Document the generic deployment and retention contracts
+
+**Files:**
+- Modify: `DEPLOY_RUNBOOK.md`
+- Create: `docs/runbooks/release-retention-policy.md`
+- Modify: `__tests__/config/deploy-contract.test.ts`
+
+- [ ] **Step 1: Add failing contract assertions**
+
+Require the public runbook to name the guard with placeholder arguments and
+require the retention policy to preserve active plus two distinct compatible
+SHAs, exclude duplicate SHA builds from rollback slots and fail closed on
+runtime data.
+
+- [ ] **Step 2: Run the contract test and confirm RED**
+
+Run: `npm test -- __tests__/config/deploy-contract.test.ts --runInBand`
+
+Expected: FAIL because the documentation contract is absent.
+
+- [ ] **Step 3: Add minimal public documentation**
+
+Document canonical-first atomic cutover, pre/post-reload guard calls and the
+approved retention criteria using placeholders only.
+
+- [ ] **Step 4: Run the contract test and confirm GREEN**
+
+Run: `npm test -- __tests__/config/deploy-contract.test.ts --runInBand`
+
+Expected: all deployment contract tests pass.
+
+## Chunk 2: Private operational application
+
+### Task 3: Secure the unique invoice copy and write private evidence
+
+**Files:**
+- Create outside Git: private durable invoice backup, checksum sidecar, private runbook and exact release inventory.
+
+- [ ] **Step 1: Re-resolve the unique file by its approved fingerprint**
+- [ ] **Step 2: Copy it without modifying the source into durable root-only storage**
+- [ ] **Step 3: Set owner `root:root`, mode `0600`, reread it and compare checksums**
+- [ ] **Step 4: Write the exact inventory and document-root mismatch into private mode-0600 evidence**
+
+### Task 4: Chain the compatibility alias without reload
+
+**Files:**
+- Modify outside Git: compatibility symlink only.
+
+- [ ] **Step 1: Prove both pointers currently resolve to the active release**
+- [ ] **Step 2: Atomically replace the compatibility alias so its raw target is the canonical pointer**
+- [ ] **Step 3: Run the generic guard with exact private arguments**
+- [ ] **Step 4: Verify PM2 PID/uptime unchanged and health remains green**
+
+## Chunk 3: Verification and publication
+
+### Task 5: Run repository gates
+
+- [ ] **Step 1:** Run both targeted Jest suites.
+- [ ] **Step 2:** Run `bash scripts/security/check-no-public-infrastructure.sh`.
+- [ ] **Step 3:** Run `npm run lint`, `npm run typecheck` and `git diff --check`.
+- [ ] **Step 4:** Review the exact diff and confirm no infrastructure literals or unrelated changes.
+
+### Task 6: Publish the PR
+
+- [ ] **Step 1:** Commit only the guard, tests and generic documentation.
+- [ ] **Step 2:** Push `agent/release-pointer-retention`.
+- [ ] **Step 3:** Open a draft PR to `main` requesting review from `abenrhouma`.
+- [ ] **Step 4:** Do not merge or deploy the versioned changes.

--- a/docs/superpowers/specs/2026-08-11-release-pointer-retention-design.md
+++ b/docs/superpowers/specs/2026-08-11-release-pointer-retention-design.md
@@ -1,0 +1,88 @@
+# Canonical Release Pointer and Retention Design
+
+## Date
+
+2026-08-11
+
+## Context
+
+Production has one pointer consumed by the process launcher and a second
+compatibility pointer historically used by operators. Two independently
+mutable pointers can diverge even when both happen to resolve to the same
+release at a given instant.
+
+The public repository must not contain concrete infrastructure paths. Exact
+topology, release inventory and operational evidence therefore belong in a
+private root-only runbook.
+
+## Decision
+
+`<CANONICAL_POINTER>` is the only mutable release pointer.
+`<COMPAT_ALIAS>` remains available, but its raw symlink target is
+`<CANONICAL_POINTER>` rather than a release directory. It therefore follows
+every future cutover automatically and cannot independently select another
+release.
+
+The public repository provides a read-only, parameterized guard. The private
+runbook supplies the concrete paths and invokes the guard before and after a
+process reload.
+
+## Guard contract
+
+The guard fails closed unless all of the following are true:
+
+1. the canonical pointer and compatibility alias are symlinks;
+2. the alias raw target is exactly the canonical pointer;
+3. both resolve to the same existing directory below `<RELEASE_ROOT>`;
+4. the resolved release contains the expected standalone server entry point;
+5. when an expected release is supplied, it matches the resolved directory.
+
+It is read-only and accepts every topology value through arguments. No real
+host, process name or server path is embedded in the repository.
+
+## Deployment sequence
+
+1. Build and validate a new immutable release directory.
+2. Atomically switch `<CANONICAL_POINTER>` using a temporary symlink and
+   rename.
+3. Run the pointer guard. A failure stops the deployment before reload.
+4. Reload the process using the private launcher.
+5. Prove pointer, process metadata and `/proc` resolve to the same release.
+6. Run the pointer guard again and complete the application smoke checks.
+
+`<COMPAT_ALIAS>` is never switched during deployment because it follows the
+canonical pointer by construction.
+
+## Retention policy
+
+- Always retain the active release.
+- Retain the two most recent prior distinct release SHAs compatible with the
+  supported embedded Node runtime.
+- Duplicate builds of the same SHA do not consume rollback slots.
+- A release containing runtime data without a verified durable copy is
+  retention-blocked regardless of age or runtime compatibility.
+- Removal requires a concrete candidate list, proof that no pointer or process
+  references a candidate, a runtime-data scan, a database-reference check and
+  explicit human approval.
+- This design performs no release deletion.
+
+## Runtime-data exception
+
+The audited inventory contains one historical release with the only known copy
+of an invoice-like PDF. The file must be copied to durable root-only storage,
+checksummed and kept in the private inventory. The source remains untouched.
+This protective copy never lifts a permanent release-retention block: a release
+declared permanently retained remains outside every removal candidate list.
+
+The separate mismatch between the configured document root and the directory
+holding existing documents is recorded but deliberately not corrected here.
+
+## Security and rollback
+
+The repository documentation uses placeholders only and remains subject to the
+public-infrastructure security scan. Exact evidence is stored outside Git with
+mode `0600` and root ownership.
+
+Changing the compatibility alias to point at the canonical pointer does not
+change the resolved active release and requires no process reload. If the
+atomic rename fails, the previous alias remains intact.

--- a/scripts/release/verify-release-pointers.sh
+++ b/scripts/release/verify-release-pointers.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'Release pointer guard failed: %s\n' "$1" >&2
+  exit 1
+}
+
+canonical=''
+compat_alias=''
+release_root=''
+expected_release=''
+
+while (($# > 0)); do
+  case "$1" in
+    --canonical)
+      (($# >= 2)) || fail 'MISSING_ARGUMENT_VALUE'
+      canonical=$2
+      shift 2
+      ;;
+    --alias)
+      (($# >= 2)) || fail 'MISSING_ARGUMENT_VALUE'
+      compat_alias=$2
+      shift 2
+      ;;
+    --release-root)
+      (($# >= 2)) || fail 'MISSING_ARGUMENT_VALUE'
+      release_root=$2
+      shift 2
+      ;;
+    --expected-release)
+      (($# >= 2)) || fail 'MISSING_ARGUMENT_VALUE'
+      expected_release=$2
+      shift 2
+      ;;
+    *)
+      fail 'UNKNOWN_ARGUMENT'
+      ;;
+  esac
+done
+
+[[ -n "$canonical" && -n "$compat_alias" && -n "$release_root" ]] \
+  || fail 'REQUIRED_ARGUMENT_MISSING'
+
+for path_value in "$canonical" "$compat_alias" "$release_root"; do
+  [[ "$path_value" = /* ]] || fail 'PATH_NOT_ABSOLUTE'
+done
+if [[ -n "$expected_release" && "$expected_release" != /* ]]; then
+  fail 'PATH_NOT_ABSOLUTE'
+fi
+
+[[ -L "$canonical" ]] || fail 'CANONICAL_NOT_SYMLINK'
+[[ -L "$compat_alias" ]] || fail 'ALIAS_NOT_SYMLINK'
+[[ -d "$release_root" ]] || fail 'RELEASE_ROOT_MISSING'
+
+canonical_resolved=$(readlink -f "$canonical")
+[[ -n "$canonical_resolved" && -d "$canonical_resolved" ]] \
+  || fail 'CANONICAL_DANGLING'
+
+alias_resolved=$(readlink -f "$compat_alias")
+[[ -n "$alias_resolved" && -d "$alias_resolved" ]] || fail 'ALIAS_DANGLING'
+[[ "$alias_resolved" == "$canonical_resolved" ]] || fail 'POINTER_DIVERGENCE'
+
+alias_raw=$(readlink "$compat_alias")
+[[ "$alias_raw" == "$canonical" ]] || fail 'ALIAS_NOT_CHAINED'
+
+release_root_resolved=$(readlink -f "$release_root")
+case "$canonical_resolved" in
+  "$release_root_resolved"/*) ;;
+  *) fail 'RELEASE_OUTSIDE_ROOT' ;;
+esac
+
+[[ -f "$canonical_resolved/.next/standalone/server.js" ]] \
+  || fail 'STANDALONE_ENTRYPOINT_MISSING'
+
+if [[ -n "$expected_release" ]]; then
+  expected_resolved=$(readlink -m "$expected_release")
+  [[ "$canonical_resolved" == "$expected_resolved" ]] \
+    || fail 'EXPECTED_RELEASE_MISMATCH'
+fi
+
+printf 'Release pointer guard passed\n'


### PR DESCRIPTION
## Résumé

- formalise un pointeur canonique unique et un alias de compatibilité chaîné ;
- ajoute un garde shell générique, paramétré et fail-closed, sans topologie réelle dans le dépôt ;
- documente le contrat de bascule et la politique de rétention sans automatiser aucune suppression.

## Sécurité et opérations

- le scan de divulgation d'infrastructure passe après staging ;
- le runbook exact et l'inventaire restent hors dépôt, root-only ;
- la donnée runtime unique a été copiée et relue dans le stockage protégé, tandis que sa source reste intacte ;
- aucune release, donnée métier ou fichier de stockage n'a été supprimé ;
- aucun reload, déploiement, migration ou changement de feature flag.

## TDD et tests

- RED initial : le test du garde échouait car le script n'existait pas ;
- GREEN : 12 scénarios de pointeurs et d'arguments fail-closed passent ;
- contrats documentation/rétention : 22/22 tests ciblés passent ;
- suite unitaire : 770 suites, 8 576 tests et 7 snapshots passent ;
- lint : 0 erreur, 29 avertissements historiques ;
- typecheck : vert ;
- build : artefact standalone valide, traces propres, aucune donnée runtime embarquée ;
- scan sécurité dépôt : vert.

## Revue demandée

Revue et approbation demandées à `abenrhouma`. Ne pas merger avant validation opérationnelle explicite.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Formalizes a single canonical release pointer with a chained compatibility alias, and adds a read-only guard to block unsafe cutovers. Documents a safe release retention policy and the deployment contract without embedding topology or deleting releases.

- **New Features**
  - Adds `scripts/release/verify-release-pointers.sh` to validate a canonical symlink, a chained alias, containment within the release root, and the standalone entry point; supports `--expected-release`; fails closed.
  - Adds Jest tests for the guard and updates the deployment contract to require pre/post-reload checks.
  - Adds `docs/runbooks/release-retention-policy.md` plus plan/design docs describing retention rules and the canonical-first cutover.

- **Migration**
  - Run `scripts/release/verify-release-pointers.sh --canonical <CANONICAL_POINTER> --alias <COMPAT_ALIAS> --release-root <RELEASE_ROOT> [--expected-release <NEW_RELEASE>]` before and after reload using values from the private runbook.
  - Ensure `<COMPAT_ALIAS>` is a symlink to `<CANONICAL_POINTER>`, not directly to a release.
  - Keep exact paths and inventories in the private runbook; public docs use placeholders.

<sup>Written for commit e5591abfe17f67200579bfc5d316ca59e0eb7ed8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

