### PR TITLE
fix(security): confinement de chemin des téléchargements (#67) + prévention disque

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -171,6 +171,13 @@ E2E=0
 LOG_LEVEL=info
 
 # =============================================================================
+# DOCUMENT STORAGE (required in production)
+# =============================================================================
+# Absolute path to persistent document storage directory.
+# Must survive release swaps — do NOT place inside a release directory.
+# DOCUMENT_STORAGE_ROOT=/var/www/nexus-shared/storage/documents
+
+# =============================================================================
 # TELEMETRY
 # =============================================================================
 NEXT_TELEMETRY_DISABLED=1

--- a/.env.production.example
+++ b/.env.production.example
@@ -49,6 +49,15 @@ POSTGRES_SHARED_BUFFERS=256MB
 POSTGRES_MAX_CONNECTIONS=100
 
 # =============================================================================
+# DOCUMENT STORAGE - REQUIRED (fail-closed: l'app refuse la requête sans elle)
+# =============================================================================
+# Chemin ABSOLU d'une racine PERSISTANTE, HORS de tout répertoire de release
+# ou de build (elle doit survivre aux bascules) — montée pour l'app ET tout
+# worker qui lit/écrit des documents. Même contrat que la CI (jobs build/E2E)
+# qui fournit un répertoire éphémère équivalent.
+DOCUMENT_STORAGE_ROOT=/srv/example-persistent-storage/documents
+
+# =============================================================================
 # NEXTAUTH (Authentication) - REQUIRED
 # =============================================================================
 # Generate secret with: openssl rand -base64 32

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -620,6 +620,27 @@ jobs:
           esac
           printf 'NPC_STORAGE_ROOT=%s\n' "$canonical_storage_root" >> "$GITHUB_ENV"
 
+      - name: Prepare isolated document storage
+        # DOCUMENT_STORAGE_ROOT est obligatoire (fail-closed) dès que
+        # NODE_ENV=production — même contrat qu'en prod : racine persistante
+        # HORS de l'arbre de release/build. Ici : répertoire éphémère du
+        # runner, même pattern que NPC_STORAGE_ROOT (#120). On complète
+        # l'environnement de CI, on n'affaiblit pas le garde.
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          document_storage_root="$RUNNER_TEMP/document-storage"
+          install -d -m 0700 -- "$document_storage_root"
+          canonical_storage_root="$(realpath -- "$document_storage_root")"
+          canonical_workspace="$(realpath -- "$GITHUB_WORKSPACE")"
+          case "$canonical_storage_root/" in
+            "$canonical_workspace/"*)
+              echo 'Document storage must remain outside the checked-out release.' >&2
+              exit 1
+              ;;
+          esac
+          printf 'DOCUMENT_STORAGE_ROOT=%s\n' "$canonical_storage_root" >> "$GITHUB_ENV"
+
       - name: Wait for Postgres (E2E) to be ready
         run: |
           for i in {1..30}; do
@@ -984,6 +1005,24 @@ jobs:
               ;;
           esac
           printf 'NPC_STORAGE_ROOT=%s\n' "$canonical_storage_root" >> "$GITHUB_ENV"
+
+      - name: Prepare isolated document storage
+        # Même contrat que le job E2E : DOCUMENT_STORAGE_ROOT fail-closed en
+        # production, fourni par l'environnement, hors arbre de build.
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          document_storage_root="$RUNNER_TEMP/document-storage"
+          install -d -m 0700 -- "$document_storage_root"
+          canonical_storage_root="$(realpath -- "$document_storage_root")"
+          canonical_workspace="$(realpath -- "$GITHUB_WORKSPACE")"
+          case "$canonical_storage_root/" in
+            "$canonical_workspace/"*)
+              echo 'Document storage must remain outside the checked-out release.' >&2
+              exit 1
+              ;;
+          esac
+          printf 'DOCUMENT_STORAGE_ROOT=%s\n' "$canonical_storage_root" >> "$GITHUB_ENV"
 
       - name: Generate Prisma Client
         run: npx prisma generate

--- a/__tests__/api/documents.id.route.test.ts
+++ b/__tests__/api/documents.id.route.test.ts
@@ -1,153 +1,130 @@
 /**
- * Documents [id] API — Complete Test Suite
- *
+ * Documents [id] API — Test Suite
  * Tests: GET /api/documents/[id]
- *
- * Source: app/api/documents/[id]/route.ts
  */
+import { Readable } from 'stream';
 
-jest.mock('@/auth', () => ({
-  auth: jest.fn(),
+jest.mock('@/auth', () => ({ auth: jest.fn() }));
+
+jest.mock('@/lib/documents/storage-root', () => ({
+  getDocumentStorageRoot: () => '/mock/storage',
+  LEGACY_STORAGE_PREFIX: '/app/storage/documents/',
 }));
 
-jest.mock('fs/promises', () => ({
-  readFile: jest.fn(),
-}));
-
-jest.mock('node:fs/promises', () => ({
-  readFile: jest.fn(),
-}));
+jest.mock('@/lib/documents/secure-file-access', () => {
+  class SecureFileAccessError extends Error {
+    code: string;
+    constructor(code: string, message: string) { super(message); this.code = code; this.name = 'SecureFileAccessError'; }
+  }
+  return {
+    openSecureDocument: jest.fn(),
+    SecureFileAccessError,
+    safeContentType: (m: string | null) => m || 'application/octet-stream',
+    safeFilename: (n: string) => n || 'document',
+  };
+});
 
 import { GET } from '@/app/api/documents/[id]/route';
 import { auth } from '@/auth';
-import { readFile } from 'fs/promises';
+import { openSecureDocument, SecureFileAccessError } from '@/lib/documents/secure-file-access';
 import { NextRequest } from 'next/server';
 
 const mockAuth = auth as jest.Mock;
-const mockReadFile = readFile as jest.Mock;
+const mockOpen = openSecureDocument as jest.Mock;
 
-let prisma: any;
-
-beforeEach(async () => {
-  const mod = await import('@/lib/prisma');
-  prisma = (mod as any).prisma;
-  jest.clearAllMocks();
-});
-
-function mockDocumentLookup(document: unknown) {
-  prisma.userDocument.findUnique.mockResolvedValue(document);
-  prisma.userDocument.findFirst.mockResolvedValue(document);
+function makeHandle() {
+  return {
+    handle: {
+      createReadStream: () => Readable.from(Buffer.from('content')),
+      close: jest.fn().mockResolvedValue(undefined),
+    },
+    sizeBytes: 7,
+  };
 }
 
-function makeRequest(id: string): [NextRequest, { params: Promise<{ id: string }> }] {
-  const req = new NextRequest(`http://localhost:3000/api/documents/${id}`, { method: 'GET' });
-  return [req, { params: Promise.resolve({ id }) }];
+let prisma: any;
+beforeEach(async () => {
+  prisma = (await import('@/lib/prisma') as any).prisma;
+  jest.clearAllMocks();
+  mockOpen.mockResolvedValue(makeHandle());
+});
+
+function req(id: string): [NextRequest, { params: Promise<{ id: string }> }] {
+  return [new NextRequest(`http://localhost/api/documents/${id}`), { params: Promise.resolve({ id }) }];
+}
+
+function mockDoc(doc: unknown) {
+  prisma.userDocument.findFirst.mockResolvedValue(doc);
 }
 
 describe('GET /api/documents/[id]', () => {
-  it('should return 401 when not authenticated', async () => {
-    mockAuth.mockResolvedValue(null as any);
-
-    const res = await GET(...makeRequest('doc-1'));
-    expect(res.status).toBe(401);
+  it('401 when not authenticated', async () => {
+    mockAuth.mockResolvedValue(null);
+    expect((await GET(...req('x'))).status).toBe(401);
   });
 
-  it('should return 404 when document not found', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
-    mockDocumentLookup(null);
-
-    const res = await GET(...makeRequest('nonexistent'));
-    expect(res.status).toBe(404);
+  it('404 when not found', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } });
+    mockDoc(null);
+    expect((await GET(...req('x'))).status).toBe(404);
   });
 
-  it('should return 404 when user is not owner and not staff without reading file', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'other-user', role: 'ELEVE' } } as any);
-    mockDocumentLookup({
-      id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/test.pdf',
-      mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
-    });
-
-    const res = await GET(...makeRequest('doc-1'));
-    expect(res.status).toBe(404);
-    expect(mockReadFile).not.toHaveBeenCalled();
+  it('404 when non-staff non-owner', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u2', role: 'ELEVE' } });
+    mockDoc({ id: 'd1', userId: 'u1', localPath: 'f.pdf', mimeType: 'application/pdf', originalName: 'f.pdf', sizeBytes: 100 });
+    expect((await GET(...req('d1'))).status).toBe(404);
+    expect(mockOpen).not.toHaveBeenCalled();
   });
 
-  it('should return document for owner', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
-    mockDocumentLookup({
-      id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/test.pdf',
-      mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
-    });
-    mockReadFile.mockResolvedValue(Buffer.from('fake-pdf-content') as any);
-
-    const res = await GET(...makeRequest('doc-1'));
-
-    expect(res.status).toBe(200);
-    expect(res.headers.get('Content-Type')).toBe('application/pdf');
-    expect(res.headers.get('Content-Disposition')).toContain('test.pdf');
-    expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff');
+  it('200 for owner', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } });
+    mockDoc({ id: 'd1', userId: 'u1', localPath: 'f.pdf', mimeType: 'application/pdf', originalName: 'f.pdf', sizeBytes: 100 });
+    const r = await GET(...req('d1'));
+    expect(r.status).toBe(200);
+    expect(r.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(r.headers.get('Cache-Control')).toBe('private, no-store');
   });
 
-  it('should return document for ADMIN', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'admin-1', role: 'ADMIN' } } as any);
-    mockDocumentLookup({
-      id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/test.pdf',
-      mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
-    });
-    mockReadFile.mockResolvedValue(Buffer.from('fake-pdf-content') as any);
-
-    const res = await GET(...makeRequest('doc-1'));
-    expect(res.status).toBe(200);
+  it('200 for ADMIN (any doc)', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'admin', role: 'ADMIN' } });
+    mockDoc({ id: 'd1', userId: 'u1', localPath: 'f.pdf', mimeType: 'application/pdf', originalName: 'f.pdf', sizeBytes: 100 });
+    expect((await GET(...req('d1'))).status).toBe(200);
   });
 
-  it('should return document for ASSISTANTE', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'assist-1', role: 'ASSISTANTE' } } as any);
-    mockDocumentLookup({
-      id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/test.pdf',
-      mimeType: 'application/pdf', originalName: 'test.pdf', sizeBytes: 1024,
-    });
-    mockReadFile.mockResolvedValue(Buffer.from('fake-pdf-content') as any);
-
-    const res = await GET(...makeRequest('doc-1'));
-    expect(res.status).toBe(200);
+  it('200 for ASSISTANTE (any doc)', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'a1', role: 'ASSISTANTE' } });
+    mockDoc({ id: 'd1', userId: 'u1', localPath: 'f.pdf', mimeType: 'application/pdf', originalName: 'f.pdf', sizeBytes: 100 });
+    expect((await GET(...req('d1'))).status).toBe(200);
   });
 
-  it('should return 404 when file missing on disk', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
-    mockDocumentLookup({
-      id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/missing.pdf',
-      mimeType: 'application/pdf', originalName: 'missing.pdf', sizeBytes: 1024,
-    });
-    mockReadFile.mockRejectedValue(new Error('ENOENT: no such file'));
-
-    const res = await GET(...makeRequest('doc-1'));
-    expect(res.status).toBe(404);
+  it('404 on PATH_ESCAPE', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } });
+    mockDoc({ id: 'd1', userId: 'u1', localPath: '../etc/passwd', mimeType: 'application/pdf', originalName: 'x', sizeBytes: 1 });
+    mockOpen.mockRejectedValue(new SecureFileAccessError('PATH_ESCAPE', 'escape'));
+    expect((await GET(...req('d1'))).status).toBe(404);
   });
 
-  it('should not log local file paths when file content is missing', async () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
-    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
-    mockDocumentLookup({
-      id: 'doc-1', userId: 'u1', localPath: '/app/storage/documents/private/missing.pdf',
-      mimeType: 'application/pdf', originalName: 'missing.pdf', sizeBytes: 1024,
-    });
-    mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT: /app/storage/documents/private/missing.pdf'), { code: 'ENOENT' }));
-
-    const res = await GET(...makeRequest('doc-1'));
-
-    expect(res.status).toBe(404);
-    const serializedLogs = JSON.stringify(errorSpy.mock.calls);
-    expect(serializedLogs).not.toContain('/app/storage');
-    expect(serializedLogs).not.toContain('private/missing.pdf');
-    errorSpy.mockRestore();
+  it('404 on FILE_NOT_FOUND', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } });
+    mockDoc({ id: 'd1', userId: 'u1', localPath: 'gone.pdf', mimeType: 'application/pdf', originalName: 'x', sizeBytes: 1 });
+    mockOpen.mockRejectedValue(new SecureFileAccessError('FILE_NOT_FOUND', 'gone'));
+    expect((await GET(...req('d1'))).status).toBe(404);
   });
 
-  it('should return 500 on DB error', async () => {
-    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } } as any);
-    prisma.userDocument.findUnique.mockRejectedValue(new Error('DB error'));
-    prisma.userDocument.findFirst.mockRejectedValue(new Error('DB error'));
+  it('does not log filesystem paths', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } });
+    mockDoc({ id: 'd1', userId: 'u1', localPath: 'secret/private.pdf', mimeType: 'application/pdf', originalName: 'x', sizeBytes: 1 });
+    mockOpen.mockRejectedValue(new SecureFileAccessError('FILE_NOT_FOUND', 'gone'));
+    await GET(...req('d1'));
+    const logs = JSON.stringify(spy.mock.calls);
+    expect(logs).not.toContain('secret/private');
+    spy.mockRestore();
+  });
 
-    const res = await GET(...makeRequest('doc-1'));
-    expect(res.status).toBe(500);
+  it('500 on DB error', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u1', role: 'ELEVE' } });
+    prisma.userDocument.findFirst.mockRejectedValue(new Error('DB'));
+    expect((await GET(...req('d1'))).status).toBe(500);
   });
 });

--- a/__tests__/api/student.documents.download.test.ts
+++ b/__tests__/api/student.documents.download.test.ts
@@ -1,9 +1,4 @@
-import { GET } from '@/app/api/student/documents/[id]/download/route';
-import { requireRole, isErrorResponse } from '@/lib/guards';
-import { prisma } from '@/lib/prisma';
-import { writeFile, unlink, mkdtemp } from 'fs/promises';
-import * as os from 'os';
-import * as path from 'path';
+import { Readable } from 'stream';
 
 jest.mock('@/lib/guards', () => ({
   requireRole: jest.fn(),
@@ -11,189 +6,137 @@ jest.mock('@/lib/guards', () => ({
 }));
 
 jest.mock('@/lib/prisma', () => ({
-  prisma: {
-    userDocument: { findFirst: jest.fn() },
-  },
+  prisma: { userDocument: { findFirst: jest.fn() } },
 }));
 
-const mockEleveSession = {
-  user: { id: 'user-eleve-1', email: 'eleve@test.com', role: 'ELEVE' as const },
-};
+jest.mock('@/lib/documents/storage-root', () => ({
+  getDocumentStorageRoot: () => '/mock/storage',
+  LEGACY_STORAGE_PREFIX: '/app/storage/documents/',
+}));
 
-const mockUnauthorizedResponse = {
-  status: 401,
-  json: async () => ({ error: 'Unauthorized' }),
-  headers: new Headers(),
-};
+// Use manual mock with lazy handle creation
+jest.mock('@/lib/documents/secure-file-access', () => {
+  class SecureFileAccessError extends Error {
+    code: string;
+    constructor(code: string, message: string) { super(message); this.code = code; this.name = 'SecureFileAccessError'; }
+  }
+  return {
+    openSecureDocument: jest.fn(),
+    SecureFileAccessError,
+    safeContentType: (m: string | null) => m || 'application/octet-stream',
+    safeFilename: (n: string) => n || 'document',
+  };
+});
 
-function makeParams(id: string) {
-  return { params: Promise.resolve({ id }) };
+import { GET } from '@/app/api/student/documents/[id]/download/route';
+import { requireRole, isErrorResponse } from '@/lib/guards';
+import { prisma } from '@/lib/prisma';
+import { openSecureDocument, SecureFileAccessError } from '@/lib/documents/secure-file-access';
+
+const mockOpenSecure = openSecureDocument as jest.Mock;
+
+function makeSuccessHandle() {
+  return {
+    handle: {
+      createReadStream: () => Readable.from(Buffer.from('pdf-content')),
+      close: jest.fn().mockResolvedValue(undefined),
+    },
+    sizeBytes: 11,
+  };
 }
+
+const mockSession = { user: { id: 'u1', email: 'e@test.com', role: 'ELEVE' as const } };
+const mock401 = { status: 401, json: async () => ({ error: 'Unauthorized' }), headers: new Headers() };
+
+function params(id: string) { return { params: Promise.resolve({ id }) }; }
 
 describe('GET /api/student/documents/[id]/download', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (requireRole as jest.Mock).mockResolvedValue(mockEleveSession);
+    (requireRole as jest.Mock).mockResolvedValue(mockSession);
     (isErrorResponse as unknown as jest.Mock).mockReturnValue(false);
+    mockOpenSecure.mockResolvedValue(makeSuccessHandle());
   });
 
   it('returns 401 when unauthenticated', async () => {
-    (requireRole as jest.Mock).mockResolvedValue(mockUnauthorizedResponse);
+    (requireRole as jest.Mock).mockResolvedValue(mock401);
     (isErrorResponse as unknown as jest.Mock).mockReturnValue(true);
-
-    const response = await GET({} as any, makeParams('doc-1'));
-    expect(response.status).toBe(401);
+    expect((await GET({} as any, params('x'))).status).toBe(401);
   });
 
-  it('returns 404 when document not found for this user', async () => {
+  it('returns 404 when document not found', async () => {
     (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue(null);
-
-    const response = await GET({} as any, makeParams('doc-nonexistent'));
-    const body = await response.json();
-
-    expect(response.status).toBe(404);
-    expect(body.error).toBe('Not found');
+    const r = await GET({} as any, params('x'));
+    expect(r.status).toBe(404);
+    expect(await r.json()).toEqual({ error: 'Not found' });
   });
 
-  it('enforces ownership — queries with authenticated userId', async () => {
+  it('enforces userId ownership in query', async () => {
     (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue(null);
-
-    await GET({} as any, makeParams('doc-other-user'));
-
+    await GET({} as any, params('x'));
     expect(prisma.userDocument.findFirst).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          userId: 'user-eleve-1',
-        }),
-      })
+      expect.objectContaining({ where: expect.objectContaining({ userId: 'u1' }) })
     );
   });
 
-  it('streams file with correct Content-Type and Content-Disposition', async () => {
-    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'nexus-test-'));
-    const tmpFile = path.join(tmpDir, 'fiche.pdf');
-    await writeFile(tmpFile, Buffer.from('%PDF-1.4 fake content'));
-
+  it('streams file with correct headers on success', async () => {
     (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
-      id: 'doc-1',
-      originalName: 'fiche revision.pdf',
-      mimeType: 'application/pdf',
-      localPath: tmpFile,
+      id: 'd1', originalName: 'fiche.pdf', mimeType: 'application/pdf', localPath: 'fiche.pdf',
     });
-
-    const response = await GET({} as any, makeParams('doc-1'));
-
-    await unlink(tmpFile).catch(() => null);
-
-    expect(response.status).toBe(200);
-    expect(response.headers.get('Content-Type')).toBe('application/pdf');
-    expect(response.headers.get('Content-Disposition')).toContain('attachment');
-    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+    const r = await GET({} as any, params('d1'));
+    expect(r.status).toBe(200);
+    expect(r.headers.get('Content-Disposition')).toContain('attachment');
+    expect(r.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(r.headers.get('Cache-Control')).toBe('private, no-store');
   });
 
-  it('returns 500 when file does not exist on disk', async () => {
+  it('rejects path traversal via containment', async () => {
     (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
-      id: 'doc-1',
-      originalName: 'missing.pdf',
-      mimeType: 'application/pdf',
-      localPath: '/tmp/nexus-nonexistent-file-that-should-never-exist.pdf',
+      id: 'evil', originalName: 'x.pdf', mimeType: 'application/pdf', localPath: '../../../etc/passwd',
     });
-
-    const response = await GET({} as any, makeParams('doc-1'));
-    const body = await response.json();
-
-    expect(response.status).toBe(500);
-    expect(body.error).toBe('File unavailable');
+    mockOpenSecure.mockRejectedValue(new SecureFileAccessError('PATH_ESCAPE', 'escape'));
+    const r = await GET({} as any, params('evil'));
+    expect(r.status).toBe(404);
   });
 
-  it('falls back to application/octet-stream when mimeType is null', async () => {
-    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'nexus-test-'));
-    const tmpFile = path.join(tmpDir, 'export.bin');
-    await writeFile(tmpFile, Buffer.from('\x00\x01\x02'));
-
+  it('rejects absolute path outside root', async () => {
     (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
-      id: 'doc-2',
-      originalName: 'export.bin',
-      mimeType: null,
-      localPath: tmpFile,
+      id: 'abs', originalName: 'x.pdf', mimeType: 'application/pdf', localPath: '/etc/shadow',
     });
-
-    const response = await GET({} as any, makeParams('doc-2'));
-
-    await unlink(tmpFile).catch(() => null);
-
-    expect(response.headers.get('Content-Type')).toBe('application/octet-stream');
+    mockOpenSecure.mockRejectedValue(new SecureFileAccessError('PATH_ESCAPE', 'outside'));
+    expect((await GET({} as any, params('abs'))).status).toBe(404);
   });
 
-  describe('Coach resource ownership (Lot C)', () => {
-    it('allows student to download self-uploaded document', async () => {
-      const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'nexus-test-'));
-      const tmpFile = path.join(tmpDir, 'self-uploaded.pdf');
-      await writeFile(tmpFile, Buffer.from('%PDF-1.4 self uploaded'));
-
-      (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
-        id: 'doc-self',
-        originalName: 'my-upload.pdf',
-        mimeType: 'application/pdf',
-        localPath: tmpFile,
-        userId: 'user-eleve-1',  // recipient is the student
-        uploadedById: 'user-eleve-1',  // uploader is also the student
-      });
-
-      const response = await GET({} as any, makeParams('doc-self'));
-
-      await unlink(tmpFile).catch(() => null);
-
-      expect(response.status).toBe(200);
+  it('accepts absolute path INSIDE storage root', async () => {
+    (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
+      id: 'ok', originalName: 'admin.pdf', mimeType: 'application/pdf',
+      localPath: '/mock/storage/admin.pdf',
     });
+    expect((await GET({} as any, params('ok'))).status).toBe(200);
+  });
 
-    it('allows student to download coach-uploaded resource', async () => {
-      const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'nexus-test-'));
-      const tmpFile = path.join(tmpDir, 'coach-resource.pdf');
-      await writeFile(tmpFile, Buffer.from('%PDF-1.4 coach uploaded'));
-
-      (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
-        id: 'doc-coach',
-        originalName: 'coach-resource.pdf',
-        mimeType: 'application/pdf',
-        localPath: tmpFile,
-        userId: 'user-eleve-1',  // recipient is the student (ownership check)
-        uploadedById: 'coach-user-123',  // uploader is the coach
-        uploadedBy: { role: 'COACH' },
-      });
-
-      const response = await GET({} as any, makeParams('doc-coach'));
-
-      await unlink(tmpFile).catch(() => null);
-
-      expect(response.status).toBe(200);
+  it('returns 404 when file missing', async () => {
+    (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
+      id: 'd1', originalName: 'x.pdf', mimeType: 'application/pdf', localPath: 'gone.pdf',
     });
+    mockOpenSecure.mockRejectedValue(new SecureFileAccessError('FILE_NOT_FOUND', 'gone'));
+    expect((await GET({} as any, params('d1'))).status).toBe(404);
+  });
 
-    it('denies access when student tries to download another student document', async () => {
-      // Document belongs to a different student
-      (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue(null);
-
-      const response = await GET({} as any, makeParams('doc-other-student'));
-      const body = await response.json();
-
-      expect(response.status).toBe(404);
-      expect(body.error).toBe('Not found');
+  it('passes legacy prefix to openSecureDocument', async () => {
+    (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue({
+      id: 'leg', originalName: 'x.pdf', mimeType: 'application/pdf',
+      localPath: '/app/storage/documents/old.pdf',
     });
+    await GET({} as any, params('leg'));
+    expect(mockOpenSecure).toHaveBeenCalledWith(
+      '/mock/storage', '/app/storage/documents/old.pdf',
+      expect.objectContaining({ legacyPrefixToStrip: '/app/storage/documents/' }),
+    );
+  });
 
-    it('verifies ownership is enforced via userId not uploadedById', async () => {
-      // Even if uploader matches current user, if recipient doesn't match → denied
-      (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue(null);
-
-      await GET({} as any, makeParams('doc-not-recipient'));
-
-      // The query should filter by userId (recipient), not uploadedById
-      expect(prisma.userDocument.findFirst).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            userId: 'user-eleve-1',  // Must be the recipient
-          }),
-        })
-      );
-    });
+  it('denies other student document', async () => {
+    (prisma.userDocument.findFirst as jest.Mock).mockResolvedValue(null);
+    expect((await GET({} as any, params('other'))).status).toBe(404);
   });
 });

--- a/__tests__/lib/documents/secure-file-access.test.ts
+++ b/__tests__/lib/documents/secure-file-access.test.ts
@@ -1,0 +1,329 @@
+import {
+  openSecureDocument,
+  resolveSecurePath,
+  SecureFileAccessError,
+  safeContentType,
+  safeFilename,
+} from '@/lib/documents/secure-file-access';
+import { writeFile, mkdir, symlink, rm, unlink } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+let testDir: string;
+let storageRoot: string;
+
+beforeAll(async () => {
+  testDir = join(tmpdir(), `secure-file-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  storageRoot = join(testDir, 'storage');
+  await mkdir(join(storageRoot, 'subdir'), { recursive: true });
+  await writeFile(join(storageRoot, 'valid.pdf'), 'PDF content here');
+  await writeFile(join(storageRoot, 'subdir', 'nested.pdf'), 'nested content');
+
+  // File outside storage root
+  await mkdir(join(testDir, 'outside'), { recursive: true });
+  await writeFile(join(testDir, 'outside', 'secret.txt'), 'secret data');
+
+  // Symlink escaping outside storage
+  await symlink(join(testDir, 'outside', 'secret.txt'), join(storageRoot, 'escape-symlink.txt'));
+  // Valid symlink inside storage
+  await symlink(join(storageRoot, 'valid.pdf'), join(storageRoot, 'internal-symlink.pdf'));
+});
+
+afterAll(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+describe('openSecureDocument', () => {
+  // ── Valid paths ──
+
+  test('opens a valid relative path', async () => {
+    const doc = await openSecureDocument(storageRoot, 'valid.pdf');
+    expect(doc.sizeBytes).toBeGreaterThan(0);
+    await doc.handle.close();
+  });
+
+  test('opens a nested valid path', async () => {
+    const doc = await openSecureDocument(storageRoot, 'subdir/nested.pdf');
+    expect(doc.sizeBytes).toBeGreaterThan(0);
+    await doc.handle.close();
+  });
+
+  // ── Absolute paths INSIDE storage root (admin/coach upload format) ──
+
+  test('accepts absolute path under storage root', async () => {
+    const absPath = join(storageRoot, 'valid.pdf');
+    const doc = await openSecureDocument(storageRoot, absPath);
+    expect(doc.sizeBytes).toBeGreaterThan(0);
+    await doc.handle.close();
+  });
+
+  test('accepts absolute path in subdirectory under storage root', async () => {
+    const absPath = join(storageRoot, 'subdir', 'nested.pdf');
+    const doc = await openSecureDocument(storageRoot, absPath);
+    expect(doc.sizeBytes).toBeGreaterThan(0);
+    await doc.handle.close();
+  });
+
+  // ── Absolute paths OUTSIDE storage root ──
+
+  test('rejects absolute path outside storage root', async () => {
+    const outsidePath = join(testDir, 'outside', 'secret.txt');
+    await expect(openSecureDocument(storageRoot, outsidePath))
+      .rejects.toThrow(SecureFileAccessError);
+    try {
+      await openSecureDocument(storageRoot, outsidePath);
+    } catch (err) {
+      expect((err as SecureFileAccessError).code).toBe('PATH_ESCAPE');
+    }
+  });
+
+  test('rejects /etc/passwd', async () => {
+    await expect(openSecureDocument(storageRoot, '/etc/passwd'))
+      .rejects.toThrow(SecureFileAccessError);
+    try {
+      await openSecureDocument(storageRoot, '/etc/passwd');
+    } catch (err) {
+      expect(['PATH_ESCAPE', 'FILE_NOT_FOUND']).toContain((err as SecureFileAccessError).code);
+    }
+  });
+
+  test('rejects absolute sibling path sharing prefix', async () => {
+    // /tmp/.../storage-evil is NOT under /tmp/.../storage
+    const evilDir = `${storageRoot}-evil`;
+    await mkdir(evilDir, { recursive: true });
+    await writeFile(join(evilDir, 'trick.txt'), 'tricked');
+    try {
+      await expect(openSecureDocument(storageRoot, join(evilDir, 'trick.txt')))
+        .rejects.toThrow(SecureFileAccessError);
+    } finally {
+      await rm(evilDir, { recursive: true, force: true });
+    }
+  });
+
+  // ── Traversal attacks ──
+
+  test('rejects ../ traversal', async () => {
+    await expect(openSecureDocument(storageRoot, '../outside/secret.txt'))
+      .rejects.toThrow(SecureFileAccessError);
+  });
+
+  test('rejects ../../ traversal', async () => {
+    await expect(openSecureDocument(storageRoot, '../../etc/passwd'))
+      .rejects.toThrow(SecureFileAccessError);
+  });
+
+  test('rejects %2e%2e encoded traversal', async () => {
+    await expect(openSecureDocument(storageRoot, '%2e%2e/outside/secret.txt'))
+      .rejects.toThrow(SecureFileAccessError);
+    try {
+      await openSecureDocument(storageRoot, '%2e%2e/outside/secret.txt');
+    } catch (err) {
+      expect((err as SecureFileAccessError).code).toBe('INVALID_PATH_FORMAT');
+    }
+  });
+
+  test('rejects %252e%252e double-encoded traversal', async () => {
+    // %25 = literal %, so %252e = %2e after one decode
+    await expect(openSecureDocument(storageRoot, '%252e%252e/outside/secret.txt'))
+      .rejects.toThrow(SecureFileAccessError);
+  });
+
+  test('rejects null byte injection', async () => {
+    await expect(openSecureDocument(storageRoot, 'valid.pdf%00.txt'))
+      .rejects.toThrow(SecureFileAccessError);
+  });
+
+  test('rejects backslash separators', async () => {
+    await expect(openSecureDocument(storageRoot, '..\\outside\\secret.txt'))
+      .rejects.toThrow(SecureFileAccessError);
+  });
+
+  // ── URL schemes ──
+
+  test('rejects http:// URL', async () => {
+    await expect(openSecureDocument(storageRoot, 'http://evil.com/file'))
+      .rejects.toThrow(SecureFileAccessError);
+    try {
+      await openSecureDocument(storageRoot, 'http://evil.com/file');
+    } catch (err) {
+      expect((err as SecureFileAccessError).code).toBe('INVALID_PATH_FORMAT');
+    }
+  });
+
+  test('rejects file:// URL', async () => {
+    await expect(openSecureDocument(storageRoot, 'file:///etc/passwd'))
+      .rejects.toThrow(SecureFileAccessError);
+  });
+
+  // ── Symlinks ──
+
+  test('rejects symlink escaping outside storage root', async () => {
+    try {
+      await openSecureDocument(storageRoot, 'escape-symlink.txt');
+      fail('Should have thrown PATH_ESCAPE');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SecureFileAccessError);
+      expect((err as SecureFileAccessError).code).toBe('PATH_ESCAPE');
+    }
+  });
+
+  test('accepts valid internal symlink', async () => {
+    const doc = await openSecureDocument(storageRoot, 'internal-symlink.pdf');
+    expect(doc.sizeBytes).toBeGreaterThan(0);
+    await doc.handle.close();
+  });
+
+  test('works when storage root itself is a symlink', async () => {
+    const symlinkRoot = join(testDir, 'symlink-root');
+    await symlink(storageRoot, symlinkRoot);
+    try {
+      const doc = await openSecureDocument(symlinkRoot, 'valid.pdf');
+      expect(doc.sizeBytes).toBeGreaterThan(0);
+      await doc.handle.close();
+    } finally {
+      await unlink(symlinkRoot);
+    }
+  });
+
+  // ── File not found ──
+
+  test('rejects non-existent file', async () => {
+    try {
+      await openSecureDocument(storageRoot, 'does-not-exist.pdf');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SecureFileAccessError);
+      expect((err as SecureFileAccessError).code).toBe('FILE_NOT_FOUND');
+    }
+  });
+
+  // ── Not a regular file ──
+
+  test('rejects directory as target', async () => {
+    try {
+      await openSecureDocument(storageRoot, 'subdir');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SecureFileAccessError);
+      expect((err as SecureFileAccessError).code).toBe('NOT_REGULAR_FILE');
+    }
+  });
+
+  // ── Size limit ──
+
+  test('rejects file exceeding size limit', async () => {
+    try {
+      await openSecureDocument(storageRoot, 'valid.pdf', { maxSizeBytes: 1 });
+    } catch (err) {
+      expect(err).toBeInstanceOf(SecureFileAccessError);
+      expect((err as SecureFileAccessError).code).toBe('FILE_TOO_LARGE');
+    }
+  });
+
+  // ── Legacy prefix ──
+
+  test('strips legacy prefix before resolving', async () => {
+    const doc = await openSecureDocument(storageRoot, '/app/storage/documents/valid.pdf', {
+      legacyPrefixToStrip: '/app/storage/documents/',
+    });
+    expect(doc.sizeBytes).toBeGreaterThan(0);
+    await doc.handle.close();
+  });
+
+  // ── Storage root errors ──
+
+  test('throws STORAGE_ROOT_UNAVAILABLE when root does not exist', async () => {
+    try {
+      await openSecureDocument('/nonexistent/root', 'file.pdf');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SecureFileAccessError);
+      expect((err as SecureFileAccessError).code).toBe('STORAGE_ROOT_UNAVAILABLE');
+    }
+  });
+
+  // ── TOCTOU: file deleted between stat and read ──
+
+  test('handle remains valid even if file is unlinked after open', async () => {
+    const tmpFile = join(storageRoot, 'toctou-victim.pdf');
+    await writeFile(tmpFile, 'will be deleted');
+
+    const doc = await openSecureDocument(storageRoot, 'toctou-victim.pdf');
+    // Delete the file AFTER opening
+    await unlink(tmpFile);
+    // Should still be readable via the open handle
+    const buf = await doc.handle.readFile();
+    expect(buf.toString()).toBe('will be deleted');
+    await doc.handle.close();
+  });
+
+  // ── Error message safety ──
+
+  test('error messages do not leak filesystem paths', async () => {
+    try {
+      await openSecureDocument(storageRoot, '../outside/secret.txt');
+    } catch (err) {
+      expect((err as Error).message).not.toContain(storageRoot);
+      expect((err as Error).message).not.toContain('outside');
+      expect((err as Error).message).not.toContain('secret');
+    }
+  });
+
+  // ── Handle cleanup on error ──
+
+  test('closes handle if file is a directory (NOT_REGULAR_FILE)', async () => {
+    // The open call succeeds on directories, but fstat check should close it
+    try {
+      await openSecureDocument(storageRoot, 'subdir');
+    } catch (err) {
+      expect((err as SecureFileAccessError).code).toBe('NOT_REGULAR_FILE');
+      // No leaked handle — verified by test completing without timeout
+    }
+  });
+});
+
+describe('resolveSecurePath', () => {
+  test('returns canonical path for relative input', async () => {
+    const result = await resolveSecurePath(storageRoot, 'valid.pdf');
+    expect(result.canonicalPath).toContain('valid.pdf');
+    expect(result.sizeBytes).toBeGreaterThan(0);
+  });
+
+  test('returns canonical path for absolute input under root', async () => {
+    const absPath = join(storageRoot, 'valid.pdf');
+    const result = await resolveSecurePath(storageRoot, absPath);
+    expect(result.sizeBytes).toBeGreaterThan(0);
+  });
+});
+
+describe('safeContentType', () => {
+  test('returns application/pdf for PDF', () => {
+    expect(safeContentType('application/pdf')).toBe('application/pdf');
+  });
+  test('returns octet-stream for text/html', () => {
+    expect(safeContentType('text/html')).toBe('application/octet-stream');
+  });
+  test('returns octet-stream for null', () => {
+    expect(safeContentType(null)).toBe('application/octet-stream');
+  });
+  test('returns octet-stream for undefined', () => {
+    expect(safeContentType(undefined)).toBe('application/octet-stream');
+  });
+});
+
+describe('safeFilename', () => {
+  test('encodes special characters', () => {
+    expect(safeFilename('file name.pdf')).toBe('file%20name.pdf');
+  });
+  test('strips path separators and quotes', () => {
+    const result = safeFilename('../malicious"file.pdf');
+    expect(result).not.toContain('"');
+    expect(result).not.toContain('/');
+  });
+  test('returns document for empty string', () => {
+    expect(safeFilename('')).toBe('document');
+  });
+  test('strips control characters', () => {
+    const result = safeFilename('file\r\nname\x00.pdf');
+    expect(result).not.toContain('\r');
+    expect(result).not.toContain('\n');
+    expect(result).not.toContain('\x00');
+  });
+});

--- a/__tests__/lib/documents/storage-root.test.ts
+++ b/__tests__/lib/documents/storage-root.test.ts
@@ -1,0 +1,77 @@
+import { join } from 'path';
+
+const env = process.env as Record<string, string | undefined>;
+
+// Reset module state between tests
+beforeEach(() => {
+  jest.resetModules();
+  delete env.DOCUMENT_STORAGE_ROOT;
+  delete env.NODE_ENV;
+});
+
+describe('getDocumentStorageRoot', () => {
+  test('returns DOCUMENT_STORAGE_ROOT when set in production', () => {
+    env.NODE_ENV = 'production';
+    env.DOCUMENT_STORAGE_ROOT = '/var/www/nexus-shared/storage/documents';
+    const { getDocumentStorageRoot } = require('@/lib/documents/storage-root');
+    expect(getDocumentStorageRoot()).toBe('/var/www/nexus-shared/storage/documents');
+  });
+
+  test('throws in production when DOCUMENT_STORAGE_ROOT is missing', () => {
+    env.NODE_ENV = 'production';
+    const { getDocumentStorageRoot } = require('@/lib/documents/storage-root');
+    expect(() => getDocumentStorageRoot()).toThrow('DOCUMENT_STORAGE_ROOT is required in production');
+  });
+
+  test('throws in production when DOCUMENT_STORAGE_ROOT is relative', () => {
+    env.NODE_ENV = 'production';
+    env.DOCUMENT_STORAGE_ROOT = 'storage/documents';
+    const { getDocumentStorageRoot } = require('@/lib/documents/storage-root');
+    expect(() => getDocumentStorageRoot()).toThrow('must be an absolute path');
+  });
+
+  test('falls back to cwd/storage/documents in development', () => {
+    env.NODE_ENV = 'development';
+    const { getDocumentStorageRoot } = require('@/lib/documents/storage-root');
+    const root = getDocumentStorageRoot();
+    expect(root).toContain('storage');
+    expect(root).toContain('documents');
+  });
+
+  test('uses DOCUMENT_STORAGE_ROOT in development when set', () => {
+    env.NODE_ENV = 'development';
+    env.DOCUMENT_STORAGE_ROOT = '/tmp/test-storage';
+    const { getDocumentStorageRoot } = require('@/lib/documents/storage-root');
+    expect(getDocumentStorageRoot()).toBe('/tmp/test-storage');
+  });
+});
+
+describe('toRelativeStoragePath', () => {
+  test('converts absolute path to relative', () => {
+    env.NODE_ENV = 'test';
+    env.DOCUMENT_STORAGE_ROOT = '/var/storage';
+    const { toRelativeStoragePath } = require('@/lib/documents/storage-root');
+    expect(toRelativeStoragePath('/var/storage/user1/file.pdf')).toBe(join('user1', 'file.pdf'));
+  });
+
+  test('handles simple filename', () => {
+    env.NODE_ENV = 'test';
+    env.DOCUMENT_STORAGE_ROOT = '/var/storage';
+    const { toRelativeStoragePath } = require('@/lib/documents/storage-root');
+    expect(toRelativeStoragePath('/var/storage/file.pdf')).toBe('file.pdf');
+  });
+
+  test('throws when path is outside storage root', () => {
+    env.NODE_ENV = 'test';
+    env.DOCUMENT_STORAGE_ROOT = '/var/storage';
+    const { toRelativeStoragePath } = require('@/lib/documents/storage-root');
+    expect(() => toRelativeStoragePath('/etc/passwd')).toThrow('not under the document storage root');
+  });
+
+  test('throws on traversal attempt', () => {
+    env.NODE_ENV = 'test';
+    env.DOCUMENT_STORAGE_ROOT = '/var/storage';
+    const { toRelativeStoragePath } = require('@/lib/documents/storage-root');
+    expect(() => toRelativeStoragePath('/var/storage/../etc/passwd')).toThrow('not under');
+  });
+});

--- a/__tests__/lib/invoice/storage.containment.test.ts
+++ b/__tests__/lib/invoice/storage.containment.test.ts
@@ -1,0 +1,80 @@
+/**
+ * readInvoicePDF — confinement canonique (realpath + path.relative).
+ *
+ * Tests sur système de fichiers réel : le guard précédent comparait des
+ * préfixes de chaînes sans realpath ni séparateur final, ce qui laissait
+ * passer un répertoire voisin (data/invoices-evil) et les symlinks
+ * sortants. Ces tests verrouillent la fermeture des deux brèches.
+ */
+import { mkdtemp, mkdir, writeFile, symlink, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+let testDir: string;
+let storageDir: string;
+
+async function loadStorage() {
+  let mod: typeof import('@/lib/invoice/storage');
+  jest.isolateModules(() => {
+    mod = require('@/lib/invoice/storage');
+  });
+  return mod!;
+}
+
+beforeAll(async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'nexus-invoice-containment-'));
+  storageDir = join(testDir, 'invoices');
+  await mkdir(storageDir, { recursive: true });
+  await writeFile(join(storageDir, 'facture_ok.pdf'), '%PDF-1.4 ok');
+
+  // Répertoire voisin partageant le préfixe : /…/invoices-evil
+  await mkdir(`${storageDir}-evil`, { recursive: true });
+  await writeFile(join(`${storageDir}-evil`, 'trick.pdf'), 'tricked');
+
+  // Fichier hors racine + symlink interne pointant dessus
+  await writeFile(join(testDir, 'outside.pdf'), 'outside');
+  await symlink(join(testDir, 'outside.pdf'), join(storageDir, 'escape-link.pdf'));
+
+  process.env.INVOICE_STORAGE_DIR = storageDir;
+});
+
+afterAll(async () => {
+  delete process.env.INVOICE_STORAGE_DIR;
+  await rm(testDir, { recursive: true, force: true });
+});
+
+describe('readInvoicePDF containment', () => {
+  it('lit un PDF légitime sous la racine', async () => {
+    const { readInvoicePDF } = await loadStorage();
+    const buffer = await readInvoicePDF(join(storageDir, 'facture_ok.pdf'));
+    expect(buffer.toString()).toContain('%PDF');
+  });
+
+  it('rejette un répertoire voisin partageant le préfixe (invoices-evil)', async () => {
+    const { readInvoicePDF } = await loadStorage();
+    await expect(readInvoicePDF(join(`${storageDir}-evil`, 'trick.pdf')))
+      .rejects.toThrow('outside storage directory');
+  });
+
+  it('rejette un symlink interne qui sort de la racine', async () => {
+    const { readInvoicePDF } = await loadStorage();
+    await expect(readInvoicePDF(join(storageDir, 'escape-link.pdf')))
+      .rejects.toThrow('outside storage directory');
+  });
+
+  it('rejette une traversée ../', async () => {
+    const { readInvoicePDF } = await loadStorage();
+    await expect(readInvoicePDF(join(storageDir, '..', 'outside.pdf')))
+      .rejects.toThrow('outside storage directory');
+  });
+
+  it('rejette un chemin absolu hors racine', async () => {
+    const { readInvoicePDF } = await loadStorage();
+    await expect(readInvoicePDF('/etc/passwd')).rejects.toThrow();
+  });
+
+  it('rejette la racine elle-même comme cible', async () => {
+    const { readInvoicePDF } = await loadStorage();
+    await expect(readInvoicePDF(storageDir)).rejects.toThrow('outside storage directory');
+  });
+});

--- a/__tests__/scripts/disk-alert.test.ts
+++ b/__tests__/scripts/disk-alert.test.ts
@@ -1,0 +1,82 @@
+/**
+ * disk-alert.sh — alerte disque à seuil, e-mail via commande injectable.
+ *
+ * La commande mail est remplacée par un capteur qui écrit le message sur
+ * disque — aucun envoi réel, aucun secret.
+ */
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, readFileSync, existsSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const script = join(process.cwd(), 'scripts/ops/disk-alert.sh');
+
+let testDir: string;
+let capturePath: string;
+let fakeMail: string;
+
+function run(args: string[], env: Record<string, string> = {}) {
+  return spawnSync('bash', [script, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, INTERNAL_NOTIFICATION_EMAIL: '', ...env },
+  });
+}
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), 'nexus-diskalert-'));
+  capturePath = join(testDir, 'sent-mail.txt');
+  fakeMail = join(testDir, 'fake-sendmail.sh');
+  writeFileSync(fakeMail, `#!/bin/sh\ncat > "${capturePath}"\n`);
+  chmodSync(fakeMail, 0o755);
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe('disk-alert.sh', () => {
+  it('silencieux (exit 0, pas de mail) sous le seuil', () => {
+    // Seuil 99 : l'occupation réelle du runner est forcément inférieure.
+    const res = run(['--threshold', '99', '--to', 'ops@example.test', '--mail-command', fakeMail]);
+    expect(res.status).toBe(0);
+    expect(existsSync(capturePath)).toBe(false);
+  });
+
+  it('envoie l\'alerte au-dessus du seuil, avec expéditeur et destinataire attendus', () => {
+    // Seuil 1 : l'occupation réelle dépasse toujours 1 %.
+    const res = run([
+      '--threshold', '1',
+      '--to', 'support@nexusreussite.academy',
+      '--from', 'contact@nexusreussite.academy',
+      '--mail-command', fakeMail,
+    ]);
+    expect(res.status).toBe(0);
+    expect(existsSync(capturePath)).toBe(true);
+    const mail = readFileSync(capturePath, 'utf8');
+    expect(mail).toContain('From: Nexus Ops <contact@nexusreussite.academy>');
+    expect(mail).toContain('To: support@nexusreussite.academy');
+    expect(mail).toContain('[ALERTE DISQUE]');
+    expect(mail).toContain('rotate-releases.sh');
+  });
+
+  it('lit le destinataire depuis INTERNAL_NOTIFICATION_EMAIL', () => {
+    const res = run(
+      ['--threshold', '1', '--mail-command', fakeMail],
+      { INTERNAL_NOTIFICATION_EMAIL: 'env-recipient@example.test' },
+    );
+    expect(res.status).toBe(0);
+    expect(readFileSync(capturePath, 'utf8')).toContain('To: env-recipient@example.test');
+  });
+
+  it('échoue sans destinataire', () => {
+    const res = run(['--threshold', '1', '--mail-command', fakeMail]);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain('RECIPIENT_MISSING');
+  });
+
+  it('rejette un seuil invalide', () => {
+    const res = run(['--threshold', 'abc', '--to', 'x@y.z', '--mail-command', fakeMail]);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain('INVALID_THRESHOLD');
+  });
+});

--- a/__tests__/scripts/purge-build-workspaces.test.ts
+++ b/__tests__/scripts/purge-build-workspaces.test.ts
@@ -1,0 +1,80 @@
+/**
+ * purge-build-workspaces.sh — purge du staging/validation de build.
+ */
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const script = join(process.cwd(), 'scripts/ops/purge-build-workspaces.sh');
+
+let testDir: string;
+let staging: string;
+let validation: string;
+
+function makeWorkspace(root: string, name: string) {
+  const dir = join(root, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'build.log'), name);
+  return dir;
+}
+
+function run(args: string[]) {
+  return spawnSync('bash', [script, ...args], { encoding: 'utf8' });
+}
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), 'nexus-purge-'));
+  staging = join(testDir, 'nexus-build-staging');
+  validation = join(testDir, 'nexus-build-validation');
+  mkdirSync(staging);
+  mkdirSync(validation);
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe('purge-build-workspaces.sh', () => {
+  it('purge tous les workspaces sauf --keep (--apply)', () => {
+    makeWorkspace(staging, 'sha-old');
+    makeWorkspace(staging, 'sha-current');
+    makeWorkspace(validation, 'sha-older');
+
+    const res = run(['--root', staging, '--root', validation, '--keep', 'sha-current', '--apply']);
+    expect(res.status).toBe(0);
+    expect(existsSync(join(staging, 'sha-current'))).toBe(true);
+    expect(existsSync(join(staging, 'sha-old'))).toBe(false);
+    expect(existsSync(join(validation, 'sha-older'))).toBe(false);
+  });
+
+  it('dry-run par défaut : ne supprime rien', () => {
+    makeWorkspace(staging, 'sha-old');
+    const res = run(['--root', staging]);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain('PLAN');
+    expect(existsSync(join(staging, 'sha-old'))).toBe(true);
+  });
+
+  it('refuse une racine qui n\'est pas un workspace de build nexus', () => {
+    const foreign = join(testDir, 'labomaths');
+    mkdirSync(foreign);
+    makeWorkspace(foreign, 'x');
+    const res = run(['--root', foreign, '--apply']);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain('ROOT_NOT_A_NEXUS_BUILD_WORKSPACE');
+    expect(existsSync(join(foreign, 'x'))).toBe(true);
+  });
+
+  it('refuse un chemin relatif', () => {
+    const res = run(['--root', 'nexus-build-staging', '--apply']);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain('PATH_NOT_ABSOLUTE');
+  });
+
+  it('tolère une racine absente (SKIP, exit 0)', () => {
+    const res = run(['--root', join(testDir, 'nexus-build-missing'), '--apply']);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain('SKIP');
+  });
+});

--- a/__tests__/scripts/rotate-releases.test.ts
+++ b/__tests__/scripts/rotate-releases.test.ts
@@ -1,0 +1,166 @@
+/**
+ * rotate-releases.sh — politique de rétention des releases.
+ *
+ * Environnement simulé sur fs temporaire : racine de releases, symlink
+ * canonique, fichier d'épinglage. Vérifie la politique validée le
+ * 2026-08-12 : active + 2 derniers SHA distincts Node22 + épinglés,
+ * dry-run par défaut, fail-closed sur le fichier d'épinglage.
+ */
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync, existsSync, utimesSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const script = join(process.cwd(), 'scripts/ops/rotate-releases.sh');
+
+let testDir: string;
+let releaseRoot: string;
+let canonical: string;
+let pinFile: string;
+
+function makeRelease(name: string, opts: { node22?: boolean; ageDays?: number } = {}) {
+  const dir = join(releaseRoot, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'marker.txt'), name);
+  if (opts.node22) {
+    const nodeDir = join(dir, '.runtime', 'node', 'bin');
+    mkdirSync(nodeDir, { recursive: true });
+    writeFileSync(join(nodeDir, 'node'), '#!/bin/sh\necho v22');
+    chmodSync(join(nodeDir, 'node'), 0o755);
+  }
+  if (opts.ageDays) {
+    const when = new Date(Date.now() - opts.ageDays * 86_400_000);
+    utimesSync(dir, when, when);
+  }
+  return dir;
+}
+
+function run(args: string[]) {
+  return spawnSync('bash', [script, ...args], { encoding: 'utf8' });
+}
+
+function baseArgs(extra: string[] = []) {
+  return [
+    '--release-root', releaseRoot,
+    '--canonical', canonical,
+    '--pin-file', pinFile,
+    ...extra,
+  ];
+}
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), 'nexus-rotate-'));
+  releaseRoot = join(testDir, 'releases');
+  mkdirSync(releaseRoot);
+  pinFile = join(testDir, 'release-retention.conf');
+  writeFileSync(pinFile, '# vide\n');
+  canonical = join(testDir, 'current');
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe('rotate-releases.sh', () => {
+  it('conserve active + 2 SHA distincts Node22, purge le reste (--apply)', () => {
+    makeRelease('aaa111-active', { node22: true, ageDays: 0 });
+    makeRelease('bbb222-rollback', { node22: true, ageDays: 1 });
+    makeRelease('ccc333-old-node22', { node22: true, ageDays: 2 });
+    makeRelease('ddd444-historical', { ageDays: 30 });
+    symlinkSync(join(releaseRoot, 'aaa111-active'), canonical);
+
+    const res = run(baseArgs(['--apply']));
+    expect(res.status).toBe(0);
+    expect(existsSync(join(releaseRoot, 'aaa111-active'))).toBe(true);
+    expect(existsSync(join(releaseRoot, 'bbb222-rollback'))).toBe(true);
+    expect(existsSync(join(releaseRoot, 'ccc333-old-node22'))).toBe(false);
+    expect(existsSync(join(releaseRoot, 'ddd444-historical'))).toBe(false);
+  });
+
+  it('dry-run par défaut : ne supprime rien', () => {
+    makeRelease('aaa111-active', { node22: true });
+    makeRelease('ddd444-historical', { ageDays: 30 });
+    symlinkSync(join(releaseRoot, 'aaa111-active'), canonical);
+
+    const res = run(baseArgs());
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain('PLAN   ddd444-historical');
+    expect(existsSync(join(releaseRoot, 'ddd444-historical'))).toBe(true);
+  });
+
+  it('une release épinglée est conservée même hors politique', () => {
+    makeRelease('aaa111-active', { node22: true });
+    makeRelease('1b8219b1-facture', { ageDays: 60 });
+    writeFileSync(pinFile, '1b8219b1-facture  # facture unique\n');
+    symlinkSync(join(releaseRoot, 'aaa111-active'), canonical);
+
+    const res = run(baseArgs(['--apply']));
+    expect(res.status).toBe(0);
+    expect(existsSync(join(releaseRoot, '1b8219b1-facture'))).toBe(true);
+    expect(res.stdout).toContain('KEEP   1b8219b1-facture');
+  });
+
+  it('échoue fail-closed si le fichier d\'épinglage est absent', () => {
+    makeRelease('aaa111-active', { node22: true });
+    symlinkSync(join(releaseRoot, 'aaa111-active'), canonical);
+    rmSync(pinFile);
+
+    const res = run(baseArgs(['--apply']));
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain('PIN_FILE_MISSING');
+    expect(existsSync(join(releaseRoot, 'aaa111-active'))).toBe(true);
+  });
+
+  it('les rebuilds du même SHA comptent pour UN groupe — seule l\'instance la plus récente est gardée', () => {
+    // Préfixes >= 7 hex pour déclencher le regroupement par SHA (comme les
+    // vrais noms ce2ba01713-…). Avec --keep-node22 3, seul un vrai
+    // regroupement garde ff66aa77 (3e SHA distinct) tout en purgeant le
+    // rebuild ancien de ee55aa77 ; sans regroupement, le rebuild ancien
+    // serait compté comme 3e « SHA » et gardé à la place de ff66aa77.
+    makeRelease('aaa111cc-active', { node22: true, ageDays: 0 });
+    makeRelease('ee55aa77-rebuild-late', { node22: true, ageDays: 1 });
+    makeRelease('ee55aa77-rebuild-early', { node22: true, ageDays: 2 });
+    makeRelease('ff66aa77-older-sha', { node22: true, ageDays: 3 });
+    symlinkSync(join(releaseRoot, 'aaa111cc-active'), canonical);
+
+    const res = run(baseArgs(['--apply', '--keep-node22', '3']));
+    expect(res.status).toBe(0);
+    expect(existsSync(join(releaseRoot, 'ee55aa77-rebuild-late'))).toBe(true);
+    expect(existsSync(join(releaseRoot, 'ee55aa77-rebuild-early'))).toBe(false);
+    expect(existsSync(join(releaseRoot, 'ff66aa77-older-sha'))).toBe(true);
+  });
+
+  it('refuse un symlink canonique pointant hors de la racine des releases', () => {
+    makeRelease('aaa111-active', { node22: true });
+    const outside = join(testDir, 'outside-root');
+    mkdirSync(outside);
+    symlinkSync(outside, canonical);
+
+    const res = run(baseArgs(['--apply']));
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain('ACTIVE_OUTSIDE_RELEASE_ROOT');
+  });
+
+  it('abandonne si le health check échoue', () => {
+    makeRelease('aaa111-active', { node22: true });
+    makeRelease('ddd444-historical', { ageDays: 30 });
+    symlinkSync(join(releaseRoot, 'aaa111-active'), canonical);
+
+    // Port fermé → curl échoue → HEALTH_CHECK_FAILED
+    const res = run(baseArgs(['--apply', '--health-url', 'http://127.0.0.1:1/health']));
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain('HEALTH_CHECK_FAILED');
+    expect(existsSync(join(releaseRoot, 'ddd444-historical'))).toBe(true);
+  });
+
+  it('la release active n\'est jamais purgée, même sans runtime Node embarqué', () => {
+    makeRelease('aaa111-active', {});
+    makeRelease('bbb222-node22', { node22: true, ageDays: 1 });
+    symlinkSync(join(releaseRoot, 'aaa111-active'), canonical);
+
+    const res = run(baseArgs(['--apply']));
+    expect(res.status).toBe(0);
+    expect(existsSync(join(releaseRoot, 'aaa111-active'))).toBe(true);
+    expect(existsSync(join(releaseRoot, 'bbb222-node22'))).toBe(true);
+  });
+});

--- a/app/api/admin/documents/route.ts
+++ b/app/api/admin/documents/route.ts
@@ -6,7 +6,7 @@ import { createId } from '@paralleldrive/cuid2';
 import path from 'path';
 import { mkdir, writeFile } from 'fs/promises';
 import { serializeError } from '@/lib/utils/serialize-error';
-import { getDocumentStorageRoot } from '@/lib/documents/storage-root';
+import { getDocumentStorageRoot, toRelativeStoragePath } from '@/lib/documents/storage-root';
 import { z } from 'zod';
 
 const STORAGE_ROOT = getDocumentStorageRoot();
@@ -103,7 +103,7 @@ export async function POST(request: NextRequest) {
         originalName,
         mimeType: file.type,
         sizeBytes: file.size,
-        localPath: localPath,
+        localPath: toRelativeStoragePath(localPath),
         userId: userId,
         uploadedById: session.user.id,
       },

--- a/app/api/admin/documents/route.ts
+++ b/app/api/admin/documents/route.ts
@@ -9,7 +9,11 @@ import { serializeError } from '@/lib/utils/serialize-error';
 import { getDocumentStorageRoot, toRelativeStoragePath } from '@/lib/documents/storage-root';
 import { z } from 'zod';
 
-const STORAGE_ROOT = getDocumentStorageRoot();
+// Lazy : la racine de stockage lève en production quand DOCUMENT_STORAGE_ROOT
+// manque, et ce fail-closed doit frapper à la requête — jamais au chargement
+// du module, que `next build` exécute en collectant les pages (même piège que
+// payments/validate). Le garde reste intact, seule son évaluation est différée.
+function getStorageRoot() { return getDocumentStorageRoot(); }
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
 const ALLOWED_UPLOAD_MIME_TYPES = new Set([
   'application/pdf',
@@ -85,11 +89,12 @@ export async function POST(request: NextRequest) {
     const secureFilename = `${uniqueId}${fileExt}`;
     // Using path.join ensures we stick to the OS separator, 
     // and combined with uniqueId prevents directory traversal like ../../
-    const localPath = path.join(STORAGE_ROOT, secureFilename);
+    const storageRoot = getStorageRoot();
+    const localPath = path.join(storageRoot, secureFilename);
     const originalName = sanitizeOriginalName(file.name);
 
     // Ensure directory exists
-    await mkdir(STORAGE_ROOT, { recursive: true });
+    await mkdir(storageRoot, { recursive: true });
 
     // Write file to disk
     const buffer = Buffer.from(await file.arrayBuffer());

--- a/app/api/coach/students/[studentId]/documents/route.ts
+++ b/app/api/coach/students/[studentId]/documents/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { mkdir, writeFile } from 'fs/promises';
 import path from 'path';
-import { getDocumentStorageRoot } from '@/lib/documents/storage-root';
+import { getDocumentStorageRoot, toRelativeStoragePath } from '@/lib/documents/storage-root';
 import { requireRole, isErrorResponse } from '@/lib/guards';
 import { assertCoachCanAccessStudent } from '@/lib/rbac/coach-student-access';
 import { prisma } from '@/lib/prisma';
@@ -253,14 +253,14 @@ export async function POST(request: Request, { params }: RouteParams) {
       const sanitizedTitle = sanitizeFilenamePart(validatedMeta.title);
       const extension = sanitizeFilenamePart(file.name.split('.').pop() || 'pdf');
       const filename = `${sanitizedTitle}-${timestamp}.${extension}`;
-      // Write to STORAGE_ROOT and store the absolute path in DB
+      // Write to STORAGE_ROOT and store a relative path in DB
       const storageRoot = getDocumentStorageRoot();
       const uploadDir = path.join(storageRoot, student.userId);
-      const localPath = path.join(uploadDir, filename);
+      const absolutePath = path.join(uploadDir, filename);
       await mkdir(uploadDir, { recursive: true });
 
       const buffer = Buffer.from(await file.arrayBuffer());
-      await writeFile(path.join(uploadDir, filename), buffer);
+      await writeFile(absolutePath, buffer);
 
       documentData = {
         title: validatedMeta.title,
@@ -268,7 +268,7 @@ export async function POST(request: Request, { params }: RouteParams) {
         subject: validatedMeta.subject ?? null,
         description: validatedMeta.description ?? null,
         visibilityScope: validatedMeta.visibilityScope,
-        localPath,
+        localPath: toRelativeStoragePath(absolutePath),
         originalName: file.name,
         mimeType: file.type,
         sizeBytes: file.size,

--- a/app/api/documents/[id]/route.ts
+++ b/app/api/documents/[id]/route.ts
@@ -1,32 +1,21 @@
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
-import { readFile } from 'fs/promises';
+import { Readable } from 'stream';
 import { UserRole } from '@prisma/client';
 import { serializeError } from '@/lib/utils/serialize-error';
 import { z } from 'zod';
+import { getDocumentStorageRoot, LEGACY_STORAGE_PREFIX } from '@/lib/documents/storage-root';
+import {
+  openSecureDocument,
+  SecureFileAccessError,
+  safeContentType,
+  safeFilename,
+} from '@/lib/documents/secure-file-access';
 
 const routeParamsSchema = z.object({
   id: z.string().min(1).max(128).regex(/^[A-Za-z0-9_-]+$/),
 });
-
-const documentDownloadSelect = {
-  id: true,
-  userId: true,
-  localPath: true,
-  mimeType: true,
-  originalName: true,
-  sizeBytes: true,
-} as const;
-
-type DocumentDownloadRecord = {
-  id: string;
-  userId: string;
-  localPath: string;
-  mimeType: string;
-  originalName: string;
-  sizeBytes: number;
-};
 
 function isStaffRole(role: string | undefined): boolean {
   return role === UserRole.ADMIN || role === UserRole.ASSISTANTE;
@@ -39,28 +28,8 @@ function buildDocumentOwnershipWhere(id: string, userId: string, role: string | 
   return { id, userId };
 }
 
-function hasDocumentOwnership(document: DocumentDownloadRecord, userId: string, role: string | undefined): boolean {
-  return isStaffRole(role) || document.userId === userId;
-}
-
-function safeFilename(name: string): string {
-  return encodeURIComponent(name.replace(/[\\/\r\n"]/g, '_'));
-}
-
-function safeContentType(mimeType: string | null | undefined): string {
-  if (!mimeType) return 'application/octet-stream';
-  const allowed = new Set([
-    'application/pdf',
-    'image/jpeg',
-    'image/png',
-    'image/webp',
-    'text/plain',
-  ]);
-  return allowed.has(mimeType) ? mimeType : 'application/octet-stream';
-}
-
 export async function GET(
-  request: NextRequest,
+  _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
@@ -76,39 +45,59 @@ export async function GET(
     const { id } = parsedParams.data;
     const userRole = session.user.role as UserRole | undefined;
 
-    // Scope the metadata query before any file-system read.
     const document = await prisma.userDocument.findFirst({
       where: buildDocumentOwnershipWhere(id, session.user.id, userRole),
-      select: documentDownloadSelect,
+      select: {
+        id: true,
+        userId: true,
+        localPath: true,
+        mimeType: true,
+        originalName: true,
+        sizeBytes: true,
+      },
     });
 
     if (!document) {
       return new NextResponse('Document not found', { status: 404 });
     }
 
-    if (!hasDocumentOwnership(document, session.user.id, userRole)) {
+    // Ownership check: staff can access any; others only their own
+    if (!isStaffRole(userRole) && document.userId !== session.user.id) {
       return new NextResponse('Document not found', { status: 404 });
     }
 
+    let secureDoc;
     try {
-      const fileBuffer = await readFile(document.localPath);
-
-      return new NextResponse(fileBuffer, {
-        headers: {
-          'Content-Type': safeContentType(document.mimeType),
-          'Content-Disposition': `inline; filename="${safeFilename(document.originalName)}"`,
-          'Content-Length': document.sizeBytes.toString(),
-          'X-Content-Type-Options': 'nosniff',
-        },
+      const storageRoot = getDocumentStorageRoot();
+      secureDoc = await openSecureDocument(storageRoot, document.localPath, {
+        legacyPrefixToStrip: LEGACY_STORAGE_PREFIX,
       });
-    } catch (fsError) {
-      const code = fsError instanceof Error && 'code' in fsError
-        ? String((fsError as NodeJS.ErrnoException).code)
-        : 'UNKNOWN';
-      console.error('[File Read Error] File content unavailable', { documentId: document.id, code });
+    } catch (err) {
+      if (err instanceof SecureFileAccessError) {
+        console.error('[documents] containment check failed', { documentId: document.id, code: err.code });
+        return new NextResponse('File content not found', { status: 404 });
+      }
+      console.error('[documents] unexpected error', { documentId: document.id });
       return new NextResponse('File content not found', { status: 404 });
     }
 
+    try {
+      const stream = secureDoc.handle.createReadStream();
+      const webStream = Readable.toWeb(stream) as ReadableStream;
+
+      return new NextResponse(webStream, {
+        headers: {
+          'Content-Type': safeContentType(document.mimeType),
+          'Content-Disposition': `inline; filename="${safeFilename(document.originalName)}"`,
+          'Content-Length': secureDoc.sizeBytes.toString(),
+          'X-Content-Type-Options': 'nosniff',
+          'Cache-Control': 'private, no-store',
+        },
+      });
+    } catch {
+      await secureDoc.handle.close().catch(() => {});
+      return new NextResponse('File content not found', { status: 404 });
+    }
   } catch (error) {
     console.error('[Download Error]', serializeError(error));
     return new NextResponse('Internal Server Error', { status: 500 });

--- a/app/api/payments/validate/route.ts
+++ b/app/api/payments/validate/route.ts
@@ -2,7 +2,7 @@ import { serializeError } from '@/lib/utils/serialize-error';
 export const dynamic = 'force-dynamic';
 
 import { auth } from '@/auth';
-import { getDocumentStorageRoot } from '@/lib/documents/storage-root';
+import { getDocumentStorageRoot, toRelativeStoragePath } from '@/lib/documents/storage-root';
 import { activateEntitlements } from '@/lib/entitlement/engine';
 import type { ProductCode } from '@/lib/entitlement/types';
 import type { InvoiceData,TaxRegime } from '@/lib/invoice';
@@ -96,8 +96,10 @@ function buildMinimalPdfBuffer(message: string): Buffer {
   return Buffer.from(pdf, 'utf8');
 }
 
-/** Base directory for secure document storage (coffre-fort) */
-const DOCUMENTS_DIR = getDocumentStorageRoot();
+/** Base directory for secure document storage (coffre-fort) — lazy: the
+ * storage root throws in production when unconfigured, and that check must
+ * fire at request time, never at module load during build. */
+function getDocumentsDir() { return getDocumentStorageRoot(); }
 
 const validatePaymentSchema = z.object({
   paymentId: z.string(),
@@ -183,11 +185,11 @@ async function generateInvoicePDFAndDocument(
     });
 
     // Store in coffre-fort (storage/documents/) + create UserDocument
-    await mkdir(DOCUMENTS_DIR, { recursive: true });
+    await mkdir(getDocumentsDir(), { recursive: true });
     const sanitizedNumber = invoice.number.replace(/[^a-zA-Z0-9-]/g, '_');
     const uniqueFileName = `facture-${sanitizedNumber}-${invoice.id}.pdf`;
-    const documentPath = path.join(DOCUMENTS_DIR, uniqueFileName);
-    await writeFile(documentPath, pdfBuffer);
+    const documentAbsPath = path.join(getDocumentsDir(), uniqueFileName);
+    await writeFile(documentAbsPath, pdfBuffer);
 
     const userDocument = await prisma.userDocument.create({
       data: {
@@ -195,7 +197,7 @@ async function generateInvoicePDFAndDocument(
         originalName: `facture-${invoice.number}.pdf`,
         mimeType: 'application/pdf',
         sizeBytes: pdfBuffer.length,
-        localPath: documentPath,
+        localPath: toRelativeStoragePath(documentAbsPath),
         userId: paymentUserId,
         uploadedById: validatorUserId,
       },

--- a/app/api/student/documents/[id]/download/route.ts
+++ b/app/api/student/documents/[id]/download/route.ts
@@ -1,11 +1,17 @@
 export const dynamic = 'force-dynamic';
 
 import { NextRequest, NextResponse } from 'next/server';
-import { readFile } from 'fs/promises';
-import path from 'path';
+import { Readable } from 'stream';
 import { UserRole } from '@prisma/client';
 import { requireRole, isErrorResponse } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
+import { getDocumentStorageRoot, LEGACY_STORAGE_PREFIX } from '@/lib/documents/storage-root';
+import {
+  openSecureDocument,
+  SecureFileAccessError,
+  safeContentType,
+  safeFilename,
+} from '@/lib/documents/secure-file-access';
 
 export async function GET(
   _req: NextRequest,
@@ -20,7 +26,7 @@ export async function GET(
   const doc = await prisma.userDocument.findFirst({
     where: {
       id,
-      userId: session.user.id, // strict ownership — prevents access to other students' docs
+      userId: session.user.id, // strict ownership
     },
     select: {
       id: true,
@@ -34,25 +40,40 @@ export async function GET(
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
 
+  let secureDoc;
   try {
-    // localPath is an absolute path outside the public directory (secure storage)
-    const resolvedPath = path.resolve(doc.localPath);
-    const buffer = await readFile(resolvedPath);
+    const storageRoot = getDocumentStorageRoot();
+    secureDoc = await openSecureDocument(storageRoot, doc.localPath, {
+      legacyPrefixToStrip: LEGACY_STORAGE_PREFIX,
+    });
+  } catch (err) {
+    if (err instanceof SecureFileAccessError) {
+      console.error('[student/documents/download] containment check failed', {
+        documentId: id,
+        code: err.code,
+      });
+      return NextResponse.json({ error: 'File unavailable' }, { status: 404 });
+    }
+    console.error('[student/documents/download] unexpected error', { documentId: id });
+    return NextResponse.json({ error: 'File unavailable' }, { status: 500 });
+  }
 
-    const safeName = encodeURIComponent(doc.originalName).replace(/['"]/g, '');
+  try {
+    const stream = secureDoc.handle.createReadStream();
+    const webStream = Readable.toWeb(stream) as ReadableStream;
 
-    return new NextResponse(buffer, {
+    return new NextResponse(webStream, {
       headers: {
-        'Content-Type': doc.mimeType ?? 'application/octet-stream',
-        'Content-Disposition': `attachment; filename="${safeName}"`,
+        'Content-Type': safeContentType(doc.mimeType),
+        'Content-Disposition': `attachment; filename="${safeFilename(doc.originalName)}"`,
+        'Content-Length': secureDoc.sizeBytes.toString(),
+        'X-Content-Type-Options': 'nosniff',
         'Cache-Control': 'private, no-store',
       },
     });
-  } catch (err) {
-    const code = err instanceof Error && 'code' in err
-      ? String((err as NodeJS.ErrnoException).code)
-      : 'UNKNOWN';
-    console.error('[documents/download] file read failed', { documentId: id, code });
+  } catch {
+    await secureDoc.handle.close().catch(() => {});
+    console.error('[student/documents/download] stream error', { documentId: id });
     return NextResponse.json({ error: 'File unavailable' }, { status: 500 });
   }
 }

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -86,6 +86,9 @@ services:
       LLM_MODE: "off"
       NPC_LLM_MODE: "off"
       NPC_STORAGE_ROOT: /mnt/npc-storage-e2e
+      # DOCUMENT_STORAGE_ROOT est fail-closed quand NODE_ENV=production :
+      # fourni ici comme en prod (racine hors release), volume jetable dédié.
+      DOCUMENT_STORAGE_ROOT: /mnt/document-storage-e2e
       SKIP_MIDDLEWARE: "true"
       # Disable external services
       OLLAMA_URL: ""
@@ -119,6 +122,7 @@ services:
       - e2e-shared:/app/e2e-shared
       - e2e-storage:/app/storage
       - e2e-npc-storage:/mnt/npc-storage-e2e
+      - e2e-document-storage:/mnt/document-storage-e2e
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/"]
       interval: 5s
@@ -164,6 +168,7 @@ volumes:
   e2e-shared:
   e2e-storage:
   e2e-npc-storage:
+  e2e-document-storage:
 
 networks:
   e2e-network:

--- a/lib/documents/secure-file-access.ts
+++ b/lib/documents/secure-file-access.ts
@@ -1,0 +1,222 @@
+import { open, realpath } from 'fs/promises';
+import { relative, resolve, sep, isAbsolute } from 'path';
+import type { FileHandle } from 'fs/promises';
+
+/**
+ * Secure file access — canonical containment for document downloads.
+ *
+ * Accepts three historical path representations:
+ * 1. Relative paths resolved against the storage root
+ * 2. Paths with a legacy prefix (e.g. /app/storage/documents/) — prefix stripped first
+ * 3. Absolute paths that, after realpath canonicalization, fall inside the storage root
+ *
+ * Containment uses realpath on BOTH sides to handle symlinks, then verifies
+ * via path.relative() that the result stays within the root.
+ *
+ * TOCTOU note: openSecureDocument opens the file handle BEFORE returning,
+ * eliminating the gap between path validation and file read. The residual
+ * risk is filesystem-level permission/mount changes, which require root
+ * access and are outside the application threat model.
+ */
+
+// ── Error types ──
+
+export type SecureFileAccessErrorCode =
+  | 'INVALID_PATH_FORMAT'
+  | 'PATH_ESCAPE'
+  | 'FILE_NOT_FOUND'
+  | 'NOT_REGULAR_FILE'
+  | 'FILE_TOO_LARGE'
+  | 'STORAGE_ROOT_UNAVAILABLE';
+
+export class SecureFileAccessError extends Error {
+  constructor(
+    public readonly code: SecureFileAccessErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SecureFileAccessError';
+  }
+}
+
+// ── Types ──
+
+export interface SecureFileAccessOptions {
+  /** Maximum file size in bytes (default: 25 MiB) */
+  maxSizeBytes?: number;
+  /** Legacy path prefix to strip before resolving (e.g. '/app/storage/documents/') */
+  legacyPrefixToStrip?: string;
+}
+
+export interface SecureDocument {
+  /** Validated file handle — caller must close it */
+  handle: FileHandle;
+  /** File size in bytes */
+  sizeBytes: number;
+}
+
+const DEFAULT_MAX_SIZE = 25 * 1024 * 1024; // 25 MiB
+const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+
+// ── Core: open a document securely ──
+
+/**
+ * Open a document file with full containment, returning an open FileHandle.
+ *
+ * Procedure:
+ * 1. Reject URLs and encoded traversal sequences
+ * 2. Strip legacy prefix if applicable
+ * 3. Resolve the candidate path (relative → from root; absolute → as-is)
+ * 4. realpath BOTH storage root and candidate
+ * 5. Verify containment via path.relative (not string prefix)
+ * 6. Open the file (O_RDONLY)
+ * 7. fstat the open handle to verify regular file + size
+ * 8. Return the open handle — caller must close it
+ *
+ * If any step fails, any opened handle is closed before throwing.
+ */
+export async function openSecureDocument(
+  storageRoot: string,
+  rawPath: string,
+  options: SecureFileAccessOptions = {},
+): Promise<SecureDocument> {
+  const maxSize = options.maxSizeBytes ?? DEFAULT_MAX_SIZE;
+
+  // Reject URL schemes
+  if (URL_SCHEME_RE.test(rawPath)) {
+    throw new SecureFileAccessError('INVALID_PATH_FORMAT', 'URL schemes are not allowed');
+  }
+
+  // Reject encoded traversal before any path processing
+  if (/%2e/i.test(rawPath) || /%00/.test(rawPath) || /%2f/i.test(rawPath) || /%5c/i.test(rawPath)) {
+    throw new SecureFileAccessError('INVALID_PATH_FORMAT', 'Encoded path components are not allowed');
+  }
+
+  // Strip legacy prefix if configured
+  let normalizedPath = rawPath;
+  if (options.legacyPrefixToStrip && normalizedPath.startsWith(options.legacyPrefixToStrip)) {
+    normalizedPath = normalizedPath.slice(options.legacyPrefixToStrip.length);
+  }
+
+  // Build candidate path:
+  // - Absolute paths → used as-is (containment verified by realpath below)
+  // - Relative paths → resolved against storage root
+  const candidatePath = isAbsolute(normalizedPath)
+    ? resolve(normalizedPath)
+    : resolve(storageRoot, normalizedPath);
+
+  // Canonicalize BOTH paths via realpath (follows symlinks)
+  let canonicalRoot: string;
+  try {
+    canonicalRoot = await realpath(storageRoot);
+  } catch {
+    throw new SecureFileAccessError('STORAGE_ROOT_UNAVAILABLE', 'Storage root is not accessible');
+  }
+
+  let canonicalPath: string;
+  try {
+    canonicalPath = await realpath(candidatePath);
+  } catch {
+    throw new SecureFileAccessError('FILE_NOT_FOUND', 'File does not exist');
+  }
+
+  // Containment check via path.relative — more robust than string prefix
+  const rel = relative(canonicalRoot, canonicalPath);
+  if (
+    !rel ||                         // empty = candidate IS the root
+    isAbsolute(rel) ||              // absolute = different volume/drive
+    rel === '..' ||                 // direct parent
+    rel.startsWith(`..${sep}`)      // any ancestor
+  ) {
+    throw new SecureFileAccessError('PATH_ESCAPE', 'Path escapes storage root');
+  }
+
+  // Open the file — eliminates TOCTOU between validation and read
+  let handle: FileHandle;
+  try {
+    handle = await open(canonicalPath, 'r');
+  } catch {
+    throw new SecureFileAccessError('FILE_NOT_FOUND', 'File cannot be opened');
+  }
+
+  // Validate via fstat on the OPEN handle
+  try {
+    const fileStat = await handle.stat();
+
+    if (!fileStat.isFile()) {
+      await handle.close();
+      throw new SecureFileAccessError('NOT_REGULAR_FILE', 'Target is not a regular file');
+    }
+
+    if (fileStat.size > maxSize) {
+      await handle.close();
+      throw new SecureFileAccessError('FILE_TOO_LARGE', 'File exceeds size limit');
+    }
+
+    return { handle, sizeBytes: fileStat.size };
+  } catch (err) {
+    // Close handle on any validation error (unless already thrown above)
+    if (err instanceof SecureFileAccessError) throw err;
+    await handle.close().catch(() => {});
+    throw new SecureFileAccessError('FILE_NOT_FOUND', 'File validation failed');
+  }
+}
+
+// ── Legacy compatibility: resolveSecurePath (returns path, not handle) ──
+
+export interface ResolvedSecurePath {
+  canonicalPath: string;
+  sizeBytes: number;
+}
+
+/**
+ * Resolve and validate a path without opening a handle.
+ * Use openSecureDocument when possible for TOCTOU-free reads.
+ */
+export async function resolveSecurePath(
+  storageRoot: string,
+  rawPath: string,
+  options: SecureFileAccessOptions = {},
+): Promise<ResolvedSecurePath> {
+  const doc = await openSecureDocument(storageRoot, rawPath, options);
+  const { sizeBytes } = doc;
+  // Read the fd path for callers that need it
+  const canonicalPath = await realpath(`/proc/self/fd/${doc.handle.fd}`).catch(
+    // Fallback: re-resolve (slight TOCTOU but only used by legacy callers)
+    async () => {
+      const normalized = rawPath.startsWith(options?.legacyPrefixToStrip ?? '\0')
+        ? rawPath.slice((options?.legacyPrefixToStrip ?? '').length)
+        : rawPath;
+      const candidate = isAbsolute(normalized) ? resolve(normalized) : resolve(storageRoot, normalized);
+      return realpath(candidate);
+    },
+  );
+  await doc.handle.close();
+  return { canonicalPath, sizeBytes };
+}
+
+// ── Safe HTTP response helpers ──
+
+const ALLOWED_MIME_TYPES = new Set([
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'text/plain',
+]);
+
+export function safeContentType(mimeType: string | null | undefined): string {
+  if (!mimeType) return 'application/octet-stream';
+  return ALLOWED_MIME_TYPES.has(mimeType) ? mimeType : 'application/octet-stream';
+}
+
+/**
+ * Produce a safe filename for Content-Disposition headers.
+ * Strips path separators, control chars, and quotes.
+ * Falls back to 'document' for empty names.
+ */
+export function safeFilename(name: string): string {
+  if (!name) return 'document';
+  const cleaned = name.replace(/[\\/\r\n"\x00-\x1f]/g, '_');
+  return encodeURIComponent(cleaned);
+}

--- a/lib/documents/storage-root.ts
+++ b/lib/documents/storage-root.ts
@@ -1,15 +1,59 @@
-import { resolve } from 'path';
+import { isAbsolute, resolve, relative } from 'path';
 
 /**
  * Single source of truth for document storage root.
  *
- * Used by: download route, admin upload, coach upload, payment validation.
- * Env-configurable via DOCUMENT_STORAGE_ROOT, defaults to cwd/storage/documents.
+ * Used by: download routes, admin upload, coach upload, payment validation.
+ *
+ * Production: DOCUMENT_STORAGE_ROOT is REQUIRED and must be absolute.
+ * Dev/test: falls back to cwd/storage/documents.
  */
+
+// Volontairement SANS cache module-level : le garde-fou de santé du
+// stockage (lib/documents/storage-health.ts) et ses tests dépendent d'une
+// lecture fraîche de DOCUMENT_STORAGE_ROOT à chaque appel. La paresse qui
+// évite le crash au build vient d'être une fonction, pas d'un cache.
 export function getDocumentStorageRoot(): string {
-  // resolve() ensures a relative env value becomes absolute against cwd
-  return resolve(process.env.DOCUMENT_STORAGE_ROOT || resolve(process.cwd(), 'storage', 'documents'));
+  const envValue = process.env.DOCUMENT_STORAGE_ROOT;
+
+  if (process.env.NODE_ENV === 'production') {
+    if (!envValue) {
+      throw new Error(
+        'DOCUMENT_STORAGE_ROOT is required in production. ' +
+        'Set it in the production environment file to a persistent absolute path.'
+      );
+    }
+    if (!isAbsolute(envValue)) {
+      throw new Error(
+        'DOCUMENT_STORAGE_ROOT must be an absolute path in production.'
+      );
+    }
+    return envValue;
+  }
+
+  return envValue
+    ? resolve(envValue)
+    : resolve(process.cwd(), 'storage', 'documents');
 }
 
 /** Legacy prefix stored in DB by older upload routes (/app/storage/documents/). */
 export const LEGACY_STORAGE_PREFIX = '/app/storage/documents/';
+
+/**
+ * Convert an absolute storage path to a relative path for DB storage.
+ *
+ * Uploads should call this before persisting localPath so that documents
+ * survive release swaps (the storage root is outside any release directory).
+ *
+ * @param absolutePath - The absolute file path (e.g. from path.join(root, filename))
+ * @returns Relative path from storage root (e.g. "userId/filename.pdf")
+ * @throws if the path is not under the storage root
+ */
+export function toRelativeStoragePath(absolutePath: string): string {
+  const root = getDocumentStorageRoot();
+  const rel = relative(root, absolutePath);
+  if (!rel || isAbsolute(rel) || rel.startsWith('..')) {
+    throw new Error('Path is not under the document storage root');
+  }
+  return rel;
+}

--- a/lib/invoice/storage.ts
+++ b/lib/invoice/storage.ts
@@ -5,7 +5,7 @@
  * In production, this can be swapped for S3/R2 without changing the API layer.
  */
 
-import { writeFile, mkdir, readFile, access } from 'fs/promises';
+import { writeFile, mkdir, readFile, realpath } from 'fs/promises';
 import path from 'path';
 
 /** Base directory for invoice PDF storage */
@@ -83,13 +83,16 @@ export async function storeInvoicePDF(invoiceNumber: string, buffer: Buffer): Pr
  * @throws Error if file doesn't exist
  */
 export async function readInvoicePDF(filePath: string): Promise<Buffer> {
-  // Security: ensure the path is within the storage directory
-  const resolved = path.resolve(filePath);
-  const storageResolved = path.resolve(STORAGE_DIR);
-  if (!resolved.startsWith(storageResolved)) {
+  // Security: containment canonique. realpath des deux côtés (suit les
+  // symlinks) puis path.relative — jamais de comparaison de préfixe de
+  // chaîne, qui laissait passer un répertoire voisin (data/invoices-evil)
+  // et les liens symboliques sortants.
+  const canonicalRoot = await realpath(path.resolve(STORAGE_DIR));
+  const canonicalPath = await realpath(path.resolve(filePath));
+  const rel = path.relative(canonicalRoot, canonicalPath);
+  if (!rel || path.isAbsolute(rel) || rel === '..' || rel.startsWith(`..${path.sep}`)) {
     throw new Error('Invalid invoice path: outside storage directory');
   }
 
-  await access(resolved);
-  return readFile(resolved);
+  return readFile(canonicalPath);
 }

--- a/scripts/ops/README-disk-prevention.md
+++ b/scripts/ops/README-disk-prevention.md
@@ -1,0 +1,80 @@
+# Prévention disque — rotation des releases, purge de build, alerte
+
+Contexte : le 2026-08-12, le disque de production a atteint 86 % (32
+releases accumulées, 52 Go, plus 11,6 Go de workspaces de build jamais
+purgés). À 100 %, l'application s'arrête. Ces trois scripts empêchent la
+récidive. **Rien n'est activé automatiquement** : l'activation se fait à la
+prochaine fenêtre d'intervention, selon la procédure ci-dessous.
+
+## 1. `rotate-releases.sh` — rotation à la bascule
+
+Politique validée le 2026-08-12 : conserver la release active + l'instance
+la plus récente de chacun des 2 derniers SHA distincts à runtime Node
+embarqué + toute release épinglée dans `/etc/nexus/release-retention.conf`.
+
+Le fichier d'épinglage est **obligatoire** (fail-closed, même vide). Une
+entrée par ligne (nom du dossier de release), commentaires `#` autorisés.
+C'est le mécanisme qui aurait protégé automatiquement la release
+`1b8219b1…` (facture unique) :
+
+```
+# /etc/nexus/release-retention.conf
+# Releases à ne jamais purger automatiquement, une par ligne.
+1b8219b1cfcfe63354d8cb4035645143e27e5a43   # facture unique (empreinte 4663d26e92dae05d)
+```
+
+Usage (dry-run par défaut, `--apply` pour agir). Les chemins réels de
+production vivent dans l'espace d'opérations privé (politique du dépôt
+public : aucun chemin d'infrastructure) — placeholders ici :
+
+```bash
+rotate-releases.sh \
+  --release-root "$RELEASE_ROOT" \
+  --canonical "$CANONICAL_SYMLINK" \
+  --pin-file /etc/nexus/release-retention.conf \
+  --health-url "$HEALTH_URL" \
+  --apply
+```
+
+Intégration : à appeler en **fin de déploiement réussi**, après la bascule
+du symlink et le smoke test — jamais avant. Le script revérifie la santé
+avant chaque suppression et refuse toute release encore référencée par un
+processus.
+
+## 2. `purge-build-workspaces.sh` — purge du staging de build
+
+À appeler au même moment, avec `--keep` sur le workspace de la release qui
+vient d'être construite :
+
+```bash
+purge-build-workspaces.sh \
+  --root "$BUILD_STAGING_ROOT" \
+  --root "$BUILD_VALIDATION_ROOT" \
+  --keep <nom-du-workspace-courant> \
+  --apply
+```
+
+Garde-fou : refuse toute racine dont le nom ne commence pas par
+`nexus-build-` (serveur mutualisé).
+
+## 3. `disk-alert.sh` + timer systemd — alerte à 85 %
+
+Envoie un e-mail à `INTERNAL_NOTIFICATION_EMAIL` (expéditeur
+`contact@nexusreussite.academy`) quand l'occupation du point de montage
+atteint le seuil. Sous le seuil : silence total (exit 0).
+
+Activation à la prochaine fenêtre (opérateur, sur le serveur) :
+
+```bash
+install -m 0755 scripts/ops/disk-alert.sh /usr/local/libexec/nexus-disk-alert.sh
+install -m 0644 scripts/ops/systemd/nexus-disk-alert.service /etc/systemd/system/
+install -m 0644 scripts/ops/systemd/nexus-disk-alert.timer /etc/systemd/system/
+# /etc/nexus/disk-alert.env doit définir INTERNAL_NOTIFICATION_EMAIL
+systemctl daemon-reload
+systemctl enable --now nexus-disk-alert.timer
+systemctl start nexus-disk-alert.service   # test immédiat (silencieux si < 85 %)
+```
+
+Prérequis : un MTA local capable de relayer (`sendmail`/`msmtp`) — le
+script ne porte aucun credential SMTP ; sinon passer `--mail-command` vers
+l'outil configuré.

--- a/scripts/ops/disk-alert.sh
+++ b/scripts/ops/disk-alert.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Alerte d'occupation disque — pensé pour un timer systemd horaire.
+#
+# df sur le point de montage surveillé ; si l'occupation atteint le seuil,
+# envoie un e-mail via la commande sendmail configurée. En dessous du
+# seuil : sortie 0 silencieuse.
+#
+# L'adresse destinataire vient de --to ou de $INTERNAL_NOTIFICATION_EMAIL.
+# Aucun secret dans ce script : le relais SMTP est la responsabilité du
+# MTA local (sendmail/msmtp) configuré côté serveur.
+set -euo pipefail
+
+fail() {
+  printf 'disk-alert failed: %s\n' "$1" >&2
+  exit 1
+}
+
+mount_point='/'
+threshold=85
+to="${INTERNAL_NOTIFICATION_EMAIL:-}"
+from='contact@nexusreussite.academy'
+mail_command='sendmail -t'
+
+while (($# > 0)); do
+  case "$1" in
+    --mount)
+      (($# >= 2)) || fail 'MISSING_ARGUMENT_VALUE'
+      mount_point=$2; shift 2 ;;
+    --threshold)
+      (($# >= 2)) || fail 'MISSING_ARGUMENT_VALUE'
+      threshold=$2; shift 2 ;;
+    --to)
+      (($# >= 2)) || fail 'MISSING_ARGUMENT_VALUE'
+      to=$2; shift 2 ;;
+    --from)
+      (($# >= 2)) || fail 'MISSING_ARGUMENT_VALUE'
+      from=$2; shift 2 ;;
+    --mail-command)
+      (($# >= 2)) || fail 'MISSING_ARGUMENT_VALUE'
+      mail_command=$2; shift 2 ;;
+    *)
+      fail 'UNKNOWN_ARGUMENT' ;;
+  esac
+done
+
+[[ "$threshold" =~ ^[0-9]+$ && "$threshold" -ge 1 && "$threshold" -le 99 ]] \
+  || fail 'INVALID_THRESHOLD'
+[[ -n "$to" ]] || fail 'RECIPIENT_MISSING'
+
+usage_line=$(df -P "$mount_point" | tail -1)
+usage_pct=$(printf '%s' "$usage_line" | awk '{print $5}' | tr -d '%')
+avail_kb=$(printf '%s' "$usage_line" | awk '{print $4}')
+[[ "$usage_pct" =~ ^[0-9]+$ ]] || fail 'DF_PARSE_ERROR'
+
+if (( usage_pct < threshold )); then
+  exit 0
+fi
+
+avail_human=$(awk -v kb="$avail_kb" 'BEGIN { printf "%.1f Gio", kb / 1048576 }')
+hostname_value=$(hostname)
+
+$mail_command <<MAIL
+From: Nexus Ops <${from}>
+To: ${to}
+Subject: [ALERTE DISQUE] ${hostname_value} — ${mount_point} à ${usage_pct}% (seuil ${threshold}%)
+Content-Type: text/plain; charset=utf-8
+
+L'occupation du disque a atteint ${usage_pct}% sur ${hostname_value}:${mount_point}
+(seuil d'alerte : ${threshold}%, espace restant : ${avail_human}).
+
+À 100%, l'application de production s'arrête. Actions recommandées :
+1. Rotation des releases : scripts/ops/rotate-releases.sh (dry-run d'abord).
+2. Purge des workspaces de build : scripts/ops/purge-build-workspaces.sh.
+3. Vérifier les gros consommateurs récents : du -x -d1 -h /var | sort -rh | head.
+
+Généré par scripts/ops/disk-alert.sh (timer systemd nexus-disk-alert).
+MAIL
+
+printf 'disk-alert: alerte envoyée (%s%% >= %s%%)\n' "$usage_pct" "$threshold"

--- a/scripts/ops/purge-build-workspaces.sh
+++ b/scripts/ops/purge-build-workspaces.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Purge des espaces de travail de build en fin de release réussie.
+#
+# /var/www/nexus-build-staging et /var/www/nexus-build-validation
+# accumulent un workspace complet (~3 Go) par build et ne sont jamais
+# nettoyés — c'était 11,6 Go de fuite constatés le 2026-08-12. À appeler
+# en fin de déploiement réussi, après la bascule du symlink.
+#
+# Fail-closed : sans --apply, plan seulement. --keep <nom> (répétable)
+# préserve le workspace de la release qui vient d'être construite.
+set -euo pipefail
+
+fail() {
+  printf 'purge-build-workspaces failed: %s\n' "$1" >&2
+  exit 1
+}
+
+roots=()
+keeps=()
+apply=0
+
+while (($# > 0)); do
+  case "$1" in
+    --root)
+      (($# >= 2)) || fail 'MISSING_ARGUMENT_VALUE'
+      roots+=("$2"); shift 2 ;;
+    --keep)
+      (($# >= 2)) || fail 'MISSING_ARGUMENT_VALUE'
+      keeps+=("$2"); shift 2 ;;
+    --apply)
+      apply=1; shift ;;
+    *)
+      fail 'UNKNOWN_ARGUMENT' ;;
+  esac
+done
+
+((${#roots[@]} > 0)) || fail 'REQUIRED_ARGUMENT_MISSING'
+for root in "${roots[@]}"; do
+  [[ "$root" = /* ]] || fail 'PATH_NOT_ABSOLUTE'
+  # Garde-fou : uniquement des racines de build nexus, jamais un chemin
+  # arbitraire (serveur mutualisé).
+  case "$(basename "$root")" in
+    nexus-build-*) ;;
+    *) fail 'ROOT_NOT_A_NEXUS_BUILD_WORKSPACE' ;;
+  esac
+done
+
+is_kept() {
+  local name=$1 k
+  for k in "${keeps[@]:-}"; do
+    [[ "$k" = "$name" ]] && return 0
+  done
+  return 1
+}
+
+purged=0
+freed_bytes=0
+for root in "${roots[@]}"; do
+  [[ -d "$root" ]] || { printf 'SKIP   %s (absent)\n' "$root"; continue; }
+  for dir in "$root"/*/; do
+    [[ -d "$dir" ]] || continue
+    name=$(basename "$dir")
+    if is_kept "$name"; then
+      printf 'KEEP   %s/%s\n' "$root" "$name"
+      continue
+    fi
+    if pgrep -f "$root/$name" >/dev/null 2>&1; then
+      printf 'SKIP   %s/%s (référencé par un processus)\n' "$root" "$name"
+      continue
+    fi
+    size=$(du -sb "$dir" | cut -f1)
+    if (( apply )); then
+      rm -rf "${root:?}/${name:?}"
+      printf 'DELETE %s/%s (%s octets)\n' "$root" "$name" "$size"
+    else
+      printf 'PLAN   %s/%s (%s octets)\n' "$root" "$name" "$size"
+    fi
+    purged=$((purged + 1))
+    freed_bytes=$((freed_bytes + size))
+  done
+done
+
+if (( apply )); then
+  printf 'purge-build-workspaces: %s workspace(s) supprimé(s), %s octets libérés\n' "$purged" "$freed_bytes"
+else
+  printf 'purge-build-workspaces (dry-run): %s workspace(s) purgeable(s), %s octets — relancer avec --apply\n' "$purged" "$freed_bytes"
+fi

--- a/scripts/ops/rotate-releases.sh
+++ b/scripts/ops/rotate-releases.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Rotation des releases à la bascule (post-flip, santé verte exigée).
+#
+# Politique (validée le 2026-08-12, après l'incident disque 86 %) :
+#   - conserver la release ACTIVE (cible du symlink canonique) ;
+#   - conserver l'instance la plus récente de chacun des N derniers SHA
+#     distincts disposant d'un runtime Node embarqué (.runtime/node/bin/node),
+#     N = --keep-node22 (défaut 2, l'active comptant pour son SHA) ;
+#   - conserver toute release épinglée dans le fichier de rétention
+#     (--pin-file, une entrée par ligne, commentaires # autorisés) — le
+#     mécanisme qui aurait protégé 1b8219b1… automatiquement ;
+#   - tout le reste est purgé, une release à la fois, avec vérification
+#     santé (--health-url) avant chaque suppression.
+#
+# Fail-closed : sans --apply le script n'est qu'un plan (dry-run). Le fichier
+# d'épinglage DOIT exister (même vide) — absence = abort. Toute release
+# encore référencée par un processus est refusée.
+set -euo pipefail
+
+fail() {
+  printf 'rotate-releases failed: %s\n' "$1" >&2
+  exit 1
+}
+
+release_root=''
+canonical=''
+pin_file=''
+keep_node22=2
+health_url=''
+apply=0
+
+while (($# > 0)); do
+  case "$1" in
+    --release-root)
+      (($# >= 2)) || fail 'MISSING_ARGUMENT_VALUE'
+      release_root=$2; shift 2 ;;
+    --canonical)
+      (($# >= 2)) || fail 'MISSING_ARGUMENT_VALUE'
+      canonical=$2; shift 2 ;;
+    --pin-file)
+      (($# >= 2)) || fail 'MISSING_ARGUMENT_VALUE'
+      pin_file=$2; shift 2 ;;
+    --keep-node22)
+      (($# >= 2)) || fail 'MISSING_ARGUMENT_VALUE'
+      keep_node22=$2; shift 2 ;;
+    --health-url)
+      (($# >= 2)) || fail 'MISSING_ARGUMENT_VALUE'
+      health_url=$2; shift 2 ;;
+    --apply)
+      apply=1; shift ;;
+    *)
+      fail 'UNKNOWN_ARGUMENT' ;;
+  esac
+done
+
+[[ -n "$release_root" && -n "$canonical" && -n "$pin_file" ]] \
+  || fail 'REQUIRED_ARGUMENT_MISSING'
+[[ "$release_root" = /* && "$canonical" = /* && "$pin_file" = /* ]] \
+  || fail 'PATH_NOT_ABSOLUTE'
+[[ "$keep_node22" =~ ^[0-9]+$ && "$keep_node22" -ge 1 ]] || fail 'INVALID_KEEP_COUNT'
+[[ -d "$release_root" ]] || fail 'RELEASE_ROOT_MISSING'
+[[ -L "$canonical" ]] || fail 'CANONICAL_NOT_SYMLINK'
+# Épinglage fail-closed : le fichier doit exister, même vide.
+[[ -f "$pin_file" ]] || fail 'PIN_FILE_MISSING'
+
+active_path=$(readlink -f "$canonical") || fail 'CANONICAL_DANGLING'
+[[ -d "$active_path" ]] || fail 'CANONICAL_DANGLING'
+case "$active_path" in
+  "$release_root"/*) ;;
+  *) fail 'ACTIVE_OUTSIDE_RELEASE_ROOT' ;;
+esac
+active_name=${active_path#"$release_root"/}
+[[ "$active_name" != */* ]] || fail 'ACTIVE_NOT_DIRECT_CHILD'
+
+check_health() {
+  [[ -n "$health_url" ]] || return 0
+  local code
+  code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$health_url" || echo 000)
+  [[ "$code" = 200 ]] || fail "HEALTH_CHECK_FAILED_$code"
+}
+
+check_health
+
+# Épinglés : une entrée (nom de dossier) par ligne, # commentaires.
+declare -A pinned=()
+while IFS= read -r line; do
+  line=${line%%#*}
+  line=$(printf '%s' "$line" | tr -d '[:space:]')
+  [[ -n "$line" ]] && pinned["$line"]=1
+done < "$pin_file"
+
+# SHA d'une release = préfixe hexadécimal du nom de dossier.
+sha_of() {
+  local name=$1
+  if [[ "$name" =~ ^([0-9a-f]{7,40}) ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+  else
+    printf '%s' "$name"
+  fi
+}
+
+# Inventaire : nom|mtime|node22(0/1), trié du plus récent au plus ancien.
+inventory=$(
+  for dir in "$release_root"/*/; do
+    [[ -d "$dir" ]] || continue
+    [[ -L "${dir%/}" ]] && continue
+    name=$(basename "$dir")
+    mtime=$(stat -c '%Y' "$dir")
+    node22=0
+    [[ -x "$dir/.runtime/node/bin/node" ]] && node22=1
+    printf '%s|%s|%s\n' "$mtime" "$name" "$node22"
+  done | sort -rn
+)
+
+declare -A keep=()
+keep["$active_name"]=1
+for name in "${!pinned[@]}"; do
+  keep["$name"]=1
+done
+
+# Les N derniers SHA distincts Node 22 : l'instance la plus récente de
+# chaque groupe. Le SHA de l'active compte pour un groupe si elle embarque
+# un runtime.
+declare -A sha_seen=()
+groups_kept=0
+active_sha=$(sha_of "$active_name")
+if [[ -x "$release_root/$active_name/.runtime/node/bin/node" ]]; then
+  sha_seen["$active_sha"]=1
+  groups_kept=1
+fi
+while IFS='|' read -r _mtime name node22; do
+  [[ -n "$name" ]] || continue
+  [[ "$node22" = 1 ]] || continue
+  sha=$(sha_of "$name")
+  if [[ -z "${sha_seen[$sha]:-}" ]]; then
+    if (( groups_kept < keep_node22 )); then
+      sha_seen["$sha"]=1
+      keep["$name"]=1
+      groups_kept=$((groups_kept + 1))
+    fi
+  fi
+done <<< "$inventory"
+
+deleted=0
+freed_bytes=0
+while IFS='|' read -r _mtime name _node22; do
+  [[ -n "$name" ]] || continue
+  if [[ -n "${keep[$name]:-}" ]]; then
+    printf 'KEEP   %s\n' "$name"
+    continue
+  fi
+  if pgrep -f "$release_root/$name" >/dev/null 2>&1; then
+    printf 'SKIP   %s (référencée par un processus)\n' "$name"
+    continue
+  fi
+  size=$(du -sb "$release_root/$name" | cut -f1)
+  if (( apply )); then
+    check_health
+    rm -rf "${release_root:?}/${name:?}"
+    printf 'DELETE %s (%s octets)\n' "$name" "$size"
+  else
+    printf 'PLAN   %s (%s octets)\n' "$name" "$size"
+  fi
+  deleted=$((deleted + 1))
+  freed_bytes=$((freed_bytes + size))
+done <<< "$inventory"
+
+check_health
+if (( apply )); then
+  printf 'rotate-releases: %s release(s) supprimée(s), %s octets libérés\n' "$deleted" "$freed_bytes"
+else
+  printf 'rotate-releases (dry-run): %s release(s) purgeable(s), %s octets récupérables — relancer avec --apply\n' "$deleted" "$freed_bytes"
+fi

--- a/scripts/ops/systemd/nexus-disk-alert.service
+++ b/scripts/ops/systemd/nexus-disk-alert.service
@@ -1,0 +1,15 @@
+# Alerte disque Nexus — unité one-shot déclenchée par nexus-disk-alert.timer.
+# NON INSTALLÉE automatiquement : à copier dans /etc/systemd/system/ lors de
+# la prochaine fenêtre d'intervention, avec le script déployé sous
+# /usr/local/libexec/ (voir scripts/ops/README-disk-prevention.md).
+[Unit]
+Description=Nexus - alerte occupation disque (seuil 85%)
+Documentation=file:/usr/local/libexec/nexus-disk-alert.sh
+
+[Service]
+Type=oneshot
+# Fichier créé par l'opérateur à l'activation ; doit définir
+# INTERNAL_NOTIFICATION_EMAIL (il peut simplement sourcer le fichier
+# d'environnement de production existant).
+EnvironmentFile=-/etc/nexus/disk-alert.env
+ExecStart=/usr/local/libexec/nexus-disk-alert.sh --mount / --threshold 85 --from contact@nexusreussite.academy

--- a/scripts/ops/systemd/nexus-disk-alert.timer
+++ b/scripts/ops/systemd/nexus-disk-alert.timer
@@ -1,0 +1,13 @@
+# Timer horaire de l'alerte disque Nexus.
+# NON INSTALLÉ automatiquement : systemctl enable --now nexus-disk-alert.timer
+# lors de la prochaine fenêtre d'intervention.
+[Unit]
+Description=Nexus - vérification horaire de l'occupation disque
+
+[Timer]
+OnCalendar=hourly
+RandomizedDelaySec=300
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## 1. SÉCURITÉ — confinement de chemin des téléchargements (commit dédié, en tête de branche)

**Nature exacte de la faille** : `UserDocument.localPath` (colonne DB) atteignait le système de fichiers sans confinement sur deux routes — `/api/documents/[id]` (`readFile(document.localPath)` brut) et `/api/student/documents/[id]/download` (`path.resolve` = normalisation sans vérification de racine). Un `localPath` empoisonné en base permettait la lecture de fichier arbitraire. La route sœur `/api/documents/[id]/download` avait été corrigée le 09/07 (73608d8c0) mais le correctif était explicitement scopé à elle seule. Des documents d'élèves et des factures nominatives sont derrière ces routes.

**Correction** : la PR #67 existante apportait déjà la bonne correction — elle est **reprise** (4 commits squashés en un commit sécurité identifié, aucune réécriture) et rebasée sur main actuel. Divergence minime : conflit d'imports dans `payments/validate` résolu, et son cache module-level de racine de stockage retiré (il cassait le garde-fou de santé du stockage mergé depuis sur main — les 27 tests de `storage-health` re-passent).

- `lib/documents/secure-file-access.ts` : realpath des DEUX côtés puis containment par `path.relative` (jamais de préfixe de chaîne), rejet des schémas URL et encodages (`%2e`/`%2f`/`%5c`/`%00`), symlink sortant refusé / interne accepté, **FileHandle ouvert avant la réponse + fstat sur le handle ouvert = fenêtre TOCTOU fermée**, streaming, fail-closed (tout échec → 404 sans chemin dans les logs).
- `lib/documents/storage-root.ts` : `DOCUMENT_STORAGE_ROOT` obligatoire et absolu en production (fail-closed à la requête, jamais au build) ; uploads (admin, coach, factures) stockent désormais un chemin **relatif** — les documents survivent aux bascules de release.

**Tests d'attaque (tous verts)** : traversée `../`, `../../`, `%2e%2e`, double-encodage, octet nul, antislash ; chemin absolu hors racine ; piège du préfixe voisin (`storage-evil`) ; symlink 3 cas ; répertoire comme cible ; taille max ; unlink post-open ; non-fuite de chemins. **Preuve inter-familles** : non-propriétaire → 404 sans même ouvrir le fichier (`openSecureDocument` jamais appelé).

**Audit exhaustif des 18 sites servant des fichiers** (documents, factures, PDF bilans, liens signés, NPC, diagnostics, ressources officielles, rapports de stage…) :
- 2 VULNÉRABLES → corrigés ci-dessus.
- 1 PARTIAL → **corrigé dans le 2e commit** : `readInvoicePDF` (`lib/invoice/storage.ts`) comparait des préfixes sans realpath ni séparateur final (`data/invoices-evil` passait) — aligné sur le même pattern, 6 tests fs réels ajoutés. Non exploitable aujourd'hui (assainisseur en amont), défense en profondeur.
- 1 PARTIAL **rapporté sans modification** (arbitrage requis) : `lib/diagnostics/candidat-libre/storage.server.ts` + `safeAbsolutePath` dupliqué dans la route documents du diagnostic — séparateur final OK mais realpath absent (brèche symlink théorique, `storageKey` machine-généré). Non touché : le chemin candidat libre est déclaré intangible par le mandat.
- 14 SAFE (constantes, whitelists, containment déjà correct — dont NPC, le plus durci du code).

## 2. Prévention disque (3e commit) — scripts testés, RIEN activé

Suite à l'incident du 12/08 (86 %, 32 releases, 11,6 Go de staging jamais purgé) :
- `scripts/ops/rotate-releases.sh` : rotation post-flip santé verte — garde l'active + les 2 derniers SHA distincts à runtime Node embarqué + les épinglés de `/etc/nexus/release-retention.conf` (fichier **obligatoire**, fail-closed — le mécanisme qui aurait protégé `1b8219b1…` automatiquement). Dry-run par défaut, santé revérifiée avant chaque suppression, refus des releases référencées par un processus, regroupement des rebuilds du même SHA.
- `scripts/ops/purge-build-workspaces.sh` : purge staging/validation en fin de release (`--keep` workspace courant), refuse toute racine non `nexus-build-*` (serveur mutualisé).
- `scripts/ops/disk-alert.sh` + unités systemd (timer horaire, **non installées**) : df >= 85 % → mail à `INTERNAL_NOTIFICATION_EMAIL`, expéditeur `contact@nexusreussite.academy`, via MTA local injectable — aucun secret embarqué. Procédure d'activation : `scripts/ops/README-disk-prevention.md` (activation à la prochaine fenêtre, pas par cette PR).
- 18 tests bash-sous-jest ; chemins d'infrastructure réels remplacés par des placeholders (politique du dépôt public, scan `security:repo` vert).

## Test plan
- [x] Suite complète : **804 suites / 8948 tests, 0 échec, 0 skip**
- [x] `npm run typecheck` propre
- [x] `npm run lint` : exit 0, 30 warnings préexistants hors du diff, 0 dans les fichiers touchés
- [x] `npm run security:repo` : scans clés privées + divulgation d'infrastructure verts
- [x] Suites reprises de #67 : 65 tests ; factures : 6 ; scripts ops : 18 ; storage-health : 27 re-verts après retrait du cache

Rien déployé, aucun commit sur main, pas de merge. Remplace la PR #67 (à fermer par son auteur après merge de celle-ci).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes document download path traversal by containing reads to a storage root and streaming from an open handle. Also adds disk-space prevention scripts and makes production builds pass by deferring `DOCUMENT_STORAGE_ROOT` checks to request time.

- Action required (production): set `DOCUMENT_STORAGE_ROOT` to an absolute, persistent directory outside release folders; ensure it exists and is writable. No data migration; legacy absolute paths with `LEGACY_STORAGE_PREFIX` remain readable.

**Security — document download containment**
- New `lib/documents/secure-file-access.ts`: realpath on root and candidate, `path.relative` containment, rejects URL schemes and encoded traversal, opens the file handle before responding, verifies regular file and size, streams with safe headers (`safeContentType`, `safeFilename`, `X-Content-Type-Options`, `Cache-Control`).
- Routes updated: `app/api/documents/[id]` and `app/api/student/documents/[id]/download` now use `openSecureDocument`; containment/file errors return 404 without leaking paths; DB errors return 500.
- Storage root governance: `lib/documents/storage-root.ts` requires `DOCUMENT_STORAGE_ROOT` in production and provides `toRelativeStoragePath`; admin/coach/payment uploads now store relative paths. `lib/invoice/storage.ts` uses the same canonical containment.
- Build/CI: avoid build-time failures by lazily evaluating `getDocumentStorageRoot()` in admin upload (same pattern as payments). CI sets `DOCUMENT_STORAGE_ROOT` to an isolated directory in Production Build and E2E jobs; `docker-compose.e2e.yml` mounts a dedicated volume. `.env.production.example` documents the requirement.

**Ops — disk-space prevention (not activated)**
- Adds `scripts/ops/rotate-releases.sh`: dry-run by default; keeps active + latest of the last N (default 2) distinct Node22 SHAs + releases pinned in `/etc/nexus/release-retention.conf` (file required); health check before each deletion; skips releases referenced by a process; groups rebuilds of the same SHA.
- Adds `scripts/ops/purge-build-workspaces.sh`: purges `nexus-build-*` roots post-release; supports `--keep`; dry-run by default; guards against non-Nexus roots.
- Adds `scripts/ops/disk-alert.sh` and systemd units (hourly timer): alerts at 85% via local MTA to `INTERNAL_NOTIFICATION_EMAIL`; disabled by default. Activation steps in `scripts/ops/README-disk-prevention.md`.

<sup>Written for commit 2b7813bb1e6148bed45be1048c43c631bcf2bffe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

