### PR TITLE
fix(saisie-papier): anti-doublon — empêcher le rattachement entre familles homonymes

### DIFF
--- a/__tests__/bilans/saisie-papier-famille.test.ts
+++ b/__tests__/bilans/saisie-papier-famille.test.ts
@@ -173,6 +173,8 @@ describe('Création du foyer — suggestion anti-doublon à décision humaine', 
     lastName: 'Bernard',
     email: null,
     phone: '99 19 28 29',
+    phoneNormalized: '99192829',
+    mergedSources: [],
     parentProfile: {
       id: 'profile-existant',
       children: [{
@@ -192,10 +194,12 @@ describe('Création du foyer — suggestion anti-doublon à décision humaine', 
     expect(response.status).toBe(409);
     expect(await response.json()).toEqual({
       error: { code: 'POTENTIAL_DUPLICATE' },
+      enteredPhone: '99 19 28 29',
       candidates: [{
         parentUserId: 'parent-existant',
         parentName: 'Claire Bernard',
         phone: '99 19 28 29',
+        matchStrength: 'PHONE',
         children: [{ studentId: 'student-existant', studentName: 'Inès Bernard', gradeLevel: 'TERMINALE' }],
       }],
     });
@@ -203,7 +207,7 @@ describe('Création du foyer — suggestion anti-doublon à décision humaine', 
     expect(students).toHaveLength(0);
   });
 
-  it('recherche aussi le couple nom, prénom et niveau de l’élève', async () => {
+  it('recherche aussi l’homonymie du parent (mêmes nom et prénom)', async () => {
     const { database, transaction } = memoryDatabase();
     transaction.user.findMany.mockResolvedValue([candidate] as never);
 
@@ -215,7 +219,12 @@ describe('Création du foyer — suggestion anti-doublon à décision humaine', 
         OR: expect.arrayContaining([
           { phoneNormalized: '99192829' },
           { mergedSources: { some: { phoneNormalized: '99192829' } } },
-          expect.objectContaining({ parentProfile: expect.any(Object) }),
+          {
+            AND: [
+              { firstName: { equals: 'Claire', mode: 'insensitive' } },
+              { lastName: { equals: 'Bernard', mode: 'insensitive' } },
+            ],
+          },
         ]),
       }),
     }));
@@ -302,6 +311,141 @@ describe('Création du foyer — suggestion anti-doublon à décision humaine', 
 
     expect(response.status).toBe(409);
     expect(users).toHaveLength(0);
+  });
+});
+
+/**
+ * Le cœur de la correction : deux familles homonymes au téléphone différent ne
+ * doivent jamais être rattachées par réflexe. Le signal faible est un
+ * avertissement, la création reste le défaut, et le rattachement exige une
+ * confirmation délibérée — faute de quoi le bilan partirait chez le mauvais
+ * parent.
+ */
+describe('Anti-doublon — homonymie et rattachement délibéré', () => {
+  // Même nom que BODY (Claire Bernard) mais téléphone différent : homonyme.
+  const homonym = {
+    id: 'parent-homonyme',
+    firstName: 'Claire',
+    lastName: 'Bernard',
+    email: null,
+    phone: '20 00 00 00',
+    phoneNormalized: '20000000',
+    mergedSources: [],
+    parentProfile: {
+      id: 'profile-homonyme',
+      children: [{
+        id: 'student-homonyme',
+        gradeLevel: 'SECONDE',
+        user: { firstName: 'Léa', lastName: 'Bernard' },
+      }],
+    },
+  };
+
+  it('un homonyme au téléphone différent est signalé comme homonymie, pas comme signal fort', async () => {
+    const { database, transaction, users, students } = memoryDatabase();
+    transaction.user.findMany.mockResolvedValue([homonym] as never);
+
+    const response = await handlerWith('ASSISTANTE', database)(familyRequest());
+
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.enteredPhone).toBe('99 19 28 29');
+    // BODY.child = Inès Terminale ; l'enfant du homonyme est en Seconde → pas de
+    // coïncidence de niveau : signal le plus faible.
+    expect(body.candidates).toEqual([expect.objectContaining({
+      parentUserId: 'parent-homonyme',
+      matchStrength: 'NAME_ONLY',
+      phone: '20 00 00 00',
+    })]);
+    expect(users).toHaveLength(0);
+    expect(students).toHaveLength(0);
+  });
+
+  it('qualifie en NAME_AND_LEVEL quand un niveau d’enfant coïncide', async () => {
+    const { database, transaction } = memoryDatabase();
+    transaction.user.findMany.mockResolvedValue([{
+      ...homonym,
+      parentProfile: {
+        ...homonym.parentProfile,
+        children: [{ id: 'c', gradeLevel: 'TERMINALE', user: { firstName: 'Léa', lastName: 'Bernard' } }],
+      },
+    }] as never);
+
+    const response = await handlerWith('ASSISTANTE', database)(familyRequest());
+
+    const body = await response.json();
+    expect(body.candidates[0].matchStrength).toBe('NAME_AND_LEVEL');
+  });
+
+  it('refuse le rattachement sur signal faible sans confirmation explicite', async () => {
+    const { database, transaction, users, students } = memoryDatabase();
+    transaction.user.findMany.mockResolvedValue([homonym] as never);
+
+    const response = await handlerWith('ASSISTANTE', database)(familyRequest({
+      ...BODY,
+      duplicateResolution: { mode: 'ATTACH', parentUserId: 'parent-homonyme' },
+    }, 'foyer-papier-weak-noconfirm-0001'));
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: { code: 'ATTACH_REQUIRES_CONFIRMATION' } });
+    // Aucune écriture : ni enfant rattaché, ni foyer créé.
+    expect(users).toHaveLength(0);
+    expect(students).toHaveLength(0);
+  });
+
+  it('rattache sur signal faible seulement avec la confirmation délibérée, et à ce foyer-là uniquement', async () => {
+    const { database, transaction, profiles, users, students } = memoryDatabase();
+    profiles.push({ id: 'profile-homonyme', userId: 'parent-homonyme' });
+    transaction.user.findMany.mockResolvedValue([homonym] as never);
+
+    const response = await handlerWith('ASSISTANTE', database)(familyRequest({
+      ...BODY,
+      duplicateResolution: { mode: 'ATTACH', parentUserId: 'parent-homonyme', confirmed: true },
+    }, 'foyer-papier-weak-confirm-0001'));
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toMatchObject({ parentUserId: 'parent-homonyme', parentCreated: false });
+    // Isolation : aucun nouveau parent, l'enfant est rattaché au foyer choisi et
+    // à aucun autre.
+    expect(users.filter((user) => user.role === 'PARENT')).toHaveLength(0);
+    expect(students).toHaveLength(1);
+    expect(students[0].parentId).toBe('profile-homonyme');
+  });
+
+  it('sur signal fort (même téléphone), le rattachement reste possible d’un clic', async () => {
+    const { database, transaction, profiles, students } = memoryDatabase();
+    profiles.push({ id: 'profile-existant', userId: 'parent-existant' });
+    transaction.user.findMany.mockResolvedValue([{
+      id: 'parent-existant',
+      firstName: 'Claire',
+      lastName: 'Bernard',
+      email: null,
+      phone: '99 19 28 29',
+      phoneNormalized: '99192829',
+      mergedSources: [],
+      parentProfile: { id: 'profile-existant', children: [] },
+    }] as never);
+
+    const response = await handlerWith('ASSISTANTE', database)(familyRequest({
+      ...BODY,
+      duplicateResolution: { mode: 'ATTACH', parentUserId: 'parent-existant' },
+    }, 'foyer-papier-strong-attach-0001'));
+
+    expect(response.status).toBe(201);
+    expect(students[0].parentId).toBe('profile-existant');
+  });
+
+  it('crée un nouveau foyer malgré un homonyme, sur décision explicite', async () => {
+    const { database, transaction, users } = memoryDatabase();
+    transaction.user.findMany.mockResolvedValue([homonym] as never);
+
+    const response = await handlerWith('ASSISTANTE', database)(familyRequest({
+      ...BODY,
+      duplicateResolution: { mode: 'CREATE_NEW' },
+    }, 'foyer-papier-homonym-create-0001'));
+
+    expect(response.status).toBe(201);
+    expect(users.filter((user) => user.role === 'PARENT')).toHaveLength(1);
   });
 });
 

--- a/__tests__/bilans/saisie-papier-household-matching.test.ts
+++ b/__tests__/bilans/saisie-papier-household-matching.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Hiérarchie des correspondances de foyer (saisie papier).
+ *
+ * Le cœur de la correction anti-doublon : le téléphone prime, l'homonymie sans
+ * téléphone commun n'est qu'un avertissement, et la normalisation des noms
+ * porte sur les deux champs séparément — jamais une concaténation.
+ */
+
+import {
+  attachRequiresConfirmation,
+  classifyHouseholdMatch,
+  compareByStrength,
+  normalizeNameKey,
+  parentNamesMatch,
+  type HouseholdCandidateFacts,
+  type HouseholdMatchInput,
+} from '@/lib/bilans/saisie-papier/household-matching';
+
+describe('normalizeNameKey', () => {
+  it('efface casse, accents, espaces multiples et bordures', () => {
+    expect(normalizeNameKey('  Bénard  ')).toBe('benard');
+    expect(normalizeNameKey('BENARD')).toBe('benard');
+    expect(normalizeNameKey('bénard')).toBe('benard');
+  });
+
+  it('assimile trait d’union et apostrophe à un espace', () => {
+    expect(normalizeNameKey('Jean-Pierre')).toBe(normalizeNameKey('Jean Pierre'));
+    expect(normalizeNameKey("D'Angelo")).toBe(normalizeNameKey('D Angelo'));
+    expect(normalizeNameKey('D’Angelo')).toBe(normalizeNameKey('d angelo'));
+  });
+
+  it('renvoie une chaîne vide pour une entrée sans lettre', () => {
+    expect(normalizeNameKey('   ')).toBe('');
+  });
+});
+
+describe('parentNamesMatch — deux champs, pas une concaténation', () => {
+  it('colle quand prénom ET nom normalisés coïncident', () => {
+    expect(parentNamesMatch(
+      { firstName: 'Alaeddine', lastName: 'Ben Rhouma' },
+      { firstName: 'alaeddine', lastName: 'ben rhouma' },
+    )).toBe(true);
+  });
+
+  it('ne colle pas si la coupure prénom/nom diffère', () => {
+    // « Ali Ben » + « Salah » ≠ « Ali » + « Ben Salah » même si la
+    // concaténation « ali ben salah » serait identique.
+    expect(parentNamesMatch(
+      { firstName: 'Ali Ben', lastName: 'Salah' },
+      { firstName: 'Ali', lastName: 'Ben Salah' },
+    )).toBe(false);
+  });
+
+  it('refuse un champ vide', () => {
+    expect(parentNamesMatch(
+      { firstName: '', lastName: 'Bernard' },
+      { firstName: '', lastName: 'Bernard' },
+    )).toBe(false);
+  });
+});
+
+const INPUT: HouseholdMatchInput = {
+  parentFirstName: 'Claire',
+  parentLastName: 'Bernard',
+  phoneNormalized: '99192829',
+  childLevels: ['TERMINALE'],
+};
+
+function candidate(overrides: Partial<HouseholdCandidateFacts> = {}): HouseholdCandidateFacts {
+  return {
+    parentFirstName: 'Claire',
+    parentLastName: 'Bernard',
+    phoneNormalized: '55000000',
+    mergedSourcePhonesNormalized: [],
+    childLevels: [],
+    ...overrides,
+  };
+}
+
+describe('classifyHouseholdMatch — hiérarchie des signaux', () => {
+  it('téléphone identique → signal fort PHONE, quel que soit le nom', () => {
+    expect(classifyHouseholdMatch(INPUT, candidate({
+      phoneNormalized: '99192829',
+      parentFirstName: 'Autre',
+      parentLastName: 'Nom',
+    }))).toBe('PHONE');
+  });
+
+  it('téléphone d’un compte source fusionné → PHONE', () => {
+    expect(classifyHouseholdMatch(INPUT, candidate({
+      phoneNormalized: '55000000',
+      mergedSourcePhonesNormalized: ['99192829'],
+    }))).toBe('PHONE');
+  });
+
+  it('même nom, téléphone différent, niveau enfant commun → NAME_AND_LEVEL', () => {
+    expect(classifyHouseholdMatch(INPUT, candidate({
+      childLevels: ['TERMINALE'],
+    }))).toBe('NAME_AND_LEVEL');
+  });
+
+  it('même nom, téléphone différent, aucun niveau commun → NAME_ONLY', () => {
+    expect(classifyHouseholdMatch(INPUT, candidate({
+      childLevels: ['SECONDE'],
+    }))).toBe('NAME_ONLY');
+  });
+
+  it('ni téléphone ni nom → aucun signal', () => {
+    expect(classifyHouseholdMatch(INPUT, candidate({
+      parentFirstName: 'Autre',
+      parentLastName: 'Nom',
+    }))).toBeNull();
+  });
+});
+
+describe('attachRequiresConfirmation — le rattachement délibéré', () => {
+  it('n’exige rien sur le signal fort', () => {
+    expect(attachRequiresConfirmation('PHONE')).toBe(false);
+  });
+
+  it('exige une confirmation sur toute correspondance de nom', () => {
+    expect(attachRequiresConfirmation('NAME_AND_LEVEL')).toBe(true);
+    expect(attachRequiresConfirmation('NAME_ONLY')).toBe(true);
+  });
+});
+
+describe('compareByStrength — présentation du fort vers l’homonymie', () => {
+  it('trie PHONE avant NAME_AND_LEVEL avant NAME_ONLY', () => {
+    const order = ['NAME_ONLY', 'PHONE', 'NAME_AND_LEVEL'] as const;
+    expect([...order].sort(compareByStrength)).toEqual(['PHONE', 'NAME_AND_LEVEL', 'NAME_ONLY']);
+  });
+});

--- a/__tests__/bilans/saisie-papier-workflow.test.tsx
+++ b/__tests__/bilans/saisie-papier-workflow.test.tsx
@@ -80,14 +80,16 @@ describe('Fil guidé de saisie papier', () => {
     );
   });
 
-  it('laisse l’assistante décider de rattacher un foyer suggéré', async () => {
+  it('sur un même téléphone, laisse rattacher le foyer suggéré d’un clic', async () => {
     fetchMock
       .mockResolvedValueOnce(new Response(JSON.stringify({
         error: { code: 'POTENTIAL_DUPLICATE' },
+        enteredPhone: '99 19 28 29',
         candidates: [{
           parentUserId: 'parent-existant',
           parentName: 'Claire Bernard',
           phone: '99 19 28 29',
+          matchStrength: 'PHONE',
           children: [{ studentId: 'student-existant', studentName: 'Inès Bernard', gradeLevel: 'TERMINALE' }],
         }],
       }), { status: 409, headers: { 'content-type': 'application/json' } }))
@@ -99,7 +101,7 @@ describe('Fil guidé de saisie papier', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Créer le foyer et continuer' }));
 
-    expect(await screen.findByText('Ce foyer existe peut-être déjà — rattacher ?')).toBeInTheDocument();
+    expect(await screen.findByText(/Même téléphone — s’agit-il du même foyer/)).toBeInTheDocument();
     const firstHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>;
     fireEvent.click(screen.getByRole('button', { name: 'Rattacher à Claire Bernard' }));
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
@@ -108,6 +110,48 @@ describe('Fil guidé de saisie papier', () => {
     expect(secondHeaders['idempotency-key']).not.toBe(firstHeaders['idempotency-key']);
     expect(JSON.parse(String(secondRequest[1].body))).toMatchObject({
       duplicateResolution: { mode: 'ATTACH', parentUserId: 'parent-existant' },
+    });
+  });
+
+  it('sur une homonymie au téléphone différent, avertit et exige la confirmation avant de rattacher', async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        error: { code: 'POTENTIAL_DUPLICATE' },
+        enteredPhone: '99 19 28 29',
+        candidates: [{
+          parentUserId: 'parent-homonyme',
+          parentName: 'Claire Bernard',
+          phone: '20 00 00 00',
+          matchStrength: 'NAME_ONLY',
+          children: [{ studentId: 'student-homonyme', studentName: 'Léa Bernard', gradeLevel: 'SECONDE' }],
+        }],
+      }), { status: 409, headers: { 'content-type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        children: [{ studentId: 'student-3' }],
+      }), { status: 201, headers: { 'content-type': 'application/json' } }));
+    render(<PaperEntryFamilyForm />);
+    fillFamilyWithoutEmail();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Créer le foyer et continuer' }));
+
+    // Avertissement d'homonymie, divergence de téléphone visible, création par défaut.
+    expect(await screen.findByText('Attention — un autre foyer porte ce nom')).toBeInTheDocument();
+    expect(screen.getByText(/téléphone saisi \(99 19 28 29\) diffère de celui de ce foyer \(20 00 00 00\)/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Créer un nouveau foyer' })).toBeEnabled();
+
+    // Le rattachement est inerte tant que « je confirme » n'est pas coché.
+    const attach = screen.getByRole('button', { name: 'Rattacher malgré le téléphone différent' });
+    expect(attach).toBeDisabled();
+    fireEvent.click(attach);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Après confirmation explicite, le rattachement part avec confirmed: true.
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(attach).toBeEnabled();
+    fireEvent.click(attach);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(JSON.parse(String((fetchMock.mock.calls[1] as [string, RequestInit])[1].body))).toMatchObject({
+      duplicateResolution: { mode: 'ATTACH', parentUserId: 'parent-homonyme', confirmed: true },
     });
   });
 

--- a/app/dashboard/assistante/bilans/saisie-papier/family-form.tsx
+++ b/app/dashboard/assistante/bilans/saisie-papier/family-form.tsx
@@ -8,12 +8,14 @@ import { normalizeParentPhone } from '@/lib/contact/parent-phone';
 
 type ChildDraft = Readonly<{ firstName: string; grade: string }>;
 type DuplicateResolution =
-  | Readonly<{ mode: 'ATTACH'; parentUserId: string }>
+  | Readonly<{ mode: 'ATTACH'; parentUserId: string; confirmed?: true }>
   | Readonly<{ mode: 'CREATE_NEW' }>;
+type MatchStrength = 'PHONE' | 'NAME_AND_LEVEL' | 'NAME_ONLY';
 type DuplicateCandidate = Readonly<{
   parentUserId: string;
   parentName: string;
   phone: string | null;
+  matchStrength: MatchStrength;
   children: readonly Readonly<{ studentId: string; studentName: string; gradeLevel: string }>[];
 }>;
 
@@ -48,6 +50,12 @@ export function PaperEntryFamilyForm() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [candidates, setCandidates] = useState<readonly DuplicateCandidate[]>([]);
+  // Téléphone tel que saisi, renvoyé par le serveur, pour montrer la divergence
+  // avec le numéro d'un foyer homonyme.
+  const [enteredPhone, setEnteredPhone] = useState('');
+  // Rattachements sur signal faible cochés « je confirme » : le bouton reste
+  // inerte tant que la case ne l'est pas.
+  const [confirmedIds, setConfirmedIds] = useState<ReadonlySet<string>>(new Set());
   // Une seule clé pour ce foyer : un renvoi après un échec ambigu rejoue la
   // même création au lieu d'en ajouter une seconde.
   const [idempotencyKey, setIdempotencyKey] = useState(newIdempotencyKey);
@@ -93,10 +101,13 @@ export function PaperEntryFamilyForm() {
       if (response.status === 409) {
         const conflict = await response.json() as {
           error?: Readonly<{ code?: string }>;
+          enteredPhone?: string;
           candidates?: readonly DuplicateCandidate[];
         };
         if (conflict.error?.code === 'POTENTIAL_DUPLICATE' && conflict.candidates !== undefined) {
           setCandidates(conflict.candidates);
+          setEnteredPhone(conflict.enteredPhone ?? parentPhone.trim());
+          setConfirmedIds(new Set());
           setIdempotencyKey(newIdempotencyKey());
           return;
         }
@@ -219,39 +230,115 @@ export function PaperEntryFamilyForm() {
         </button>
       </div>
 
-      {candidates.length > 0 && (
-        <section className="rounded-2xl border border-amber-300/30 bg-amber-300/10 p-4" aria-label="Foyers similaires">
-          <h3 className="font-semibold text-amber-100">Ce foyer existe peut-être déjà — rattacher ?</h3>
-          <p className="mt-1 text-sm text-slate-300">Vérifiez les informations puis choisissez explicitement.</p>
-          <ul className="mt-3 space-y-3">
-            {candidates.map((candidate) => (
-              <li key={candidate.parentUserId} className="rounded-xl border border-white/10 bg-slate-950/50 p-3">
-                <p className="font-semibold text-white">{candidate.parentName}</p>
-                <p className="text-sm text-slate-300">
-                  {candidate.phone ?? 'Téléphone non affiché'}
-                  {candidate.children.map((child) => ` · ${child.studentName} (${child.gradeLevel})`).join('')}
+      {candidates.length > 0 && (() => {
+        const strongCandidates = candidates.filter((candidate) => candidate.matchStrength === 'PHONE');
+        const homonymCandidates = candidates.filter((candidate) => candidate.matchStrength !== 'PHONE');
+        const enteredName = `${parentFirstName.trim()} ${parentLastName.trim()}`.trim();
+
+        function toggleConfirmed(parentUserId: string) {
+          setConfirmedIds((current) => {
+            const next = new Set(current);
+            if (next.has(parentUserId)) next.delete(parentUserId);
+            else next.add(parentUserId);
+            return next;
+          });
+        }
+
+        return (
+          <div className="space-y-4" aria-label="Foyers similaires">
+            {strongCandidates.length > 0 && (
+              <section className="rounded-2xl border border-emerald-300/30 bg-emerald-300/10 p-4">
+                <h3 className="font-semibold text-emerald-100">Même téléphone — s’agit-il du même foyer&nbsp;?</h3>
+                <p className="mt-1 text-sm text-slate-300">
+                  Un foyer existant porte le téléphone que vous avez saisi. Le rattachement est probablement légitime.
                 </p>
-                <button
-                  type="button"
-                  disabled={submitting}
-                  onClick={() => void submit({ mode: 'ATTACH', parentUserId: candidate.parentUserId })}
-                  className="mt-3 rounded-xl border border-amber-300 px-3 py-2 text-sm font-semibold text-amber-100 disabled:opacity-40"
-                >
-                  Rattacher à {candidate.parentName}
-                </button>
-              </li>
-            ))}
-          </ul>
-          <button
-            type="button"
-            disabled={submitting}
-            onClick={() => void submit({ mode: 'CREATE_NEW' })}
-            className="mt-3 rounded-xl border border-white/20 px-3 py-2 text-sm font-semibold text-slate-200 disabled:opacity-40"
-          >
-            Créer un nouveau foyer
-          </button>
-        </section>
-      )}
+                <ul className="mt-3 space-y-3">
+                  {strongCandidates.map((candidate) => (
+                    <li key={candidate.parentUserId} className="rounded-xl border border-white/10 bg-slate-950/50 p-3">
+                      <p className="font-semibold text-white">{candidate.parentName}</p>
+                      <p className="text-sm text-slate-300">
+                        {candidate.phone ?? 'Téléphone non enregistré'}
+                        {candidate.children.map((child) => ` · ${child.studentName} (${child.gradeLevel})`).join('')}
+                      </p>
+                      <button
+                        type="button"
+                        disabled={submitting}
+                        onClick={() => void submit({ mode: 'ATTACH', parentUserId: candidate.parentUserId })}
+                        className="mt-3 rounded-xl bg-emerald-400 px-3 py-2 text-sm font-semibold text-slate-950 disabled:opacity-40"
+                      >
+                        Rattacher à {candidate.parentName}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
+
+            {homonymCandidates.length > 0 && (
+              <section className="rounded-2xl border border-amber-300/40 bg-amber-300/10 p-4">
+                <h3 className="font-semibold text-amber-100">Attention — un autre foyer porte ce nom</h3>
+                <p className="mt-1 text-sm text-slate-300">
+                  Le téléphone diffère&nbsp;: il s’agit très probablement d’une famille homonyme. Dans le doute,
+                  créez un nouveau foyer — c’est le choix par défaut.
+                </p>
+                <ul className="mt-3 space-y-3">
+                  {homonymCandidates.map((candidate) => (
+                    <li key={candidate.parentUserId} className="rounded-xl border border-white/10 bg-slate-950/50 p-3">
+                      <dl className="grid gap-2 text-sm sm:grid-cols-2">
+                        <div className="rounded-lg border border-white/10 bg-black/20 p-2">
+                          <dt className="text-xs uppercase tracking-wide text-slate-400">Ce que vous saisissez</dt>
+                          <dd className="mt-1 font-semibold text-white">{enteredName || 'Parent'}</dd>
+                          <dd className="text-slate-300">{enteredPhone || 'Téléphone en cours de saisie'}</dd>
+                        </div>
+                        <div className="rounded-lg border border-white/10 bg-black/20 p-2">
+                          <dt className="text-xs uppercase tracking-wide text-slate-400">Foyer déjà enregistré</dt>
+                          <dd className="mt-1 font-semibold text-white">{candidate.parentName}</dd>
+                          <dd className="text-amber-200">{candidate.phone ?? 'Téléphone non enregistré'}</dd>
+                          {candidate.children.length > 0 && (
+                            <dd className="mt-1 text-slate-300">
+                              {candidate.children.map((child) => `${child.studentName} (${child.gradeLevel})`).join(' · ')}
+                            </dd>
+                          )}
+                        </div>
+                      </dl>
+                      <p className="mt-2 text-sm text-amber-100">
+                        Le téléphone saisi ({enteredPhone || '—'}) diffère de celui de ce foyer
+                        ({candidate.phone ?? 'non enregistré'}) — s’agit-il vraiment de la même famille&nbsp;?
+                      </p>
+                      <label className="mt-3 flex items-start gap-2 text-sm text-slate-200">
+                        <input
+                          type="checkbox"
+                          checked={confirmedIds.has(candidate.parentUserId)}
+                          onChange={() => toggleConfirmed(candidate.parentUserId)}
+                          className="mt-0.5 h-4 w-4 rounded border-white/30 bg-slate-950"
+                        />
+                        <span>Je confirme qu’il s’agit bien du même foyer que {candidate.parentName}.</span>
+                      </label>
+                      <button
+                        type="button"
+                        disabled={submitting || !confirmedIds.has(candidate.parentUserId)}
+                        onClick={() => void submit({ mode: 'ATTACH', parentUserId: candidate.parentUserId, confirmed: true })}
+                        className="mt-3 rounded-xl border border-amber-300/60 px-3 py-2 text-sm font-semibold text-amber-100 disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        Rattacher malgré le téléphone différent
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
+
+            <button
+              type="button"
+              disabled={submitting}
+              onClick={() => void submit({ mode: 'CREATE_NEW' })}
+              className="w-full rounded-xl bg-amber-400 px-4 py-2.5 text-sm font-semibold text-slate-950 disabled:opacity-40"
+            >
+              Créer un nouveau foyer
+            </button>
+          </div>
+        );
+      })()}
 
       {children.length >= MAX_CHILDREN && (
         <p className="text-sm text-slate-400">

--- a/lib/bilans/saisie-papier/famille.ts
+++ b/lib/bilans/saisie-papier/famille.ts
@@ -29,6 +29,12 @@ import {
   type IdempotencyDatabase,
 } from '../api/idempotency';
 import { assertStaffActor } from './access';
+import {
+  attachRequiresConfirmation,
+  classifyHouseholdMatch,
+  compareByStrength,
+  type HouseholdMatchStrength,
+} from './household-matching';
 
 /**
  * Création du foyer, côté staff, préalable à une saisie papier.
@@ -60,7 +66,13 @@ const requestSchema = z.object({
   parentLastName: z.string().trim().min(1).max(80),
   children: z.array(childSchema).min(1).max(PAPER_ENTRY_MAX_CHILDREN),
   duplicateResolution: z.discriminatedUnion('mode', [
-    z.object({ mode: z.literal('ATTACH'), parentUserId: z.string().trim().min(1).max(80) }).strict(),
+    z.object({
+      mode: z.literal('ATTACH'),
+      parentUserId: z.string().trim().min(1).max(80),
+      // Confirmation délibérée exigée sur un signal faible (homonymie sans
+      // téléphone commun) : le rattachement réflexe est ainsi impossible.
+      confirmed: z.literal(true).optional(),
+    }).strict(),
     z.object({ mode: z.literal('CREATE_NEW') }).strict(),
   ]).optional(),
 }).strict();
@@ -105,6 +117,8 @@ type DuplicateCandidateRecord = Readonly<{
   lastName: string | null;
   email: string | null;
   phone: string | null;
+  phoneNormalized: string | null;
+  mergedSources: readonly Readonly<{ phoneNormalized: string | null }>[];
   parentProfile: Readonly<{
     id: string;
     children: readonly Readonly<{
@@ -119,6 +133,8 @@ export type PaperEntryDuplicateCandidate = Readonly<{
   parentUserId: string;
   parentName: string;
   phone: string | null;
+  /** Force du signal : téléphone identique, homonymie, homonymie + niveau. */
+  matchStrength: HouseholdMatchStrength;
   children: readonly Readonly<{
     studentId: string;
     studentName: string;
@@ -128,7 +144,14 @@ export type PaperEntryDuplicateCandidate = Readonly<{
 
 type PotentialDuplicateResult = Readonly<{
   error: Readonly<{ code: 'POTENTIAL_DUPLICATE' }>;
+  /** Téléphone tel que saisi (affichage), pour montrer la divergence côté UI. */
+  enteredPhone: string;
   candidates: readonly PaperEntryDuplicateCandidate[];
+}>;
+
+type ClassifiedCandidate = Readonly<{
+  record: DuplicateCandidateRecord;
+  strength: HouseholdMatchStrength;
 }>;
 
 type FamilyResponse = FamilyResult | PotentialDuplicateResult;
@@ -151,12 +174,14 @@ function displayName(firstName: string | null, lastName: string | null, fallback
   return `${firstName ?? ''} ${lastName ?? ''}`.trim() || fallback;
 }
 
-function projectDuplicateCandidate(candidate: DuplicateCandidateRecord): PaperEntryDuplicateCandidate {
+function projectDuplicateCandidate(candidate: ClassifiedCandidate): PaperEntryDuplicateCandidate {
+  const { record, strength } = candidate;
   return Object.freeze({
-    parentUserId: candidate.id,
-    parentName: displayName(candidate.firstName, candidate.lastName, 'Parent'),
-    phone: candidate.phone,
-    children: Object.freeze((candidate.parentProfile?.children ?? []).map((child) => Object.freeze({
+    parentUserId: record.id,
+    parentName: displayName(record.firstName, record.lastName, 'Parent'),
+    phone: record.phone,
+    matchStrength: strength,
+    children: Object.freeze((record.parentProfile?.children ?? []).map((child) => Object.freeze({
       studentId: child.id,
       studentName: displayName(child.user.firstName, child.user.lastName, 'Élève'),
       gradeLevel: child.gradeLevel,
@@ -164,10 +189,48 @@ function projectDuplicateCandidate(candidate: DuplicateCandidateRecord): PaperEn
   });
 }
 
+/**
+ * Qualifie un candidat brut en lui associant sa force de signal, ou l'écarte
+ * si aucun signal ne le relie réellement au foyer saisi (le filtre SQL est
+ * volontairement large ; la classification, autorité, tranche en mémoire à
+ * partir des clés normalisées). Les candidats sont triés du signal fort vers
+ * l'homonymie.
+ */
+function classifyCandidates(
+  records: readonly DuplicateCandidateRecord[],
+  input: z.infer<typeof requestSchema>,
+  phoneNormalized: string,
+  children: readonly ResolvedChild[],
+): readonly ClassifiedCandidate[] {
+  const childLevels = children.map((child) => child.level);
+  return records
+    .flatMap((record) => {
+      const strength = classifyHouseholdMatch(
+        {
+          parentFirstName: input.parentFirstName,
+          parentLastName: input.parentLastName,
+          phoneNormalized,
+          childLevels,
+        },
+        {
+          parentFirstName: record.firstName,
+          parentLastName: record.lastName,
+          phoneNormalized: record.phoneNormalized,
+          mergedSourcePhonesNormalized: record.mergedSources
+            .map((source) => source.phoneNormalized)
+            .filter((value): value is string => value !== null),
+          childLevels: (record.parentProfile?.children ?? []).map((child) => child.gradeLevel),
+        },
+      );
+      return strength === null ? [] : [{ record, strength }];
+    })
+    .sort((a, b) => compareByStrength(a.strength, b.strength));
+}
+
 async function findPotentialDuplicateFamilies(
   transaction: Prisma.TransactionClient,
   phoneNormalized: string,
-  children: readonly ResolvedChild[],
+  input: z.infer<typeof requestSchema>,
 ): Promise<readonly DuplicateCandidateRecord[]> {
   return transaction.user.findMany({
     where: {
@@ -179,21 +242,16 @@ async function findPotentialDuplicateFamilies(
         // fusion additive. La suggestion doit présenter le compte actif
         // cible, pas ignorer ce numéro parce que sa source est tombstonée.
         { mergedSources: { some: { phoneNormalized } } },
-        ...children.map((child) => ({
-          parentProfile: {
-            is: {
-              children: {
-                some: {
-                  gradeLevel: child.level,
-                  user: {
-                    firstName: { equals: child.firstName, mode: 'insensitive' as const },
-                    lastName: { equals: child.lastName, mode: 'insensitive' as const },
-                  },
-                },
-              },
-            },
-          },
-        })),
+        // Homonymie de parent : mêmes nom et prénom, même quand le téléphone
+        // diffère. Le filtre SQL est insensible à la casse ; la robustesse aux
+        // accents, espaces et traits d'union est portée par la classification
+        // en mémoire (clés normalisées), autorité de la décision.
+        {
+          AND: [
+            { firstName: { equals: input.parentFirstName, mode: 'insensitive' as const } },
+            { lastName: { equals: input.parentLastName, mode: 'insensitive' as const } },
+          ],
+        },
       ],
     },
     select: {
@@ -202,6 +260,8 @@ async function findPotentialDuplicateFamilies(
       lastName: true,
       email: true,
       phone: true,
+      phoneNormalized: true,
+      mergedSources: { select: { phoneNormalized: true } },
       parentProfile: {
         select: {
           id: true,
@@ -473,27 +533,37 @@ export function createPaperEntryFamilyHandler(
         now,
         action: async (transaction: CanonicalTransaction) => {
           const familyTransaction = transaction as unknown as Prisma.TransactionClient;
-          const candidates = await findPotentialDuplicateFamilies(
+          const records = await findPotentialDuplicateFamilies(
             familyTransaction,
             parentPhone.normalized,
-            children,
+            input,
           );
+          const candidates = classifyCandidates(records, input, parentPhone.normalized, children);
           const resolution = input.duplicateResolution;
           if (candidates.length > 0 && resolution === undefined) {
             return {
               status: 409,
               body: Object.freeze({
                 error: Object.freeze({ code: 'POTENTIAL_DUPLICATE' as const }),
+                enteredPhone: parentPhone.display,
                 candidates: Object.freeze(candidates.map(projectDuplicateCandidate)),
               }),
             };
           }
 
           const attachTo = resolution?.mode === 'ATTACH'
-            ? candidates.find(({ id }) => id === resolution.parentUserId)
+            ? candidates.find(({ record }) => record.id === resolution.parentUserId)
             : undefined;
-          if (resolution?.mode === 'ATTACH' && attachTo === undefined) {
-            throw CanonicalApiError.conflict('POTENTIAL_DUPLICATE_SELECTION_INVALID');
+          if (resolution?.mode === 'ATTACH') {
+            if (attachTo === undefined) {
+              throw CanonicalApiError.conflict('POTENTIAL_DUPLICATE_SELECTION_INVALID');
+            }
+            // Le rattachement sur un signal faible (homonymie sans téléphone
+            // commun) n'est jamais implicite : sans la confirmation délibérée,
+            // on refuse plutôt que d'envoyer le bilan au mauvais foyer.
+            if (attachRequiresConfirmation(attachTo.strength) && resolution.confirmed !== true) {
+              throw CanonicalApiError.conflict('ATTACH_REQUIRES_CONFIRMATION');
+            }
           }
 
           return {
@@ -503,7 +573,7 @@ export function createPaperEntryFamilyHandler(
               children,
               parentEmail,
               parentPhone,
-              attachTo,
+              attachTo: attachTo?.record,
               now,
             }),
           };

--- a/lib/bilans/saisie-papier/household-matching.ts
+++ b/lib/bilans/saisie-papier/household-matching.ts
@@ -1,0 +1,127 @@
+import type { GradeLevel } from '@prisma/client';
+
+/**
+ * Hiérarchie des correspondances de foyer, côté saisie papier.
+ *
+ * Le défaut corrigé : la suggestion « ce foyer existe peut-être » se déclenchait
+ * sur le seul nom du parent et présentait le rattachement au même niveau que la
+ * création — une assistante qui enchaîne les saisies rattachait par réflexe
+ * l'enfant d'une famille au compte d'une autre famille homonyme, envoyant le
+ * bilan chez le mauvais parent.
+ *
+ * On distingue désormais trois forces de signal :
+ *   - PHONE          : téléphone normalisé identique — la clé de contact réelle
+ *                      du foyer. Le rattachement est légitime, proposé en premier.
+ *   - NAME_AND_LEVEL : mêmes nom et prénom du parent, téléphone différent, ET un
+ *                      enfant existant partage un niveau avec un enfant saisi —
+ *                      homonymie avec coïncidence, à qualifier explicitement.
+ *   - NAME_ONLY      : mêmes nom et prénom du parent, téléphone différent, aucune
+ *                      coïncidence de niveau — homonymie probable.
+ *
+ * Seul PHONE autorise un rattachement d'un simple clic ; tout signal fondé sur
+ * le nom exige une confirmation délibérée supplémentaire (cf.
+ * `attachRequiresConfirmation`). Le chemin le plus facile reste le plus sûr :
+ * la création d'un nouveau foyer.
+ */
+
+export type HouseholdMatchStrength = 'PHONE' | 'NAME_AND_LEVEL' | 'NAME_ONLY';
+
+/**
+ * Clé de comparaison d'un nom de personne, insensible à la casse, aux accents,
+ * aux espaces multiples et aux séparateurs de noms composés (trait d'union,
+ * apostrophe droite ou typographique). « Bénard », « BENARD », « be-nard » et
+ * « Bénard » collent à la même clé. Une chaîne vide reste vide.
+ */
+export function normalizeNameKey(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/['’-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Deux noms de parent correspondent quand leurs prénoms ET leurs noms partagent
+ * la même clé normalisée. Jamais une concaténation approximative : chaque champ
+ * est comparé séparément, pour qu'« Ali Ben » + « Salah » ne colle pas à « Ali »
+ * + « Ben Salah ».
+ */
+export function parentNamesMatch(
+  a: Readonly<{ firstName: string; lastName: string }>,
+  b: Readonly<{ firstName: string; lastName: string }>,
+): boolean {
+  const firstA = normalizeNameKey(a.firstName);
+  const lastA = normalizeNameKey(a.lastName);
+  if (firstA === '' || lastA === '') return false;
+  return firstA === normalizeNameKey(b.firstName) && lastA === normalizeNameKey(b.lastName);
+}
+
+export type HouseholdMatchInput = Readonly<{
+  parentFirstName: string;
+  parentLastName: string;
+  phoneNormalized: string;
+  childLevels: readonly GradeLevel[];
+}>;
+
+export type HouseholdCandidateFacts = Readonly<{
+  parentFirstName: string | null;
+  parentLastName: string | null;
+  /** Téléphone normalisé du compte cible, ou d'un compte source fusionné. */
+  phoneNormalized: string | null;
+  mergedSourcePhonesNormalized: readonly string[];
+  childLevels: readonly GradeLevel[];
+}>;
+
+/**
+ * Qualifie la force du signal entre le foyer saisi et un foyer candidat, ou
+ * `null` si aucun signal ne les relie (le candidat ne devrait alors pas être
+ * proposé). Le téléphone prime : un numéro identique classe en PHONE quelles
+ * que soient les autres coïncidences.
+ */
+export function classifyHouseholdMatch(
+  input: HouseholdMatchInput,
+  candidate: HouseholdCandidateFacts,
+): HouseholdMatchStrength | null {
+  const phoneMatches = input.phoneNormalized !== ''
+    && (candidate.phoneNormalized === input.phoneNormalized
+      || candidate.mergedSourcePhonesNormalized.includes(input.phoneNormalized));
+  if (phoneMatches) return 'PHONE';
+
+  const nameMatches = candidate.parentFirstName !== null
+    && candidate.parentLastName !== null
+    && parentNamesMatch(
+      { firstName: input.parentFirstName, lastName: input.parentLastName },
+      { firstName: candidate.parentFirstName, lastName: candidate.parentLastName },
+    );
+  if (!nameMatches) return null;
+
+  const enteredLevels = new Set(input.childLevels);
+  const levelOverlap = candidate.childLevels.some((level) => enteredLevels.has(level));
+  return levelOverlap ? 'NAME_AND_LEVEL' : 'NAME_ONLY';
+}
+
+/**
+ * Ordre de présentation : le signal fort d'abord, l'homonymie ensuite. Deux
+ * candidats de même force gardent leur ordre d'arrivée (tri stable).
+ */
+const STRENGTH_RANK: Readonly<Record<HouseholdMatchStrength, number>> = {
+  PHONE: 0,
+  NAME_AND_LEVEL: 1,
+  NAME_ONLY: 2,
+};
+
+export function compareByStrength(a: HouseholdMatchStrength, b: HouseholdMatchStrength): number {
+  return STRENGTH_RANK[a] - STRENGTH_RANK[b];
+}
+
+/**
+ * Le rattachement délibéré : seul le signal fort (téléphone identique) peut être
+ * accepté d'un clic. Toute correspondance fondée sur le nom exige une
+ * confirmation explicite supplémentaire — c'est ce qui empêche le rattachement
+ * réflexe entre familles homonymes.
+ */
+export function attachRequiresConfirmation(strength: HouseholdMatchStrength): boolean {
+  return strength !== 'PHONE';
+}


### PR DESCRIPTION
## Contexte — un défaut vu sur un cas réel

Dans l'écran de saisie papier (`/dashboard/assistante/bilans/saisie-papier`), la suggestion « ce foyer existe peut-être déjà — rattacher ? » se déclenchait sur le nom du parent et présentait le rattachement **au même niveau visuel** que la création. Deux parents pouvant parfaitement porter les mêmes nom et prénom, une assistante qui enchaîne les saisies pouvait cliquer « Rattacher » par réflexe et **rattacher l'enfant d'une famille au compte d'une autre famille homonyme** — le bilan partait alors chez le mauvais parent. Fuite de données personnelles entre familles.

## Correction

### 1. Hiérarchie des signaux (`lib/bilans/saisie-papier/household-matching.ts`, module pur)

| Signal | Condition | Traitement |
|---|---|---|
| **PHONE** (fort) | Téléphone normalisé identique (y compris via un compte source fusionné) | Clé de contact réelle du foyer — rattachement légitime, **proposé en premier**, d'un clic. |
| **NAME_AND_LEVEL** (faible) | Mêmes nom + prénom du parent, **téléphone différent**, et un niveau d'enfant coïncide | Avertissement d'homonymie qualifié. |
| **NAME_ONLY** (faible) | Mêmes nom + prénom du parent, **téléphone différent**, aucun niveau commun | Avertissement d'homonymie. |

Le téléphone prime : un numéro identique classe en PHONE quelles que soient les autres coïncidences.

### 2. Divergence rendue explicite et visible

Sur un signal faible, l'écran affiche **côte à côte** le foyer saisi et le foyer existant, et souligne : « le téléphone saisi (X) diffère de celui de ce foyer (Y) — s'agit-il vraiment de la même famille ? ». L'assistante décide sans deviner.

### 3. Rattachement délibéré, pas réflexe

Tout signal fondé sur le nom exige une **confirmation explicite supplémentaire** (case « je confirme qu'il s'agit du même foyer ») ; le bouton de rattachement reste inerte tant qu'elle n'est pas cochée, et « **Créer un nouveau foyer** » est l'action par défaut. L'exigence est portée **aussi côté serveur** : un `ATTACH` sur signal non-PHONE sans `confirmed: true` est refusé (`ATTACH_REQUIRES_CONFIRMATION`) — l'UI ne peut être contournée. Le chemin le plus facile est le plus sûr.

### 4. Correspondance de nom robuste

`normalizeNameKey` compare **les deux champs séparément** (prénom, puis nom), insensible à la casse, aux accents, aux espaces multiples, aux traits d'union et apostrophes. Jamais une concaténation approximative : « Ali Ben » + « Salah » ne colle pas à « Ali » + « Ben Salah ».

## Les trois cas (prouvés par les tests)

**A — Même téléphone → rattachement légitime.**
`saisie-papier-famille` « suggère le foyer portant le même téléphone » (matchStrength PHONE) et « sur signal fort, le rattachement reste possible d'un clic ». UI : `saisie-papier-workflow` « sur un même téléphone, laisse rattacher le foyer suggéré d'un clic » (titre « Même téléphone — s'agit-il du même foyer ? », bouton primaire).

**B — Homonymie, téléphone différent → avertissement, création par défaut, pas de rattachement au premier plan.**
`saisie-papier-famille` « un homonyme au téléphone différent est signalé comme homonymie, pas comme signal fort » (matchStrength NAME_ONLY). UI « sur une homonymie au téléphone différent, avertit… » : titre « Attention — un autre foyer porte ce nom », divergence de téléphone affichée, « Créer un nouveau foyer » activé.

**C — Rattachement délibéré.**
`saisie-papier-famille` « refuse le rattachement sur signal faible sans confirmation explicite » → 409 `ATTACH_REQUIRES_CONFIRMATION`, **aucune écriture** ; « rattache sur signal faible seulement avec la confirmation délibérée, et à ce foyer-là uniquement » → 201. UI : bouton désactivé, un clic prématuré n'envoie rien ; après la case cochée, l'appel part avec `confirmed: true`.

## Preuve d'isolation

Le test « rattache… et à ce foyer-là uniquement » vérifie qu'après un rattachement confirmé : **aucun nouveau parent créé**, l'enfant est rattaché au **seul** profil choisi (`students[0].parentId === 'profile-homonyme'`), et aucun autre foyer n'est touché. Sur rattachement refusé (sans confirmation), **zéro écriture** — ni enfant rattaché, ni foyer créé.

## Garde-fous respectés

- Aucune donnée existante modifiée, **aucune migration**.
- Le téléphone reste **obligatoire** à la saisie et **non unique** en base (deux enfants d'un même parent partagent le numéro).
- Banques, scoring, snapshots append-only, candidat libre : **intacts**. Single-writer.
- Charte nexus-lux (avertissement ambré, signal fort émeraude), français soigné.

## Vérifications

- Suite complète sans filtre : **808 suites, 9001 tests, 0 échec, 0 skip**.
- `tsc --noEmit` propre.
- Les **cinq** contrôles du job Lint verts : ESLint, `check:no-hardcoded`, `security:repo`, `check:test-quarantines`, `check:docs-archive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Empêche le rattachement réflexe entre familles homonymes en saisie papier. Avant, la suggestion basée sur le nom mettait le rattachement au même niveau que la création et pouvait envoyer un bilan au mauvais parent. Désormais, le téléphone prime, l’homonymie devient un avertissement, et un rattachement sur nom seul exige une confirmation explicite.

- Hiérarchie des signaux dans `lib/bilans/saisie-papier/household-matching.ts` : `PHONE` (fort) > `NAME_AND_LEVEL` > `NAME_ONLY`. Normalisation robuste des noms (prénom et nom séparés), tri fort→faible.
- Côté serveur (`lib/bilans/saisie-papier/famille.ts`) : classification en mémoire, réponse 409 enrichie avec `enteredPhone` et `matchStrength` par candidat, et refus `ATTACH_REQUIRES_CONFIRMATION` sur tout `ATTACH` non-`PHONE` sans `confirmed: true`. Le filtrage SQL inclut le téléphone (y compris sources fusionnées) et l’homonymie de parent, la décision finale se fait en mémoire.
- Côté UI (`app/dashboard/assistante/bilans/saisie-papier/family-form.tsx`) : séparation explicite des cas “Même téléphone” (rattachement en un clic) et “Homonymie” (avertissement). Affichage côte à côte des données saisies vs enregistrées avec divergence de téléphone. “Créer un nouveau foyer” devient l’action par défaut. Le bouton de rattachement sur homonymie reste inerte tant que la case “je confirme” n’est pas cochée et envoie `confirmed: true`.

**Migration et vérifications**
- Action requise pour tout appelant de l’API: lors d’un `duplicateResolution: { mode: 'ATTACH' }` sans correspondance de téléphone, envoyer `confirmed: true`, sinon 409 `ATTACH_REQUIRES_CONFIRMATION`.
- Aucune migration de schéma ni modification de données. Le téléphone reste obligatoire et non unique.
- Nouveaux tests unitaires et d’intégration couvrant la classification, l’API (hiérarchie, refus sans confirmation, isolation), et l’UI (avertissement, confirmation, divergence de téléphone).

<sup>Written for commit ea2b5fa10b3f8b88df2f5937a3dba6e25692b621. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

