### PR TITLE
fix(saisie-papier): correspondance de nom robuste (accents, ponctuation, espaces) — cause racine du doublon

### DIFF
--- a/__tests__/bilans/saisie-papier-famille.test.ts
+++ b/__tests__/bilans/saisie-papier-famille.test.ts
@@ -50,11 +50,19 @@ function memoryDatabase() {
   const students: (Record<string, unknown> & { id: string; parentId: string })[] = [];
   const profiles: (Record<string, unknown> & { id: string; userId: string })[] = [];
   const links: Record<string, unknown>[] = [];
+  // Foyers candidats connus de la base : la recherche anti-doublon en résout
+  // les identifiants via `$queryRaw` (clé de nom normalisée) puis les hydrate
+  // via `findMany({ where: { id: { in } } })`. Le test les enregistre ici.
+  const duplicateCandidates: (Record<string, unknown> & { id: string })[] = [];
 
   const transaction = {
     user: {
       findUnique: jest.fn(async () => null),
-      findMany: jest.fn(async () => []),
+      findMany: jest.fn(async (args: { where?: { id?: { in?: readonly string[] } } }) => {
+        const ids = args?.where?.id?.in;
+        if (Array.isArray(ids)) return duplicateCandidates.filter((candidate) => ids.includes(candidate.id));
+        return [];
+      }),
       update: jest.fn(async ({ where, data }: { where: object; data: object }) => ({ ...where, ...data })),
       create: jest.fn(async ({ data }: { data: Record<string, unknown> }) => {
         users.push(data);
@@ -90,9 +98,15 @@ function memoryDatabase() {
         return { id: `link-${links.length}`, state: data.state, consentedAt: null, verifiedAt: null };
       }),
     },
-    // `lockOwnedStudent` relit l'élève FOR UPDATE ; le double rend la ligne
-    // réellement créée, sans quoi le lien de consentement échouerait.
-    $queryRaw: jest.fn(async (query: { values?: readonly unknown[] }) => {
+    // Deux usages de `$queryRaw` : la résolution des identifiants de foyers
+    // candidats (requête portant `nexus_household_name_key`) et le verrou
+    // `lockOwnedStudent` (relit l'élève FOR UPDATE). On les distingue par le
+    // texte SQL.
+    $queryRaw: jest.fn(async (query: { strings?: readonly string[]; sql?: string; values?: readonly unknown[] }) => {
+      const text = Array.isArray(query?.strings) ? query.strings.join(' ') : String(query?.sql ?? '');
+      if (text.includes('nexus_household_name_key')) {
+        return duplicateCandidates.map((candidate) => ({ id: candidate.id }));
+      }
       const studentId = query.values?.[0];
       const student = students.find((candidate) => candidate.id === studentId);
       return student === undefined ? [] : [{ id: student.id, parentId: student.parentId }];
@@ -128,7 +142,7 @@ function memoryDatabase() {
     })),
   };
 
-  return { database, transaction, users, students, profiles, links };
+  return { database, transaction, users, students, profiles, links, duplicateCandidates };
 }
 
 function handlerWith(role: string | undefined, database: ReturnType<typeof memoryDatabase>['database']) {
@@ -186,8 +200,8 @@ describe('Création du foyer — suggestion anti-doublon à décision humaine', 
   };
 
   it('suggère le foyer portant le même téléphone normalisé sans rien créer', async () => {
-    const { database, transaction, users, students } = memoryDatabase();
-    transaction.user.findMany.mockResolvedValue([candidate] as never);
+    const { database, transaction, users, students, duplicateCandidates } = memoryDatabase();
+    duplicateCandidates.push(candidate as never);
 
     const response = await handlerWith('ASSISTANTE', database)(familyRequest());
 
@@ -207,33 +221,24 @@ describe('Création du foyer — suggestion anti-doublon à décision humaine', 
     expect(students).toHaveLength(0);
   });
 
-  it('recherche aussi l’homonymie du parent (mêmes nom et prénom)', async () => {
-    const { database, transaction } = memoryDatabase();
-    transaction.user.findMany.mockResolvedValue([candidate] as never);
+  it('recherche l’homonymie via la clé de nom normalisée en SQL', async () => {
+    const { database, transaction, duplicateCandidates } = memoryDatabase();
+    duplicateCandidates.push(candidate as never);
 
     await handlerWith('ASSISTANTE', database)(familyRequest());
 
-    expect(transaction.user.findMany).toHaveBeenCalledWith(expect.objectContaining({
-      where: expect.objectContaining({
-        role: 'PARENT',
-        OR: expect.arrayContaining([
-          { phoneNormalized: '99192829' },
-          { mergedSources: { some: { phoneNormalized: '99192829' } } },
-          {
-            AND: [
-              { firstName: { equals: 'Claire', mode: 'insensitive' } },
-              { lastName: { equals: 'Bernard', mode: 'insensitive' } },
-            ],
-          },
-        ]),
-      }),
-    }));
+    const rawSql = transaction.$queryRaw.mock.calls.map(([query]) => {
+      const q = query as { strings?: readonly string[]; sql?: string };
+      return Array.isArray(q?.strings) ? q.strings.join(' ') : String(q?.sql ?? '');
+    });
+    // La recherche passe par la fonction indexée, pas par un ILIKE Prisma.
+    expect(rawSql.some((sql) => sql.includes('nexus_household_name_key'))).toBe(true);
   });
 
   it('rattache au foyer choisi explicitement sans créer un parent', async () => {
-    const { database, transaction, profiles, users, students } = memoryDatabase();
+    const { database, transaction, profiles, users, students, duplicateCandidates } = memoryDatabase();
     profiles.push({ id: 'profile-existant', userId: 'parent-existant' });
-    transaction.user.findMany.mockResolvedValue([candidate] as never);
+    duplicateCandidates.push(candidate as never);
 
     const response = await handlerWith('ASSISTANTE', database)(familyRequest({
       ...BODY,
@@ -248,9 +253,9 @@ describe('Création du foyer — suggestion anti-doublon à décision humaine', 
   });
 
   it('complète le contact du foyer choisi quand son e-mail était différé', async () => {
-    const { database, transaction, profiles } = memoryDatabase();
+    const { database, transaction, profiles, duplicateCandidates } = memoryDatabase();
     profiles.push({ id: 'profile-existant', userId: 'parent-existant' });
-    transaction.user.findMany.mockResolvedValue([candidate] as never);
+    duplicateCandidates.push(candidate as never);
 
     const response = await handlerWith('ASSISTANTE', database)(familyRequest({
       ...BODY,
@@ -273,8 +278,8 @@ describe('Création du foyer — suggestion anti-doublon à décision humaine', 
   });
 
   it('complète le profil d’un parent sélectionné qui n’en avait pas encore', async () => {
-    const { database, transaction, profiles, users, students } = memoryDatabase();
-    transaction.user.findMany.mockResolvedValue([{ ...candidate, parentProfile: null }] as never);
+    const { database, transaction, profiles, users, students, duplicateCandidates } = memoryDatabase();
+    duplicateCandidates.push({ ...candidate, parentProfile: null } as never);
 
     const response = await handlerWith('ASSISTANTE', database)(familyRequest({
       ...BODY,
@@ -288,8 +293,8 @@ describe('Création du foyer — suggestion anti-doublon à décision humaine', 
   });
 
   it('crée un nouveau foyer uniquement après la décision explicite', async () => {
-    const { database, transaction, users } = memoryDatabase();
-    transaction.user.findMany.mockResolvedValue([candidate] as never);
+    const { database, transaction, users, duplicateCandidates } = memoryDatabase();
+    duplicateCandidates.push(candidate as never);
 
     const response = await handlerWith('ASSISTANTE', database)(familyRequest({
       ...BODY,
@@ -301,8 +306,8 @@ describe('Création du foyer — suggestion anti-doublon à décision humaine', 
   });
 
   it('refuse un rattachement vers un foyer absent des candidats', async () => {
-    const { database, transaction, users } = memoryDatabase();
-    transaction.user.findMany.mockResolvedValue([candidate] as never);
+    const { database, transaction, users, duplicateCandidates } = memoryDatabase();
+    duplicateCandidates.push(candidate as never);
 
     const response = await handlerWith('ASSISTANTE', database)(familyRequest({
       ...BODY,
@@ -342,8 +347,8 @@ describe('Anti-doublon — homonymie et rattachement délibéré', () => {
   };
 
   it('un homonyme au téléphone différent est signalé comme homonymie, pas comme signal fort', async () => {
-    const { database, transaction, users, students } = memoryDatabase();
-    transaction.user.findMany.mockResolvedValue([homonym] as never);
+    const { database, transaction, users, students, duplicateCandidates } = memoryDatabase();
+    duplicateCandidates.push(homonym as never);
 
     const response = await handlerWith('ASSISTANTE', database)(familyRequest());
 
@@ -362,14 +367,14 @@ describe('Anti-doublon — homonymie et rattachement délibéré', () => {
   });
 
   it('qualifie en NAME_AND_LEVEL quand un niveau d’enfant coïncide', async () => {
-    const { database, transaction } = memoryDatabase();
-    transaction.user.findMany.mockResolvedValue([{
+    const { database, transaction, duplicateCandidates } = memoryDatabase();
+    duplicateCandidates.push({
       ...homonym,
       parentProfile: {
         ...homonym.parentProfile,
         children: [{ id: 'c', gradeLevel: 'TERMINALE', user: { firstName: 'Léa', lastName: 'Bernard' } }],
       },
-    }] as never);
+    } as never);
 
     const response = await handlerWith('ASSISTANTE', database)(familyRequest());
 
@@ -378,8 +383,8 @@ describe('Anti-doublon — homonymie et rattachement délibéré', () => {
   });
 
   it('refuse le rattachement sur signal faible sans confirmation explicite', async () => {
-    const { database, transaction, users, students } = memoryDatabase();
-    transaction.user.findMany.mockResolvedValue([homonym] as never);
+    const { database, transaction, users, students, duplicateCandidates } = memoryDatabase();
+    duplicateCandidates.push(homonym as never);
 
     const response = await handlerWith('ASSISTANTE', database)(familyRequest({
       ...BODY,
@@ -394,9 +399,9 @@ describe('Anti-doublon — homonymie et rattachement délibéré', () => {
   });
 
   it('rattache sur signal faible seulement avec la confirmation délibérée, et à ce foyer-là uniquement', async () => {
-    const { database, transaction, profiles, users, students } = memoryDatabase();
+    const { database, transaction, profiles, users, students, duplicateCandidates } = memoryDatabase();
     profiles.push({ id: 'profile-homonyme', userId: 'parent-homonyme' });
-    transaction.user.findMany.mockResolvedValue([homonym] as never);
+    duplicateCandidates.push(homonym as never);
 
     const response = await handlerWith('ASSISTANTE', database)(familyRequest({
       ...BODY,
@@ -413,9 +418,9 @@ describe('Anti-doublon — homonymie et rattachement délibéré', () => {
   });
 
   it('sur signal fort (même téléphone), le rattachement reste possible d’un clic', async () => {
-    const { database, transaction, profiles, students } = memoryDatabase();
+    const { database, transaction, profiles, students, duplicateCandidates } = memoryDatabase();
     profiles.push({ id: 'profile-existant', userId: 'parent-existant' });
-    transaction.user.findMany.mockResolvedValue([{
+    duplicateCandidates.push({
       id: 'parent-existant',
       firstName: 'Claire',
       lastName: 'Bernard',
@@ -424,7 +429,7 @@ describe('Anti-doublon — homonymie et rattachement délibéré', () => {
       phoneNormalized: '99192829',
       mergedSources: [],
       parentProfile: { id: 'profile-existant', children: [] },
-    }] as never);
+    } as never);
 
     const response = await handlerWith('ASSISTANTE', database)(familyRequest({
       ...BODY,
@@ -436,8 +441,8 @@ describe('Anti-doublon — homonymie et rattachement délibéré', () => {
   });
 
   it('crée un nouveau foyer malgré un homonyme, sur décision explicite', async () => {
-    const { database, transaction, users } = memoryDatabase();
-    transaction.user.findMany.mockResolvedValue([homonym] as never);
+    const { database, transaction, users, duplicateCandidates } = memoryDatabase();
+    duplicateCandidates.push(homonym as never);
 
     const response = await handlerWith('ASSISTANTE', database)(familyRequest({
       ...BODY,

--- a/__tests__/bilans/saisie-papier-household-matching.test.ts
+++ b/__tests__/bilans/saisie-papier-household-matching.test.ts
@@ -32,6 +32,13 @@ describe('normalizeNameKey', () => {
   it('renvoie une chaîne vide pour une entrée sans lettre', () => {
     expect(normalizeNameKey('   ')).toBe('');
   });
+
+  it('plie ensemble toutes les variantes exigées de « Ben Rhouma »', () => {
+    const reference = normalizeNameKey('Ben Rhouma');
+    for (const variant of ['ben-rhouma', 'Bén Rhouma', 'ben  rhouma', 'BEN RHOUMA', "Ben-Rhouma'", 'Ben Rhouma']) {
+      expect(`${variant} → ${normalizeNameKey(variant)}`).toBe(`${variant} → ${reference}`);
+    }
+  });
 });
 
 describe('parentNamesMatch — deux champs, pas une concaténation', () => {

--- a/__tests__/integration/saisie-papier-normalisation.real.test.ts
+++ b/__tests__/integration/saisie-papier-normalisation.real.test.ts
@@ -1,0 +1,177 @@
+jest.unmock('@/lib/prisma');
+
+/**
+ * Correspondance de nom robuste de l'anti-doublon, sur PostgreSQL réel.
+ *
+ * C'est ici — et seulement ici — que se prouve la correction du défaut relevé
+ * au déploiement de #131 : la recherche de foyers candidats reposait sur un
+ * `ILIKE` exact (casse seule), si bien qu'une variante d'accent ou de
+ * ponctuation (« ben-rhouma », « Bén Rhouma ») échappait à la recherche et
+ * créait un doublon.
+ *
+ * On vérifie la fonction indexée `nexus_household_name_key` de bout en bout,
+ * à travers le vrai handler de création de foyer : chaque variante d'un même
+ * nom, saisie avec un téléphone DIFFÉRENT, doit remonter le foyer stocké comme
+ * homonyme (409, aucune écriture), dans les deux sens (saisi normalisé /
+ * stocké non normalisé, et l'inverse). L'invariant serveur
+ * `ATTACH_REQUIRES_CONFIRMATION` reste tenu.
+ */
+
+import { NextRequest } from 'next/server';
+
+import { createPaperEntryFamilyHandler } from '@/lib/bilans/saisie-papier/famille';
+import { prisma } from '@/lib/prisma';
+
+const PREFIX = `norm-${Date.now()}-`;
+const NOW = new Date('2026-08-13T10:00:00.000Z');
+const STAFF_ID = `${PREFIX}staff`;
+
+let dbReady = false;
+
+function handler() {
+  return createPaperEntryFamilyHandler({
+    prisma: prisma as never,
+    authenticate: async () => ({ user: { id: STAFF_ID, role: 'ASSISTANTE' } } as never),
+    now: () => NOW,
+  });
+}
+
+let requestCounter = 0;
+function familyRequest(body: unknown) {
+  requestCounter += 1;
+  return new NextRequest('http://localhost/api/bilans/saisie-papier/famille', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'idempotency-key': `${PREFIX}${requestCounter}` },
+    body: JSON.stringify(body),
+  });
+}
+
+async function seedParent(input: Readonly<{ firstName: string; lastName: string; phoneNormalized: string }>): Promise<string> {
+  const user = await prisma.user.create({
+    data: {
+      email: `${PREFIX}${input.phoneNormalized}@example.test`,
+      role: 'PARENT',
+      firstName: input.firstName,
+      lastName: input.lastName,
+      phone: input.phoneNormalized,
+      phoneNormalized: input.phoneNormalized,
+      password: null,
+      activatedAt: null,
+    },
+  });
+  await prisma.parentProfile.create({ data: { userId: user.id } });
+  return user.id;
+}
+
+beforeAll(async () => {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    // La fonction de normalisation doit exister (migration appliquée).
+    await prisma.$queryRaw`SELECT nexus_household_name_key('a', 'b')`;
+    dbReady = true;
+  } catch {
+    dbReady = false;
+  }
+});
+
+afterAll(async () => {
+  if (!dbReady) return;
+  await prisma.student.deleteMany({ where: { user: { email: { startsWith: PREFIX } } } });
+  await prisma.parentProfile.deleteMany({ where: { user: { email: { startsWith: PREFIX } } } });
+  await prisma.user.deleteMany({ where: { email: { startsWith: PREFIX } } });
+  await prisma.canonicalApiIdempotencyKey.deleteMany({ where: { key: { startsWith: PREFIX } } });
+  await prisma.$disconnect();
+});
+
+// Variantes qui DOIVENT toutes coller à « Alaeddine Ben Rhouma ».
+const VARIANTS: ReadonlyArray<Readonly<{ label: string; firstName: string; lastName: string }>> = [
+  { label: 'trait d’union minuscule', firstName: 'alaeddine', lastName: 'ben-rhouma' },
+  { label: 'accent', firstName: 'Alaeddine', lastName: 'Bén Rhouma' },
+  { label: 'espaces multiples', firstName: 'Alaeddine', lastName: 'ben  rhouma' },
+  { label: 'majuscules', firstName: 'ALAEDDINE', lastName: 'BEN RHOUMA' },
+  { label: 'trait d’union + apostrophe', firstName: 'Alaeddine', lastName: "Ben-Rhouma'" },
+  { label: 'orthographe exacte', firstName: 'Alaeddine', lastName: 'Ben Rhouma' },
+];
+
+describe('Anti-doublon — correspondance de nom normalisée (PostgreSQL réel)', () => {
+  it('remonte le foyer stocké pour chaque variante saisie, avec un téléphone différent', async () => {
+    if (!dbReady) {
+      console.warn('DB indisponible — test de normalisation ignoré');
+      return;
+    }
+    const storedId = await seedParent({ firstName: 'Alaeddine', lastName: 'Ben Rhouma', phoneNormalized: '55110011' });
+
+    for (const variant of VARIANTS) {
+      const response = await handler()(familyRequest({
+        parentPhone: '20000001', // téléphone DIFFÉRENT → seule la clé de nom peut relier
+        parentFirstName: variant.firstName,
+        parentLastName: variant.lastName,
+        children: [{ firstName: 'Enfant', grade: 'Terminale' }],
+      }));
+
+      expect(response.status).toBe(409);
+      const payload = await response.json();
+      expect(payload.error.code).toBe('POTENTIAL_DUPLICATE');
+      const found = (payload.candidates as ReadonlyArray<{ parentUserId: string; matchStrength: string }>)
+        .find((candidate) => candidate.parentUserId === storedId);
+      expect(`${variant.label}: ${found?.matchStrength ?? 'ABSENT'}`).toBe(`${variant.label}: NAME_ONLY`);
+    }
+  });
+
+  it('remonte un foyer stocké sous une variante quand la saisie est l’orthographe exacte (sens inverse)', async () => {
+    if (!dbReady) return;
+    // Stocké NON normalisé, saisi normalisé : la clé indexée les rapproche
+    // quand même, dans ce sens aussi.
+    const storedId = await seedParent({ firstName: 'josé', lastName: "de l'Île", phoneNormalized: '55220022' });
+
+    const response = await handler()(familyRequest({
+      parentPhone: '20000002',
+      parentFirstName: 'Jose',
+      parentLastName: 'de l Ile',
+      children: [{ firstName: 'Enfant', grade: 'Seconde' }],
+    }));
+
+    expect(response.status).toBe(409);
+    const payload = await response.json();
+    const found = (payload.candidates as ReadonlyArray<{ parentUserId: string }>)
+      .some((candidate) => candidate.parentUserId === storedId);
+    expect(found).toBe(true);
+  });
+
+  it('n’écrit rien sur un rattachement faible sans confirmation, même nom reconnu', async () => {
+    if (!dbReady) return;
+    const storedId = await seedParent({ firstName: 'Amine', lastName: 'Trabelsi', phoneNormalized: '55330033' });
+    const before = await prisma.user.count();
+
+    const response = await handler()(familyRequest({
+      parentPhone: '20000003',
+      parentFirstName: 'amine',
+      parentLastName: 'TRABELSI',
+      children: [{ firstName: 'Enfant', grade: 'Première' }],
+      duplicateResolution: { mode: 'ATTACH', parentUserId: storedId },
+    }));
+
+    expect(response.status).toBe(409);
+    expect((await response.json()).error.code).toBe('ATTACH_REQUIRES_CONFIRMATION');
+    // Invariant : le refus n'a créé ni parent ni enfant.
+    expect(await prisma.user.count()).toBe(before);
+  });
+
+  it('ne relie pas deux noms dont seule la frontière prénom/nom diffère', async () => {
+    if (!dbReady) return;
+    const storedId = await seedParent({ firstName: 'Ali Ben', lastName: 'Salah', phoneNormalized: '55440044' });
+
+    const response = await handler()(familyRequest({
+      parentPhone: '20000004',
+      parentFirstName: 'Ali',
+      parentLastName: 'Ben Salah',
+      children: [{ firstName: 'Enfant', grade: 'Terminale' }],
+    }));
+
+    // « Ali Ben » + « Salah » ≠ « Ali » + « Ben Salah » : aucune correspondance,
+    // donc création directe (201), pas de faux positif.
+    expect(response.status).toBe(201);
+    const payload = await response.json();
+    expect(payload.parentUserId).not.toBe(storedId);
+  });
+});

--- a/lib/bilans/saisie-papier/famille.ts
+++ b/lib/bilans/saisie-papier/famille.ts
@@ -1,5 +1,6 @@
 import { createId } from '@paralleldrive/cuid2';
-import type { GradeLevel, Prisma, PrismaClient } from '@prisma/client';
+import { Prisma } from '@prisma/client';
+import type { GradeLevel, PrismaClient } from '@prisma/client';
 import type { Session } from 'next-auth';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
@@ -190,11 +191,11 @@ function projectDuplicateCandidate(candidate: ClassifiedCandidate): PaperEntryDu
 }
 
 /**
- * Qualifie un candidat brut en lui associant sa force de signal, ou l'écarte
- * si aucun signal ne le relie réellement au foyer saisi (le filtre SQL est
- * volontairement large ; la classification, autorité, tranche en mémoire à
- * partir des clés normalisées). Les candidats sont triés du signal fort vers
- * l'homonymie.
+ * Qualifie un candidat remonté par la recherche en lui associant sa force de
+ * signal (téléphone fort, homonymie faible), ou l'écarte si plus aucun signal
+ * ne le relie au foyer saisi. La classification en mémoire reste l'autorité :
+ * elle applique `normalizeNameKey`, cohérente avec la clé SQL indexée. Les
+ * candidats sont triés du signal fort vers l'homonymie.
  */
 function classifyCandidates(
   records: readonly DuplicateCandidateRecord[],
@@ -232,28 +233,35 @@ async function findPotentialDuplicateFamilies(
   phoneNormalized: string,
   input: z.infer<typeof requestSchema>,
 ): Promise<readonly DuplicateCandidateRecord[]> {
-  return transaction.user.findMany({
-    where: {
-      role: 'PARENT',
-      mergedIntoUserId: null,
-      OR: [
-        { phoneNormalized },
-        // Le téléphone du compte source reste un alias de contact après une
-        // fusion additive. La suggestion doit présenter le compte actif
-        // cible, pas ignorer ce numéro parce que sa source est tombstonée.
-        { mergedSources: { some: { phoneNormalized } } },
-        // Homonymie de parent : mêmes nom et prénom, même quand le téléphone
-        // diffère. Le filtre SQL est insensible à la casse ; la robustesse aux
-        // accents, espaces et traits d'union est portée par la classification
-        // en mémoire (clés normalisées), autorité de la décision.
-        {
-          AND: [
-            { firstName: { equals: input.parentFirstName, mode: 'insensitive' as const } },
-            { lastName: { equals: input.parentLastName, mode: 'insensitive' as const } },
-          ],
-        },
-      ],
-    },
+  // Résolution des identifiants candidats en SQL, pour comparer les noms sur
+  // leur clé NORMALISÉE (`nexus_household_name_key` : casse, accents, traits
+  // d'union, apostrophes, espaces multiples). Une comparaison Prisma
+  // `insensitive` ne plierait que la casse et laisserait « ben-rhouma » ou
+  // « Bén Rhouma » échapper à la recherche. La même fonction indexée sert des
+  // deux côtés de l'égalité — aucune dérive entre la valeur stockée et la
+  // valeur saisie.
+  const matches = await transaction.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+    SELECT u.id
+    FROM users u
+    WHERE u.role = 'PARENT'
+      AND u."mergedIntoUserId" IS NULL
+      AND (
+        u."phoneNormalized" = ${phoneNormalized}
+        OR EXISTS (
+          SELECT 1 FROM users s
+          WHERE s."mergedIntoUserId" = u.id
+            AND s."phoneNormalized" = ${phoneNormalized}
+        )
+        OR nexus_household_name_key(u."firstName", u."lastName")
+             = nexus_household_name_key(${input.parentFirstName}, ${input.parentLastName})
+      )
+    ORDER BY u."createdAt" ASC
+    LIMIT 10`);
+  const ids = matches.map((row) => row.id);
+  if (ids.length === 0) return [];
+
+  const records = await transaction.user.findMany({
+    where: { id: { in: ids } },
     select: {
       id: true,
       firstName: true,
@@ -276,8 +284,13 @@ async function findPotentialDuplicateFamilies(
         },
       },
     },
-    orderBy: { createdAt: 'asc' },
-    take: 10,
+  });
+  // `findMany({ in })` ne garantit pas l'ordre : on rétablit l'ordre de
+  // création déjà fixé par la requête SQL.
+  const byId = new Map(records.map((record) => [record.id, record]));
+  return ids.flatMap((id) => {
+    const record = byId.get(id);
+    return record === undefined ? [] : [record];
   });
 }
 

--- a/prisma/migrations/20260813100000_add_household_name_key_index/migration.sql
+++ b/prisma/migrations/20260813100000_add_household_name_key_index/migration.sql
@@ -1,0 +1,60 @@
+-- Anti-doublon de foyer (saisie papier) — correspondance de nom robuste.
+--
+-- Le pré-filtre de recherche des foyers candidats comparait les noms avec
+-- `ILIKE` exact : insensible à la casse, mais PAS aux accents ni à la
+-- ponctuation. Une variante comme « ben-rhouma » ou « Bén Rhouma » n'était
+-- donc jamais remontée, et un doublon se créait silencieusement.
+--
+-- On dote la recherche d'une clé de nom normalisée, calculée par une fonction
+-- IMMUTABLE et matérialisée dans un index d'expression partiel (parents
+-- actifs uniquement). Choix de l'index d'expression plutôt qu'une colonne
+-- stockée : même déterminisme et même performance, mais SANS colonne à
+-- maintenir en cohérence sur chaque écriture (aucun trigger, aucun chemin
+-- d'écriture applicatif à modifier, aucun backfill — l'index se peuple depuis
+-- les colonnes existantes). La même fonction sert à la construction de
+-- l'index ET à la requête : aucune dérive possible.
+
+-- Normalisation d'un composant de nom : pli des accents latins (translate,
+-- insensible à la locale, contrairement à un lower() seul), minuscules,
+-- apostrophes/traits d'union ramenés à un espace, espaces multiples réduits.
+CREATE OR REPLACE FUNCTION nexus_normalize_name_part(value text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+  SELECT btrim(
+    regexp_replace(
+      regexp_replace(
+        lower(
+          translate(
+            coalesce(value, ''),
+            'ÀÁÂÃÄÅàáâãäåÈÉÊËèéêëÌÍÎÏìíîïÒÓÔÕÖØòóôõöøÙÚÛÜùúûüÑñÇçŸÿ',
+            'AAAAAAaaaaaaEEEEeeeeIIIIiiiiOOOOOOooooooUUUUuuuuNnCcYy'
+          )
+        ),
+        '[''’`\-]+', ' ', 'g'
+      ),
+      '\s+', ' ', 'g'
+    )
+  )
+$$;
+
+-- Clé de foyer : prénom et nom normalisés séparément puis joints par une
+-- tabulation. Le séparateur préserve la frontière entre les deux champs, pour
+-- que « Ali Ben » + « Salah » ne colle pas à « Ali » + « Ben Salah ».
+CREATE OR REPLACE FUNCTION nexus_household_name_key(first_name text, last_name text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+  SELECT nexus_normalize_name_part(first_name) || E'\t' || nexus_normalize_name_part(last_name)
+$$;
+
+-- Index d'expression partiel : seuls les parents actifs (non fusionnés) sont
+-- des cibles de rattachement, ce qui garde l'index petit et la recherche
+-- rapide. La requête filtre exactement sur ce prédicat pour l'exploiter.
+CREATE INDEX IF NOT EXISTS "users_household_name_key_idx"
+ON "users" (nexus_household_name_key("firstName", "lastName"))
+WHERE "role" = 'PARENT' AND "mergedIntoUserId" IS NULL;


### PR DESCRIPTION
## Cause racine

Le déploiement de #131 a révélé un doublon silencieux : le pré-filtre de recherche des foyers candidats comparait les noms avec un `ILIKE` exact — insensible à la **casse**, mais **pas** aux accents ni à la ponctuation. `normalizeNameKey` (TS) pliait bien tout cela, mais n'était appliqué qu'aux candidats **déjà remontés** par le SQL. Une variante comme « ben-rhouma » ou « Bén Rhouma » n'était donc jamais récupérée, jamais rapprochée — et un doublon se créait.

## Correction — au niveau du fetch

**Choix : index d'expression plutôt que colonne stockée.** Même déterminisme et même performance qu'une colonne indexée, mais **sans colonne à maintenir en cohérence** sur chaque écriture (aucun trigger, aucun chemin d'écriture applicatif modifié) et **sans backfill** (l'index d'expression se peuple depuis les colonnes existantes). La **même fonction** sert à la construction de l'index ET à la requête : aucune dérive possible entre la valeur stockée et la valeur saisie.

Migration additive `20260813100000_add_household_name_key_index` :
- Fonction `IMMUTABLE nexus_household_name_key(first, last)` : pli des accents latins par `translate` (insensible à la locale, contrairement à un `lower()` seul), minuscules, apostrophes et traits d'union ramenés à un espace, espaces multiples réduits. Le prénom et le nom sont normalisés **séparément** puis joints par une tabulation — la frontière est préservée.
- Index d'expression **partiel** sur `users(firstName, lastName) WHERE role='PARENT' AND mergedIntoUserId IS NULL` : petit et rapide, exactement le périmètre interrogé.

`findPotentialDuplicateFamilies` résout les identifiants candidats par une requête paramétrée utilisant cette fonction des deux côtés de l'égalité, puis hydrate via `findMany`. La classification en mémoire (`normalizeNameKey`) reste l'autorité, cohérente avec la clé SQL.

## Prouvé sur PostgreSQL réel (`saisie-papier-normalisation.real.test.ts`)

Tiennent désormais, **dans les deux sens** (saisi normalisé ↔ stocké non normalisé) :

```
Ben Rhouma = ben-rhouma = Bén Rhouma = ben  rhouma = BEN RHOUMA = Ben-Rhouma'
```

Chaque variante saisie avec un **téléphone différent** remonte le foyer stocké comme homonymie (`NAME_ONLY`, 409, aucune écriture). Le sens inverse (stocké « josé de l'Île », saisi « Jose de l Ile ») est couvert aussi.

Et le faux positif de frontière est évité : « Ali Ben » + « Salah » **ne colle pas** à « Ali » + « Ben Salah » (création directe, 201).

## Invariant préservé

`ATTACH_REQUIRES_CONFIRMATION` inchangé : un rattachement sur signal faible sans confirmation est **refusé côté serveur**, même nom reconnu — la mésattribution entre familles reste bloquée (test real-db dédié : le refus ne crée ni parent ni enfant).

## Garde-fous

- Aucune donnée existante modifiée, migration additive uniquement, index auto-peuplé.
- Le téléphone reste obligatoire et non unique.
- Banques, scoring, snapshots append-only, candidat libre : intacts. Single-writer.

## Vérifications

- Suite unitaire complète : **808 suites, 9002 tests, 0 échec, 0 skip**.
- Real-db normalisation : **4/4** (base éphémère jetable, `NEXUS_DISPOSABLE_POSTGRES=1`).
- Suite d'intégration/real-db sur base éphémère : **232/235** (les 3 restants relèvent du harnais NPC tombstone — chiffrement + double client — fourni séparément par la CI, sans rapport avec la saisie papier).
- `tsc --noEmit` propre. Les **cinq** contrôles du job Lint verts.
- `prisma migrate deploy` applique la migration proprement sur base neuve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Évite les doublons en saisie papier en recherchant les foyers sur une clé de nom normalisée (casse, accents, ponctuation, espaces) au lieu d’un ILIKE. Les variantes orthographiques se rapprochent, la frontière prénom/nom est conservée, et `ATTACH_REQUIRES_CONFIRMATION` ne change pas.

- Ajoute les fonctions SQL immuables `nexus_normalize_name_part` et `nexus_household_name_key`, plus un index d’expression partiel sur `users` pour les parents actifs.
- Remplace le filtre Prisma par une requête SQL paramétrée qui compare la clé normalisée et renvoie des IDs, puis hydrate via `findMany` en conservant l’ordre de création.
- Ajoute un test d’intégration Postgres réel et adapte les tests unitaires pour la résolution via `$queryRaw`.
- Aucun backfill, aucune donnée existante modifiée.

**Rollout**
- Exécuter `prisma migrate deploy` pour créer les fonctions et l’index.

<sup>Written for commit 035e855595c52db30f96b6da483ea38b5742ee31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

