### PR TITLE
fix(saisie-papier): foyers sans e-mail invisibles — filtres NULL-safe (classe NOT-sur-nullable)

### DIFF
--- a/__tests__/integration/saisie-papier-visibilite-sans-email.real.test.ts
+++ b/__tests__/integration/saisie-papier-visibilite-sans-email.real.test.ts
@@ -1,0 +1,77 @@
+jest.unmock('@/lib/prisma');
+
+/**
+ * Visibilité d'un foyer SANS e-mail sur l'écran de saisie papier — PostgreSQL réel.
+ *
+ * Défaut attrapé par le parcours E2E, invisible aux tests unitaires : le filtre
+ * `paperEntryVisibleStudentWhere` reposait sur `NOT { parent: { is: { user: {
+ * is: … } } } }`, dont la logique SQL à trois valeurs écarte une ligne dont le
+ * parent a `email = NULL`. Un foyer créé par la saisie papier sans e-mail
+ * (flux différé) devenait donc introuvable pour l'assistante juste après
+ * création — le parcours se bloquait.
+ *
+ * Ce test crée exactement ce foyer (parent sans e-mail) et exige qu'il soit
+ * résolu par le filtre, tout en vérifiant que les comptes de test restent bien
+ * masqués.
+ */
+
+import { prisma } from '@/lib/prisma';
+import { paperEntryVisibleStudentWhere } from '@/lib/bilans/saisie-papier/test-account-filter';
+
+const PREFIX = `visi-${Date.now()}-`;
+let dbReady = false;
+
+async function seedHousehold(input: Readonly<{ studentEmail: string; parentEmail: string | null }>): Promise<string> {
+  const parentUser = await prisma.user.create({
+    data: { email: input.parentEmail, role: 'PARENT', firstName: 'Foyer', lastName: 'Test', phone: '55000000' },
+  });
+  const parent = await prisma.parentProfile.create({ data: { userId: parentUser.id } });
+  const studentUser = await prisma.user.create({ data: { email: input.studentEmail, role: 'ELEVE' } });
+  const student = await prisma.student.create({
+    data: { userId: studentUser.id, parentId: parent.id, gradeLevel: 'SECONDE' },
+  });
+  return student.id;
+}
+
+function resolvable(studentId: string) {
+  return prisma.student.findFirst({ where: { AND: [{ id: studentId }, paperEntryVisibleStudentWhere()] }, select: { id: true } });
+}
+
+beforeAll(async () => {
+  try { await prisma.$queryRaw`SELECT 1`; dbReady = true; } catch { dbReady = false; }
+});
+
+afterAll(async () => {
+  if (!dbReady) return;
+  await prisma.student.deleteMany({ where: { user: { email: { startsWith: PREFIX } } } });
+  await prisma.parentProfile.deleteMany({ where: { user: { email: { startsWith: PREFIX } } } });
+  await prisma.parentProfile.deleteMany({ where: { user: { firstName: 'Foyer', lastName: 'Test' } } });
+  await prisma.user.deleteMany({ where: { OR: [{ email: { startsWith: PREFIX } }, { AND: [{ firstName: 'Foyer' }, { lastName: 'Test' }] }] } });
+  await prisma.$disconnect();
+});
+
+describe('paperEntryVisibleStudentWhere — foyer sans e-mail (PostgreSQL réel)', () => {
+  it('résout un foyer dont le PARENT n’a pas d’e-mail (le défaut historique)', async () => {
+    if (!dbReady) { console.warn('DB indisponible'); return; }
+    const id = await seedHousehold({ studentEmail: `${PREFIX}eleve@nexus-student.local`, parentEmail: null });
+    expect((await resolvable(id))?.id).toBe(id);
+  });
+
+  it('résout un foyer avec e-mail parent ordinaire', async () => {
+    if (!dbReady) return;
+    const id = await seedHousehold({ studentEmail: `${PREFIX}eleve2@nexus-student.local`, parentEmail: `${PREFIX}parent@gmail.com` });
+    expect((await resolvable(id))?.id).toBe(id);
+  });
+
+  it('masque toujours un compte de test (e-mail @example.test)', async () => {
+    if (!dbReady) return;
+    const id = await seedHousehold({ studentEmail: `${PREFIX}eleve3@nexus-student.local`, parentEmail: `${PREFIX}parent@example.test` });
+    expect(await resolvable(id)).toBeNull();
+  });
+
+  it('masque toujours un compte de test même si le PARENT est propre mais l’ÉLÈVE est un compte résiduel', async () => {
+    if (!dbReady) return;
+    const id = await seedHousehold({ studentEmail: `${PREFIX}smoke-residual@example.test`, parentEmail: null });
+    expect(await resolvable(id)).toBeNull();
+  });
+});

--- a/__tests__/integration/stage-reservation-richstatus-nullsafe.real.test.ts
+++ b/__tests__/integration/stage-reservation-richstatus-nullsafe.real.test.ts
@@ -1,0 +1,117 @@
+jest.unmock('@/lib/prisma');
+
+/**
+ * Deuxième instance de la classe « NOT sur champ nullable » (PostgreSQL réel).
+ *
+ * `StageReservation.richStatus` est nullable (compat legacy). Le planning
+ * assistante filtrait les réservations annulées avec
+ * `NOT: [{ richStatus: 'CANCELLED' }, …]` : en logique SQL à trois valeurs,
+ * `NOT (richStatus = 'CANCELLED')` vaut NULL quand `richStatus` est NULL, et
+ * la réservation legacy disparaissait du filtre — même mécanique que le foyer
+ * sans e-mail invisible en saisie papier.
+ *
+ * Ce test matérialise la classe : la ligne à richStatus NULL est écartée par
+ * l'ANCIEN prédicat et trouvée par le NOUVEAU (null-safe).
+ */
+
+import { prisma } from '@/lib/prisma';
+
+const PREFIX = `richnull-${Date.now()}`;
+let dbReady = false;
+let stageId = '';
+
+beforeAll(async () => {
+  try { await prisma.$queryRaw`SELECT 1`; dbReady = true; } catch { dbReady = false; return; }
+  const stage = await prisma.stage.create({
+    data: {
+      slug: `${PREFIX}-stage`,
+      title: 'Stage test classe NOT-nullable',
+      startDate: new Date('2026-08-17'),
+      endDate: new Date('2026-08-21'),
+      priceAmount: 0,
+    },
+    select: { id: true },
+  });
+  stageId = stage.id;
+  await prisma.stageReservation.create({
+    data: {
+      stageId,
+      parentName: `Test ${PREFIX}`,
+      email: `${PREFIX}@nexus-internal.local`,
+      phone: '55000001',
+      classe: 'Seconde',
+      academyId: `${PREFIX}-academy`,
+      academyTitle: 'Stage test',
+      price: 0,
+      status: 'CONFIRMED',
+      richStatus: null,
+    },
+  });
+});
+
+afterAll(async () => {
+  if (!dbReady) return;
+  await prisma.stageReservation.deleteMany({ where: { academyId: `${PREFIX}-academy` } });
+  await prisma.stage.deleteMany({ where: { slug: `${PREFIX}-stage` } });
+  await prisma.$disconnect();
+});
+
+describe('richStatus nullable — prédicat null-safe (PostgreSQL réel)', () => {
+  it('l’ancien prédicat écarte la réservation legacy, le nouveau la trouve', async () => {
+    if (!dbReady) { console.warn('DB indisponible'); return; }
+
+    const oldPredicate = await prisma.stageReservation.findFirst({
+      where: {
+        stageId,
+        NOT: [{ richStatus: 'CANCELLED' }, { status: 'CANCELLED' }],
+      },
+      select: { id: true },
+    });
+    const newPredicate = await prisma.stageReservation.findFirst({
+      where: {
+        stageId,
+        AND: [
+          { OR: [{ richStatus: null }, { NOT: { richStatus: 'CANCELLED' } }] },
+          { NOT: { status: 'CANCELLED' } },
+        ],
+      },
+      select: { id: true },
+    });
+
+    // La classe de bug, matérialisée : NULL fait disparaître la ligne de
+    // l'ancien prédicat…
+    expect(oldPredicate).toBeNull();
+    // …le prédicat null-safe la retrouve.
+    expect(newPredicate).not.toBeNull();
+  });
+
+  it('une réservation réellement annulée (richStatus CANCELLED) reste exclue par le nouveau prédicat', async () => {
+    if (!dbReady) return;
+    await prisma.stageReservation.create({
+      data: {
+        stageId,
+        parentName: `Test ${PREFIX}`,
+        email: `${PREFIX}-cancel@nexus-internal.local`,
+        phone: '55000002',
+        classe: 'Seconde',
+        academyId: `${PREFIX}-academy`,
+        academyTitle: 'Stage test',
+        price: 0,
+        status: 'CONFIRMED',
+        richStatus: 'CANCELLED',
+      },
+    });
+    const found = await prisma.stageReservation.findMany({
+      where: {
+        stageId,
+        AND: [
+          { OR: [{ richStatus: null }, { NOT: { richStatus: 'CANCELLED' } }] },
+          { NOT: { status: 'CANCELLED' } },
+        ],
+      },
+      select: { richStatus: true },
+    });
+    expect(found).toHaveLength(1);
+    expect(found[0].richStatus).toBeNull();
+  });
+});

--- a/app/api/assistante/planning/route.ts
+++ b/app/api/assistante/planning/route.ts
@@ -95,7 +95,13 @@ export async function GET(req: NextRequest) {
                       reservations: {
                         some: {
                           studentId,
-                          NOT: [{ richStatus: 'CANCELLED' }, { status: 'CANCELLED' }],
+                          // `richStatus` est nullable (compat) : `NOT { richStatus: 'CANCELLED' }`
+                          // écarterait une réservation à richStatus NULL (logique SQL à
+                          // trois valeurs). NULL = non annulée, donc visible.
+                          AND: [
+                            { OR: [{ richStatus: null }, { NOT: { richStatus: 'CANCELLED' } }] },
+                            { NOT: { status: 'CANCELLED' } },
+                          ],
                         },
                       },
                     },

--- a/app/api/assistante/sessions/route.ts
+++ b/app/api/assistante/sessions/route.ts
@@ -190,7 +190,13 @@ export async function POST(req: NextRequest) {
               reservations: {
                 some: {
                   studentId: studentEntity.id,
-                  NOT: [{ richStatus: 'CANCELLED' }, { status: 'CANCELLED' }],
+                  // `richStatus` est nullable (compat) : `NOT { richStatus: 'CANCELLED' }`
+                  // écarterait une réservation à richStatus NULL (logique SQL à
+                  // trois valeurs). NULL = non annulée, donc à considérer.
+                  AND: [
+                    { OR: [{ richStatus: null }, { NOT: { richStatus: 'CANCELLED' } }] },
+                    { NOT: { status: 'CANCELLED' } },
+                  ],
                 },
               },
             },

--- a/lib/bilans/saisie-papier/test-account-filter.ts
+++ b/lib/bilans/saisie-papier/test-account-filter.ts
@@ -40,15 +40,36 @@ const excludedUserWhere: Prisma.UserWhereInput = {
 };
 
 /**
+ * « Cet utilisateur n'est PAS un compte de test masquable » — formulée de façon
+ * NULL-safe.
+ *
+ * Défaut corrigé : `{ NOT: { parent: { is: { user: { is: excludedUserWhere } } } } }`
+ * excluait un foyer dont le PARENT n'a pas d'e-mail (`email = NULL`). En SQL,
+ * `NOT (email LIKE '%…%')` vaut NULL quand `email` est NULL, et une ligne dont
+ * la condition WHERE est NULL est écartée. Résultat : un foyer créé par la
+ * saisie papier SANS e-mail (flux différé légitime) devenait invisible sur
+ * l'écran assistante — l'élève tout juste saisi restait introuvable.
+ *
+ * Un e-mail absent n'est jamais un compte de test : on le rend explicitement
+ * visible. Pour un e-mail présent, on garde l'exclusion des motifs de test.
+ */
+const notExcludedUserWhere: Prisma.UserWhereInput = {
+  OR: [
+    { email: null },
+    { NOT: excludedUserWhere },
+  ],
+};
+
+/**
  * Database-side privacy guard. The projection is filtered again with
  * `isVisiblePaperEntryHousehold` because this staff screen must fail closed if
  * a future query refactor accidentally drops or weakens a relation condition.
  */
 export function paperEntryVisibleStudentWhere(): Prisma.StudentWhereInput {
   return {
-    NOT: [
-      { user: { is: excludedUserWhere } },
-      { parent: { is: { user: { is: excludedUserWhere } } } },
+    AND: [
+      { user: { is: notExcludedUserWhere } },
+      { parent: { is: { user: { is: notExcludedUserWhere } } } },
     ],
   };
 }


### PR DESCRIPTION
## Urgence — 2 foyers réels invisibles en production

Sur l'écran de saisie papier, un foyer dont le **parent n'a pas d'e-mail** (flux différé légitime, cœur de la fonctionnalité) était **introuvable** : l'assistante restait bloquée juste après la création. Vérifié en production (lecture seule) : **2 foyers réels** sont actuellement écartés par ce filtre.

Défaut attrapé par le parcours E2E réel — invisible aux tests unitaires tous verts.

## Cause racine — logique SQL à trois valeurs

`paperEntryVisibleStudentWhere` filtrait avec `NOT { parent: { is: { user: { is: excludedUserWhere } } } }`. En SQL, `NOT (email LIKE '%…%')` vaut **NULL** quand `email` est NULL, et une ligne dont la condition WHERE est NULL est **écartée**. Un parent sans e-mail rendait donc tout le foyer invisible. Le garde en mémoire `isVisiblePaperEntryHousehold` gérait correctement le NULL — d'où l'incohérence silencieuse.

## Correctif

Un e-mail absent n'est **jamais** un compte de test à masquer :
- `notExcludedUserWhere` NULL-safe : `OR: [{ email: null }, { NOT: excludedUserWhere }]`.
- Conditions **positives** (`AND: [{ user: { is: … } }, { parent: … }]`) au lieu du `NOT`-sur-relation piégeux.
- Les comptes de test (`@example.test`, `residual`, `smoke`, `DO_NOT_USE`, `@invalid.residual`, `parent-technique@…`) **restent masqués**, e-mail présent ou non côté élève — prouvé par test.

Prouvé sur PostgreSQL réel (`saisie-papier-visibilite-sans-email.real.test.ts`, 4/4) : foyer parent-sans-e-mail résolu, e-mail ordinaire résolu, comptes de test toujours masqués (côté parent ET côté élève). Seul appelant : la page de saisie papier.

## Audit de la classe — « NOT Prisma sur champ nullable »

C'est une classe de bug, pas un cas isolé. Toutes les occurrences `NOT:`/`not:` du code de production ont été auditées :

| Occurrence | Champ | Nullable ? | Verdict |
|---|---|---|---|
| `test-account-filter.ts` (saisie papier) | `users.email` | **oui** | 🔴 **Affecté — corrigé** (2 foyers réels en prod) |
| `planning/route.ts` + `sessions/route.ts` (assistante) | `stage_reservations.richStatus` | **oui** | 🟠 **Affecté — corrigé** (latent : 1 réservation NULL en prod, sans studentId, donc hors chemin filtré aujourd'hui) |
| `parent-student-consent.ts` (`parentUserId: { not: … }`) | non-nullable (FK) | non | ✅ sûr |
| `score-job.ts` (`status: { not: 'COMPLETED' }`) | non-nullable | non | ✅ sûr |
| `dashboard/{parent,eleve}/npc` (`status: { not: 'UNAVAILABLE' }`) | non-nullable (`@default`) | non | ✅ sûr |

Le correctif richStatus est prouvé de la même façon (`stage-reservation-richstatus-nullsafe.real.test.ts`) : l'ancien prédicat écarte la ligne legacy NULL, le nouveau la trouve, une annulation réelle reste exclue.

## Vérifications

- Suite unitaire complète : **808 suites, 9001 tests, 0 échec, 0 skip**.
- Real-db : visibilité 4/4 + richStatus 2/2 (base éphémère jetable).
- `tsc --noEmit` propre ; les cinq contrôles du job Lint verts (les seuls warnings ESLint sont préexistants, dans candidat-libre, non touchés).
- Aucune migration, aucune donnée modifiée. Banques/scoring/append-only/candidat libre intacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make paper-entry households without a parent email visible and make assistant planning/session filters NULL-safe. Previously, `NOT` predicates on nullable fields dropped legitimate rows; now a missing email is treated as non-test and a NULL `richStatus` is treated as not cancelled, while still excluding test accounts and cancelled reservations.

- Paper entry: replace the `NOT`-on-relation test-account filter with a positive, NULL-safe predicate applied to both parent and student (`email IS NULL OR NOT excluded`). Test accounts remain masked.
- Assistant planning/sessions: replace `NOT { richStatus: 'CANCELLED' }` with a NULL-safe predicate that includes `richStatus = NULL` and still excludes real cancellations.
- Add real-DB integration tests for both cases; no schema changes or data migrations. Only affects the paper-entry screen and assistant planning/session queries. Deploy normally.

<sup>Written for commit 8d3ecd9c90a8ef635a4614bc394d26af17fec373. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

