### PR TITLE
ci: job requis « E2E Parcours Authentifiés » — ferme l'angle mort e2e/auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -976,6 +976,10 @@ jobs:
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET || 'test-secret-min-32-chars-long-for-ci-environment' }}
           AUTH_TRUST_HOST: 'true'
           MAILPIT_API_URL: http://localhost:8025
+          # Le helper de remise à zéro du rate-limit (e2e/helpers/rate-limit.ts)
+          # exige cette URL dès que E2E_DISPOSABLE_STACK=1 — même Redis jetable
+          # que le serveur, base dédiée.
+          E2E_DISPOSABLE_REDIS_URL: redis://localhost:6380/0
           NEXUS_BILAN_PACK_ENTREE_SECONDE_MATHS_V1_ENABLED: 'true'
         run: npx playwright test --config=playwright.auth.config.ts --project=chromium
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -788,6 +788,213 @@ jobs:
   # ===========================================================================
   # JOB 7: SECURITY SCANNING
   # ===========================================================================
+  e2e-auth:
+    name: E2E Parcours Authentifiés
+    # Ferme l'angle mort structurel : les specs de e2e/auth (gate incrémental
+    # playwright.auth.config.ts — golden-path bilan, RBAC, activation, cycle de
+    # vie parent…) n'étaient invoqués par AUCUN job CI. Les deux défauts
+    # historiques (bilan invisible après consentement, blocage anti-doublon) et
+    # le foyer sans e-mail invisible sont passés à travers des CI vertes pour
+    # cette raison. Ce job les exécute contre le vrai standalone, avec le
+    # worker bilan en process (BILAN_WORKER_ENABLED) et Mailpit pour les
+    # e-mails d'activation. Requis via l'agrégat CI Success.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      E2E_DISPOSABLE_STACK: '1'
+
+    services:
+      postgres-e2e:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: nexus_e2e
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d nexus_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+      redis-e2e:
+        image: redis:7-alpine
+        ports:
+          - 6380:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+      mailpit:
+        image: axllent/mailpit:v1.30.6
+        ports:
+          - 1025:1025
+          - 8025:8025
+        options: >-
+          --health-cmd "wget -qO- http://localhost:8025/api/v1/info || exit 1"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Pin npm version
+        run: npm install -g npm@${{ env.NPM_VERSION }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare isolated NPC storage
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          npc_storage_root="$RUNNER_TEMP/npc-storage"
+          install -d -m 0700 -- "$npc_storage_root"
+          canonical_storage_root="$(realpath -- "$npc_storage_root")"
+          canonical_workspace="$(realpath -- "$GITHUB_WORKSPACE")"
+          case "$canonical_storage_root/" in
+            "$canonical_workspace/"*)
+              echo 'NPC storage must remain outside the checked-out release.' >&2
+              exit 1
+              ;;
+          esac
+          printf 'NPC_STORAGE_ROOT=%s\n' "$canonical_storage_root" >> "$GITHUB_ENV"
+
+      - name: Prepare isolated document storage
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          document_storage_root="$RUNNER_TEMP/document-storage"
+          install -d -m 0700 -- "$document_storage_root"
+          canonical_storage_root="$(realpath -- "$document_storage_root")"
+          canonical_workspace="$(realpath -- "$GITHUB_WORKSPACE")"
+          case "$canonical_storage_root/" in
+            "$canonical_workspace/"*)
+              echo 'Document storage must remain outside the checked-out release.' >&2
+              exit 1
+              ;;
+          esac
+          printf 'DOCUMENT_STORAGE_ROOT=%s\n' "$canonical_storage_root" >> "$GITHUB_ENV"
+
+      - name: Wait for Postgres (E2E) to be ready
+        run: |
+          for i in {1..30}; do
+            if pg_isready -h localhost -p 5433 -U postgres; then
+              echo "Postgres is ready"
+              exit 0
+            fi
+            echo "Waiting for Postgres... ($i/30)"
+            sleep 2
+          done
+          echo "Postgres did not become ready in time"
+          exit 1
+
+      - name: Generate Prisma Client
+        run: npx prisma generate
+
+      - name: Seed E2E test data
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5433/nexus_e2e
+        run: |
+          npx prisma db execute --schema=prisma/schema.prisma --stdin <<SQL
+          DROP SCHEMA IF EXISTS public CASCADE;
+          CREATE SCHEMA public;
+          SQL
+          npx prisma migrate deploy
+          npx tsx scripts/seed-e2e-db.ts
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Build Next.js for E2E
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5433/nexus_e2e
+          NEXTAUTH_URL: http://localhost:3000
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET || 'test-secret-min-32-chars-long-for-ci-environment' }}
+          AUTH_TRUST_HOST: 'true'
+          OPENAI_API_KEY: sk-test-mock-key-for-ci-build-only
+          NODE_ENV: production
+          NODE_OPTIONS: --max-old-space-size=4096
+        run: npm run build:e2e
+
+      - name: Start Next.js server in background (worker bilan actif)
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5433/nexus_e2e
+          NEXTAUTH_URL: http://localhost:3000
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET || 'test-secret-min-32-chars-long-for-ci-environment' }}
+          AUTH_TRUST_HOST: 'true'
+          OPENAI_API_KEY: sk-test-mock-key-for-ci-build-only
+          NODE_ENV: production
+          RATE_LIMIT_DISABLE: '1'
+          RATE_LIMIT_BACKEND: redis
+          REDIS_URL: redis://localhost:6380
+          RATE_LIMIT_KEY_SECRET: ci-e2e-rate-limit-key-secret-placeholder-32chars
+          RATE_LIMIT_KEY_NAMESPACE: nexus-ci-e2e-auth
+          RATE_LIMIT_TRUST_PROXY_HOPS: '1'
+          EMAIL_OUTBOX_WORKER_ENABLED: 'true'
+          EMAIL_OUTBOX_ENCRYPTION_KEY: ci-e2e-outbox-encryption-key-0123456789
+          SMTP_HOST: 127.0.0.1
+          SMTP_PORT: '1025'
+          SMTP_FROM: ci-e2e-auth@example.test
+          # Le pipeline bilan (scoring + génération) tourne en process, comme
+          # en prod : sans lui, le golden-path et le parcours saisie papier ne
+          # peuvent pas avancer au-delà de la soumission.
+          BILAN_WORKER_ENABLED: 'true'
+          NEXUS_BILAN_PACK_ENTREE_SECONDE_MATHS_V1_ENABLED: 'true'
+        run: |
+          cp -r .next/static .next/standalone/.next/static 2>/dev/null || true
+          cp -r public .next/standalone/public 2>/dev/null || true
+          node .next/standalone/server.js &
+          echo $! > .next-server.pid
+          for i in {1..30}; do
+            if curl -sf http://localhost:3000/api/health > /dev/null 2>&1; then
+              echo "Server + Health API ready"
+              exit 0
+            fi
+            echo "Waiting for server... ($i/30)"
+            sleep 2
+          done
+          echo "Server failed to start (health endpoint not responding)"
+          curl -v http://localhost:3000/api/health 2>&1 || true
+          exit 1
+
+      - name: Run Playwright auth E2E gate
+        timeout-minutes: 25
+        env:
+          BASE_URL: http://localhost:3000
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5433/nexus_e2e
+          NEXTAUTH_URL: http://localhost:3000
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET || 'test-secret-min-32-chars-long-for-ci-environment' }}
+          AUTH_TRUST_HOST: 'true'
+          MAILPIT_API_URL: http://localhost:8025
+          NEXUS_BILAN_PACK_ENTREE_SECONDE_MATHS_V1_ENABLED: 'true'
+        run: npx playwright test --config=playwright.auth.config.ts --project=chromium
+
+      - name: Stop Next.js server
+        if: always()
+        run: |
+          if [ -f .next-server.pid ]; then
+            kill $(cat .next-server.pid) || true
+            rm .next-server.pid
+          fi
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-auth-report
+          path: playwright-report/
+          retention-days: 7
+
   security:
     name: Security Scan
     runs-on: ubuntu-latest
@@ -1145,6 +1352,7 @@ jobs:
       - integration
       - real-db-integration
       - e2e
+      - e2e-auth
       - security
       - build
       - documents
@@ -1165,6 +1373,7 @@ jobs:
             "integration:${{ needs.integration.result }}" \
             "real-db-integration:${{ needs.real-db-integration.result }}" \
             "e2e:${{ needs.e2e.result }}" \
+            "e2e-auth:${{ needs.e2e-auth.result }}" \
             "security:${{ needs.security.result }}" \
             "build:${{ needs.build.result }}" \
             "documents:${{ needs.documents.result }}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -967,6 +967,12 @@ jobs:
           curl -v http://localhost:3000/api/health 2>&1 || true
           exit 1
 
+      - name: Alias redis-e2e vers le service Redis jetable
+        # Le garde fail-closed de e2e/helpers/rate-limit.ts n'accepte QUE le
+        # hostname `redis-e2e` (le DNS du compose jetable) — on ne l'affaiblit
+        # pas : on donne au runner le même nom, pointé sur le service du job.
+        run: echo "127.0.0.1 redis-e2e" | sudo tee -a /etc/hosts
+
       - name: Run Playwright auth E2E gate
         timeout-minutes: 25
         env:
@@ -978,8 +984,8 @@ jobs:
           MAILPIT_API_URL: http://localhost:8025
           # Le helper de remise à zéro du rate-limit (e2e/helpers/rate-limit.ts)
           # exige cette URL dès que E2E_DISPOSABLE_STACK=1 — même Redis jetable
-          # que le serveur, base dédiée.
-          E2E_DISPOSABLE_REDIS_URL: redis://localhost:6380/0
+          # que le serveur (alias /etc/hosts ci-dessus), base dédiée.
+          E2E_DISPOSABLE_REDIS_URL: redis://redis-e2e:6380/0
           NEXUS_BILAN_PACK_ENTREE_SECONDE_MATHS_V1_ENABLED: 'true'
         run: npx playwright test --config=playwright.auth.config.ts --project=chromium
 

--- a/__tests__/ci/pr79-ci-evidence.test.js
+++ b/__tests__/ci/pr79-ci-evidence.test.js
@@ -13,6 +13,10 @@ const independentEvidenceJobs = [
   'integration',
   'real-db-integration',
   'e2e',
+  // Gate des parcours authentifiés (playwright.auth.config.ts) : requis
+  // depuis #134 — c'est l'angle mort par lequel les défauts d'enchaînement
+  // passaient malgré des CI vertes.
+  'e2e-auth',
   'security',
   'build',
   'documents',


### PR DESCRIPTION
## L'angle mort structurel, fermé

**Aucun job CI n'invoquait `playwright.auth.config.ts`.** Le gate incrémental de 15 specs authentifiés — golden-path bilan de bout en bout, RBAC des dashboards, activation élève, cycle de vie parent, révocation de session, garde de niveau des attempts… — ne protégeait **rien**. C'est par cet angle mort que les défauts d'enchaînement sont passés à travers des CI toutes vertes : bilan invisible après consentement, blocage anti-doublon, foyer sans e-mail invisible (#133).

## Le job « E2E Parcours Authentifiés »

Calqué sur le job E2E existant (mêmes gardes de stockage isolé NPC/documents, même seed `seed-e2e-db.ts`, même standalone), avec les trois ajouts qui rendent les parcours réels exécutables :

- **`BILAN_WORKER_ENABLED=true`** — le pipeline scoring + génération tourne en process, comme en prod. Sans lui, le golden-path s'arrête à la soumission.
- **Mailpit** (service + `MAILPIT_API_URL`) — les e-mails d'activation réels sont récupérables par les specs.
- Le flag du pack `entree-seconde-maths-v1` (exigé par le golden-path).

**Requis** : branché dans l'agrégat **CI Success** (qui est le check requis) — à la fois dans `needs` et dans la **liste explicite de vérification des résultats** (sans cette seconde ligne, `if: always()` avalerait silencieusement un échec du job).

## Recensement des 15 specs promus

Les specs du gate sont « promus » (censés verts). La CI de cette PR est l'environnement de vérité : tout échec sera **corrigé** (si défaut réel) ou mis en **quarantaine documentée et justifiée** (si spec obsolète) — jamais de skip silencieux. Décompte final dans les commentaires de cette PR après le premier run.

## Les ~63 specs e2e/auth restants (orphelins même du gate)

`e2e/auth/` contient ~78 specs ; 15 sont promus dans le gate, le reste n'est couvert par **rien** (liste complète : audits dashboards par rôle, parcours élève EDS/STMG, parcours parent multi-enfants, parcours coach cohorte, sécurité avancée, a11y, mobile…). Proposition de rattachement par vagues, chacune promue dans `testMatch` du gate une fois verte :
1. **Vague parcours** : `parcours-*.spec.ts`, `student-journey`, `auth-and-booking` (les enchaînements — la valeur la plus haute) ;
2. **Vague audits par rôle** : `*-dashboard-audit`, `test-all-pages`, `axe-dashboards` ;
3. **Vague spécialisés** : NSI/EAM/EAF, ARIA, survival, devis.

Chaque vague = une PR courte : promotion + tri (vert / corrigé / quarantaine motivée). Le temps d'exécution du job est rapporté après le premier run ; si le gate complet dépasse ~20 min de specs, découpage en jobs parallèles **tous requis** (parcours / audits / spécialisés), aucun optionnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs authenticated Playwright E2E specs in CI and makes them required, closing the e2e/auth gap. Previously no job executed `playwright.auth.config.ts`; now `e2e-auth` gates `CI Success`.

- Adds `e2e-auth` in `.github/workflows/ci.yml`: isolated NPC/document storage, Prisma seed via `scripts/seed-e2e-db.ts`, standalone Next.js build/start; timeouts: job 30m, Playwright 25m.
- Enables `BILAN_WORKER_ENABLED`, Mailpit (`MAILPIT_API_URL`), and `NEXUS_BILAN_PACK_ENTREE_SECONDE_MATHS_V1_ENABLED`; services/ports: Postgres 5433, Redis 6380, SMTP 1025, Mailpit UI 8025.
- Provides disposable Redis for rate-limit reset: sets `E2E_DISPOSABLE_REDIS_URL` and adds `/etc/hosts` alias `redis-e2e` → localhost to keep the fail-closed guard intact.
- Executes `npx playwright test --config=playwright.auth.config.ts --project=chromium` and uploads the Playwright report artifact.
- Integrates with `CI Success`: added to `needs` and the explicit results list; updates `__tests__/ci/pr79-ci-evidence.test.js` to include `e2e-auth` in the required inventory.

**Rollout**
- No app code changes; CI may run longer. Monitor duration and flakiness.
- No developer action; failing specs block merges and must be fixed or quarantined with justification.

<sup>Written for commit 72e6e462f40bb259dbccfd463d33712a72b2c159. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

