### PR TITLE
fix(bilans): liens jamais transformés (WhatsApp corrompu) + bouton de diffusion explicite

### DIFF
--- a/__tests__/bilans/diffusion-motifs-explicites.test.ts
+++ b/__tests__/bilans/diffusion-motifs-explicites.test.ts
@@ -1,0 +1,55 @@
+/**
+ * « Valider et diffuser aux familles » : chaque condition non remplie
+ * s'explique en toutes lettres au bouton — un bouton désactivé muet est un
+ * bug d'UX, pas une sécurité (défaut du 13/08/2026 : bilan d'un foyer sans
+ * e-mail, bouton grisé sans explication à côté). Le garde lui-même n'est pas
+ * affaibli : la validation humaine et le contact parent restent requis.
+ */
+
+import { diffusionBlockedReasons, type RecentReportReview } from '@/lib/bilans/staff/review-service';
+
+function review(overrides: Partial<{
+  diffusable: boolean;
+  actionable: boolean;
+  parentEmailMissing: boolean;
+  validationFailures: readonly string[];
+}>): RecentReportReview {
+  return {
+    diffusable: overrides.diffusable ?? false,
+    actionable: overrides.actionable ?? true,
+    parentEmailMissing: overrides.parentEmailMissing ?? false,
+    validationFailures: overrides.validationFailures ?? [],
+  } as unknown as RecentReportReview;
+}
+
+describe('diffusionBlockedReasons', () => {
+  it('aucun motif quand la diffusion est possible', () => {
+    expect(diffusionBlockedReasons(review({ diffusable: true }))).toEqual([]);
+  });
+
+  it('e-mail parent manquant — le cas des foyers créés sans e-mail', () => {
+    const reasons = diffusionBlockedReasons(review({ parentEmailMissing: true }));
+    expect(reasons).toHaveLength(1);
+    expect(reasons[0]).toContain('e-mail du parent');
+    expect(reasons[0]).toContain('aucun bilan ne part sans contact famille');
+  });
+
+  it('points bloquants de validation présents', () => {
+    const reasons = diffusionBlockedReasons(review({ validationFailures: ['Identité élève à compléter'] }));
+    expect(reasons.some((r) => r.includes('points bloquants'))).toBe(true);
+  });
+
+  it('bilan qui n’est plus en attente (diffusé, rejeté ou en correction)', () => {
+    const reasons = diffusionBlockedReasons(review({ actionable: false }));
+    expect(reasons.some((r) => r.includes('plus en attente de diffusion'))).toBe(true);
+  });
+
+  it('les motifs se cumulent sans doublon', () => {
+    const reasons = diffusionBlockedReasons(review({
+      parentEmailMissing: true,
+      validationFailures: ['x'],
+    }));
+    expect(reasons).toHaveLength(2);
+    expect(new Set(reasons).size).toBe(2);
+  });
+});

--- a/__tests__/bilans/liens-opaques-jamais-transformes.test.ts
+++ b/__tests__/bilans/liens-opaques-jamais-transformes.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Les valeurs opaques — URL, jetons signés — ne traversent JAMAIS une passe
+ * de transformation de texte.
+ *
+ * Défaut réel du 13/08/2026 : le message WhatsApp passait entier (liens
+ * inclus) dans `frenchTypography`, dont la notation mathématique convertit
+ * `lettre_chiffre` en indice. Un secret base64url `…3U_5zM…` devenait
+ * `…3U₅zM…` : « page introuvable » chez le parent. La base était saine —
+ * seule la présentation corrompait le jeton.
+ *
+ * Ces tests verrouillent la chaîne complète : génération (alphabet strict),
+ * passe typographique (URL préservées octet par octet), et message WhatsApp
+ * (le lien reçu EST le lien signé).
+ */
+
+import { randomBytes } from 'node:crypto';
+
+import { frenchTypography, mathNotation } from '@/lib/bilans/render/typography';
+import { buildBilanWhatsAppMessage } from '@/lib/bilans/staff/whatsapp-message';
+
+// Le secret du cas réel, et des secrets adversariaux couvrant chaque règle
+// de transformation : indice (_5), exposant (^2 après lettre/chiffre),
+// apostrophe absente de base64url mais présente dans un chemin.
+const ADVERSARIAL_SECRETS = [
+  '3U_5zMcvM585aeFqrVpUiHET23cAkN8AAcPRqatoNUc',
+  'a_1b_2c_3d_4e_5f_6g_7h_8i_9j_0',
+  'x2_9YZ-aa_0Qq',
+  'AAAA____9999----zzzz',
+];
+
+describe('frenchTypography — les URL sont opaques', () => {
+  it.each(ADVERSARIAL_SECRETS)('préserve octet par octet un lien portant le secret %s', (secret) => {
+    const url = `https://nexusreussite.academy/bilan/consultation/cmsric0ej0024mgsunrncueeh.${secret}`;
+    const message = `Voici vos accès : ${url} — valables 30 jours. L'équation v_0 = 3^2 reste convertie.`;
+    const out = frenchTypography(message);
+    expect(out).toContain(url);
+    // La prose autour, elle, reste typographiée.
+    expect(out).toContain('v₀');
+    expect(out).toContain('3²');
+    expect(out).toContain('’');
+  });
+
+  it('préserve plusieurs URL dans un même texte, dans l’ordre', () => {
+    const a = 'https://exemple.fr/a_1/b^2';
+    const b = 'https://exemple.fr/autre_5';
+    const out = frenchTypography(`Lien parent : ${a} puis lien élève : ${b} !`);
+    expect(out.indexOf(a)).toBeGreaterThan(-1);
+    expect(out.indexOf(b)).toBeGreaterThan(out.indexOf(a));
+  });
+
+  it('reste idempotente avec des URL', () => {
+    const once = frenchTypography(`Voir https://exemple.fr/x_1 : c'est prêt !`);
+    expect(frenchTypography(once)).toBe(once);
+  });
+
+  it('mathNotation seule convertit toujours la prose (non-régression du rendu)', () => {
+    expect(mathNotation('v_0 et 3^5')).toBe('v₀ et 3⁵');
+  });
+});
+
+describe('Message WhatsApp — le lien reçu est le lien signé', () => {
+  it.each(ADVERSARIAL_SECRETS)('chaîne complète intacte pour le secret %s', (secret) => {
+    const parentLink = `https://nexusreussite.academy/bilan/consultation/lnk1.${secret}`;
+    const studentLink = `https://nexusreussite.academy/bilan/consultation/lnk2.${secret}X`;
+    const message = buildBilanWhatsAppMessage({
+      parentDisplayName: 'Alaeddine Ben Rhouma',
+      studentFirstName: 'Kam',
+      subjectLabel: 'Mathématiques',
+      levelLabel: 'Seconde',
+      parentLink,
+      studentLink,
+      validityDays: 30,
+    });
+    expect(message).toContain(parentLink);
+    expect(message).toContain(studentLink);
+  });
+
+  it('le cas réel du 13/08 : le secret 3U_5… survit au message', () => {
+    const link = 'https://nexusreussite.academy/bilan/consultation/cmsric0ej0024mgsunrncueeh.3U_5zMcvM585aeFqrVpUiHET23cAkN8AAcPRqatoNUc';
+    const message = buildBilanWhatsAppMessage({
+      parentDisplayName: 'Parent',
+      studentFirstName: 'Kam',
+      subjectLabel: 'Mathématiques',
+      levelLabel: 'Seconde',
+      parentLink: link,
+      studentLink: link,
+      validityDays: 30,
+    });
+    expect(message).toContain(link);
+    expect(message).not.toContain('₅');
+  });
+});
+
+describe('Génération — alphabet strictement base64url', () => {
+  it('10 000 secrets générés ne contiennent que [A-Za-z0-9_-]', () => {
+    for (let i = 0; i < 10_000; i += 1) {
+      expect(randomBytes(32).toString('base64url')).toMatch(/^[A-Za-z0-9_-]+$/);
+    }
+  });
+});

--- a/app/dashboard/assistante/bilans/page.tsx
+++ b/app/dashboard/assistante/bilans/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 
 import { auth } from '@/auth';
 import {
+  diffusionBlockedReasons,
   listRecentReportReviews,
   previewPendingReport,
   StaffReviewError,
@@ -307,6 +308,13 @@ export default async function CanonicalBilansReviewPage({
                           <button type="submit" disabled={blocked || !revision.diffusable} className="mt-3 rounded-xl bg-emerald-500 px-4 py-2.5 font-semibold text-slate-950 disabled:cursor-not-allowed disabled:opacity-40">
                             Valider et diffuser aux familles
                           </button>
+                          {(blocked || !revision.diffusable) && (
+                            <ul className="mt-3 space-y-1 text-sm text-amber-100" data-testid="diffusion-bloquee-motifs">
+                              {diffusionBlockedReasons(revision).map((reason) => (
+                                <li key={reason}>{reason}</li>
+                              ))}
+                            </ul>
+                          )}
                         </form>
 
                         {canReject && (

--- a/lib/bilans/render/typography.ts
+++ b/lib/bilans/render/typography.ts
@@ -45,11 +45,30 @@ export function mathNotation(value: string): string {
 
 export const NBSP = '\u00A0';
 
+/**
+ * Les URL sont des valeurs OPAQUES : jetons signés, identifiants, chemins.
+ * Aucune règle typographique ni notation mathématique ne doit jamais s'y
+ * appliquer — un secret base64url contenant `_5` deviendrait `₅` et le lien
+ * mourrait en « page introuvable » chez le parent (défaut réel du 13/08/2026,
+ * lien WhatsApp corrompu). La protection vit ICI, dans la passe elle-même :
+ * chaque appelant présent et futur est couvert sans devoir y penser.
+ */
+const URL_PATTERN = /https?:\/\/[^\s«»"<>]+/g;
+
+function transformProtectingUrls(value: string, transform: (text: string) => string): string {
+  const urls: string[] = [];
+  const masked = value.replace(URL_PATTERN, (url) => {
+    urls.push(url);
+    return `\u0000${urls.length - 1}\u0000`;
+  });
+  return transform(masked).replace(/\u0000(\d+)\u0000/g, (_match, index: string) => urls[Number(index)]);
+}
+
 export function frenchTypography(value: string): string {
-  return mathNotation(value)
-    .replace(/'/g, '’')
+  return transformProtectingUrls(value, (text) => mathNotation(text)
+    .replace(/'/g, '\u2019')
     .replace(/[ \u00A0]+([:;!?%])/g, `${NBSP}$1`)
     .replace(/«[ \u00A0]+/g, `«${NBSP}`)
     .replace(/[ \u00A0]+»/g, `${NBSP}»`)
-    .replace(/ — /g, `${NBSP}— `);
+    .replace(/ — /g, `${NBSP}— `));
 }

--- a/lib/bilans/staff/review-service.ts
+++ b/lib/bilans/staff/review-service.ts
@@ -302,6 +302,28 @@ export function hasAvailableParentContact(revision: PendingReportReview): boolea
   return Boolean(revision.reportArtifact.student.parent?.user.email?.trim());
 }
 
+/**
+ * Pourquoi « Valider et diffuser aux familles » est inactif — en toutes
+ * lettres. Un bouton désactivé sans explication est un bug d'UX, pas une
+ * sécurité : l'assistante doit savoir exactement quel prérequis manque
+ * (défaut constaté le 13/08/2026 sur un bilan au parent sans e-mail).
+ * Renvoie une liste vide quand la diffusion est possible.
+ */
+export function diffusionBlockedReasons(review: RecentReportReview): readonly string[] {
+  if (review.diffusable && review.validationFailures.length === 0) return Object.freeze([]);
+  const reasons: string[] = [];
+  if (review.validationFailures.length > 0) {
+    reasons.push('Corrigez d’abord les points bloquants signalés en haut de la carte.');
+  }
+  if (review.parentEmailMissing) {
+    reasons.push('Complétez l’e-mail du parent (encadré « Prêt — e-mail parent manquant » ci-dessus) : aucun bilan ne part sans contact famille.');
+  }
+  if (!review.actionable && review.validationFailures.length === 0) {
+    reasons.push('Ce bilan n’est plus en attente de diffusion (déjà diffusé, rejeté ou en correction).');
+  }
+  return Object.freeze(reasons);
+}
+
 function latestWhatsAppTransmission(revision: PendingReportReview): Date | null {
   const transmission = revision.reportArtifact.transmissions
     .find(({ channel }) => channel === 'WHATSAPP');

--- a/lib/bilans/staff/share-link-service.ts
+++ b/lib/bilans/staff/share-link-service.ts
@@ -40,6 +40,21 @@ function hashSecret(secret: string): string {
   return createHash('sha256').update(secret, 'utf8').digest('hex');
 }
 
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Le secret doit être STRICTEMENT base64url : tout caractère hors alphabet
+ * rendrait le jeton fragile aux transformations de texte en aval (le lien
+ * WhatsApp corrompu du 13/08/2026 venait d'une passe typographique — la passe
+ * est corrigée, cette garde échoue fermé si la génération dérivait un jour).
+ */
+function assertBase64UrlSecret(secret: string): string {
+  if (!BASE64URL_PATTERN.test(secret)) {
+    throw new ReportShareLinkError('SHARE_LINK_SECRET_NOT_BASE64URL');
+  }
+  return secret;
+}
+
 function constantTimeMatches(expectedHash: string, secret: string): boolean {
   const expected = Buffer.from(expectedHash, 'hex');
   const actual = Buffer.from(hashSecret(secret), 'hex');
@@ -109,7 +124,7 @@ export async function createReportShareLinks(input: CreateInput): Promise<readon
 
     const created: CreatedShareLink[] = [];
     for (const audience of SHAREABLE_AUDIENCES) {
-      const secret = randomBytes(32).toString('base64url');
+      const secret = assertBase64UrlSecret(randomBytes(32).toString('base64url'));
       const link = await transaction.reportShareLink.create({
         data: {
           reportArtifactId: artifact.id,


### PR DESCRIPTION
## Deux blocages du workflow assistante, corrigés à la cause

### 1. 🔴 Lien WhatsApp corrompu — « page introuvable » chez le parent (bloquant)

**Cause racine (Piste A, reproduction exacte)** : `buildBilanWhatsAppMessage` passait le message **entier, liens inclus**, dans `frenchTypography`. Sa notation mathématique convertit `lettre_chiffre` en indice : le secret base64url `…3U_5zM…` devenait `…3U₅zM…` (U+2085) — jeton mort.

**Base SAINE, prouvée** : sha256 du secret original = hash stocké (`093a1c1d…` identiques). Seule la présentation corrompait le jeton — **le lien du responsable est réparable immédiatement** en rétablissant `3U_5` à la place de `3U₅` (lien PARENTS actif, valable jusqu'au 12/09).

**Ampleur en production** : **0 transmission WhatsApp confirmée** (le cas rapporté est le seul envoi connu ; le lien kamel antérieur avait été consulté avec succès — son secret ne contenait pas le motif). **E-mails d'activation parent/élève : aucune passe de texte → non touchés.** Deux e-mails de notification exposaient `dashboardUrl` à la même classe (URL fixe, sans impact actuel) — couverts par la correction structurelle.

**Correction structurelle — pas ponctuelle** : la protection vit **dans la passe elle-même** (`transformProtectingUrls` : URL extraites avant transformation, réinsérées octet par octet). Tout appelant présent et futur est couvert sans devoir y penser. Plus une garde **fail-closed** à la génération du secret (`SHARE_LINK_SECRET_NOT_BASE64URL`) : si la génération dérivait un jour de l'alphabet base64url, elle échoue au lieu d'émettre un jeton fragile.

**Verrouillé par tests** : 4 secrets adversariaux traversant la chaîne complète du message (le cas réel `3U_5…` inclus, assertion `not.toContain('₅')`), multi-URL dans l'ordre, idempotence, prose toujours typographiée (`v₀`, `3⁵`, apostrophes — le rendu premium ne perd rien), 10 000 secrets générés strictement `[A-Za-z0-9_-]`. Le parcours E2E en cours ouvre déjà **le lien extrait du message wa.me réel** (pas un lien reconstruit) — sa promotion au gate requis suivra son achèvement.

### 2. 🟠 Bouton « Valider et diffuser aux familles » muet

**Cause exacte** : `diffusable = actionable && !parentEmailMissing`. Les 2 bilans de « Kam » viennent des foyers créés **sans e-mail** le 13/08 → garde légitime (aucune diffusion sans contact famille), mais **rien près du bouton ne le disait**. Ampleur : **2 bilans bloqués** (les 2 « Kam ») ; les 5 autres en attente sont diffusables. **Déblocage immédiat** : renseigner l'e-mail parent dans l'encadré « Prêt — e-mail parent manquant » de la carte.

**Correction** : `diffusionBlockedReasons()` (service, pur, testé — 5 cas) énonce chaque prérequis manquant **sous le bouton** (`data-testid="diffusion-bloquee-motifs"`), même patron que « Créer le foyer ». Le garde n'est **pas affaibli** : validation humaine et contact parent restent obligatoires.

## Vérifications
Suite complète **809 suites / 9 014 tests / 0 échec / 0 skip** · `tsc` propre · les cinq contrôles du job Lint verts · sécurité des liens intacte (expiration, révocation, journalisation, Nexus interdit) · banques/scoring/append-only intacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Empêche la corruption des liens dans les messages de bilans et explique pourquoi “Valider et diffuser aux familles” est inactif. Avant: `frenchTypography` transformait aussi les URL (`3U_5` → `3U₅`, lien WhatsApp mort) et le bouton était grisé sans contexte. Maintenant: la passe préserve les URL octet par octet, la génération échoue hors alphabet base64url, et l’UI liste les prérequis manquants sans changer les règles.

- Protection des liens: `frenchTypography` masque temporairement les URL et les réinsère intactes; la prose reste typographiée. Tests ajoutés (multi-URL, idempotence, cas réel).
- Secret strict: `createReportShareLinks` vérifie `[A-Za-z0-9_-]+` et lève `SHARE_LINK_SECRET_NOT_BASE64URL` sinon.
- Motifs de diffusion: `diffusionBlockedReasons()` synthétise e-mail parent manquant, points bloquants, bilan non actionnable; `page.tsx` les affiche sous le bouton. Gardes inchangées (validation humaine et contact parent requis).

<sup>Written for commit db5da9885f8509830f84c8ecd10f5054f663603e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

