### PR TITLE
fix(bilans): parcours WhatsApp cohérent — un contact suffit, page d'arrivée sans cul-de-sac, document visible

### DIFF
--- a/__tests__/bilans/diffusion-motifs-explicites.test.ts
+++ b/__tests__/bilans/diffusion-motifs-explicites.test.ts
@@ -11,13 +11,13 @@ import { diffusionBlockedReasons, type RecentReportReview } from '@/lib/bilans/s
 function review(overrides: Partial<{
   diffusable: boolean;
   actionable: boolean;
-  parentEmailMissing: boolean;
+  parentContactMissing: boolean;
   validationFailures: readonly string[];
 }>): RecentReportReview {
   return {
     diffusable: overrides.diffusable ?? false,
     actionable: overrides.actionable ?? true,
-    parentEmailMissing: overrides.parentEmailMissing ?? false,
+    parentContactMissing: overrides.parentContactMissing ?? false,
     validationFailures: overrides.validationFailures ?? [],
   } as unknown as RecentReportReview;
 }
@@ -27,11 +27,11 @@ describe('diffusionBlockedReasons', () => {
     expect(diffusionBlockedReasons(review({ diffusable: true }))).toEqual([]);
   });
 
-  it('e-mail parent manquant — le cas des foyers créés sans e-mail', () => {
-    const reasons = diffusionBlockedReasons(review({ parentEmailMissing: true }));
+  it('aucun canal de contact (ni téléphone ni e-mail) — le seul blocage de contact légitime', () => {
+    const reasons = diffusionBlockedReasons(review({ parentContactMissing: true }));
     expect(reasons).toHaveLength(1);
-    expect(reasons[0]).toContain('e-mail du parent');
-    expect(reasons[0]).toContain('aucun bilan ne part sans contact famille');
+    expect(reasons[0]).toContain('téléphone ou e-mail');
+    expect(reasons[0]).toContain('aucun bilan ne part sans canal vers la famille');
   });
 
   it('points bloquants de validation présents', () => {
@@ -46,7 +46,7 @@ describe('diffusionBlockedReasons', () => {
 
   it('les motifs se cumulent sans doublon', () => {
     const reasons = diffusionBlockedReasons(review({
-      parentEmailMissing: true,
+      parentContactMissing: true,
       validationFailures: ['x'],
     }));
     expect(reasons).toHaveLength(2);

--- a/__tests__/bilans/family-landing-access.test.ts
+++ b/__tests__/bilans/family-landing-access.test.ts
@@ -90,14 +90,25 @@ describe('attachParentEmailFromShareToken', () => {
     expect(intent.html).toContain('Kamel');
   });
 
-  it('idempotent : la même adresse déjà posée ne renvoie pas d’activation', async () => {
-    const { database, token } = harness({ email: 'parent@exemple.fr' });
+  it('même adresse sur un compte ACTIVÉ : aucun renvoi', async () => {
+    const { database, token } = harness({ email: 'parent@exemple.fr', activatedAt: NOW });
     const result = await attachParentEmailFromShareToken(token, 'parent@exemple.fr', {
       prisma: database as never,
       now: () => NOW,
     });
     expect(result).toEqual({ activationQueued: false });
     expect(mockedEnqueue).not.toHaveBeenCalled();
+  });
+
+  it('même adresse sur un compte NON activé : RENVOIE l’activation (fin du cul-de-sac)', async () => {
+    const { database, token } = harness({ email: 'parent@exemple.fr' });
+    const result = await attachParentEmailFromShareToken(token, 'parent@exemple.fr', {
+      prisma: database as never,
+      now: () => NOW,
+    });
+    expect(result).toEqual({ activationQueued: true });
+    expect(mockedEnqueue).toHaveBeenCalledTimes(1);
+    expect(mockedEnqueue.mock.calls[0][1].messageType).toBe('PARENT_ACTIVATION');
   });
 
   it('GARDE : refuse d’écraser une adresse différente déjà posée', async () => {

--- a/__tests__/bilans/staff-review-surface.test.ts
+++ b/__tests__/bilans/staff-review-surface.test.ts
@@ -155,8 +155,21 @@ describe('staff Canonical report review service', () => {
     expect(deps.validate.mock.invocationCallOrder[0]).toBeLessThan(deps.publish.mock.invocationCallOrder[0]);
   });
 
-  test('distingue un bilan prêt dont l’e-mail parent manque et garde sa prévisualisation disponible', async () => {
-    const missingEmail = {
+  test('un canal de contact suffit : téléphone seul → diffusable ; aucun contact → bloqué', async () => {
+    // La règle du parcours (#116 e-mail différé + #124 WhatsApp) : exiger
+    // l'e-mail annulait les deux. Téléphone seul = diffusion possible, voie
+    // WhatsApp. Sans AUCUN canal, le garde légitime bloque.
+    const phoneOnly = {
+      ...revision,
+      reportArtifact: {
+        ...revision.reportArtifact,
+        student: {
+          ...revision.reportArtifact.student,
+          parent: { user: { email: null, phoneNormalized: '99192829' } },
+        },
+      },
+    };
+    const noContact = {
       ...revision,
       reportArtifact: {
         ...revision.reportArtifact,
@@ -167,8 +180,8 @@ describe('staff Canonical report review service', () => {
       },
     };
     const deps = dependencies({
-      listRecent: jest.fn().mockResolvedValue([missingEmail]),
-      findPending: jest.fn().mockResolvedValue(missingEmail),
+      listRecent: jest.fn().mockResolvedValue([phoneOnly, noContact]),
+      findPending: jest.fn().mockResolvedValue(noContact),
     });
 
     await expect(listRecentReportReviews(
@@ -176,8 +189,16 @@ describe('staff Canonical report review service', () => {
       serviceDependencies(deps),
     )).resolves.toEqual([
       expect.objectContaining({
-        displayStatus: 'Prêt — e-mail parent manquant',
+        displayStatus: 'En attente de diffusion',
         parentEmailMissing: true,
+        parentContactMissing: false,
+        diffusable: true,
+        actionable: true,
+      }),
+      expect.objectContaining({
+        displayStatus: 'Prêt — contact parent manquant',
+        parentEmailMissing: true,
+        parentContactMissing: true,
         diffusable: false,
         actionable: true,
       }),
@@ -341,8 +362,8 @@ describe('staff Canonical report review service', () => {
     expect(source).toContain('Prévisualiser le PDF');
     expect(source).toContain('Télécharger le PDF');
     expect(source).toContain('En attente de diffusion');
-    expect(source).toContain('Prêt — e-mail parent manquant');
-    expect(source).toContain('bilans prêts en attente d’e-mail parent');
+    expect(source).toContain('Prêt — contact parent manquant');
+    expect(source).toContain('bilans prêts sans contact parent');
     expect(source).toContain('Ajouter l’e-mail du parent');
     expect(source).toContain('Diffusé');
     expect(source).toContain('Rejeté');

--- a/app/api/bilan/consultation/[token]/consent/route.ts
+++ b/app/api/bilan/consultation/[token]/consent/route.ts
@@ -10,6 +10,7 @@ import {
   FamilyAccessError,
   attachParentEmailFromShareToken,
   readParentAccessState,
+  resendParentActivationFromShareToken,
 } from '@/lib/bilans/family-landing/access';
 import { checkCsrf } from '@/lib/csrf';
 import { kickEmailOutboxDrain } from '@/lib/email/outbox-scheduler';
@@ -39,6 +40,10 @@ function notFound(): NextResponse {
 const consentSchema = z.object({
   consent: z.literal(true),
   parentEmail: z.string().trim().max(254).optional(),
+  // Renvoi de l'e-mail d'activation SANS ressaisir l'adresse (jamais affichée
+  // sur la page publique) : le parent dont le premier e-mail s'est égaré ne
+  // reste pas en cul-de-sac.
+  resendActivation: z.literal(true).optional(),
 }).strict();
 
 export async function GET(
@@ -118,6 +123,10 @@ export async function POST(
           throw accessError;
         }
       }
+    } else if (parsed.data.resendActivation === true) {
+      const resent = await resendParentActivationFromShareToken(token);
+      email = { status: resent.activationQueued ? 'QUEUED' : 'ALREADY_SET' };
+      if (resent.activationQueued) kickEmailOutboxDrain();
     }
 
     return NextResponse.json({ state: consent.state, email }, { headers: NO_STORE });

--- a/app/bilan/consultation/[token]/family-landing-consent.tsx
+++ b/app/bilan/consultation/[token]/family-landing-consent.tsx
@@ -43,6 +43,8 @@ export function FamilyLandingConsent({
   const [consentChecked, setConsentChecked] = useState(false);
   const [parentEmail, setParentEmail] = useState('');
   const [parentHasEmail, setParentHasEmail] = useState(true);
+  const [parentActivated, setParentActivated] = useState(false);
+  const [resendState, setResendState] = useState<'IDLE' | 'SENDING' | 'SENT'>('IDLE');
   const [emailOutcome, setEmailOutcome] = useState<EmailOutcome | null>(null);
 
   const endpoint = `/api/bilan/consultation/${encodeURIComponent(token)}/consent`;
@@ -56,6 +58,7 @@ export function FamilyLandingConsent({
         const payload = await response.json();
         if (!active) return;
         setParentHasEmail(payload.parentHasEmail === true);
+        setParentActivated(payload.parentActivated === true);
         setStatus(payload.state === 'VERIFIED' ? 'VERIFIED' : 'IDLE');
       } catch {
         if (active) setStatus('LOAD_ERROR');
@@ -103,30 +106,112 @@ export function FamilyLandingConsent({
   }
 
   if (status === 'VERIFIED') {
+    const accessGranted = emailOutcome?.status === 'QUEUED';
+    const submitEmail = async (): Promise<void> => {
+      if (parentEmail.trim() === '') return;
+      setResendState('SENDING');
+      try {
+        const response = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ consent: true, parentEmail: parentEmail.trim() }),
+        });
+        if (!response.ok) throw new Error('ATTACH_FAILED');
+        const payload = await response.json() as { email?: EmailOutcome };
+        setEmailOutcome(payload.email ?? null);
+        if (payload.email?.status === 'QUEUED') setParentHasEmail(true);
+        setResendState('IDLE');
+      } catch {
+        setResendState('IDLE');
+        setEmailOutcome({ status: 'ERROR', code: 'ATTACH_FAILED' });
+      }
+    };
+    const resend = async (): Promise<void> => {
+      setResendState('SENDING');
+      try {
+        const response = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ consent: true, resendActivation: true }),
+        });
+        if (!response.ok) throw new Error('RESEND_FAILED');
+        setResendState('SENT');
+      } catch {
+        setResendState('IDLE');
+      }
+    };
+
     return (
       <div className="rounded-[28px] border border-lux-gold/40 bg-lux-gold/10 p-6" role="status">
         <p className="font-fraunces text-lg text-lux-ivory">Votre accord est enregistré.</p>
-        <p className="mt-2 text-sm leading-6 text-lux-on-dark-muted">
-          Le bilan de {studentFirstName} est désormais visible dans votre
-          espace parent, dès que votre compte est activé.
-        </p>
-        {emailOutcome?.status === 'QUEUED' ? (
-          <p className="mt-2 text-sm leading-6 text-lux-on-dark-muted">
-            Un e-mail d'activation vient de vous être envoyé : il vous permet
-            de choisir votre mot de passe et d'ouvrir votre espace.
-          </p>
-        ) : null}
+
+        {parentActivated ? (
+          <>
+            <p className="mt-2 text-sm leading-6 text-lux-on-dark-muted">
+              Le bilan de {studentFirstName} est disponible dans votre espace parent.
+            </p>
+            <a
+              href="/auth/signin"
+              className="lux-cta-primary lux-focus mt-4 inline-flex items-center rounded-full px-5 py-2.5 text-sm font-semibold"
+            >
+              Ouvrir mon espace parent
+            </a>
+          </>
+        ) : parentHasEmail || accessGranted ? (
+          <>
+            <p className="mt-2 text-sm leading-6 text-lux-on-dark-muted">
+              {accessGranted
+                ? 'Un e-mail d’activation vient de vous être envoyé : ouvrez-le pour choisir votre mot de passe — votre espace parent s’ouvrira ensuite.'
+                : 'Un lien d’activation vous attend dans votre boîte e-mail : ouvrez-le pour choisir votre mot de passe. Pensez à vérifier vos courriers indésirables.'}
+            </p>
+            <button
+              type="button"
+              onClick={() => void resend()}
+              disabled={resendState !== 'IDLE'}
+              className="lux-focus mt-4 inline-flex items-center rounded-full border border-lux-gold/50 px-5 py-2.5 text-sm font-semibold text-lux-ivory disabled:opacity-60"
+            >
+              {resendState === 'SENDING' ? 'Envoi…' : resendState === 'SENT' ? 'E-mail renvoyé ✓' : 'Renvoyer l’e-mail d’activation'}
+            </button>
+          </>
+        ) : (
+          <>
+            <p className="mt-2 text-sm leading-6 text-lux-on-dark-muted">
+              Dernière étape pour retrouver ce bilan à tout moment : indiquez
+              votre e-mail, vous recevrez un lien pour choisir votre mot de
+              passe et ouvrir votre espace parent.
+            </p>
+            <label htmlFor="family-landing-email-after" className="mt-4 block text-sm font-medium text-lux-ivory">
+              Votre e-mail
+            </label>
+            <input
+              id="family-landing-email-after"
+              type="email"
+              inputMode="email"
+              autoComplete="email"
+              value={parentEmail}
+              onChange={(event) => setParentEmail(event.target.value)}
+              placeholder="vous@exemple.fr"
+              className="lux-focus mt-2 w-full max-w-md rounded-xl border border-lux-line/40 bg-lux-ink/60 px-4 py-2.5 text-sm text-lux-ivory placeholder:text-lux-on-dark-subtle"
+            />
+            <button
+              type="button"
+              onClick={() => void submitEmail()}
+              disabled={parentEmail.trim() === '' || resendState === 'SENDING'}
+              className="lux-cta-primary lux-focus mt-4 inline-flex items-center rounded-full px-5 py-2.5 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {resendState === 'SENDING' ? 'Création…' : 'Créer mon accès parent'}
+            </button>
+            <p className="mt-3 text-xs leading-5 text-lux-on-dark-subtle">
+              Facultatif : sans adresse, vous gardez la lecture et le PDF via ce lien.
+            </p>
+          </>
+        )}
+
         {emailOutcome?.status === 'ERROR' ? (
-          <p className="mt-2 text-sm leading-6 text-amber-200" role="alert">
-            {EMAIL_ERROR_MESSAGES[emailOutcome.code] ?? 'La création de votre accès a échoué — votre accord, lui, est bien enregistré.'}
+          <p className="mt-3 text-sm leading-6 text-amber-200" role="alert">
+            {EMAIL_ERROR_MESSAGES[emailOutcome.code] ?? 'La création de votre accès a échoué — votre accord, lui, est bien enregistré. Réessayez, ou rapprochez-vous de l’équipe.'}
           </p>
         ) : null}
-        <a
-          href="/auth/signin"
-          className="lux-cta-primary lux-focus mt-4 inline-flex items-center rounded-full px-5 py-2.5 text-sm font-semibold"
-        >
-          Ouvrir mon espace parent
-        </a>
       </div>
     );
   }

--- a/app/dashboard/assistante/bilans/page.tsx
+++ b/app/dashboard/assistante/bilans/page.tsx
@@ -107,7 +107,7 @@ export default async function CanonicalBilansReviewPage({
     throw error;
   }
   const statusCounts = {
-    missingEmail: revisions.filter(({ displayStatus }) => displayStatus === 'Prêt — e-mail parent manquant').length,
+    missingEmail: revisions.filter(({ displayStatus }) => displayStatus === 'Prêt — contact parent manquant').length,
     pending: revisions.filter(({ displayStatus }) => displayStatus === 'En attente de diffusion').length,
     correction: revisions.filter(({ displayStatus }) => displayStatus === 'Correction demandée').length,
     published: revisions.filter(({ displayStatus }) => displayStatus === 'Diffusé').length,
@@ -177,14 +177,14 @@ export default async function CanonicalBilansReviewPage({
 
         <section className="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-6" aria-label="Synthèse des états de diffusion">
           {[
-            ['bilans prêts en attente d’e-mail parent', statusCounts.missingEmail],
+            ['bilans prêts sans contact parent', statusCounts.missingEmail],
             ['En attente de diffusion', statusCounts.pending],
             ['Correction demandée', statusCounts.correction],
             ['Diffusé, à transmettre', statusCounts.published],
             ['Transmis au parent', statusCounts.transmitted],
             ['Rejeté', statusCounts.rejected],
           ].map(([label, count]) => (
-            <article key={label} className={`rounded-2xl border p-4 ${label === 'bilans prêts en attente d’e-mail parent' ? 'border-amber-300/50 bg-amber-300/10' : 'border-white/10 bg-white/[0.05]'}`}>
+            <article key={label} className={`rounded-2xl border p-4 ${label === 'bilans prêts sans contact parent' ? 'border-amber-300/50 bg-amber-300/10' : 'border-white/10 bg-white/[0.05]'}`}>
               <p className="text-2xl font-semibold text-white">{count}</p>
               <p className="mt-1 text-sm text-slate-300">{label}</p>
             </article>

--- a/lib/bilans/family-landing/access.ts
+++ b/lib/bilans/family-landing/access.ts
@@ -95,14 +95,20 @@ export async function attachParentEmailFromShareToken(
     return await database.$transaction(async (transaction) => {
       const parent = await transaction.user.findUnique({
         where: { id: context.parentUserId },
-        select: { id: true, email: true, firstName: true, lastName: true },
+        select: { id: true, email: true, firstName: true, lastName: true, activatedAt: true },
       });
       if (parent === null) throw new FamilyAccessError('INVALID_LINK');
       if (parent.email !== null) {
         if (normalizeUserEmail(parent.email) === email) {
-          return Object.freeze({ activationQueued: false });
+          // Compte déjà activé : rien à renvoyer. Sinon, c'est une demande de
+          // RENVOI : sans elle, un parent dont l'e-mail d'activation s'est
+          // perdu resterait en cul-de-sac sur la page d'arrivée.
+          if (parent.activatedAt !== null) {
+            return Object.freeze({ activationQueued: false });
+          }
+        } else {
+          throw new FamilyAccessError('PARENT_EMAIL_ALREADY_SET');
         }
-        throw new FamilyAccessError('PARENT_EMAIL_ALREADY_SET');
       }
 
       const activation = createParentActivationToken(now);
@@ -142,4 +148,34 @@ export async function attachParentEmailFromShareToken(
     }
     throw error;
   }
+}
+
+/**
+ * Renvoie l'e-mail d'activation du parent SANS ressaisir l'adresse — elle
+ * n'est jamais affichée sur la page publique. Depuis la page d'arrivée, un
+ * parent dont le premier e-mail s'est égaré peut relancer l'activation ;
+ * un compte déjà activé ou sans adresse ne renvoie rien.
+ */
+export async function resendParentActivationFromShareToken(
+  rawToken: string,
+  dependencies: Readonly<{ prisma?: FamilyAccessDatabase; now?: () => Date }> = {},
+): Promise<Readonly<{ activationQueued: boolean }>> {
+  const database = dependencies.prisma ?? prisma;
+  const context = await resolveShareLinkContext(rawToken, {
+    prisma: database,
+    now: dependencies.now,
+  });
+  if (context === null) throw new FamilyAccessError('INVALID_LINK');
+
+  const parent = await database.user.findUnique({
+    where: { id: context.parentUserId },
+    select: { email: true, activatedAt: true },
+  });
+  if (parent === null || parent.email === null) {
+    return Object.freeze({ activationQueued: false });
+  }
+  if (parent.activatedAt !== null) {
+    return Object.freeze({ activationQueued: false });
+  }
+  return attachParentEmailFromShareToken(rawToken, parent.email, dependencies);
 }

--- a/lib/bilans/staff/review-service.ts
+++ b/lib/bilans/staff/review-service.ts
@@ -66,10 +66,11 @@ export type PendingReportReview = Readonly<{
 export type RecentReportReview = PendingReportReview & Readonly<{
   studentName: string;
   packLabel: string;
-  displayStatus: 'Prêt — e-mail parent manquant' | 'En attente de diffusion' | 'Correction demandée' | 'Diffusé' | 'Transmis au parent' | 'Rejeté';
+  displayStatus: 'Prêt — contact parent manquant' | 'En attente de diffusion' | 'Correction demandée' | 'Diffusé' | 'Transmis au parent' | 'Rejeté';
   actionable: boolean;
   parentEmailMissing: boolean;
   parentPhoneMissing: boolean;
+  parentContactMissing: boolean;
   diffusable: boolean;
   /** Envoi WhatsApp possible : diffusé, téléphone présent, pas encore transmis. */
   whatsappReady: boolean;
@@ -298,8 +299,17 @@ function assertStudentIdentity(revision: PendingReportReview): void {
 
 /** Point d'extension : un autre canal d'activation pourra satisfaire ce
  * prédicat sans modifier le state machine du bilan. Seul l'e-mail existe ici. */
+/**
+ * Un canal de contact suffit pour diffuser : téléphone (voie WhatsApp, #124)
+ * OU e-mail. Exiger l'e-mail annulait exprès deux décisions d'architecture —
+ * la saisie papier sans e-mail (#116) et l'envoi WhatsApp sans compte (#124) :
+ * un foyer au téléphone seul restait bloqué à jamais (contradiction constatée
+ * le 13/08/2026). Sans AUCUN canal, la diffusion reste bloquée — ce garde-là
+ * est légitime.
+ */
 export function hasAvailableParentContact(revision: PendingReportReview): boolean {
-  return Boolean(revision.reportArtifact.student.parent?.user.email?.trim());
+  const parentUser = revision.reportArtifact.student.parent?.user;
+  return Boolean(parentUser?.email?.trim()) || Boolean(parentUser?.phoneNormalized?.trim());
 }
 
 /**
@@ -315,8 +325,8 @@ export function diffusionBlockedReasons(review: RecentReportReview): readonly st
   if (review.validationFailures.length > 0) {
     reasons.push('Corrigez d’abord les points bloquants signalés en haut de la carte.');
   }
-  if (review.parentEmailMissing) {
-    reasons.push('Complétez l’e-mail du parent (encadré « Prêt — e-mail parent manquant » ci-dessus) : aucun bilan ne part sans contact famille.');
+  if (review.parentContactMissing) {
+    reasons.push('Renseignez un contact parent — téléphone ou e-mail (encadré « Compléter le contact parent » ci-dessus) : aucun bilan ne part sans canal vers la famille.');
   }
   if (!review.actionable && review.validationFailures.length === 0) {
     reasons.push('Ce bilan n’est plus en attente de diffusion (déjà diffusé, rejeté ou en correction).');
@@ -336,7 +346,7 @@ function displayStatus(revision: PendingReportReview): RecentReportReview['displ
   if (revision.reportArtifact.status === 'PUBLISHED') {
     return latestWhatsAppTransmission(revision) !== null ? 'Transmis au parent' : 'Diffusé';
   }
-  if (!hasAvailableParentContact(revision)) return 'Prêt — e-mail parent manquant';
+  if (!hasAvailableParentContact(revision)) return 'Prêt — contact parent manquant';
   return 'En attente de diffusion';
 }
 
@@ -356,8 +366,9 @@ function recentReview(
       || revision.status === ReportRevisionStatus.COACH_VALIDATED
     )
     && revision.reportArtifact.status === 'PENDING_REVIEW';
-  const parentEmailMissing = !hasAvailableParentContact(revision);
+  const parentEmailMissing = !revision.reportArtifact.student.parent?.user.email?.trim();
   const parentPhoneMissing = !revision.reportArtifact.student.parent?.user.phoneNormalized?.trim();
+  const parentContactMissing = !hasAvailableParentContact(revision);
   const transmittedAt = latestWhatsAppTransmission(revision);
   return Object.freeze({
     ...revision,
@@ -370,7 +381,8 @@ function recentReview(
     actionable,
     parentEmailMissing,
     parentPhoneMissing,
-    diffusable: actionable && !parentEmailMissing,
+    parentContactMissing,
+    diffusable: actionable && !parentContactMissing,
     whatsappReady: revision.reportArtifact.status === 'PUBLISHED'
       && !parentPhoneMissing
       && transmittedAt === null,

--- a/middleware.ts
+++ b/middleware.ts
@@ -73,6 +73,23 @@ const authenticatedMiddleware = auth((req) => {
   const response = NextResponse.next();
   applySecurityHeaders(response);
 
+  // La page d'arrivée famille intègre le document du bilan dans une iframe
+  // MÊME ORIGINE (« Il se lit ci-dessous »). Le DENY global la laissait vide :
+  // le navigateur refusait l'inclusion, le texte mentait au parent (défaut du
+  // 13/08/2026). SAMEORIGIN suffit et reste fermé aux sites tiers.
+  if (pathname.startsWith('/bilan/consultation/')) {
+    response.headers.set('X-Frame-Options', 'SAMEORIGIN');
+    const csp = response.headers.get('Content-Security-Policy');
+    if (csp !== null) {
+      // On ne touche qu'à frame-ancestors : le reste de la politique
+      // (script-src, object-src…) reste strictement celle du site.
+      response.headers.set(
+        'Content-Security-Policy',
+        csp.replace("frame-ancestors 'none'", "frame-ancestors 'self'"),
+      );
+    }
+  }
+
   if (pathname.startsWith('/dashboard/assistante/devis/app')) {
     response.headers.set('X-Frame-Options', 'SAMEORIGIN');
     response.headers.set(


### PR DESCRIPTION
## La contradiction de fond, résolue

Le parcours WhatsApp était annulé par ses propres gardes : la saisie papier permet un foyer **sans e-mail** (#116), l'envoi WhatsApp existe pour toucher le parent **sans compte** (#124) — et la diffusion **exigeait l'e-mail**. Un foyer au téléphone seul restait bloqué à jamais.

> PR empilée sur #135 (elle inclut ses commits : liens jamais transformés + motifs du bouton). À merger après elle.

### 1. Un canal de contact suffit — téléphone OU e-mail
`hasAvailableParentContact` = e-mail **ou** téléphone normalisé. Téléphone seul → **diffusion autorisée**, voie WhatsApp (`whatsappReady` exige déjà le téléphone). Sans **aucun** canal → bloqué, statut « Prêt — contact parent manquant » (garde légitime conservé). **Aval vérifié** : `notifyParentPublished` skippe proprement sans e-mail ; aucune transmission/notification/état ne présuppose l'e-mail. Le motif sous le bouton énonce la vraie règle. Prouvé par test : téléphone-seul → `diffusable: true` ; aucun contact → bloqué.

### 2. Matrice des états de la page d'arrivée — aucun cul-de-sac

| État | Ce que voit le parent | Action proposée |
|---|---|---|
| Lien invalide/expiré/révoqué | 404 uniforme | — (sécurité) |
| Audience ELEVE | lecture + PDF, pas de consentement | (l'élève lit) |
| PARENTS, pas encore consenti, sans e-mail | consentement + e-mail **facultatif** | « Confirmer mon accord » |
| PARENTS, pas encore consenti, e-mail connu | consentement seul | « Confirmer mon accord » |
| **Consenti, sans e-mail** | « Dernière étape… indiquez votre e-mail » | **« Créer mon accès parent »** (nouveau — l'ancien écran affichait « Ouvrir mon espace » à quelqu'un sans compte) |
| **Consenti, e-mail posé, non activé** | « un lien d'activation vous attend… vérifiez vos indésirables » | **« Renvoyer l'e-mail d'activation »** (nouveau : `resendActivation` sur la route, sans ressaisir l'adresse — jamais affichée ; `attachParentEmailFromShareToken` ré-émet désormais sur compte non activé, l'ancien no-op laissait un e-mail égaré définitivement coincé) |
| Consenti, compte activé | confirmation | « Ouvrir mon espace parent » (enfin pertinent) |
| Erreur de chargement/soumission | message explicite | recharger/réessayer — la lecture reste ouverte |

L'échec d'attache (`EMAIL_ALREADY_USED`…) affiche son message sans perdre le consentement.

### 3. Le document s'affiche — « Il se lit ci-dessous » ne ment plus
Cause : le middleware pose `X-Frame-Options: DENY` + `frame-ancestors 'none'` sur tout le site → l'iframe **même origine** de la page d'arrivée restait vide. Exception ciblée `/bilan/consultation/*` : `SAMEORIGIN` + `frame-ancestors 'self'`, **le reste de la CSP inchangé** (seule cette directive est réécrite, pas la politique). Mobile : le document A4 défile dans le cadre ; le bouton PDF reste l'accès privilégié — captures desktop+mobile à joindre via la stack e2e au parcours (spec en cours, qui ouvre déjà le lien réel du message wa.me).

## Garde-fous tenus
Consentement obligatoire et tracé (transition inchangée) · bilan Nexus inaccessible (CHECK + gardes) · aucune diffusion sans validation humaine · banques/scoring/append-only intacts.

## Vérifications
Suite complète **810 suites / 9 020 tests / 0 échec / 0 skip** · `tsc` propre · cinq contrôles Lint verts · scans OK. Tests dédiés : règle de contact (2 cas), motifs bouton (5), renvoi d'activation (activé/non activé), 136 tests famille/consentement verts.

**Reste au parcours E2E** (spec en cours, sera promu au gate) : diffusion téléphone-seul de bout en bout + création d'accès depuis la page d'arrivée + captures desktop/mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rend le parcours WhatsApp cohérent et sans impasse: la diffusion accepte désormais un contact parent suffisant (téléphone ou e‑mail), la page d’arrivée propose toujours une action suivante, les liens signés restent intacts et le document s’affiche dans l’iframe. Avant: e‑mail obligatoire, écran de fin bloqué, liens WhatsApp altérés, iframe vide.

- Diffusion: `hasAvailableParentContact` accepte téléphone ou e‑mail; sans aucun canal → statut « Prêt — contact parent manquant ». `diffusable` s’appuie sur `parentContactMissing`. `diffusionBlockedReasons` reflète la règle. La surface assistante affiche « bilans prêts sans contact parent ».
- Page d’arrivée: après consentement, trois états guidés — sans e‑mail (“Créer mon accès parent”), e‑mail posé non activé (“Renvoyer l’e‑mail d’activation”), compte activé (“Ouvrir mon espace parent”). L’API accepte `resendActivation`. `attachParentEmailFromShareToken` renvoie l’activation si le compte n’est pas activé. Nouveau `resendParentActivationFromShareToken`.
- Liens et rendu: `frenchTypography` protège les URL (extraction puis réinsertion octet à octet). Le secret est généré strictement en base64url (garde fail‑closed). Les liens WhatsApp restent intacts; la prose demeure typographiée.
- Affichage du document: exception ciblée sur `/bilan/consultation/*` — `X‑Frame‑Options: SAMEORIGIN` et CSP `frame‑ancestors 'self'`; le reste de la politique ne change pas.

**Rollout**
- Aucune migration. Vérifier en préprod: diffusion d’un dossier téléphone‑seul, réception et ouverture des liens WhatsApp, renvoi d’activation depuis la page d’arrivée, affichage du document intégré.

<sup>Written for commit 1d5a4f999f0b1343d2ea286348030aa45f6ba9d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

