### PR TITLE
feat(bilans): régénération — une seule génération visible (+ ré-acheminement de #138 vers main)

### DIFF
--- a/__tests__/bilans/canonical-worker-migration.test.ts
+++ b/__tests__/bilans/canonical-worker-migration.test.ts
@@ -2,6 +2,10 @@ import { readFileSync } from 'node:fs';
 
 describe('A86 worker idempotence migration', () => {
   const schema = readFileSync('prisma/schema.prisma', 'utf8');
+  const regenMigration = readFileSync(
+    'prisma/migrations/20260814090000_add_report_regeneration/migration.sql',
+    'utf8',
+  );
   const migration = readFileSync(
     'prisma/migrations/20260802170000_harden_canonical_scoring_worker/migration.sql',
     'utf8',
@@ -10,10 +14,14 @@ describe('A86 worker idempotence migration', () => {
   it('enforces one score, artifact and scoring revision per attempt chain', () => {
     expect(schema).toMatch(/model ScoreSnapshot[\s\S]*@@unique\(\[assessmentAttemptId\]\)/);
     expect(schema).toMatch(/model ReportArtifact[\s\S]*@@unique\(\[assessmentAttemptId\]\)/);
-    expect(schema).toMatch(/model ReportRevision[\s\S]*@@unique\(\[scoreSnapshotId\]\)/);
+    // Depuis la régénération (13/08/2026) : une génération de rendu par
+    // snapshot ET par version de règle — le snapshot reste unique par attempt,
+    // la révision est unique par [snapshot, génération].
+    expect(schema).toMatch(/model ReportRevision[\s\S]*@@unique\(\[scoreSnapshotId, generation\]\)/);
     expect(migration).toContain('canonical_score_snapshots_assessmentAttemptId_key');
     expect(migration).toContain('canonical_report_artifacts_assessmentAttemptId_key');
     expect(migration).toContain('canonical_report_revisions_scoreSnapshotId_key');
+    expect(regenMigration).toContain('canonical_report_revisions_scoreSnapshotId_generation_key');
   });
 
   it('keeps validation failures blocked and permits only a traced rejection', () => {

--- a/__tests__/bilans/staff-review-surface.test.ts
+++ b/__tests__/bilans/staff-review-surface.test.ts
@@ -14,6 +14,7 @@ import { BilanReportServiceError } from '@/lib/bilans/core/report-service';
 const revision = {
   id: 'revision-1',
   status: 'PENDING_REVIEW',
+  generation: 1,
   validationFailures: [] as string[],
   reportPackId: 'fixture-pack',
   reportPackVersion: '1',
@@ -371,5 +372,69 @@ describe('staff Canonical report review service', () => {
     expect(source).toContain('revision.studentName');
     expect(source).not.toContain('JSON.stringify');
     expect(source).not.toContain('<pre');
+  });
+});
+
+describe('une seule génération visible sur le dashboard — régénération sans encombrement', () => {
+  // Un même artefact avec trois générations : gén.1 rejetée à la
+  // régénération, gén.2 ancienne version publiée, gén.3 courante.
+  const artifact = (over: Record<string, unknown> = {}) => ({
+    ...revision.reportArtifact,
+    id: 'artifact-regen',
+    ...over,
+  });
+  const gen = (id: string, generation: number, status: string, artStatus = 'PUBLISHED') => ({
+    ...revision,
+    id,
+    generation,
+    status,
+    reportArtifact: artifact({ status: artStatus }),
+  });
+
+  it('ne remonte que la génération maximale par artefact', async () => {
+    const deps = dependencies({
+      listRecent: jest.fn().mockResolvedValue([
+        gen('rev-g3', 3, 'PENDING_REVIEW'),
+        gen('rev-g2', 2, 'COACH_VALIDATED'),
+        gen('rev-g1', 1, 'REJECTED'),
+      ]),
+    });
+    const rows = await listRecentReportReviews(
+      { userId: 'user-assistante', role: 'ASSISTANTE' },
+      serviceDependencies(deps),
+    );
+    const forArtifact = rows.filter((r) => r.reportArtifact.id === 'artifact-regen');
+    expect(forArtifact).toHaveLength(1);
+    expect(forArtifact[0].id).toBe('rev-g3');
+    expect(forArtifact[0].generation).toBe(3);
+  });
+
+  it('un bilan simplement rejeté (jamais régénéré) reste visible', async () => {
+    const deps = dependencies({
+      listRecent: jest.fn().mockResolvedValue([
+        { ...revision, id: 'rev-seul', generation: 1, status: 'REJECTED',
+          reportArtifact: artifact({ id: 'artifact-rejet', status: 'PENDING_REVIEW' }) },
+      ]),
+    });
+    const rows = await listRecentReportReviews(
+      { userId: 'user-assistante', role: 'ASSISTANTE' },
+      serviceDependencies(deps),
+    );
+    expect(rows.some((r) => r.id === 'rev-seul')).toBe(true);
+  });
+
+  it('deux bilans distincts restent deux lignes', async () => {
+    const deps = dependencies({
+      listRecent: jest.fn().mockResolvedValue([
+        { ...revision, id: 'a', generation: 1, reportArtifact: artifact({ id: 'art-A' }) },
+        { ...revision, id: 'b', generation: 1, reportArtifact: artifact({ id: 'art-B' }) },
+      ]),
+    });
+    const rows = await listRecentReportReviews(
+      { userId: 'user-assistante', role: 'ASSISTANTE' },
+      serviceDependencies(deps),
+    );
+    expect(new Set(rows.map((r) => r.reportArtifact.id)).size).toBe(rows.length);
+    expect(rows).toHaveLength(2);
   });
 });

--- a/__tests__/bilans/whatsapp-message-mise-a-jour.test.ts
+++ b/__tests__/bilans/whatsapp-message-mise-a-jour.test.ts
@@ -1,0 +1,22 @@
+
+describe('Message d’information de mise à jour — cas B option 3', () => {
+  const { buildBilanUpdateWhatsAppMessage } = jest.requireActual('@/lib/bilans/staff/whatsapp-message');
+
+  it('registre courtois : affiner, jamais s’excuser ; aucun lien, l’accès reste le même', () => {
+    const message = buildBilanUpdateWhatsAppMessage({
+      parentDisplayName: 'Alaeddine Ben Rhouma',
+      studentFirstName: 'Kamel',
+      updatedAtLabel: '14 août 2026',
+    });
+    expect(message).toContain('affiné');
+    expect(message).toContain('même accès');
+    expect(message).toContain('14 août 2026');
+    expect(message).toContain('Bien cordialement');
+    // Non anxiogène : on a affiné le diagnostic, on ne s'était pas « trompé ».
+    for (const banned of ['erreur', 'trompé', 'faux', 'excuse', 'anomalie']) {
+      expect(message.toLowerCase()).not.toContain(banned);
+    }
+    // Aucun lien : un lien enregistré ne meurt jamais, rien à retransmettre.
+    expect(message).not.toContain('http');
+  });
+});

--- a/__tests__/integration/bilans-canonical-worker-review.test.ts
+++ b/__tests__/integration/bilans-canonical-worker-review.test.ts
@@ -236,7 +236,7 @@ describe('A86 deterministic worker and internal review service', () => {
     expect((await prisma.canonicalAssessmentAttempt.findUniqueOrThrow({ where: { id: seeded.attempt.id } })).status)
       .toBe('REPORT_PENDING_REVIEW');
     const snapshot = await prisma.scoreSnapshot.findUniqueOrThrow({ where: { assessmentAttemptId: seeded.attempt.id } });
-    const revision = await prisma.reportRevision.findUniqueOrThrow({ where: { scoreSnapshotId: snapshot.id } });
+    const revision = await prisma.reportRevision.findFirstOrThrow({ where: { scoreSnapshotId: snapshot.id } });
     const deterministicContent = revision.content as { NEXUS: { content: { internalFacts: { globalScore: number } } } };
     expect(deterministicContent.NEXUS.content.internalFacts.globalScore).toBe(snapshot.score);
     expect((await prisma.jobOutbox.findUniqueOrThrow({ where: { id: generateJob.id } }))).toMatchObject({ status: 'COMPLETED' });

--- a/__tests__/integration/bilans-regeneration.real.test.ts
+++ b/__tests__/integration/bilans-regeneration.real.test.ts
@@ -569,3 +569,53 @@ describe('cas B option 3 — mention de remplacement, lien conservé, message d�
     expect(replacement).not.toBeNull();
   });
 });
+
+describe('une seule version visible sur toutes les surfaces', () => {
+  it('dashboard assistante : une seule ligne pour l’artefact, la génération courante', async () => {
+    const { listRecentReportReviews } = await import('@/lib/bilans/staff/review-service');
+    const rows = await listRecentReportReviews({ userId: assistantId, role: 'ASSISTANTE' });
+    const forArtifact = rows.filter((r) => r.reportArtifact.id === artifactId);
+    expect(forArtifact).toHaveLength(1);
+    // C'est la génération maximale (3 après re-publication) — jamais 1 ni 2.
+    expect(forArtifact[0].generation).toBe(3);
+    expect(forArtifact.some((r) => r.generation === 1 || r.generation === 2)).toBe(false);
+  });
+
+  it('lien signé + surfaces familles : servent la génération courante, l’ancienne matérialisation n’est plus référencée', async () => {
+    const artifact = await prisma.reportArtifact.findUniqueOrThrow({
+      where: { id: artifactId },
+      select: { currentPublishedRevisionId: true },
+    });
+    const gen3 = await prisma.reportRevision.findFirstOrThrow({
+      where: { scoreSnapshotId: snapshotId, generation: 3 }, select: { id: true },
+    });
+    // Toutes les surfaces familles (lien, parent, élève, PDF) sélectionnent
+    // currentPublishedRevisionId : il pointe la génération 3, jamais 1/2.
+    expect(artifact.currentPublishedRevisionId).toBe(gen3.id);
+
+    // L'ancienne génération 2 garde sa matérialisation en base (append-only)
+    // mais n'est plus la version courante — donc invisible partout.
+    const gen2 = await prisma.reportRevision.findFirstOrThrow({
+      where: { scoreSnapshotId: snapshotId, generation: 2 },
+      select: { id: true, materialization: { select: { id: true } } },
+    });
+    expect(gen2.materialization).not.toBeNull();
+    expect(gen2.id).not.toBe(artifact.currentPublishedRevisionId);
+
+    // Le document servi par un lien signé frais n'est PAS l'ancienne
+    // matérialisation gén.2 (HTML de test « <html>gen2-PARENTS</html> »).
+    const { createReportShareLinks, verifyAndConsumeShareToken } = await import('@/lib/bilans/staff/share-link-service');
+    const parentUserId = (await prisma.reportArtifact.findUniqueOrThrow({
+      where: { id: artifactId },
+      select: { student: { select: { parent: { select: { userId: true } } } } },
+    })).student.parent.userId;
+    const links = await createReportShareLinks({
+      reportArtifactId: artifactId, recipientUserId: parentUserId, createdById: assistantId,
+    });
+    const token = links.find(({ audience }) => audience === 'PARENTS')!.token;
+    const served = await verifyAndConsumeShareToken(token);
+    expect(served).not.toBeNull();
+    expect(served!.html).not.toBe('<html>gen2-PARENTS</html>');
+  });
+});
+

--- a/__tests__/integration/bilans-regeneration.real.test.ts
+++ b/__tests__/integration/bilans-regeneration.real.test.ts
@@ -496,3 +496,76 @@ describe('exécution — bilan déjà publié', () => {
     expect(oldMaterialized?.html).toBe('<html>gen2-PARENTS</html>');
   });
 });
+
+describe('cas B option 3 — mention de remplacement, lien conservé, message d’information', () => {
+  let shareToken: string;
+
+  beforeAll(async () => {
+    // Un lien signé créé À L'ÉPOQUE de la génération 2 publiée + transmission
+    // confirmée : le parent a reçu et probablement lu la version précédente.
+    const { createReportShareLinks } = await import('@/lib/bilans/staff/share-link-service');
+    const parentUserId = (await prisma.reportArtifact.findUniqueOrThrow({
+      where: { id: artifactId },
+      select: { student: { select: { parent: { select: { userId: true } } } } },
+    })).student.parent!.userId;
+    const links = await createReportShareLinks({
+      reportArtifactId: artifactId,
+      recipientUserId: parentUserId,
+      createdById: assistantId,
+    });
+    shareToken = links.find(({ audience }) => audience === 'PARENTS')!.token;
+    await prisma.reportTransmission.create({
+      data: {
+        reportArtifactId: artifactId,
+        channel: 'WHATSAPP',
+        recipientUserId: parentUserId,
+        confirmedById: assistantId,
+        confirmedAt: new Date('2026-08-14T09:00:00Z'),
+      },
+    });
+  });
+
+  it('le MÊME lien reste valide et sert la génération re-publiée, avec l’information de remplacement datée', async () => {
+    const { verifyAndConsumeShareToken } = await import('@/lib/bilans/staff/share-link-service');
+    const verified = await verifyAndConsumeShareToken(shareToken);
+    expect(verified).not.toBeNull();
+    expect(verified!.updatedVersion).not.toBeNull();
+    // updatedAt = matérialisation de la génération 3 ; replacesDate = celle de la génération 2.
+    expect(verified!.updatedVersion!.updatedAt.getTime())
+      .toBeGreaterThan(verified!.updatedVersion!.replacesDate.getTime());
+  });
+
+  it('transmission confirmée → le message d’information est préparé (sans toucher aux liens)', async () => {
+    const { prepareUpdateInfoMessage } = await import('@/lib/bilans/staff/whatsapp-send-service');
+    const activeLinksBefore = await prisma.reportShareLink.count({
+      where: { reportArtifactId: artifactId, revokedAt: null },
+    });
+    const prepared = await prepareUpdateInfoMessage({
+      actor: { userId: assistantId, role: 'ASSISTANTE' },
+      reportArtifactId: artifactId,
+    });
+    expect(prepared.whatsappUrl).toContain('https://wa.me/');
+    expect(prepared.message).toContain('affiné');
+    expect(prepared.message).toContain('même accès');
+    // Rien n'est révoqué, rien n'est réémis.
+    const activeLinksAfter = await prisma.reportShareLink.count({
+      where: { reportArtifactId: artifactId, revokedAt: null },
+    });
+    expect(activeLinksAfter).toBe(activeLinksBefore);
+  });
+
+  it('sans transmission confirmée → la mention sur la page suffit, pas de message', async () => {
+    await prisma.$executeRawUnsafe('ALTER TABLE "canonical_report_transmissions" DISABLE TRIGGER USER');
+    await prisma.reportTransmission.deleteMany({ where: { reportArtifactId: artifactId } });
+    await prisma.$executeRawUnsafe('ALTER TABLE "canonical_report_transmissions" ENABLE TRIGGER USER');
+    const { prepareUpdateInfoMessage } = await import('@/lib/bilans/staff/whatsapp-send-service');
+    await expect(prepareUpdateInfoMessage({
+      actor: { userId: assistantId, role: 'ASSISTANTE' },
+      reportArtifactId: artifactId,
+    })).rejects.toThrow('WHATSAPP_UPDATE_INFO_NO_PRIOR_TRANSMISSION');
+    // La mention de la page, elle, reste disponible (données de génération).
+    const { readPublishedVersionReplacement } = await import('@/lib/bilans/staff/share-link-service');
+    const replacement = await readPublishedVersionReplacement(artifactId);
+    expect(replacement).not.toBeNull();
+  });
+});

--- a/__tests__/integration/bilans-regeneration.real.test.ts
+++ b/__tests__/integration/bilans-regeneration.real.test.ts
@@ -1,0 +1,498 @@
+jest.unmock('@/lib/prisma');
+
+/**
+ * Régénération d'un bilan — prouvée sur PostgreSQL réel, gardes compris.
+ *
+ * Le scénario est le défaut du 13/08/2026 : un snapshot calculé sous
+ * l'ancienne règle §6 (un nœud avec une erreur confiante minoritaire classé
+ * MAITRISE) est régénéré sous la règle courante. On prouve :
+ *   1. le score n'est jamais recalculé (re-dérivé identique, sinon STOP) ;
+ *   2. la nouvelle génération arrive EN PLUS (historique conservé),
+ *      l'ancienne révision est retirée de la file par un rejet tracé ;
+ *   3. la trace est append-only (UPDATE/DELETE refusés par la base) ;
+ *   4. le cas « déjà publié » exige la confirmation délibérée, fait
+ *      transiter l'attempt par le chemin prévu, et l'artefact RESTE publié
+ *      (la famille garde l'ancienne version jusqu'à re-publication) ;
+ *   5. answers, snapshot et matérialisations restent intacts au octet près.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { prisma } from '@/lib/prisma';
+import { score } from '@/lib/bilans/facts/compute-facts';
+import type { FactSheet } from '@/lib/bilans/facts/fact-sheet';
+import {
+  executeReportRegeneration,
+  prepareReportRegeneration,
+  ReportRegenerationError,
+} from '@/lib/bilans/staff/regeneration-service';
+import { resolveEnabledPack } from '@/lib/bilans/api/pack-access';
+
+const PREFIX = `regen-${Date.now()}-`;
+const PACK_SLUG = 'entree-seconde-maths-v1';
+
+// Le pack doit être activé pour que le service le résolve — même mécanisme
+// que la production (drapeau d'activation par pack).
+process.env.NEXUS_BILAN_PACK_ENTREE_SECONDE_MATHS_V1_ENABLED = 'true';
+
+type RawPack = {
+  slug: string;
+  version: number;
+  scoring: { domains: readonly string[] };
+  questionnaire: { items: readonly {
+    id: string; nodeCpsId: string; domainId: string; difficulty: number;
+    targetTimeSec: number;
+    options: readonly { id: string; isCorrect?: boolean }[];
+  }[] };
+};
+
+function loadPack(): RawPack {
+  return JSON.parse(readFileSync(join(process.cwd(), 'data/bilans/banks', `${PACK_SLUG}.json`), 'utf8')) as RawPack;
+}
+
+/**
+ * Entrées du moteur depuis la banque réelle (QCM_SIMPLE, comme le worker) :
+ * tout juste à 4/4, sauf UN item faux à 4/4 — le défaut du 13/08/2026.
+ */
+function buildScoring(pack: RawPack) {
+  const items = pack.questionnaire.items.map((item) => {
+    const correct = item.options.find(({ isCorrect }) => isCorrect === true);
+    if (correct === undefined) throw new Error(`option correcte absente : ${item.id}`);
+    return {
+      item: {
+        id: item.id,
+        nodeCpsId: item.nodeCpsId,
+        type: 'QCM_SIMPLE' as const,
+        difficulty: item.difficulty as 1 | 2 | 3,
+        answerKey: { kind: 'QCM_SIMPLE' as const, correct: correct.id },
+        targetTimeSec: item.targetTimeSec,
+      },
+      correctId: correct.id,
+      wrongId: item.options.find(({ isCorrect }) => isCorrect !== true)?.id ?? correct.id,
+    };
+  });
+  return {
+    items: items.map(({ item }) => item),
+    answers: items.map(({ item, correctId, wrongId }, index) => ({
+      itemId: item.id,
+      rawAnswer: index === 0 ? wrongId : correctId,
+      confidence: 4 as const,
+      elapsedMs: 30_000,
+    })),
+    targetDurationMin: 30,
+  };
+}
+
+let assistantId: string;
+let revisionId: string;
+let snapshotId: string;
+let attemptId: string;
+let artifactId: string;
+let storedFactSheet: FactSheet;
+let answersFrozen: string;
+
+beforeAll(async () => {
+  const pack = loadPack();
+  const output = score(buildScoring(pack) as never);
+
+  const assistant = await prisma.user.create({
+    data: { email: `${PREFIX}assistante@example.test`, role: 'ASSISTANTE' },
+  });
+  assistantId = assistant.id;
+  const parentUser = await prisma.user.create({
+    data: { email: null, role: 'PARENT', phone: '99 19 28 29', phoneNormalized: '99192829' },
+  });
+  const parent = await prisma.parentProfile.create({ data: { userId: parentUser.id } });
+  const studentUser = await prisma.user.create({
+    data: { email: `${PREFIX}eleve@example.test`, role: 'ELEVE', firstName: 'RegenTest', lastName: 'Cas' },
+  });
+  const student = await prisma.student.create({
+    data: { userId: studentUser.id, parentId: parent.id, gradeLevel: 'SECONDE' },
+  });
+  const attempt = await prisma.canonicalAssessmentAttempt.create({
+    data: {
+      studentId: student.id,
+      status: 'REPORT_PENDING_REVIEW',
+      subject: 'MATHEMATIQUES',
+      gradeLevel: 'SECONDE',
+      answers: { frozen: true },
+      submittedAt: new Date('2026-08-13T10:00:00Z'),
+      provenance: 'SAISIE_PAPIER',
+      enteredById: assistantId,
+      enteredAt: new Date('2026-08-13T10:00:00Z'),
+      curriculumId: 'c',
+      curriculumVersion: '1',
+      assessmentPackId: PACK_SLUG,
+      assessmentPackVersion: '1',
+      assessmentPackChecksum: resolveEnabledPack(PACK_SLUG, 1)?.checksum ?? 'x'.repeat(64),
+      scoringPolicyId: 's',
+      scoringPolicyVersion: '1',
+      seed: '42',
+      expiresAt: new Date(Date.now() + 3_600_000),
+    },
+  });
+  attemptId = attempt.id;
+  answersFrozen = JSON.stringify(attempt.answers);
+
+  // FactSheet « ancienne règle » : le moteur COURANT calcule, puis on rétablit
+  // le classement de l'époque (le nœud en erreur confiante minoritaire était
+  // MAITRISE) — exactement l'état des snapshots de production concernés.
+  const buildSheet = await import('@/lib/bilans/facts/fact-sheet');
+  const currentSheet = buildSheet.buildFactSheet(
+    { slug: pack.slug, version: pack.version, scoring: pack.scoring, questionnaire: pack.questionnaire } as never,
+    { result: output, student: { alias: 'ELEVE_REGEN', level: 'seconde' } },
+  );
+  const brokenNode = currentSheet.nodes.find((node) => node.profile === 'ERREUR_CONFIANTE');
+  if (brokenNode === undefined) throw new Error('scénario invalide : aucun nœud EC');
+  const brokenDomain = pack.questionnaire.items.find((item) => item.nodeCpsId === brokenNode.nodeCpsId)?.domainId;
+  storedFactSheet = {
+    ...currentSheet,
+    engineVersion: '1.0.1',
+    nodes: currentSheet.nodes.map((node) => (
+      node.nodeCpsId === brokenNode.nodeCpsId ? { ...node, profile: 'MAITRISE' as const } : node
+    )),
+    domains: currentSheet.domains.map((domain) => (
+      domain.id === brokenDomain ? { ...domain, profile: 'MAITRISE' as const } : domain
+    )),
+  } as FactSheet;
+
+  const snapshot = await prisma.scoreSnapshot.create({
+    data: {
+      assessmentAttemptId: attempt.id,
+      scoringPolicyId: 's',
+      scoringPolicyVersion: '1',
+      scoringPolicyChecksum: 'x',
+      score: storedFactSheet.globalScore,
+      result: storedFactSheet as never,
+      scoredAt: new Date(),
+    },
+  });
+  snapshotId = snapshot.id;
+  await prisma.evidenceItem.createMany({
+    data: output.items.map((item) => ({
+      scoreSnapshotId: snapshot.id,
+      kind: 'ANSWER' as const,
+      competencyId: item.nodeCpsId,
+      sourceKey: item.itemId,
+      payload: JSON.parse(JSON.stringify(item)),
+    })),
+  });
+  const artifact = await prisma.reportArtifact.create({
+    data: { studentId: student.id, assessmentAttemptId: attempt.id, status: 'PENDING_REVIEW' },
+  });
+  artifactId = artifact.id;
+  const revision = await prisma.reportRevision.create({
+    data: {
+      reportArtifactId: artifact.id,
+      scoreSnapshotId: snapshot.id,
+      status: 'PENDING_REVIEW',
+      reportPackId: PACK_SLUG,
+      reportPackVersion: '1',
+      corpusManifestId: 'disabled',
+      corpusManifestVersion: '1',
+      promptRevision: 'deterministic-no-agent-v1',
+      contextChecksum: 'e'.repeat(64),
+      content: {},
+    },
+  });
+  revisionId = revision.id;
+});
+
+afterAll(async () => {
+  await prisma.$executeRawUnsafe(`
+    TRUNCATE TABLE
+      "canonical_report_regenerations",
+      "canonical_share_link_accesses", "canonical_report_share_links",
+      "canonical_report_transmissions", "canonical_report_review_annotations",
+      "canonical_report_reviews", "canonical_report_revisions", "canonical_report_artifacts",
+      "canonical_evidence_items", "canonical_score_snapshots", "canonical_job_outbox",
+      "canonical_assessment_attempts", "canonical_parent_student_links" CASCADE
+  `);
+  await prisma.$disconnect();
+});
+
+describe('aperçu (lecture seule)', () => {
+  it('annonce le diff M → ERREUR_CONFIANTE, versions de règle, génération suivante', async () => {
+    const preview = await prepareReportRegeneration({
+      actor: { userId: assistantId, role: 'ASSISTANTE' },
+      revisionId,
+    });
+    expect(preview.engineVersionBefore).toBe('1.0.1');
+    expect(preview.nextGeneration).toBe(2);
+    expect(preview.profilesChanged).toBe(true);
+    expect(preview.changes.some((change) => change.before === 'MAITRISE' && change.after === 'ERREUR_CONFIANTE')).toBe(true);
+    expect(preview.briefWillRegenerate).toBe(false);
+  });
+
+  it('refuse un rôle non-staff', async () => {
+    await expect(prepareReportRegeneration({
+      actor: { userId: assistantId, role: 'PARENT' },
+      revisionId,
+    })).rejects.toThrow('REGENERATION_FORBIDDEN');
+  });
+
+  it('STOP si le score re-dérivé diverge du snapshot', async () => {
+    // On sabote UNE évidence en mémoire ? Non : on prouve sur une copie DB.
+    // Un deuxième snapshot avec une évidence altérée doit être refusé.
+    const attempt2 = await prisma.canonicalAssessmentAttempt.create({
+      data: {
+        studentId: (await prisma.reportArtifact.findUniqueOrThrow({ where: { id: artifactId }, select: { studentId: true } })).studentId,
+        status: 'REPORT_PENDING_REVIEW',
+        subject: 'MATHEMATIQUES',
+        gradeLevel: 'SECONDE',
+        answers: {},
+        submittedAt: new Date(),
+        curriculumId: 'c', curriculumVersion: '1',
+        assessmentPackId: PACK_SLUG, assessmentPackVersion: '1',
+        assessmentPackChecksum: 'x'.repeat(64),
+        scoringPolicyId: 's', scoringPolicyVersion: '1', seed: '43',
+        expiresAt: new Date(Date.now() + 3_600_000),
+      },
+    });
+    const snapshot2 = await prisma.scoreSnapshot.create({
+      data: {
+        assessmentAttemptId: attempt2.id,
+        scoringPolicyId: 's', scoringPolicyVersion: '1', scoringPolicyChecksum: 'x',
+        score: storedFactSheet.globalScore,
+        result: storedFactSheet as never,
+        scoredAt: new Date(),
+      },
+    });
+    const first = storedFactSheet.nodes[0];
+    await prisma.evidenceItem.create({
+      data: {
+        scoreSnapshotId: snapshot2.id,
+        kind: 'ANSWER',
+        competencyId: first.nodeCpsId,
+        sourceKey: 'ALTERED',
+        // rawSuccess incohérent avec le score stocké du nœud → mismatch.
+        payload: { itemId: 'ALTERED', nodeCpsId: first.nodeCpsId, weight: 3, rawSuccess: 0, profile: 'LACUNE_CONSCIENTE', isSuccess: false, isConfident: false, answered: true, elapsedMs: 1 },
+      },
+    });
+    const revision2 = await prisma.reportRevision.create({
+      data: {
+        reportArtifactId: (await prisma.reportArtifact.create({
+          data: { studentId: attempt2.studentId, assessmentAttemptId: attempt2.id, status: 'PENDING_REVIEW' },
+        })).id,
+        scoreSnapshotId: snapshot2.id,
+        status: 'PENDING_REVIEW',
+        reportPackId: PACK_SLUG, reportPackVersion: '1',
+        corpusManifestId: 'disabled', corpusManifestVersion: '1',
+        promptRevision: 'deterministic-no-agent-v1',
+        contextChecksum: 'e'.repeat(64), content: {},
+      },
+    });
+    await expect(prepareReportRegeneration({
+      actor: { userId: assistantId, role: 'ASSISTANTE' },
+      revisionId: revision2.id,
+    })).rejects.toThrow('REGENERATION_SCORE_MISMATCH');
+  });
+});
+
+describe('exécution — bilan en attente de revue', () => {
+  let newRevisionId: string;
+
+  it('crée la génération 2 en PENDING_REVIEW, retire l’ancienne par un rejet tracé', async () => {
+    const result = await executeReportRegeneration({
+      actor: { userId: assistantId, role: 'ASSISTANTE' },
+      revisionId,
+      motif: 'Correction de la règle de profil (v1.1.0)',
+    });
+    newRevisionId = result.newRevisionId;
+    expect(result.generation).toBe(2);
+    expect(result.changes.length).toBeGreaterThan(0);
+
+    const oldRevision = await prisma.reportRevision.findUniqueOrThrow({
+      where: { id: revisionId },
+      select: { status: true, generation: true, reviews: { select: { decision: true, motif: true } } },
+    });
+    expect(oldRevision.status).toBe('REJECTED');
+    expect(oldRevision.generation).toBe(1);
+    expect(oldRevision.reviews.some((review) => review.decision === 'REJECTED' && review.motif.includes('génération 2'))).toBe(true);
+
+    const fresh = await prisma.reportRevision.findUniqueOrThrow({
+      where: { id: newRevisionId },
+      select: { status: true, generation: true, scoreSnapshotId: true, content: true },
+    });
+    expect(fresh.status).toBe('PENDING_REVIEW');
+    expect(fresh.generation).toBe(2);
+    expect(fresh.scoreSnapshotId).toBe(snapshotId);
+    // Le contenu régénéré classe bien le nœud en erreur confiante.
+    expect(JSON.stringify(fresh.content)).toContain('ERREUR_CONFIANTE');
+  });
+
+  it('answers et snapshot sont intacts au octet près', async () => {
+    const attempt = await prisma.canonicalAssessmentAttempt.findUniqueOrThrow({
+      where: { id: attemptId }, select: { answers: true, status: true },
+    });
+    expect(JSON.stringify(attempt.answers)).toBe(answersFrozen);
+    expect(attempt.status).toBe('REPORT_PENDING_REVIEW');
+    const snapshot = await prisma.scoreSnapshot.findUniqueOrThrow({
+      where: { id: snapshotId }, select: { result: true },
+    });
+    expect((snapshot.result as unknown as FactSheet).engineVersion).toBe('1.0.1');
+    expect((snapshot.result as unknown as FactSheet).nodes.some((node) => node.profile === 'MAITRISE')).toBe(true);
+  });
+
+  it('la trace de régénération existe et la base refuse toute réécriture', async () => {
+    const trace = await prisma.reportRegeneration.findFirstOrThrow({
+      where: { toRevisionId: newRevisionId },
+    });
+    expect(trace.motif).toContain('règle de profil');
+    expect(trace.engineVersionBefore).toBe('1.0.1');
+    expect(trace.requestedById).toBe(assistantId);
+    expect(trace.wasPublished).toBe(false);
+    expect(Array.isArray(trace.profileDiff)).toBe(true);
+
+    await expect(prisma.reportRegeneration.update({
+      where: { id: trace.id },
+      data: { motif: 'réécrit' },
+    })).rejects.toThrow(/append-only/);
+    await expect(prisma.reportRegeneration.delete({
+      where: { id: trace.id },
+    })).rejects.toThrow(/append-only/);
+  });
+
+  it('un motif trop court est refusé', async () => {
+    await expect(executeReportRegeneration({
+      actor: { userId: assistantId, role: 'ASSISTANTE' },
+      revisionId: newRevisionId,
+      motif: 'ras',
+    })).rejects.toThrow('REGENERATION_MOTIF_REQUIRED');
+  });
+});
+
+describe('exécution — bilan déjà publié', () => {
+  beforeAll(async () => {
+    // On publie la génération 2 par le chemin réel : revue APPROVED tracée,
+    // COACH_VALIDATED, matérialisation, artefact PUBLISHED, attempt PUBLISHED.
+    const generation2 = await prisma.reportRevision.findFirstOrThrow({
+      where: { scoreSnapshotId: snapshotId, generation: 2 },
+      select: { id: true },
+    });
+    await prisma.reportReview.create({
+      data: {
+        reportRevisionId: generation2.id,
+        reviewerId: assistantId,
+        decision: 'APPROVED',
+        motif: 'Validation pour test de régénération publiée',
+        reviewedAt: new Date(),
+      },
+    });
+    await prisma.reportRevision.update({ where: { id: generation2.id }, data: { status: 'COACH_VALIDATED' } });
+    const materialization = await prisma.reportMaterialization.create({
+      data: {
+        revisionId: generation2.id,
+        brandVersion: 'nexus-lux.v1',
+        globalChecksum: 'm'.repeat(64),
+        materializedAt: new Date(),
+      },
+    });
+    await prisma.reportAudienceArtifact.createMany({
+      data: (['ELEVE', 'PARENTS', 'NEXUS'] as const).map((audience) => ({
+        materializationId: materialization.id,
+        audience,
+        html: `<html>gen2-${audience}</html>`,
+        pdfStatus: 'UNAVAILABLE' as const,
+        checksum: audience.padEnd(64, 'c').slice(0, 64),
+      })),
+    });
+    await prisma.reportArtifact.update({
+      where: { id: artifactId },
+      data: { status: 'PUBLISHED', currentPublishedRevisionId: generation2.id, publishedAt: new Date() },
+    });
+    await prisma.canonicalAssessmentAttempt.update({ where: { id: attemptId }, data: { status: 'COACH_VALIDATED' } });
+    await prisma.canonicalAssessmentAttempt.update({ where: { id: attemptId }, data: { status: 'PUBLISHED' } });
+  });
+
+  it('sans confirmation délibérée : refus explicite', async () => {
+    const generation2 = await prisma.reportRevision.findFirstOrThrow({
+      where: { scoreSnapshotId: snapshotId, generation: 2 }, select: { id: true },
+    });
+    await expect(executeReportRegeneration({
+      actor: { userId: assistantId, role: 'ASSISTANTE' },
+      revisionId: generation2.id,
+      motif: 'Nouvelle version du rendu',
+    })).rejects.toThrow('REGENERATION_CONFIRMATION_REQUIRED');
+  });
+
+  it('avec confirmation : génération 3 en revue, artefact TOUJOURS publié (la famille garde l’ancienne version)', async () => {
+    const generation2 = await prisma.reportRevision.findFirstOrThrow({
+      where: { scoreSnapshotId: snapshotId, generation: 2 }, select: { id: true },
+    });
+    const result = await executeReportRegeneration({
+      actor: { userId: assistantId, role: 'ASSISTANTE' },
+      revisionId: generation2.id,
+      motif: 'Nouvelle version du rendu (test cas publié)',
+      confirmAlreadyPublished: true,
+    });
+    expect(result.generation).toBe(3);
+
+    const attempt = await prisma.canonicalAssessmentAttempt.findUniqueOrThrow({
+      where: { id: attemptId }, select: { status: true },
+    });
+    expect(attempt.status).toBe('REPORT_PENDING_REVIEW');
+
+    const artifact = await prisma.reportArtifact.findUniqueOrThrow({
+      where: { id: artifactId },
+      select: { status: true, currentPublishedRevisionId: true },
+    });
+    expect(artifact.status).toBe('PUBLISHED');
+    expect(artifact.currentPublishedRevisionId).toBe(generation2.id);
+
+    const trace = await prisma.reportRegeneration.findFirstOrThrow({
+      where: { toRevisionId: result.newRevisionId },
+      select: { wasPublished: true },
+    });
+    expect(trace.wasPublished).toBe(true);
+
+    // Publiée reste servie : la matérialisation de la génération 2 est intacte.
+    const materialized = await prisma.reportAudienceArtifact.findFirst({
+      where: { materialization: { revisionId: generation2.id }, audience: 'PARENTS' },
+      select: { html: true },
+    });
+    expect(materialized?.html).toBe('<html>gen2-PARENTS</html>');
+  });
+
+  it('re-validation + re-publication : le lien famille bascule sur la génération 3, l’historique reste', async () => {
+    const generation3 = await prisma.reportRevision.findFirstOrThrow({
+      where: { scoreSnapshotId: snapshotId, generation: 3 }, select: { id: true },
+    });
+    const { validateReportRevision, publishReportRevision } = await import('@/lib/bilans/core/report-service');
+    await validateReportRevision({
+      prisma,
+      revisionId: generation3.id,
+      reviewerId: assistantId,
+      motif: 'Re-validation après régénération (test)',
+      reviewedAt: new Date(),
+    } as never);
+    await publishReportRevision({
+      prisma,
+      revisionId: generation3.id,
+      reviewerId: assistantId,
+      publishedAt: new Date(),
+    } as never);
+
+    const artifact = await prisma.reportArtifact.findUniqueOrThrow({
+      where: { id: artifactId },
+      select: { status: true, currentPublishedRevisionId: true },
+    });
+    expect(artifact.status).toBe('PUBLISHED');
+    expect(artifact.currentPublishedRevisionId).toBe(generation3.id);
+
+    // L'historique intégral est là : trois générations pour UN snapshot.
+    const generations = await prisma.reportRevision.findMany({
+      where: { scoreSnapshotId: snapshotId },
+      select: { generation: true, status: true },
+      orderBy: { generation: 'asc' },
+    });
+    expect(generations.map(({ generation }) => generation)).toEqual([1, 2, 3]);
+    // Et l'ancienne matérialisation publiée n'a pas bougé d'un octet.
+    const oldMaterialized = await prisma.reportAudienceArtifact.findFirst({
+      where: { materialization: { revisionId: artifact.currentPublishedRevisionId === null ? '' : (await prisma.reportRevision.findFirstOrThrow({ where: { scoreSnapshotId: snapshotId, generation: 2 }, select: { id: true } })).id }, audience: 'PARENTS' },
+      select: { html: true },
+    });
+    expect(oldMaterialized?.html).toBe('<html>gen2-PARENTS</html>');
+  });
+});

--- a/__tests__/integration/bilans-saisie-papier.real.test.ts
+++ b/__tests__/integration/bilans-saisie-papier.real.test.ts
@@ -243,8 +243,8 @@ describe('Saisie papier — parité et provenance sur PostgreSQL réel', () => {
 
     await Promise.all([generateReport(paperAttemptId), generateReport(onlineAttemptId)]);
     const [paperRevision, onlineRevision] = await Promise.all([
-      prisma.reportRevision.findUniqueOrThrow({ where: { scoreSnapshotId: paper.id } }),
-      prisma.reportRevision.findUniqueOrThrow({ where: { scoreSnapshotId: online.id } }),
+      prisma.reportRevision.findFirstOrThrow({ where: { scoreSnapshotId: paper.id } }),
+      prisma.reportRevision.findFirstOrThrow({ where: { scoreSnapshotId: online.id } }),
     ]);
     const paperIdentity = (paperRevision.content as {
       NEXUS: { identity: { durationMeasurement?: string } };

--- a/app/bilan/consultation/[token]/page.tsx
+++ b/app/bilan/consultation/[token]/page.tsx
@@ -33,6 +33,8 @@ export default async function FamilyLandingPage({
   const { token } = await params;
   const context = await resolveShareLinkContext(token);
   if (context === null) notFound();
+  const { readPublishedVersionReplacement } = await import('@/lib/bilans/staff/share-link-service');
+  const updatedVersion = await readPublishedVersionReplacement(context.reportArtifactId);
 
   const isParentAudience = context.audience === 'PARENTS';
   const firstName = context.studentFirstName?.trim() || 'votre enfant';
@@ -53,6 +55,18 @@ export default async function FamilyLandingPage({
               ? 'Vous consultez le document destiné aux parents. Il se lit ci-dessous et se télécharge en PDF. Ce lien est personnel : ne le partagez pas.'
               : 'Tu consultes ton document. Il se lit ci-dessous et se télécharge en PDF. Ce lien est personnel : ne le partage pas.'}
           </p>
+          {updatedVersion !== null && (
+            <p
+              className="mt-5 max-w-2xl rounded-2xl border border-lux-gold/40 bg-lux-gold/10 px-4 py-3 text-sm leading-6 text-lux-ivory"
+              data-testid="version-mise-a-jour"
+            >
+              Version mise à jour le {new Intl.DateTimeFormat('fr-FR', { dateStyle: 'long' }).format(updatedVersion.updatedAt)} —
+              elle remplace la version du {new Intl.DateTimeFormat('fr-FR', { dateStyle: 'long' }).format(updatedVersion.replacesDate)}.
+              {isParentAudience
+                ? ' Notre équipe a affiné la lecture pédagogique de certains points ; votre accès, lui, reste le même.'
+                : ' Notre équipe a affiné la lecture de certains points de ton bilan ; ton accès, lui, reste le même.'}
+            </p>
+          )}
           <div className="mt-6 flex flex-wrap items-center gap-4">
             <a
               href={`/bilan/consultation/${encodeURIComponent(token)}/pdf`}

--- a/app/dashboard/assistante/bilans/actions.ts
+++ b/app/dashboard/assistante/bilans/actions.ts
@@ -199,3 +199,20 @@ export async function requestTeacherBriefCorrectionAction(formData: FormData): P
     handleAccessError(error);
   }
 }
+
+export async function executeRegenerationAction(formData: FormData): Promise<void> {
+  const { executeReportRegeneration, ReportRegenerationError } = await import('@/lib/bilans/staff/regeneration-service');
+  try {
+    await executeReportRegeneration({
+      actor: await actor(),
+      revisionId: field(formData, 'revisionId'),
+      motif: field(formData, 'motif'),
+      confirmAlreadyPublished: formData.get('confirmAlreadyPublished') === 'on',
+    });
+    revalidatePath('/dashboard/assistante/bilans');
+  } catch (error) {
+    if (error instanceof ReportRegenerationError) notFound();
+    handleAccessError(error);
+  }
+  redirect('/dashboard/assistante/bilans');
+}

--- a/app/dashboard/assistante/bilans/actions.ts
+++ b/app/dashboard/assistante/bilans/actions.ts
@@ -216,3 +216,19 @@ export async function executeRegenerationAction(formData: FormData): Promise<voi
   }
   redirect('/dashboard/assistante/bilans');
 }
+
+export async function prepareUpdateInfoMessageAction(formData: FormData): Promise<void> {
+  const { prepareUpdateInfoMessage } = await import('@/lib/bilans/staff/whatsapp-send-service');
+  let whatsappUrl: string;
+  try {
+    const prepared = await prepareUpdateInfoMessage({
+      actor: await actor(),
+      reportArtifactId: field(formData, 'artifactId'),
+    });
+    whatsappUrl = prepared.whatsappUrl;
+  } catch (error) {
+    if (error instanceof WhatsAppSendError) notFound();
+    handleAccessError(error);
+  }
+  redirect(whatsappUrl);
+}

--- a/app/dashboard/assistante/bilans/page.tsx
+++ b/app/dashboard/assistante/bilans/page.tsx
@@ -17,6 +17,7 @@ import type { TeacherBriefContent } from '@/lib/bilans/llm/teacher-brief-schema'
 import {
   addParentEmailAction,
   executeRegenerationAction,
+  prepareUpdateInfoMessageAction,
   approveTeacherBriefAction,
   confirmWhatsAppTransmissionAction,
   generateTeacherBriefAction,
@@ -469,9 +470,23 @@ export default async function CanonicalBilansReviewPage({
                     <section className="border-t border-emerald-300/20 bg-emerald-300/5 px-6 py-5">
                       <h3 className="font-semibold text-emerald-100">Envoi au parent par WhatsApp</h3>
                       {revision.transmittedAt !== null ? (
-                        <p className="mt-1 text-sm text-emerald-100">
-                          Transmis au parent le {dateLabel(revision.transmittedAt)} par WhatsApp.
-                        </p>
+                        <>
+                          <p className="mt-1 text-sm text-emerald-100">
+                            Transmis au parent le {dateLabel(revision.transmittedAt)} par WhatsApp.
+                          </p>
+                          {revision.generation > 1 && !revision.parentPhoneMissing && (
+                            <form action={prepareUpdateInfoMessageAction} target="_blank" className="mt-3">
+                              <input type="hidden" name="artifactId" value={revision.reportArtifact.id} />
+                              <button type="submit" className="rounded-xl border border-emerald-300 px-4 py-2.5 font-semibold text-emerald-100" data-testid="whatsapp-info-mise-a-jour">
+                                Préparer le message d’information (bilan mis à jour)
+                              </button>
+                              <p className="mt-2 text-xs leading-5 text-slate-400">
+                                Ce bilan régénéré remplace une version que la famille a déjà reçue : un court message courtois
+                                l’informe de la mise à jour. Les liens existants restent valables — rien n’est révoqué.
+                              </p>
+                            </form>
+                          )}
+                        </>
                       ) : revision.parentPhoneMissing ? (
                         <p className="mt-1 text-sm text-slate-300">
                           Aucun téléphone enregistré pour ce parent : l’envoi WhatsApp est indisponible.

--- a/app/dashboard/assistante/bilans/page.tsx
+++ b/app/dashboard/assistante/bilans/page.tsx
@@ -16,6 +16,7 @@ import type { TeacherBriefContent } from '@/lib/bilans/llm/teacher-brief-schema'
 
 import {
   addParentEmailAction,
+  executeRegenerationAction,
   approveTeacherBriefAction,
   confirmWhatsAppTransmissionAction,
   generateTeacherBriefAction,
@@ -94,7 +95,7 @@ function dateLabel(date: Date): string {
 
 export default async function CanonicalBilansReviewPage({
   searchParams,
-}: Readonly<{ searchParams: Promise<Readonly<{ preview?: string }>> }>) {
+}: Readonly<{ searchParams: Promise<Readonly<{ preview?: string; regen?: string }>> }>) {
   const session = await auth();
   if (session?.user?.id === undefined || session.user.role === undefined) notFound();
 
@@ -130,7 +131,22 @@ export default async function CanonicalBilansReviewPage({
   }
   const briefUsage = await teacherBriefMonthlyUsage();
 
-  const requestedPreview = (await searchParams).preview;
+  const resolvedParams = await searchParams;
+  const requestedPreview = resolvedParams.preview;
+  const requestedRegen = resolvedParams.regen;
+  let regenPreview: Awaited<ReturnType<typeof import('@/lib/bilans/staff/regeneration-service').prepareReportRegeneration>> | null = null;
+  if (requestedRegen !== undefined) {
+    const { prepareReportRegeneration, ReportRegenerationError } = await import('@/lib/bilans/staff/regeneration-service');
+    try {
+      regenPreview = await prepareReportRegeneration({
+        actor: { userId: session.user.id, role: session.user.role },
+        revisionId: requestedRegen,
+      });
+    } catch (error) {
+      if (!(error instanceof ReportRegenerationError)) throw error;
+      regenPreview = null;
+    }
+  }
   let preview: Awaited<ReturnType<typeof previewPendingReport>> | null = null;
   if (requestedPreview !== undefined) {
     try {
@@ -300,6 +316,64 @@ export default async function CanonicalBilansReviewPage({
                         <a href={`/dashboard/assistante/bilans?preview=${encodeURIComponent(revision.id)}`} className="lg:col-span-2 rounded-xl border border-amber-300 px-4 py-2.5 text-center font-semibold text-amber-100">
                           Prévisualiser les trois rendus HTML
                         </a>
+
+                        {(revision.status === 'PENDING_REVIEW' || revision.status === 'CORRECTION_REQUESTED' || revision.reportArtifact.status === 'PUBLISHED') && (
+                          regenPreview !== null && regenPreview.revisionId === revision.id ? (
+                            <section className="lg:col-span-2 rounded-2xl border border-sky-300/30 bg-sky-300/5 p-5" data-testid="regeneration-apercu">
+                              <h3 className="font-semibold text-sky-100">Régénérer le bilan — aperçu avant validation</h3>
+                              <p className="mt-1 text-sm text-slate-300">
+                                Règle {regenPreview.engineVersionBefore} → {regenPreview.engineVersionAfter} · génération {regenPreview.generation} → {regenPreview.nextGeneration}.
+                                Le snapshot de score reste intact ; le bilan régénéré repasse en revue avant toute diffusion.
+                              </p>
+                              {regenPreview.changes.length === 0 ? (
+                                <p className="mt-3 text-sm text-emerald-100">Aucun profil ne change : seule la mise en page et la prose seraient actualisées.</p>
+                              ) : (
+                                <ul className="mt-3 space-y-1 text-sm text-slate-200" data-testid="regeneration-diff">
+                                  {regenPreview.changes.map((change) => (
+                                    <li key={`${change.kind}-${change.id}`}>
+                                      <span className="font-mono text-xs text-slate-400">{change.kind === 'DOMAIN' ? 'domaine' : 'nœud'}</span>{' '}
+                                      <span className="font-semibold">{change.id}</span> : {change.before} → <span className="font-semibold text-amber-200">{change.after}</span>
+                                    </li>
+                                  ))}
+                                </ul>
+                              )}
+                              <p className="mt-3 text-sm text-slate-300">
+                                {regenPreview.briefWillRegenerate
+                                  ? 'Le brief enseignant sera régénéré (1 appel LLM facturé) puis repassera en relecture.'
+                                  : 'Aucun appel LLM : pas de brief actif à régénérer.'}
+                              </p>
+                              {regenPreview.artifactStatus === 'PUBLISHED' && (
+                                <p className="mt-3 rounded-xl border border-amber-300/40 bg-amber-300/10 p-3 text-sm text-amber-100" role="alert">
+                                  Ce bilan a été diffusé{regenPreview.transmittedAt !== null ? ` et transmis le ${dateLabel(regenPreview.transmittedAt)}` : regenPreview.publishedAt !== null ? ` le ${dateLabel(regenPreview.publishedAt)}` : ''}.
+                                  La famille verra la nouvelle version par son lien après re-validation et re-publication.
+                                </p>
+                              )}
+                              <form action={executeRegenerationAction} className="mt-4">
+                                <input type="hidden" name="revisionId" value={revision.id} />
+                                <label className="block text-sm font-semibold text-white" htmlFor={`regen-motif-${revision.id}`}>Motif de la régénération</label>
+                                <textarea id={`regen-motif-${revision.id}`} name="motif" required minLength={5} className="mt-2 min-h-20 w-full rounded-xl border border-white/15 bg-slate-950 p-3 text-sm text-white" placeholder="Ex. : correction de la règle de profil (v1.1.0)" />
+                                {regenPreview.artifactStatus === 'PUBLISHED' && (
+                                  <label className="mt-3 flex items-start gap-2 text-sm text-amber-100">
+                                    <input type="checkbox" name="confirmAlreadyPublished" required className="mt-1" />
+                                    <span>Je confirme la régénération d’un bilan déjà diffusé à une famille.</span>
+                                  </label>
+                                )}
+                                <button type="submit" className="mt-3 rounded-xl bg-sky-400 px-4 py-2.5 font-semibold text-slate-950">
+                                  Régénérer le bilan
+                                </button>
+                                <Link href="/dashboard/assistante/bilans" className="ml-3 text-sm text-slate-300 underline">Annuler</Link>
+                              </form>
+                            </section>
+                          ) : (
+                            <a
+                              href={`/dashboard/assistante/bilans?regen=${encodeURIComponent(revision.id)}`}
+                              className="lg:col-span-2 rounded-xl border border-sky-300/50 px-4 py-2.5 text-center font-semibold text-sky-100"
+                              data-testid="regeneration-preparer"
+                            >
+                              Préparer une régénération du bilan
+                            </a>
+                          )
+                        )}
                         <form action={validateAndPublishReportAction} className="rounded-2xl border border-emerald-300/20 bg-emerald-300/5 p-4">
                           <input type="hidden" name="revisionId" value={revision.id} />
                           <label className="block text-sm font-semibold text-white" htmlFor={`approve-${revision.id}`}>Motif de validation et diffusion</label>

--- a/docs/specs/bilans/09-amelioration-differee-purge-pdf.md
+++ b/docs/specs/bilans/09-amelioration-differee-purge-pdf.md
@@ -1,0 +1,55 @@
+# 09 — Amélioration différée : purge des PDF des générations remplacées
+
+> **Statut : DIFFÉRÉ (arbitrage responsable, 14/08/2026).** L'idée est bonne,
+> le moment est mauvais. À reprendre à froid si le volume le justifie.
+
+## Le besoin
+
+Après régénération d'un bilan **publié**, l'ancienne matérialisation subsiste
+(append-only) : révision + matérialisation + 3 artefacts d'audience, dont le
+**PDF en `bytea` (~563 Ko/audience, ≈ 1,7 Mo par bilan publié régénéré)**.
+Ces octets ne peuvent pas être libérés : la table
+`canonical_report_audience_artifacts` porte le trigger
+`canonical_report_audience_artifacts_immutable` (`BEFORE UPDATE OR DELETE →
+insert-only`), garant de l'inaltérabilité du diagnostic. Un `UPDATE pdf=NULL`
+ou un `DELETE` est rejeté.
+
+Les 12 attempts en attente ne matérialisent qu'à la publication → **0 octet**
+échoué en les régénérant. Seul un bilan **déjà publié** paie la taxe.
+
+## Le principe : séparer la PREUVE du RENDU
+
+Ce qui doit rester inaltérable, c'est la **preuve du diagnostic** : le HTML de
+chaque audience + son checksum. Le **PDF est un rendu dérivé** du HTML — un
+cache, pas une preuve.
+
+- Déplacer la colonne `pdf` `bytea` vers une **nouvelle table mutable**
+  `canonical_report_pdf_cache` (clé = artefact d'audience), **sans trigger
+  append-only**.
+- La table immuable garde HTML + checksum → **inaltérabilité intacte**.
+- À la re-publication d'une génération, **purger le cache PDF des générations
+  remplacées** → libère les ~1,7 Mo. Seul le PDF de la génération courante
+  reste ; seule elle est jamais servie (toutes les surfaces lisent
+  `currentPublishedRevisionId`).
+
+## Coût
+
+- Migration **déplaçant des données existantes** hors de la table la plus
+  protégée du système (6,76 Mo de `bytea` aujourd'hui).
+- Adaptation de **trois points de lecture** : lien signé
+  (`verifyAndConsumeShareToken`), `get-report`, écriture de matérialisation.
+- Tests de non-régression sur le service PDF servi.
+
+## Gain
+
+- Récupère ~1,7 Mo par bilan **publié** régénéré. Négligeable au volume actuel
+  (1 bilan publié concerné, serveur à ~181 Go libres) ; devient pertinent si
+  les régénérations de bilans diffusés se multiplient.
+
+## Décision
+
+Différé. La demande initiale (« une seule version visible, ni encombrement ni
+confusion ») est **intégralement satisfaite par le filtre `listRecent`** (une
+ligne par bilan sur le dashboard) : voir `lib/bilans/staff/review-service.ts`
+(`onlyCurrentGeneration`) et les tests de surface. Cette purge ne concerne que
+l'espace disque, jugé non prioritaire à ce jour.

--- a/e2e/auth/bilan-golden-path.spec.ts
+++ b/e2e/auth/bilan-golden-path.spec.ts
@@ -181,7 +181,7 @@ test.describe('Golden-path — bilan de bout en bout (rapport LLM stubbé)', () 
 
     const artifact = await prisma.reportArtifact.findUniqueOrThrow({ where: { assessmentAttemptId: attemptId } });
     expect(artifact.status).toBe('PENDING_REVIEW');
-    const revisionRow = await prisma.reportRevision.findUniqueOrThrow({ where: { scoreSnapshotId: snapshot.id } });
+    const revisionRow = await prisma.reportRevision.findFirstOrThrow({ where: { scoreSnapshotId: snapshot.id } });
     // Les nombres viennent toujours du FactSheet, jamais du bundle LLM
     // (buildLlmReports ne fait que narrer -- voir sa documentation).
     const narratedContent = revisionRow.content as { NEXUS: { content: { internalFacts: { globalScore: number } } } };

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -24,6 +24,13 @@ const customJestConfig = {
   testPathIgnorePatterns: [
     '<rootDir>/.next/',
     '<rootDir>/node_modules/',
+    '<rootDir>/.worktrees/',
+  ],
+  // Les worktrees d'agents portent leur propre node_modules (dont un client
+  // Prisma generé sous un autre schéma) : ils ne doivent jamais entrer dans
+  // la résolution de modules de la suite.
+  modulePathIgnorePatterns: [
+    '<rootDir>/.worktrees/',
   ],
 };
 

--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -24,6 +24,7 @@ const customJestConfig = {
   },
   modulePathIgnorePatterns: [
     '<rootDir>/.next/',
+    '<rootDir>/.worktrees/',
   ],
   testMatch: [
     '**/__tests__/**/*.test.(js|ts|tsx)',

--- a/lib/bilans/core/report-service.ts
+++ b/lib/bilans/core/report-service.ts
@@ -376,6 +376,7 @@ export async function publishReportRevision(input: Readonly<{
       id: true,
       status: true,
       validationFailures: true,
+      generation: true,
       content: true,
       materialization: { select: { id: true } },
       scoreSnapshot: { select: { result: true } },
@@ -412,8 +413,11 @@ export async function publishReportRevision(input: Readonly<{
     throw new BilanReportServiceError('REPORT_VALIDATION_FAILURES');
   }
   if (candidate.materialization !== null) throw new BilanReportServiceError('REPORT_ALREADY_MATERIALIZED');
+  // Re-publication d'une régénération : l'artefact est resté PUBLISHED
+  // pendant la re-revue (même règle que dans la transaction finale).
   if (
-    candidate.reportArtifact.status !== 'PENDING_REVIEW'
+    (candidate.reportArtifact.status !== 'PENDING_REVIEW'
+      && !(candidate.generation > 1 && candidate.reportArtifact.status === 'PUBLISHED'))
     || candidate.reportArtifact.assessmentAttempt.status !== 'COACH_VALIDATED'
   ) throw new BilanReportServiceError('REPORT_CONCURRENT_PUBLICATION');
   if (candidate.reviews.length !== 1) throw new BilanReportServiceError('REPORT_APPROVED_REVIEW_REQUIRED');
@@ -435,6 +439,7 @@ export async function publishReportRevision(input: Readonly<{
       select: {
         id: true,
         status: true,
+        generation: true,
         validationFailures: true,
         materialization: { select: { id: true } },
         reportArtifact: {
@@ -454,8 +459,15 @@ export async function publishReportRevision(input: Readonly<{
       throw new BilanReportServiceError('REPORT_VALIDATION_FAILURES');
     }
     if (revision.materialization !== null) throw new BilanReportServiceError('REPORT_ALREADY_MATERIALIZED');
+    // Régénération (génération > 1) : l'artefact est resté PUBLISHED pendant
+    // la re-revue — la famille conservait l'ancienne version. La
+    // re-publication bascule currentPublishedRevisionId ; tout le reste du
+    // chemin (revue APPROVED tracée, matérialisation, attempt COACH_VALIDATED)
+    // est identique à une première publication.
+    const isRepublication = revision.generation > 1
+      && revision.reportArtifact.status === 'PUBLISHED';
     if (
-      revision.reportArtifact.status !== 'PENDING_REVIEW'
+      (revision.reportArtifact.status !== 'PENDING_REVIEW' && !isRepublication)
       || revision.reportArtifact.assessmentAttempt.status !== 'COACH_VALIDATED'
     ) throw new BilanReportServiceError('REPORT_CONCURRENT_PUBLICATION');
     const approvedReview = await transaction.reportReview.findFirst({
@@ -481,11 +493,9 @@ export async function publishReportRevision(input: Readonly<{
       },
     });
     const artifact = await transaction.reportArtifact.updateMany({
-      where: {
-        id: revision.reportArtifact.id,
-        status: 'PENDING_REVIEW',
-        currentPublishedRevisionId: null,
-      },
+      where: isRepublication
+        ? { id: revision.reportArtifact.id, status: 'PUBLISHED' }
+        : { id: revision.reportArtifact.id, status: 'PENDING_REVIEW', currentPublishedRevisionId: null },
       data: {
         status: 'PUBLISHED',
         currentPublishedRevisionId: revision.id,

--- a/lib/bilans/family-landing/access.ts
+++ b/lib/bilans/family-landing/access.ts
@@ -35,7 +35,7 @@ export class FamilyAccessError extends Error {
 
 type FamilyAccessDatabase = Pick<
   PrismaClient,
-  '$transaction' | 'reportShareLink' | 'reportArtifact' | 'shareLinkAccess' | 'user' | 'jobOutbox'
+  '$transaction' | 'reportShareLink' | 'reportArtifact' | 'reportRevision' | 'shareLinkAccess' | 'user' | 'jobOutbox'
 >;
 
 const EMAIL_SHAPE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;

--- a/lib/bilans/family-landing/consent.ts
+++ b/lib/bilans/family-landing/consent.ts
@@ -31,7 +31,7 @@ export class FamilyConsentError extends Error {
 
 type FamilyConsentDatabase = Pick<
   PrismaClient,
-  '$transaction' | 'reportShareLink' | 'reportArtifact' | 'shareLinkAccess'
+  '$transaction' | 'reportShareLink' | 'reportArtifact' | 'reportRevision' | 'shareLinkAccess'
 >;
 
 type Dependencies = Readonly<{

--- a/lib/bilans/staff/regeneration-service.ts
+++ b/lib/bilans/staff/regeneration-service.ts
@@ -1,0 +1,545 @@
+import type { Prisma, PrismaClient } from '@prisma/client';
+
+import { prisma } from '@/lib/prisma';
+
+import { computeNodeProfile } from '../facts/compute-facts';
+import { ENGINE_VERSION } from '../facts/constants';
+import { SEVERITY_RANK } from '../facts/constants';
+import { buildFactSheet, type FactSheet } from '../facts/fact-sheet';
+import type { ItemProfile, NodeProfile, NodeResult, ScoringOutput } from '../facts/types';
+import { resolveEnabledPack, type PackResolver } from '../api/pack-access';
+import { advanceAttemptLifecycle } from '../core/report-service';
+import { sha256Canonical } from '../local-first/hash';
+import { buildDeterministicReports } from '../render/report';
+import { buildPreRentreeStageLabel } from '../render/stage-label';
+import { prepareReportPassationPresentation } from '../render/passation-presentation';
+import type { RenderIdentity } from '../render/render-identity';
+import { generateTeacherBrief, type GenerateBriefResult } from '../llm/teacher-brief-service';
+import { requestTeacherBriefCorrection } from './teacher-brief-review-service';
+
+/**
+ * Régénération d'un bilan — décision responsable du 13/08/2026.
+ *
+ * Quand une règle d'agrégation ou un rendu évolue, l'assistante régénère
+ * elle-même le bilan, sans intervention technique. La SOURCE est l'évidence
+ * par item (append-only) — jamais le snapshot, qui porte les profils calculés
+ * sous la règle de son époque. Le score n'est JAMAIS recalculé : le service
+ * re-dérive les scores depuis l'évidence et STOPPE si le moindre écart
+ * apparaît avec le snapshot (REGENERATION_SCORE_MISMATCH) — c'est le contrôle
+ * qui garantit qu'on ne change que les profils et le rendu.
+ *
+ * Historique intégral conservé : l'ancienne révision et sa matérialisation
+ * restent ; la nouvelle génération (colonne `generation`) arrive à côté, en
+ * PENDING_REVIEW — validation humaine obligatoire avant toute re-diffusion.
+ * Chaque régénération est tracée (canonical_report_regenerations, append-only).
+ */
+
+export const REGENERATION_SERVICE_VERSION = 'report-regeneration.v1' as const;
+
+export class ReportRegenerationError extends Error {
+  constructor(readonly code: string) {
+    super(code);
+    this.name = 'ReportRegenerationError';
+  }
+}
+
+const STAFF_ROLES = new Set(['ASSISTANTE', 'ADMIN']);
+
+type RegenDatabase = Pick<
+  PrismaClient,
+  '$transaction' | 'reportRevision' | 'reportArtifact' | 'reportRegeneration'
+  | 'evidenceItem' | 'canonicalAssessmentAttempt' | 'user' | 'notification'
+  | 'reportReview' | 'teacherBrief' | 'scoreSnapshot'
+>;
+
+export type ProfileChange = Readonly<{
+  kind: 'NODE' | 'DOMAIN';
+  id: string;
+  before: NodeProfile;
+  after: NodeProfile;
+}>;
+
+export type RegenerationPreview = Readonly<{
+  revisionId: string;
+  reportArtifactId: string;
+  generation: number;
+  nextGeneration: number;
+  engineVersionBefore: string;
+  engineVersionAfter: string;
+  artifactStatus: string;
+  /** Date de dernière transmission WhatsApp confirmée — null si jamais transmis. */
+  transmittedAt: Date | null;
+  publishedAt: Date | null;
+  changes: readonly ProfileChange[];
+  profilesChanged: boolean;
+  /** Un brief enseignant actif existe et sera régénéré (1 appel LLM). */
+  briefWillRegenerate: boolean;
+}>;
+
+type EvidenceRow = Readonly<{
+  itemId: string;
+  nodeCpsId: string;
+  weight: number;
+  rawSuccess: number;
+  isSuccess: boolean;
+  isConfident: boolean;
+  profile: ItemProfile;
+  answered: boolean;
+  elapsedMs: number;
+}>;
+
+function parseEvidence(payloads: readonly Prisma.JsonValue[]): readonly EvidenceRow[] {
+  return payloads.map((payload) => {
+    const row = payload as Record<string, unknown>;
+    if (
+      typeof row?.itemId !== 'string' || typeof row?.nodeCpsId !== 'string'
+      || typeof row?.weight !== 'number' || typeof row?.rawSuccess !== 'number'
+      || typeof row?.profile !== 'string'
+    ) throw new ReportRegenerationError('REGENERATION_EVIDENCE_MALFORMED');
+    return Object.freeze({
+      itemId: row.itemId,
+      nodeCpsId: row.nodeCpsId,
+      weight: row.weight,
+      rawSuccess: row.rawSuccess,
+      isSuccess: row.isSuccess === true,
+      isConfident: row.isConfident === true,
+      profile: row.profile as ItemProfile,
+      answered: row.answered === true,
+      elapsedMs: typeof row.elapsedMs === 'number' ? row.elapsedMs : 0,
+    });
+  });
+}
+
+const round1 = (value: number): number => Math.round(value * 10) / 10;
+
+/**
+ * Reconstruit les nœuds sous la règle COURANTE depuis l'évidence, en
+ * re-dérivant les scores pour les confronter au snapshot (non-régression).
+ */
+function rebuildNodes(
+  evidence: readonly EvidenceRow[],
+  storedNodes: readonly NodeResult[],
+): readonly NodeResult[] {
+  const byNode = new Map<string, EvidenceRow[]>();
+  for (const row of evidence) {
+    const bucket = byNode.get(row.nodeCpsId) ?? [];
+    bucket.push(row);
+    byNode.set(row.nodeCpsId, bucket);
+  }
+
+  const rebuilt = storedNodes.map((stored) => {
+    const rows = byNode.get(stored.nodeCpsId);
+    if (rows === undefined) throw new ReportRegenerationError('REGENERATION_EVIDENCE_MISSING_NODE');
+    const totalWeight = rows.reduce((sum, row) => sum + row.weight, 0);
+    const weighted = rows.reduce((sum, row) => sum + row.rawSuccess * row.weight, 0);
+    const nodeScore = totalWeight === 0 ? 0 : round1((100 * weighted) / totalWeight);
+    // LE contrôle : le score re-dérivé doit être identique au snapshot.
+    // Tout écart signifierait qu'on ne régénère pas le même diagnostic → STOP.
+    if (nodeScore !== stored.nodeScore) {
+      throw new ReportRegenerationError('REGENERATION_SCORE_MISMATCH');
+    }
+    const mass: Record<ItemProfile, number> = {
+      MAITRISE: 0, MAITRISE_FRAGILE: 0, LACUNE_CONSCIENTE: 0, ERREUR_CONFIANTE: 0, NON_TRAITE: 0,
+    };
+    for (const row of rows) mass[row.profile] += row.weight;
+    return {
+      ...stored,
+      profile: computeNodeProfile(mass),
+    };
+  });
+
+  // Priorisation — spec §9, à l'identique du moteur (échelle unique).
+  return rebuilt
+    .slice()
+    .sort((a, b) => {
+      const sev = SEVERITY_RANK[b.profile] - SEVERITY_RANK[a.profile];
+      if (sev !== 0) return sev;
+      const crit = b.criticality - a.criticality;
+      if (crit !== 0) return crit;
+      const sc = a.nodeScore - b.nodeScore;
+      if (sc !== 0) return sc;
+      return a.nodeCpsId.localeCompare(b.nodeCpsId);
+    })
+    .map((node, index) => ({ ...node, priorityRank: index }));
+}
+
+function computeChanges(before: FactSheet, after: FactSheet): readonly ProfileChange[] {
+  const changes: ProfileChange[] = [];
+  const beforeNodes = new Map(before.nodes.map((node) => [node.nodeCpsId, node.profile]));
+  for (const node of after.nodes) {
+    const previous = beforeNodes.get(node.nodeCpsId);
+    if (previous !== undefined && previous !== node.profile) {
+      changes.push(Object.freeze({ kind: 'NODE' as const, id: node.nodeCpsId, before: previous, after: node.profile }));
+    }
+  }
+  const beforeDomains = new Map(before.domains.map((domain) => [domain.id, domain.profile]));
+  for (const domain of after.domains) {
+    const previous = beforeDomains.get(domain.id);
+    if (previous !== undefined && previous !== domain.profile) {
+      changes.push(Object.freeze({ kind: 'DOMAIN' as const, id: domain.id, before: previous, after: domain.profile }));
+    }
+  }
+  return Object.freeze(changes);
+}
+
+const revisionSelect = {
+  id: true,
+  status: true,
+  generation: true,
+  scoreSnapshotId: true,
+  reportPackId: true,
+  reportPackVersion: true,
+  content: true,
+  reportArtifact: {
+    select: {
+      id: true,
+      status: true,
+      publishedAt: true,
+      studentId: true,
+      assessmentAttemptId: true,
+      assessmentAttempt: { select: { id: true, status: true, provenance: true, submittedAt: true } },
+      transmissions: {
+        select: { confirmedAt: true },
+        where: { channel: 'WHATSAPP' },
+        orderBy: { confirmedAt: 'desc' as const },
+        take: 1,
+      },
+    },
+  },
+  scoreSnapshot: { select: { id: true, result: true } },
+} as const;
+
+type LoadedRevision = Prisma.ReportRevisionGetPayload<{ select: typeof revisionSelect }>;
+
+async function loadForRegeneration(
+  database: RegenDatabase,
+  revisionId: string,
+): Promise<Readonly<{
+  revision: LoadedRevision;
+  storedFactSheet: FactSheet;
+  correctedFactSheet: FactSheet;
+  changes: readonly ProfileChange[];
+  enabled: NonNullable<ReturnType<PackResolver>>;
+  maxGeneration: number;
+}>> {
+  const revision = await database.reportRevision.findUnique({
+    where: { id: revisionId },
+    select: revisionSelect,
+  });
+  if (revision === null) throw new ReportRegenerationError('REGENERATION_NOT_FOUND');
+  // Une révision validée mais PAS ENCORE PUBLIÉE est en main de l'assistante :
+  // publier ou rejeter d'abord — on ne régénère pas sous une validation en
+  // vol. (Une révision publiée reste COACH_VALIDATED : c'est l'artefact qui
+  // porte PUBLISHED — ce cas-là se régénère, avec confirmation délibérée.)
+  if (revision.status === 'COACH_VALIDATED' && revision.reportArtifact.status !== 'PUBLISHED') {
+    throw new ReportRegenerationError('REGENERATION_REVISION_LOCKED');
+  }
+
+  const enabled = resolveEnabledPack(revision.reportPackId, Number(revision.reportPackVersion));
+  if (enabled === null) throw new ReportRegenerationError('REGENERATION_PACK_UNAVAILABLE');
+
+  const storedFactSheet = revision.scoreSnapshot.result as unknown as FactSheet;
+
+  const evidencePayloads = await database.evidenceItem.findMany({
+    where: { scoreSnapshotId: revision.scoreSnapshotId, kind: 'ANSWER' },
+    select: { payload: true },
+    orderBy: { id: 'asc' },
+  });
+  if (evidencePayloads.length === 0) throw new ReportRegenerationError('REGENERATION_EVIDENCE_MISSING');
+  const evidence = parseEvidence(evidencePayloads.map((row: { payload: Prisma.JsonValue }) => row.payload));
+
+  const nodes = rebuildNodes(evidence, storedFactSheet.nodes);
+
+  // FactSheet corrigée par l'UNIQUE chemin d'agrégation du moteur :
+  // buildFactSheet re-dérive domaines (scores + pire nœud) depuis items+nodes.
+  const scoringResult: ScoringOutput = Object.freeze({
+    engineVersion: ENGINE_VERSION,
+    globalScore: storedFactSheet.globalScore,
+    coverage: storedFactSheet.coverage,
+    calibrationIndex: storedFactSheet.calibrationIndex,
+    flags: storedFactSheet.flags,
+    groupBand: storedFactSheet.groupBand,
+    items: evidence,
+    nodes,
+  }) as unknown as ScoringOutput;
+
+  const correctedFactSheet = buildFactSheet(
+    {
+      slug: enabled.pack.slug,
+      version: enabled.pack.version,
+      scoring: enabled.pack.scoring,
+      questionnaire: enabled.pack.questionnaire,
+    } as never,
+    { result: scoringResult, student: storedFactSheet.student },
+  );
+
+  // Non-régression sur les scores de domaines aussi : mêmes items, mêmes
+  // poids → les scores re-dérivés doivent être identiques au snapshot.
+  const storedDomainScores = new Map(storedFactSheet.domains.map((domain) => [domain.id, domain.score]));
+  for (const domain of correctedFactSheet.domains) {
+    if (storedDomainScores.get(domain.id) !== domain.score) {
+      throw new ReportRegenerationError('REGENERATION_SCORE_MISMATCH');
+    }
+  }
+
+  const aggregate = await database.reportRevision.aggregate({
+    _max: { generation: true },
+    where: { scoreSnapshotId: revision.scoreSnapshotId },
+  });
+
+  return Object.freeze({
+    revision,
+    storedFactSheet,
+    correctedFactSheet,
+    changes: computeChanges(storedFactSheet, correctedFactSheet),
+    enabled,
+    maxGeneration: aggregate._max.generation ?? 1,
+  });
+}
+
+function assertStaff(actor: Readonly<{ userId: string; role: string }>): void {
+  if (!STAFF_ROLES.has(actor.role) || !actor.userId.trim()) {
+    throw new ReportRegenerationError('REGENERATION_FORBIDDEN');
+  }
+}
+
+/** Aperçu lecture seule : ce qui changerait, et ce que la régénération coûte. */
+export async function prepareReportRegeneration(input: Readonly<{
+  prisma?: RegenDatabase;
+  actor: Readonly<{ userId: string; role: string }>;
+  revisionId: string;
+}>): Promise<RegenerationPreview> {
+  assertStaff(input.actor);
+  const database: RegenDatabase = input.prisma ?? (prisma as unknown as RegenDatabase);
+  const loaded = await loadForRegeneration(database, input.revisionId);
+
+  const activeBrief = await database.teacherBrief.findFirst({
+    where: {
+      reportArtifactId: loaded.revision.reportArtifact.id,
+      status: { in: ['PENDING_REVIEW', 'APPROVED'] },
+    },
+    orderBy: { version: 'desc' },
+    select: { id: true },
+  });
+
+  const profilesChanged = loaded.changes.length > 0;
+  return Object.freeze({
+    revisionId: loaded.revision.id,
+    reportArtifactId: loaded.revision.reportArtifact.id,
+    generation: loaded.revision.generation,
+    nextGeneration: loaded.maxGeneration + 1,
+    engineVersionBefore: loaded.storedFactSheet.engineVersion,
+    engineVersionAfter: ENGINE_VERSION,
+    artifactStatus: loaded.revision.reportArtifact.status,
+    transmittedAt: loaded.revision.reportArtifact.transmissions[0]?.confirmedAt ?? null,
+    publishedAt: loaded.revision.reportArtifact.publishedAt,
+    changes: loaded.changes,
+    profilesChanged,
+    briefWillRegenerate: profilesChanged && activeBrief !== null,
+  });
+}
+
+export type RegenerationResult = Readonly<{
+  newRevisionId: string;
+  generation: number;
+  changes: readonly ProfileChange[];
+  brief: Readonly<{ regenerated: boolean; reason: string | null }>;
+}>;
+
+/**
+ * Exécute la régénération : nouvelle révision (génération N+1) en
+ * PENDING_REVIEW, ancienne révision retirée de la file par un rejet TRACÉ
+ * (ses annotations restent), trace append-only, brief LLM régénéré si les
+ * profils ont changé (repli PLANCHER : jamais bloquant).
+ */
+export async function executeReportRegeneration(input: Readonly<{
+  prisma?: RegenDatabase;
+  actor: Readonly<{ userId: string; role: string }>;
+  revisionId: string;
+  motif: string;
+  /** Obligatoire quand le bilan a déjà été diffusé : décision consciente. */
+  confirmAlreadyPublished?: boolean;
+  environment?: Readonly<Record<string, string | undefined>>;
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+}>): Promise<RegenerationResult> {
+  assertStaff(input.actor);
+  const database: RegenDatabase = input.prisma ?? (prisma as unknown as RegenDatabase);
+  const now = (input.now ?? (() => new Date()))();
+  const motif = input.motif.trim();
+  if (motif.length < 5) throw new ReportRegenerationError('REGENERATION_MOTIF_REQUIRED');
+
+  const loaded = await loadForRegeneration(database, input.revisionId);
+  const artifact = loaded.revision.reportArtifact;
+  const wasPublished = artifact.status === 'PUBLISHED';
+  if (wasPublished && input.confirmAlreadyPublished !== true) {
+    // Ce bilan a été transmis à une famille : jamais de nouvelle version
+    // sans décision consciente de l'assistante.
+    throw new ReportRegenerationError('REGENERATION_CONFIRMATION_REQUIRED');
+  }
+
+  const attempt = artifact.assessmentAttempt;
+  if (attempt.submittedAt === null) throw new ReportRegenerationError('REGENERATION_ATTEMPT_NOT_SUBMITTED');
+
+  // Rendu PLANCHER déterministe — même recette que la génération d'origine.
+  const presentation = prepareReportPassationPresentation(loaded.correctedFactSheet, attempt.provenance);
+  const identity: RenderIdentity = Object.freeze({
+    displayName: loaded.correctedFactSheet.student.alias,
+    level: loaded.enabled.pack.level,
+    subject: loaded.enabled.pack.subject,
+    date: attempt.submittedAt.toISOString().slice(0, 10),
+    stageLabel: buildPreRentreeStageLabel(loaded.enabled.pack.level, loaded.enabled.pack.subject),
+    ...(presentation.durationMeasurement === undefined
+      ? {}
+      : { durationMeasurement: presentation.durationMeasurement }),
+  });
+  const content = buildDeterministicReports(presentation.factSheet, identity);
+
+  const created = await database.$transaction(async (transaction) => {
+    // 1. L'ancienne révision quitte la file de revue par un rejet TRACÉ.
+    //    (Une révision CORRECTION_REQUESTED repasse d'abord par PENDING_REVIEW
+    //    — transitions autorisées par le garde SQL ; ses annotations restent.)
+    if (loaded.revision.status === 'CORRECTION_REQUESTED') {
+      await transaction.reportRevision.update({
+        where: { id: loaded.revision.id },
+        data: { status: 'PENDING_REVIEW' },
+      });
+    }
+    if (loaded.revision.status === 'PENDING_REVIEW' || loaded.revision.status === 'CORRECTION_REQUESTED') {
+      await transaction.reportReview.create({
+        data: {
+          reportRevisionId: loaded.revision.id,
+          reviewerId: input.actor.userId,
+          decision: 'REJECTED',
+          motif: `Remplacée par la génération ${loaded.maxGeneration + 1} — ${motif}`,
+          reviewedAt: now,
+        },
+      });
+      await transaction.reportRevision.update({
+        where: { id: loaded.revision.id },
+        data: { status: 'REJECTED' },
+      });
+    }
+
+    // 2. Cycle de vie de l'attempt : un bilan publié repasse en revue par le
+    //    chemin prévu de la machine à états (PUBLISHED → SCORED →
+    //    REPORT_PENDING_REVIEW). L'artefact, lui, reste PUBLISHED : la famille
+    //    garde l'ancienne version par son lien jusqu'à re-publication.
+    if (attempt.status === 'PUBLISHED') {
+      await advanceAttemptLifecycle(transaction, {
+        attemptId: attempt.id,
+        from: 'PUBLISHED',
+        action: 'REQUEST_REGENERATION',
+        actor: 'ASSISTANTE',
+      });
+      await advanceAttemptLifecycle(transaction, {
+        attemptId: attempt.id,
+        from: 'SCORED',
+        action: 'REGENERATE_REPORT',
+        actor: 'WORKER',
+      });
+    } else if (attempt.status !== 'REPORT_PENDING_REVIEW') {
+      throw new ReportRegenerationError('REGENERATION_ATTEMPT_STATE');
+    }
+
+    // 3. Nouvelle génération, en revue.
+    const revision = await transaction.reportRevision.create({
+      data: {
+        reportArtifactId: artifact.id,
+        scoreSnapshotId: loaded.revision.scoreSnapshotId,
+        status: 'PENDING_REVIEW',
+        generation: loaded.maxGeneration + 1,
+        reportPackId: loaded.revision.reportPackId,
+        reportPackVersion: loaded.revision.reportPackVersion,
+        corpusManifestId: 'disabled',
+        corpusManifestVersion: '1',
+        promptRevision: 'deterministic-no-agent-v1',
+        contextChecksum: sha256Canonical(content),
+        content: content as unknown as Prisma.InputJsonValue,
+        validationFailures: [],
+      },
+      select: { id: true, generation: true },
+    });
+    return revision;
+  });
+
+  // 4. Brief enseignant : régénéré si les profils ont changé — un brief ancré
+  //    sur un diagnostic obsolète ferait préparer la mauvaise séance. Repli
+  //    PLANCHER : indisponible → le bilan est régénéré sans brief, jamais bloqué.
+  let briefOutcome: Readonly<{ regenerated: boolean; reason: string | null; promptVersion: string | null; model: string | null }> =
+    Object.freeze({ regenerated: false, reason: 'PROFILS_INCHANGES', promptVersion: null, model: null });
+  if (loaded.changes.length > 0) {
+    const activeBrief = await database.teacherBrief.findFirst({
+      where: { reportArtifactId: artifact.id, status: { in: ['PENDING_REVIEW', 'APPROVED'] } },
+      orderBy: { version: 'desc' },
+      select: { id: true },
+    });
+    if (activeBrief === null) {
+      briefOutcome = Object.freeze({ regenerated: false, reason: 'AUCUN_BRIEF_ACTIF', promptVersion: null, model: null });
+    } else {
+      try {
+        await requestTeacherBriefCorrection({
+          actor: { userId: input.actor.userId, role: 'ASSISTANTE' },
+          briefId: activeBrief.id,
+          motif: `Profils régénérés (génération ${created.generation}) — ${motif}`,
+          annotation: {
+            section: 'autre',
+            remark: 'Brief obsolète : les profils du bilan ont été régénérés sous la règle courante.',
+          },
+        });
+        const result: GenerateBriefResult = await generateTeacherBrief({
+          actor: { userId: input.actor.userId, role: 'ASSISTANTE' },
+          reportArtifactId: artifact.id,
+          environment: input.environment,
+          fetchImpl: input.fetchImpl,
+          now: input.now,
+        });
+        if (result.mode === 'GENERATED') {
+          const generated = await database.teacherBrief.findUnique({
+            where: { id: result.briefId },
+            select: { promptVersion: true, model: true },
+          });
+          briefOutcome = Object.freeze({
+            regenerated: true,
+            reason: null,
+            promptVersion: generated?.promptVersion ?? null,
+            model: generated?.model ?? null,
+          });
+        } else {
+          briefOutcome = Object.freeze({
+            regenerated: false,
+            reason: result.mode === 'PLANCHER' ? result.reason : result.mode,
+            promptVersion: null,
+            model: null,
+          });
+        }
+      } catch {
+        briefOutcome = Object.freeze({ regenerated: false, reason: 'BRIEF_REGENERATION_FAILED', promptVersion: null, model: null });
+      }
+    }
+  }
+
+  // 5. Trace append-only — l'issue réelle du brief y figure.
+  await database.reportRegeneration.create({
+    data: {
+      fromRevisionId: loaded.revision.id,
+      toRevisionId: created.id,
+      requestedById: input.actor.userId,
+      motif,
+      engineVersionBefore: loaded.storedFactSheet.engineVersion,
+      engineVersionAfter: ENGINE_VERSION,
+      briefRegenerated: briefOutcome.regenerated,
+      briefPromptVersion: briefOutcome.promptVersion,
+      briefModel: briefOutcome.model,
+      profileDiff: loaded.changes as unknown as Prisma.InputJsonValue,
+      wasPublished,
+    },
+  });
+
+  return Object.freeze({
+    newRevisionId: created.id,
+    generation: created.generation,
+    changes: loaded.changes,
+    brief: Object.freeze({ regenerated: briefOutcome.regenerated, reason: briefOutcome.reason }),
+  });
+}

--- a/lib/bilans/staff/review-service.ts
+++ b/lib/bilans/staff/review-service.ts
@@ -415,13 +415,44 @@ export async function listPendingReportReviews(
   return Object.freeze(revisions.filter((revision) => packIsEnabled(revision, dependencies)));
 }
 
+/**
+ * Une régénération crée une nouvelle génération À CÔTÉ de l'ancienne
+ * (append-only : rien n'est supprimé). Sur le tableau de bord, l'assistante
+ * ne doit voir qu'UNE ligne par bilan — la génération courante. Les
+ * générations remplacées (rejetées à la régénération, ou anciennes versions
+ * publiées) sont masquées : ni encombrement, ni confusion, aucun sélecteur.
+ * La trace de régénération, elle, subsiste en base (audit sur requête).
+ *
+ * « Génération courante » = la génération maximale pour un même artefact.
+ * Un bilan simplement rejeté (jamais régénéré) reste visible : sa génération
+ * est la seule, donc la maximale.
+ */
+function onlyCurrentGeneration(
+  revisions: readonly PendingReportReview[],
+): readonly PendingReportReview[] {
+  const maxGenByArtifact = new Map<string, number>();
+  for (const revision of revisions) {
+    const artifactId = revision.reportArtifact.id;
+    const current = maxGenByArtifact.get(artifactId);
+    if (current === undefined || revision.generation > current) {
+      maxGenByArtifact.set(artifactId, revision.generation);
+    }
+  }
+  return revisions.filter(
+    (revision) => revision.generation === maxGenByArtifact.get(revision.reportArtifact.id),
+  );
+}
+
 export async function listRecentReportReviews(
   actor: ReviewActor,
   overrides: Partial<ReviewServiceDependencies> = {},
 ): Promise<readonly RecentReportReview[]> {
   const dependencies = { ...defaultDependencies, ...overrides };
   assertAssistante(actor);
-  return Object.freeze((await dependencies.listRecent()).map((revision) => recentReview(revision, dependencies)));
+  const recent = await dependencies.listRecent();
+  return Object.freeze(
+    onlyCurrentGeneration(recent).map((revision) => recentReview(revision, dependencies)),
+  );
 }
 
 export async function validateAndPublishPendingReport(

--- a/lib/bilans/staff/review-service.ts
+++ b/lib/bilans/staff/review-service.ts
@@ -26,6 +26,7 @@ import { bilanPackLevelLabel } from '../render/stage-label';
 export type PendingReportReview = Readonly<{
   id: string;
   status: string;
+  generation: number;
   validationFailures: readonly string[];
   reportPackId: string;
   reportPackVersion: string;
@@ -83,6 +84,7 @@ type ReviewAction = ReviewActor & Readonly<{ revisionId: string; motif: string }
 const revisionSelection = {
   id: true,
   status: true,
+  generation: true,
   validationFailures: true,
   reportPackId: true,
   reportPackVersion: true,

--- a/lib/bilans/staff/share-link-service.ts
+++ b/lib/bilans/staff/share-link-service.ts
@@ -27,7 +27,7 @@ export type ShareableAudience = 'ELEVE' | 'PARENTS';
 
 const SHAREABLE_AUDIENCES: readonly ShareableAudience[] = ['ELEVE', 'PARENTS'];
 
-type ShareDatabase = Pick<PrismaClient, '$transaction' | 'reportShareLink' | 'reportArtifact' | 'shareLinkAccess'>;
+type ShareDatabase = Pick<PrismaClient, '$transaction' | 'reportShareLink' | 'reportArtifact' | 'reportRevision' | 'shareLinkAccess'>;
 
 export class ReportShareLinkError extends Error {
   constructor(readonly code: string) {
@@ -127,10 +127,77 @@ export async function createReportShareLinks(input: CreateInput): Promise<readon
   });
 }
 
+
+export type PublishedVersionReplacement = Readonly<{ updatedAt: Date; replacesDate: Date }>;
+
+/**
+ * Régénération publiée (cas B, option 3) : la version servie remplace une
+ * version précédemment publiée. Retrouve la date de la version antérieure —
+ * uniquement depuis des données déjà tracées (générations, matérialisations).
+ */
+async function computeUpdatedVersion(
+  database: ShareDatabase,
+  current: Readonly<{
+    generation: number;
+    scoreSnapshotId: string;
+    materialization: Readonly<{ materializedAt: Date }> | null;
+  }> | null,
+): Promise<PublishedVersionReplacement | null> {
+  // Défensif : une génération absente (anciens doubles de test) vaut 1.
+  if (current === null || !(current.generation > 1) || current.materialization === null) return null;
+  const previous = await database.reportRevision.findFirst({
+    where: {
+      scoreSnapshotId: current.scoreSnapshotId,
+      generation: { lt: current.generation },
+      materialization: { isNot: null },
+    },
+    orderBy: { generation: 'desc' },
+    select: { materialization: { select: { materializedAt: true } } },
+  });
+  if (previous?.materialization == null) return null;
+  return Object.freeze({
+    updatedAt: current.materialization.materializedAt,
+    replacesDate: previous.materialization.materializedAt,
+  });
+}
+
+/**
+ * Information de remplacement pour la PAGE D'ARRIVÉE (qui résout le contexte
+ * sans consommer le jeton) : mêmes données que le vérificateur.
+ */
+export async function readPublishedVersionReplacement(
+  reportArtifactId: string,
+  dependencies: Readonly<{ prisma?: ShareDatabase }> = {},
+): Promise<PublishedVersionReplacement | null> {
+  const database = dependencies.prisma ?? prisma;
+  const artifact = await database.reportArtifact.findUnique({
+    where: { id: reportArtifactId },
+    select: {
+      currentPublishedRevision: {
+        select: {
+          generation: true,
+          scoreSnapshotId: true,
+          materialization: { select: { materializedAt: true } },
+        },
+      },
+    },
+  });
+  if (artifact === null) return null;
+  return computeUpdatedVersion(database, artifact.currentPublishedRevision);
+}
+
 export type VerifiedShareLink = Readonly<{
   audience: ShareableAudience;
   html: string;
   studentFirstName: string | null;
+  /**
+   * Non-null quand la version servie REMPLACE une version précédemment
+   * publiée (régénération, cas B option 3) : la page d'arrivée l'affiche
+   * — « Version mise à jour le [date] — remplace la version du [date] ».
+   * S'appuie uniquement sur des données déjà tracées (générations et dates
+   * de matérialisation) ; le lien, lui, ne change jamais.
+   */
+  updatedVersion: Readonly<{ updatedAt: Date; replacesDate: Date }> | null;
 }>;
 
 /**
@@ -164,8 +231,11 @@ export async function verifyAndConsumeShareToken(
           student: { select: { user: { select: { firstName: true } } } },
           currentPublishedRevision: {
             select: {
+              generation: true,
+              scoreSnapshotId: true,
               materialization: {
                 select: {
+                  materializedAt: true,
                   audienceArtifacts: { select: { audience: true, html: true } },
                 },
               },
@@ -189,10 +259,13 @@ export async function verifyAndConsumeShareToken(
 
   await database.shareLinkAccess.create({ data: { shareLinkId: link.id } });
 
+  const updatedVersion = await computeUpdatedVersion(database, link.reportArtifact.currentPublishedRevision);
+
   return Object.freeze({
     audience: link.audience,
     html: artifact.html,
     studentFirstName: link.reportArtifact.student.user.firstName,
+    updatedVersion,
   });
 }
 

--- a/lib/bilans/staff/whatsapp-message.ts
+++ b/lib/bilans/staff/whatsapp-message.ts
@@ -35,3 +35,31 @@ export function buildBilanWhatsAppMessage(input: BilanWhatsAppMessageInput): str
     'Nexus Réussite',
   ].join('\n'));
 }
+
+export type BilanUpdateWhatsAppMessageInput = Readonly<{
+  parentDisplayName: string;
+  studentFirstName: string;
+  /** Date de la nouvelle version, déjà formatée en français (ex. « 14 août 2026 »). */
+  updatedAtLabel: string;
+}>;
+
+/**
+ * Message d'information après régénération d'un bilan déjà transmis —
+ * cas B, option 3 (arbitrage responsable, 14/08/2026). Le parent a
+ * probablement lu la version précédente : on l'informe courtoisement que le
+ * diagnostic a été affiné, sans lien (son accès reste le même — un lien
+ * enregistré ne doit jamais mourir), sans jargon, sans inquiéter.
+ * Préparé comme le message initial : l'assistante envoie, jamais d'automate.
+ */
+export function buildBilanUpdateWhatsAppMessage(input: BilanUpdateWhatsAppMessageInput): string {
+  return frenchTypography([
+    `Bonjour ${input.parentDisplayName},`,
+    '',
+    `Petit mot de l'équipe Nexus Réussite : nous avons affiné le bilan de ${input.studentFirstName}. La lecture pédagogique de certains points a été précisée — la nouvelle version, datée du ${input.updatedAtLabel}, est disponible par le même accès que celui que vous avez déjà reçu.`,
+    '',
+    `Rien d'autre ne change : vos liens restent valables, et nous restons à votre disposition pour en parler ensemble.`,
+    '',
+    'Bien cordialement,',
+    'Nexus Réussite',
+  ].join('\n'));
+}

--- a/lib/bilans/staff/whatsapp-send-service.ts
+++ b/lib/bilans/staff/whatsapp-send-service.ts
@@ -39,7 +39,7 @@ export function shareLinkValidityDays(
   return value;
 }
 
-type SendDatabase = Pick<PrismaClient, '$transaction' | 'reportArtifact' | 'reportShareLink' | 'shareLinkAccess'>;
+type SendDatabase = Pick<PrismaClient, '$transaction' | 'reportArtifact' | 'reportRevision' | 'reportShareLink' | 'shareLinkAccess'>;
 
 export type PreparedWhatsAppSend = Readonly<{
   whatsappUrl: string;
@@ -161,5 +161,75 @@ function resolvePackLabels(reportPackId: string): Readonly<{ pack: Readonly<{ su
       subjectLabel: bilanPackSubjectLabel(subject),
       levelLabel: bilanPackLevelLabel(level),
     }),
+  });
+}
+
+export type PreparedUpdateInfoMessage = Readonly<{
+  whatsappUrl: string;
+  message: string;
+}>;
+
+/**
+ * Message d'information après régénération d'un bilan déjà transmis — cas B,
+ * option 3. NE TOUCHE PAS AUX LIENS (aucune révocation, aucune réémission :
+ * un lien enregistré par le parent ne meurt jamais) ; prépare seulement le
+ * wa.me courtois que l'assistante enverra elle-même. Exigences : bilan
+ * PUBLIÉ en génération > 1, téléphone parent présent, et une transmission
+ * WhatsApp CONFIRMÉE antérieure (sinon la mention sur la page suffit —
+ * décision responsable du 14/08/2026).
+ */
+export async function prepareUpdateInfoMessage(input: Readonly<{
+  prisma?: SendDatabase;
+  actor: Readonly<{ userId: string; role: string }>;
+  reportArtifactId: string;
+}>): Promise<PreparedUpdateInfoMessage> {
+  if (input.actor.role !== 'ASSISTANTE' || !input.actor.userId.trim()) {
+    throw new WhatsAppSendError('WHATSAPP_FORBIDDEN');
+  }
+  const database = input.prisma ?? prisma;
+  const artifact = await database.reportArtifact.findUnique({
+    where: { id: input.reportArtifactId },
+    select: {
+      status: true,
+      currentPublishedRevision: { select: { generation: true, materialization: { select: { materializedAt: true } } } },
+      transmissions: {
+        where: { channel: 'WHATSAPP' },
+        orderBy: { confirmedAt: 'desc' },
+        take: 1,
+        select: { confirmedAt: true },
+      },
+      student: {
+        select: {
+          user: { select: { firstName: true } },
+          parent: { select: { user: { select: { firstName: true, lastName: true, phoneNormalized: true } } } },
+        },
+      },
+    },
+  });
+  if (artifact === null || artifact.status !== 'PUBLISHED') {
+    throw new WhatsAppSendError('WHATSAPP_REPORT_NOT_PUBLISHED');
+  }
+  const current = artifact.currentPublishedRevision;
+  if (current === null || current.generation <= 1 || current.materialization === null) {
+    throw new WhatsAppSendError('WHATSAPP_UPDATE_INFO_NOT_A_REGENERATION');
+  }
+  if (artifact.transmissions.length === 0) {
+    // Jamais transmis-confirmé : la mention sur la page d'arrivée suffit.
+    throw new WhatsAppSendError('WHATSAPP_UPDATE_INFO_NO_PRIOR_TRANSMISSION');
+  }
+  const parentUser = artifact.student.parent?.user;
+  const phoneNormalized = parentUser?.phoneNormalized?.trim();
+  if (!phoneNormalized) throw new WhatsAppSendError('WHATSAPP_PARENT_PHONE_MISSING');
+
+  const parentDisplayName = [parentUser.firstName, parentUser.lastName].filter(Boolean).join(' ') || 'Madame, Monsieur';
+  const { buildBilanUpdateWhatsAppMessage } = await import('./whatsapp-message');
+  const message = buildBilanUpdateWhatsAppMessage({
+    parentDisplayName,
+    studentFirstName: artifact.student.user.firstName?.trim() || 'votre enfant',
+    updatedAtLabel: new Intl.DateTimeFormat('fr-FR', { dateStyle: 'long' }).format(current.materialization.materializedAt),
+  });
+  return Object.freeze({
+    whatsappUrl: buildParentWhatsAppUrl(phoneNormalized, message),
+    message,
   });
 }

--- a/lib/bilans/worker/generate-report-job.ts
+++ b/lib/bilans/worker/generate-report-job.ts
@@ -181,7 +181,7 @@ async function claimJob(
   if (job.status === 'COMPLETED') {
     const snapshot = await transaction.scoreSnapshot.findUnique({ where: { assessmentAttemptId: job.aggregateId } });
     if (snapshot === null) throw new GenerateReportJobError('A88_COMPLETED_JOB_INCONSISTENT');
-    const revision = await transaction.reportRevision.findUnique({ where: { scoreSnapshotId: snapshot.id } });
+    const revision = await transaction.reportRevision.findFirst({ where: { scoreSnapshotId: snapshot.id, generation: 1 } });
     if (revision === null) throw new GenerateReportJobError('A88_COMPLETED_JOB_INCONSISTENT');
     return { replayed: true, revisionId: revision.id, artifactId: revision.reportArtifactId };
   }

--- a/prisma/migrations/20260814090000_add_report_regeneration/migration.sql
+++ b/prisma/migrations/20260814090000_add_report_regeneration/migration.sql
@@ -1,0 +1,70 @@
+-- Régénération des bilans — évolution ADDITIVE.
+--
+-- Décision responsable (13/08/2026) : quand une règle évolue, l'assistante
+-- régénère elle-même le rendu depuis l'évidence. Le snapshot de score reste
+-- intact ; l'historique intégral des révisions est conservé (aucune ligne
+-- existante modifiée ni supprimée) ; chaque régénération est tracée
+-- (append-only) : qui, quand, motif, versions de règle avant/après.
+
+-- 1. Une génération de rendu par snapshot ET par version de règle :
+--    l'unicité stricte (un seul rendu à vie) devient [snapshot, génération].
+ALTER TABLE "canonical_report_revisions"
+  ADD COLUMN "generation" INTEGER NOT NULL DEFAULT 1;
+
+DROP INDEX "canonical_report_revisions_scoreSnapshotId_key";
+
+CREATE UNIQUE INDEX "canonical_report_revisions_scoreSnapshotId_generation_key"
+  ON "canonical_report_revisions"("scoreSnapshotId", "generation");
+
+-- 2. Trace append-only des régénérations.
+CREATE TABLE "canonical_report_regenerations" (
+  "id" TEXT NOT NULL,
+  "fromRevisionId" TEXT NOT NULL,
+  "toRevisionId" TEXT NOT NULL,
+  "requestedById" TEXT NOT NULL,
+  "motif" TEXT NOT NULL,
+  "engineVersionBefore" TEXT NOT NULL,
+  "engineVersionAfter" TEXT NOT NULL,
+  "briefRegenerated" BOOLEAN NOT NULL DEFAULT false,
+  "briefPromptVersion" TEXT,
+  "briefModel" TEXT,
+  "profileDiff" JSONB NOT NULL,
+  "wasPublished" BOOLEAN NOT NULL DEFAULT false,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "canonical_report_regenerations_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "canonical_report_regenerations_toRevisionId_idx"
+  ON "canonical_report_regenerations"("toRevisionId");
+CREATE INDEX "canonical_report_regenerations_createdAt_idx"
+  ON "canonical_report_regenerations"("createdAt");
+
+ALTER TABLE "canonical_report_regenerations"
+  ADD CONSTRAINT "canonical_report_regenerations_fromRevisionId_fkey"
+  FOREIGN KEY ("fromRevisionId") REFERENCES "canonical_report_revisions"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "canonical_report_regenerations"
+  ADD CONSTRAINT "canonical_report_regenerations_toRevisionId_fkey"
+  FOREIGN KEY ("toRevisionId") REFERENCES "canonical_report_revisions"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "canonical_report_regenerations"
+  ADD CONSTRAINT "canonical_report_regenerations_requestedById_fkey"
+  FOREIGN KEY ("requestedById") REFERENCES "users"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Un motif vide n'est pas un motif.
+ALTER TABLE "canonical_report_regenerations"
+  ADD CONSTRAINT "canonical_report_regenerations_motif_meaningful"
+  CHECK (length(btrim("motif")) >= 5);
+
+-- Append-only : la trace ne se réécrit jamais.
+CREATE OR REPLACE FUNCTION canonical_bilans_guard_regeneration_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'canonical report regenerations are append-only and cannot be %', TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER canonical_report_regenerations_append_only
+  BEFORE UPDATE OR DELETE ON "canonical_report_regenerations"
+  FOR EACH ROW EXECUTE FUNCTION canonical_bilans_guard_regeneration_mutation();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -259,6 +259,7 @@ model User {
   @@index([phoneNormalized])
   @@index([mergedIntoUserId])
   @@map("users")
+  reportRegenerationsRequested ReportRegeneration[] @relation("ReportRegenerationsRequested")
 }
 
 // Profil Parent
@@ -1661,17 +1662,51 @@ model ReportRevision {
   content               Json
   validationFailures    String[] @default([])
 
+  /// Génération du rendu pour ce snapshot : 1 à la création, incrémentée à
+  /// chaque régénération (règle/rendu mis à jour). Le snapshot de score,
+  /// lui, ne change jamais.
+  generation Int @default(1)
+
   currentForArtifact ReportArtifact?        @relation("ReportArtifactCurrentPublishedRevision")
   reviews            ReportReview[]
   materialization    ReportMaterialization?
+  regenerationsFrom  ReportRegeneration[]   @relation("RegenerationFromRevision")
+  regenerationsTo    ReportRegeneration[]   @relation("RegenerationToRevision")
 
   createdAt DateTime @default(now())
 
-  @@unique([scoreSnapshotId])
+  @@unique([scoreSnapshotId, generation])
   @@unique([id, reportArtifactId])
   @@index([reportArtifactId, createdAt])
   @@index([scoreSnapshotId])
   @@map("canonical_report_revisions")
+}
+
+/// Trace append-only d'une régénération de bilan : qui, quand, pourquoi,
+/// versions de règle avant/après, brief LLM régénéré ou non, et le diff de
+/// profils constaté. L'historique intégral des révisions est conservé —
+/// cette table dit pourquoi une nouvelle génération existe.
+model ReportRegeneration {
+  id             String         @id @default(cuid())
+  fromRevisionId String
+  fromRevision   ReportRevision @relation("RegenerationFromRevision", fields: [fromRevisionId], references: [id], onDelete: Restrict)
+  toRevisionId   String
+  toRevision     ReportRevision @relation("RegenerationToRevision", fields: [toRevisionId], references: [id], onDelete: Restrict)
+  requestedById  String
+  requestedBy    User           @relation("ReportRegenerationsRequested", fields: [requestedById], references: [id], onDelete: Restrict)
+  motif          String
+  engineVersionBefore String
+  engineVersionAfter  String
+  briefRegenerated    Boolean  @default(false)
+  briefPromptVersion  String?
+  briefModel          String?
+  profileDiff         Json
+  wasPublished        Boolean  @default(false)
+  createdAt           DateTime @default(now())
+
+  @@index([toRevisionId])
+  @@index([createdAt])
+  @@map("canonical_report_regenerations")
 }
 
 model ReportMaterialization {


### PR DESCRIPTION
## Une seule version visible après régénération — point 1 (arbitrage responsable)

> ⚠️ **Cette PR ré-achemine aussi #138 vers main.** #138 (régénération + option 3) avait été mergée dans la branche de #137 **après** que celle-ci soit passée sur main — elle n'a donc **jamais atteint main**. main (`567d2fa9e`) n'a ni le service de régénération ni sa migration. Ce lot les apporte, avec le filtre par-dessus. **À merger vers main.**

### Ce qui était déjà correct
Les surfaces familles — **lien signé, espace parent, espace élève, PDF servis** — sélectionnent toutes `currentPublishedRevisionId`, que la re-publication bascule vers la dernière génération. L'ancienne génération y était **déjà invisible**. La seule fuite : le **dashboard assistante**, dont `listRecent` remontait toute révision d'un artefact publié (gén. rejetée + ancienne publiée + courante).

### Le correctif
`listRecentReportReviews` filtre sur la **génération maximale par artefact** (`onlyCurrentGeneration`). Une ligne par bilan, la génération courante. Aucun sélecteur de version. Un bilan simplement **rejeté** (jamais régénéré) reste visible (sa génération est la seule, donc la maximale). La **trace de régénération subsiste** en base — consultable par requête d'audit, hors de toute surface courante.

### Décompte dashboard — les 13 attempts concernés
| | Sans filtre | Avec filtre |
|---|---|---|
| Aujourd'hui (0 régénération) | 13 lignes | 13 lignes |
| Après régénération des 13 | **26 lignes** (remplacée + courante) | **13 lignes** (une courante par bilan) |

### Tests
- **Unitaires** : génération max par artefact ; bilan rejeté conservé ; deux bilans distincts = deux lignes.
- **Réels (PostgreSQL)** : après régénération jusqu'à la génération 3 — le dashboard ne montre qu'une ligne (gén. 3) ; `currentPublishedRevisionId` pointe la gén. 3 ; l'ancienne matérialisation gén. 2 **subsiste** (append-only) mais n'est **plus référencée** ; un lien signé frais **ne sert jamais** l'ancien rendu.

### Purge disque — non livrée (documentée, différée)
`docs/specs/bilans/09-amelioration-differee-purge-pdf.md` : les PDF sont des `bytea` dans la table **immuable** ; les libérer exigerait de séparer le cache PDF de la preuve HTML+checksum — migration lourde sur la table la plus protégée, pour **~1,7 Mo une seule fois** (kamel), 0 octet pour les 12 en attente. Non justifié maintenant, à reprendre à froid si le volume l'exige. Le besoin exprimé (ni encombrement, ni confusion) est **intégralement réglé par le filtre**.

Suite complète **9 067 tests** verte, tsc, cinq contrôles Lint, scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Affiche une seule génération par bilan sur le dashboard assistante et livre la régénération tracée des bilans. Avant, le dashboard listait toutes les révisions d’un artefact publié; maintenant, il montre une seule ligne par bilan (génération courante). Les liens famille restent inchangés, l’historique et la trace de régénération sont conservés. Cette PR réachemine aussi #138 vers `main` pour apporter le service et la migration de régénération.

- La régénération crée une nouvelle révision avec `generation` incrémentée, retire l’ancienne de la file par un rejet tracé, et exige une confirmation explicite si le bilan était déjà publié. La re-publication bascule `currentPublishedRevisionId` en gardant l’artefact à l’état PUBLISHED pendant la re-revue.
- Les surfaces familles (lien signé, espace parent/élève, PDF) servent toujours la génération courante; la page d’arrivée affiche “Version mise à jour … remplace …” quand une régénération a été re-publiée. Un message WhatsApp d’information peut être préparé si une transmission antérieure a été confirmée; aucun lien n’est révoqué ni réémis.

**Revue et déploiement**
- Migration additive Prisma:
  - Ajoute `generation` sur `canonical_report_revisions` et rend l’unicité `[@scoreSnapshotId, generation]`.
  - Crée `canonical_report_regenerations` avec trigger append-only et contrainte de motif (≥ 5 caractères).
  - Action requise: exécuter la migration; aucun backfill ni suppression de données existantes.
- Comportements à vérifier:
  - Dashboard: `listRecentReportReviews` filtre sur la génération maximale par artefact (une ligne par bilan).
  - Publication: `publishReportRevision` accepte la re-publication d’une génération > 1 sur un artefact PUBLISHED.
  - Lien famille: `verifyAndConsumeShareToken` expose `updatedVersion`; la page `/bilan/consultation/[token]` affiche la mention de remplacement.

<sup>Written for commit de32d9fbe161bc7316fe4d85165b8a6c4f14b4d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

