### PR TITLE
fix(bilans): le libellé ne dit plus « diffusion bloquée » quand un téléphone suffit

### DIFF
--- a/app/dashboard/assistante/bilans/page.tsx
+++ b/app/dashboard/assistante/bilans/page.tsx
@@ -265,7 +265,10 @@ export default async function CanonicalBilansReviewPage({
                     <section className="border-b border-amber-300/20 bg-amber-300/10 px-6 py-5">
                       <h3 className="font-semibold text-amber-100">Ajouter l’e-mail du parent</h3>
                       <p className="mt-1 text-sm text-slate-300">
-                        Le bilan est prêt. L'activation parent et la diffusion restent bloquées jusqu'à cette complétion.
+                        L'e-mail est nécessaire pour créer l'accès en ligne du parent (activation du compte).
+                        {revision.parentPhoneMissing
+                          ? ' La diffusion attend un contact : renseignez un e-mail ou un téléphone.'
+                          : ' La diffusion, elle, est déjà possible par WhatsApp au téléphone enregistré.'}
                       </p>
                       <form action={addParentEmailAction} className="mt-3 flex flex-col gap-3 sm:flex-row">
                         <input type="hidden" name="revisionId" value={revision.id} />

--- a/app/dashboard/assistante/bilans/saisie-papier/family-form.tsx
+++ b/app/dashboard/assistante/bilans/saisie-papier/family-form.tsx
@@ -169,7 +169,8 @@ export function PaperEntryFamilyForm() {
       </div>
 
       <p className="text-sm text-slate-400">
-        Sans e-mail, le bilan peut être saisi et généré. L'accès parent et la diffusion seront débloqués après sa complétion.
+        Sans e-mail, le bilan peut être saisi, généré et diffusé au parent par WhatsApp (téléphone). L'e-mail
+        reste utile pour lui ouvrir un accès en ligne (activation du compte) — il peut être ajouté plus tard.
       </p>
 
       <ul className="space-y-3">


### PR DESCRIPTION
Défaut de libellé constaté en prod lors du déploiement #139 (Fares Darghouth, foyer au **téléphone seul**) : l'encadré ambre « Ajouter l'e-mail du parent » affirmait « L'activation parent et **la diffusion restent bloquées** jusqu'à cette complétion » — mais depuis #136 la diffusion marche dès qu'il existe **un canal** (téléphone OU e-mail). Le bouton « Valider et diffuser » était bien **actionnable** (vérifié dans le DOM : `disabled: false`) ; seul le texte mentait.

**Correction** : l'e-mail est présenté pour ce qu'il fait — créer l'**accès en ligne** du parent (activation du compte) — et le texte distingue *téléphone présent* (« diffusion déjà possible par WhatsApp ») de *aucun contact* (« la diffusion attend un contact »). Même correction sur le formulaire de saisie papier. Le garde est inchangé : sans **aucun** canal, la diffusion reste bloquée.

Audit : aucun autre libellé ne contredit la règle téléphone-OU-e-mail (le seul autre emploi de « diffusion bloquée » est un commentaire exact du service sur le cas *sans aucun canal*).

Suite complète **9067 tests** verte, tsc, cinq contrôles Lint, scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrige les libellés qui annonçaient à tort « diffusion bloquée » quand un téléphone est déjà présent. Avant: l’encadré demandant l’e‑mail disait que l’activation parent et la diffusion étaient bloquées. Maintenant: l’e‑mail est présenté comme nécessaire pour créer l’accès en ligne du parent, et la diffusion est indiquée comme possible par WhatsApp si un téléphone existe; elle n’attend un contact que si aucun canal n’est renseigné.

- Points de revue
  - Texte mis à jour dans `app/dashboard/assistante/bilans/page.tsx` (message conditionnel selon présence du téléphone) et `app/dashboard/assistante/bilans/saisie-papier/family-form.tsx`.
  - La logique métier ne change pas: sans aucun canal (ni téléphone ni e‑mail), la diffusion reste bloquée.
  - Vérifier l’affichage dans les deux états: avec téléphone présent (diffusion possible) et sans aucun contact (diffusion en attente).

<sup>Written for commit d5241220661db4de7b33e9e5931db9cdd6922e22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

