### PR TITLE
fix(worker): plafond de tentatives — un job en échec ne boucle plus à l'infini

### DIFF
--- a/__tests__/integration/bilans-canonical-outbox-drainer.test.ts
+++ b/__tests__/integration/bilans-canonical-outbox-drainer.test.ts
@@ -1,7 +1,7 @@
 jest.unmock('@/lib/prisma');
 
 import { prisma } from '@/lib/prisma';
-import { drainScoreAttemptJobs } from '@/lib/bilans/worker/drain-outbox';
+import { drainScoreAttemptJobs, MAX_JOB_ATTEMPTS } from '@/lib/bilans/worker/drain-outbox';
 import { processScoreAttemptJob } from '@/lib/bilans/worker/score-job';
 import {
   CANONICAL_WORKER_ANSWERS,
@@ -32,6 +32,58 @@ describe('Canonical scoring outbox drainer', () => {
 
   afterAll(async () => {
     await prisma.$disconnect();
+  });
+
+  test('quarantaine : un job ayant atteint le plafond de tentatives n’est plus réclamé', async () => {
+    // Le job poison du 13/08/2026 : échec déterministe répété. Au plafond, il
+    // sort de la file active mais reste en base (diagnostic + supervision).
+    const poison = await prisma.jobOutbox.create({
+      data: {
+        jobType: 'SCORE_ATTEMPT',
+        aggregateType: 'CanonicalAssessmentAttempt',
+        aggregateId: `${PREFIX}poison`,
+        sourceEventKey: `${PREFIX}source-poison`,
+        idempotencyKey: `${PREFIX}idem-poison`,
+        status: 'FAILED',
+        attemptCount: MAX_JOB_ATTEMPTS,
+        lastError: 'A86_SCORING_FAILED',
+        payload: { attemptId: `${PREFIX}poison`, packSlug: 'fixture', packVersion: 1 },
+      },
+    });
+    const processed: string[] = [];
+    const result = await drainScoreAttemptJobs({ limit: 10 }, {
+      prisma,
+      processJob: async (jobId) => { processed.push(jobId); },
+    });
+    // Jamais réclamé, et signalé en quarantaine.
+    expect(processed).not.toContain(poison.id);
+    expect(result.claimed).toBe(0);
+    expect(result.quarantined).toBeGreaterThanOrEqual(1);
+    // Toujours en base — non supprimé.
+    const still = await prisma.jobOutbox.findUnique({ where: { id: poison.id } });
+    expect(still).not.toBeNull();
+    expect(still?.attemptCount).toBe(MAX_JOB_ATTEMPTS);
+  });
+
+  test('un job juste sous le plafond reste réclamé', async () => {
+    const almost = await prisma.jobOutbox.create({
+      data: {
+        jobType: 'SCORE_ATTEMPT',
+        aggregateType: 'CanonicalAssessmentAttempt',
+        aggregateId: `${PREFIX}almost`,
+        sourceEventKey: `${PREFIX}source-almost`,
+        idempotencyKey: `${PREFIX}idem-almost`,
+        status: 'FAILED',
+        attemptCount: MAX_JOB_ATTEMPTS - 1,
+        payload: { attemptId: `${PREFIX}almost`, packSlug: 'fixture', packVersion: 1 },
+      },
+    });
+    const processed: string[] = [];
+    await drainScoreAttemptJobs({ limit: 10 }, {
+      prisma,
+      processJob: async (jobId) => { processed.push(jobId); },
+    });
+    expect(processed).toContain(almost.id);
   });
 
   test('drains a pending job once', async () => {

--- a/lib/bilans/worker/drain-outbox.ts
+++ b/lib/bilans/worker/drain-outbox.ts
@@ -7,7 +7,7 @@ import { prisma } from '@/lib/prisma';
 import { processScoreAttemptJob } from './score-job';
 import { processGenerateReportJob } from './generate-report-job';
 
-type DrainDatabase = Pick<PrismaClient, '$transaction'>;
+type DrainDatabase = Pick<PrismaClient, '$transaction' | '$queryRaw'>;
 type DrainLogger = Readonly<{
   info(event: Readonly<Record<string, unknown>>): void;
   error(event: Readonly<Record<string, unknown>>): void;
@@ -53,6 +53,17 @@ function boundedLimit(value: number | undefined): number {
   return limit;
 }
 
+/**
+ * Plafond de tentatives : au-delà, un job en échec DÉTERMINISTE (pack
+ * indisponible, réponses malformées…) n'est plus réclamé — sinon il boucle à
+ * l'infini et occupe un créneau de worker à chaque cycle (incident du
+ * 13/08/2026 : un job SCORE en échec 806 fois). Le job reste en base
+ * (diagnostic possible) mais sort de la file active : c'est une quarantaine,
+ * pas une suppression. Chaque cycle journalise les jobs ainsi mis de côté
+ * pour qu'ils restent visibles.
+ */
+export const MAX_JOB_ATTEMPTS = 20;
+
 function leaseDuration(value: number | undefined): number {
   const duration = value ?? 5 * 60_000;
   if (!Number.isSafeInteger(duration) || duration < 1_000 || duration > 30 * 60_000) {
@@ -72,6 +83,7 @@ async function claimJobs(
       FROM "canonical_job_outbox"
       WHERE "jobType" = ${jobType}::"CanonicalJobType"
         AND "availableAt" <= ${input.now}
+        AND "attemptCount" < ${MAX_JOB_ATTEMPTS}
         AND (
           "status" IN ('PENDING'::"CanonicalOutboxStatus", 'FAILED'::"CanonicalOutboxStatus")
           OR (
@@ -131,7 +143,21 @@ async function drainJobs(
     }
   }
 
-  const result = Object.freeze({ claimed: jobIds.length, completed, failed });
+  // Visibilité : les jobs mis en quarantaine (plafond de tentatives atteint)
+  // ne sont plus réclamés mais restent en base. On les compte à chaque cycle
+  // pour qu'ils ne disparaissent pas silencieusement de la supervision.
+  const quarantined = await deps.prisma.$queryRaw<Array<{ count: bigint }>>(Prisma.sql`
+    SELECT count(*)::bigint AS count
+    FROM "canonical_job_outbox"
+    WHERE "jobType" = ${jobType}::"CanonicalJobType"
+      AND "attemptCount" >= ${MAX_JOB_ATTEMPTS}
+  `);
+  const quarantinedCount = Number(quarantined[0]?.count ?? BigInt(0));
+  if (quarantinedCount > 0) {
+    deps.logger.error({ event: `${eventPrefix}_JOBS_QUARANTINED`, jobType, count: quarantinedCount, maxAttempts: MAX_JOB_ATTEMPTS });
+  }
+
+  const result = Object.freeze({ claimed: jobIds.length, completed, failed, quarantined: quarantinedCount });
   deps.logger.info({ event: `${eventPrefix}_DRAIN_COMPLETED`, ...result, durationMs: Date.now() - startedAt });
   return result;
 }


### PR DESCRIPTION
Incident constaté au déploiement #139 : un job `SCORE_ATTEMPT` en échec **déterministe** (un attempt dont le scoring échoue de façon reproductible) a été réclamé et a échoué **806 fois** — la requête de claim ré-attrapait les `FAILED` **sans plafond**, occupant un créneau de worker à chaque cycle.

**Correctif** : `MAX_JOB_ATTEMPTS = 20`. Au plafond, le job n'est plus réclamé (`attemptCount < MAX` dans le claim) mais **reste en base** — quarantaine, pas suppression. Chaque cycle compte et journalise les jobs en quarantaine (`*_JOBS_QUARANTINED`) pour la supervision, et le drain expose `quarantined`.

**Tests réels** : un job à MAX n'est jamais réclamé et subsiste ; un job juste sous le plafond reste réclamé.

Le job poison de prod a été **mis en quarantaine manuellement** (availableAt différé, réversible) en attendant ce garde ; l'attempt sous-jacent (`cmsrts3qf…`, entree-seconde-francais-v1) reste à investiguer côté données — il ne bloque plus le worker.

Suite complète **9067 tests** verte, tsc, cinq contrôles Lint, scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents infinite re-claiming of deterministically failing SCORE_ATTEMPT jobs. Previously FAILED jobs were re-claimed without limit; now jobs with attemptCount >= MAX_JOB_ATTEMPTS (20) are skipped, remain in the database for diagnosis, and are reported as quarantined.

- Enforces attemptCount < MAX_JOB_ATTEMPTS in the claim query and exports MAX_JOB_ATTEMPTS from `lib/bilans/worker/drain-outbox`.
- Counts and logs quarantined jobs each drain cycle (`*_JOBS_QUARANTINED`) and adds quarantined to the drain result.
- Extends DrainDatabase to include $queryRaw; integration tests cover ceiling and near-ceiling scenarios.
- No migration required; existing poison jobs will quarantine automatically once they reach the ceiling.

<sup>Written for commit ee37f94c07807b76891758563ec1a0e2d194775f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

