### PR TITLE
fix(bilans): « Sans réponse » scorable de bout en bout + échec de scoring visible et alerté

### DIFF
--- a/__tests__/bilans/saisie-papier-parite.test.ts
+++ b/__tests__/bilans/saisie-papier-parite.test.ts
@@ -223,3 +223,54 @@ describe('Saisie papier — refus des réponses hors pack', () => {
     expect(() => assertAttemptComplete(stored, CANONICAL_WORKER_ENABLED_PACK)).toThrow();
   });
 });
+
+describe('Saisie papier — « Sans réponse » scorable de bout en bout', () => {
+  /**
+   * Le défaut du 13/08/2026 : la saisie acceptait « Sans réponse »
+   * (optionId null) — grille, API, assertAttemptComplete — mais le worker de
+   * scoring la rejetait (A86_ANSWER_MISSING, masqué en A86_WORKER_FAILED). Un
+   * élève avec une copie partielle restait sans bilan. Parité rétablie : ce
+   * que la saisie accepte, le moteur le score.
+   */
+  const withBlanks: readonly AttemptAnswerPatch[] = ITEMS.map((item, index) => (
+    index < 2
+      ? { itemId: item.id, optionId: null as unknown as string, confidence: null }
+      : {
+          itemId: item.id,
+          optionId: item.options.find(({ isCorrect }) => isCorrect)!.id,
+          confidence: 3 as const,
+        }
+  ));
+
+  it('la saisie accepte la copie avec « Sans réponse » (assertAttemptComplete passe)', () => {
+    const stored = buildPaperEntryAnswers(CANONICAL_WORKER_ENABLED_PACK, withBlanks.map((r) => ({
+      itemId: r.itemId, optionId: r.optionId, confidence: r.confidence,
+    })));
+    expect(() => assertAttemptComplete(stored, CANONICAL_WORKER_ENABLED_PACK)).not.toThrow();
+    expect(stored[ITEMS[0].id]).toEqual({ optionId: null, confidence: null });
+  });
+
+  it('le worker score la même copie : les items sans réponse deviennent NON_TRAITE', () => {
+    const stored = buildPaperEntryAnswers(CANONICAL_WORKER_ENABLED_PACK, withBlanks.map((r) => ({
+      itemId: r.itemId, optionId: r.optionId, confidence: r.confidence,
+    })));
+    // Ne jette plus A86_ANSWER_MISSING.
+    const scoring = scoringOf(stored);
+    const nonTraites = scoring.facts.items.filter((i) => i.profile === 'NON_TRAITE');
+    expect(nonTraites).toHaveLength(2);
+    // La couverture reflète les items réellement traités.
+    expect(scoring.factSheet.coverage).toBeCloseTo(100 * (ITEMS.length - 2) / ITEMS.length, 1);
+  });
+
+  it('une non-réponse assortie d’une certitude est refusée (donnée incohérente)', () => {
+    const incoherent = { [ITEMS[0].id]: { optionId: null, confidence: 3 } } as unknown;
+    const full: Record<string, unknown> = {};
+    ITEMS.forEach((item, index) => {
+      full[item.id] = index === 0
+        ? { optionId: null, confidence: 3 }
+        : { optionId: item.options.find(({ isCorrect }) => isCorrect)!.id, confidence: 3 };
+    });
+    expect(() => scoringOf(full)).toThrow('A86_ANSWER_OPTION_INVALID');
+    void incoherent;
+  });
+});

--- a/__tests__/integration/bilans-canonical-outbox-drainer.test.ts
+++ b/__tests__/integration/bilans-canonical-outbox-drainer.test.ts
@@ -86,6 +86,37 @@ describe('Canonical scoring outbox drainer', () => {
     expect(processed).toContain(almost.id);
   });
 
+
+  test('quarantaine : une alerte (notification assistante) est créée, puis dédupliquée', async () => {
+    // Isole du bruit d'autres suites partageant la base jetable.
+    await prisma.notification.deleteMany({ where: { type: 'SCORING_JOB_QUARANTINED' } });
+    const assistant = await prisma.user.create({
+      data: { email: `${PREFIX}assistante@example.test`, role: 'ASSISTANTE' },
+    });
+    await prisma.jobOutbox.create({
+      data: {
+        jobType: 'SCORE_ATTEMPT', aggregateType: 'CanonicalAssessmentAttempt',
+        aggregateId: `${PREFIX}alert`, sourceEventKey: `${PREFIX}src-alert`,
+        idempotencyKey: `${PREFIX}idem-alert`, status: 'FAILED',
+        attemptCount: MAX_JOB_ATTEMPTS, lastError: 'A86_ANSWER_MISSING',
+        payload: { attemptId: `${PREFIX}alert`, packSlug: 'fixture', packVersion: 1 },
+      },
+    });
+    await drainScoreAttemptJobs({ limit: 5 }, { prisma, processJob: async () => {} });
+    const first = await prisma.notification.count({
+      where: { userId: assistant.id, type: 'SCORING_JOB_QUARANTINED', read: false },
+    });
+    expect(first).toBe(1);
+    // Deuxième cycle : pas de doublon tant que non lue.
+    await drainScoreAttemptJobs({ limit: 5 }, { prisma, processJob: async () => {} });
+    const second = await prisma.notification.count({
+      where: { userId: assistant.id, type: 'SCORING_JOB_QUARANTINED', read: false },
+    });
+    expect(second).toBe(1);
+    await prisma.notification.deleteMany({ where: { userId: assistant.id } });
+    await prisma.user.delete({ where: { id: assistant.id } });
+  });
+
   test('drains a pending job once', async () => {
     const job = await seedJob('pending');
     const processed: string[] = [];

--- a/__tests__/integration/bilans-canonical-worker-review.test.ts
+++ b/__tests__/integration/bilans-canonical-worker-review.test.ts
@@ -181,10 +181,29 @@ describe('A86 deterministic worker and internal review service', () => {
       prisma.jobOutbox.findUniqueOrThrow({ where: { id: seeded.job.id } }),
       prisma.canonicalAssessmentAttempt.findUniqueOrThrow({ where: { id: seeded.attempt.id } }),
     ]);
-    expect(job).toMatchObject({ status: 'FAILED', lastError: code });
+    // La cause réelle (« injected ») est préservée, jamais écrasée par le code seul.
+    expect(job.status).toBe('FAILED');
+    expect(job.lastError).toBe(`${code}: injected`);
     expect(attempt.status).toBe('SUBMITTED');
     expect(await prisma.scoreSnapshot.count({ where: { assessmentAttemptId: attempt.id } })).toBe(0);
     expect(await prisma.reportArtifact.count({ where: { assessmentAttemptId: attempt.id } })).toBe(0);
+  });
+
+  test('préserve la cause réelle au lieu du code générique (fin du masquage A86_WORKER_FAILED)', async () => {
+    // buildInputs lève `A86_ANSWER_MISSING` AVANT toute étape → le code de
+    // stage est le générique A86_WORKER_FAILED. Sans préservation, la cause
+    // réelle était perdue (834 tentatives opaques du 13/08/2026). On prouve
+    // qu'elle figure désormais dans lastError et n'est pas remplacée.
+    const seeded = await seedAttempt('mask');
+    const brokenScoring = {
+      computeFacts: () => { throw new Error('A86_ANSWER_MISSING'); },
+    };
+    await expect(processScoreAttemptJob(seeded.job.id, { ...dependencies, ...brokenScoring } as never))
+      .rejects.toThrow();
+    const job = await prisma.jobOutbox.findUniqueOrThrow({ where: { id: seeded.job.id } });
+    expect(job.status).toBe('FAILED');
+    // La cause réelle est lisible, pas noyée sous un code générique seul.
+    expect(job.lastError).toContain('A86_ANSWER_MISSING');
   });
 
   test('never publishes an invented report on LLM failure, then recovers on the next drain', async () => {

--- a/app/dashboard/assistante/bilans/page.tsx
+++ b/app/dashboard/assistante/bilans/page.tsx
@@ -5,6 +5,7 @@ import { auth } from '@/auth';
 import {
   diffusionBlockedReasons,
   listRecentReportReviews,
+  listScoringFailures,
   previewPendingReport,
   StaffReviewError,
   type RecentReportReview,
@@ -108,6 +109,7 @@ export default async function CanonicalBilansReviewPage({
     if (error instanceof StaffReviewError && error.code === 'NOT_FOUND') notFound();
     throw error;
   }
+  const scoringFailures = await listScoringFailures({ userId: session.user.id, role: session.user.role });
   const statusCounts = {
     missingEmail: revisions.filter(({ displayStatus }) => displayStatus === 'Prêt — contact parent manquant').length,
     pending: revisions.filter(({ displayStatus }) => displayStatus === 'En attente de diffusion').length,
@@ -179,6 +181,25 @@ export default async function CanonicalBilansReviewPage({
             Saisir un bilan passé sur copie papier
           </Link>
         </header>
+
+        {scoringFailures.length > 0 && (
+          <section className="mt-6 rounded-2xl border border-red-400/40 bg-red-400/10 p-5" data-testid="scoring-impossible">
+            <h2 className="font-semibold text-red-100">Scoring impossible — élève sans bilan, à reprendre</h2>
+            <p className="mt-1 text-sm text-red-100/80">
+              {scoringFailures.length === 1 ? 'Une passation n’a pas pu être scorée' : `${scoringFailures.length} passations n’ont pas pu être scorées`} : l’élève n’a pas de bilan. Vérifiez la copie et re-saisissez-la, ou signalez-la à l’équipe technique.
+            </p>
+            <ul className="mt-3 space-y-2 text-sm text-red-50">
+              {scoringFailures.map((failure) => (
+                <li key={failure.attemptId} className="flex flex-wrap items-baseline gap-x-3">
+                  <span className="font-semibold">{failure.studentName}</span>
+                  <span className="text-red-100/70">{provenanceLabel(failure.provenance)}</span>
+                  {failure.submittedAt !== null && <span className="text-red-100/70">soumis le {dateLabel(failure.submittedAt)}</span>}
+                  <span className="text-red-100/70">· {failure.attempts} tentative{failure.attempts > 1 ? 's' : ''}{failure.quarantined ? ' · en quarantaine' : ''}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
 
         <nav aria-label="Fil du workflow" className="mt-8 overflow-x-auto">
           <ol className="flex min-w-max items-center gap-2 text-xs text-slate-300">

--- a/lib/bilans/staff/review-service.ts
+++ b/lib/bilans/staff/review-service.ts
@@ -1,4 +1,4 @@
-import { ReportRevisionStatus, type UserRole } from '@prisma/client';
+import { ReportRevisionStatus, type PrismaClient, type UserRole } from '@prisma/client';
 
 import { prisma } from '@/lib/prisma';
 
@@ -453,6 +453,67 @@ export async function listRecentReportReviews(
   return Object.freeze(
     onlyCurrentGeneration(recent).map((revision) => recentReview(revision, dependencies)),
   );
+}
+
+export type ScoringFailure = Readonly<{
+  attemptId: string;
+  studentName: string;
+  provenance: string;
+  submittedAt: Date | null;
+  attempts: number;
+  quarantined: boolean;
+  lastError: string | null;
+}>;
+
+/**
+ * Les élèves restés SANS bilan parce que leur passation ne se score pas : une
+ * passation SOUMISE dont le job de scoring est en échec (et non un bilan déjà
+ * produit). Sans cette liste, un échec de scoring disparaît silencieusement —
+ * personne ne sait qu'un élève attend son bilan (défaut du 13/08/2026, copie
+ * « Sans réponse » rejetée par le worker). L'assistante voit l'état explicite
+ * « scoring impossible — à reprendre » et peut agir (re-saisir la copie).
+ */
+export async function listScoringFailures(
+  actor: ReviewActor,
+  overrides: Readonly<{ prisma?: Pick<PrismaClient, 'jobOutbox'>; maxAttempts?: number }> = {},
+): Promise<readonly ScoringFailure[]> {
+  assertAssistante(actor);
+  const database = overrides.prisma ?? prisma;
+  const maxAttempts = overrides.maxAttempts ?? 20;
+  const jobs = await database.jobOutbox.findMany({
+    where: { jobType: 'SCORE_ATTEMPT', status: 'FAILED', attemptCount: { gt: 0 } },
+    select: { aggregateId: true, attemptCount: true, lastError: true },
+    orderBy: { updatedAt: 'desc' },
+    take: 100,
+  });
+  if (jobs.length === 0) return Object.freeze([]);
+  const attemptIds = jobs.map((job) => job.aggregateId);
+  const attempts = await prisma.canonicalAssessmentAttempt.findMany({
+    where: { id: { in: attemptIds }, status: 'SUBMITTED' },
+    select: {
+      id: true, provenance: true, submittedAt: true,
+      student: { select: { user: { select: { firstName: true, lastName: true } } } },
+    },
+  });
+  const byId = new Map(attempts.map((attempt) => [attempt.id, attempt]));
+  const failures: ScoringFailure[] = [];
+  for (const job of jobs as ReadonlyArray<{ aggregateId: string; attemptCount: number; lastError: string | null }>) {
+    const attempt = byId.get(job.aggregateId);
+    if (attempt === undefined) continue; // job d'une passation déjà scorée ou disparue
+    failures.push(Object.freeze({
+      attemptId: attempt.id,
+      studentName: buildHumanRenderIdentity({
+        firstName: attempt.student.user.firstName,
+        lastName: attempt.student.user.lastName,
+      }).displayName,
+      provenance: attempt.provenance,
+      submittedAt: attempt.submittedAt,
+      attempts: job.attemptCount,
+      quarantined: job.attemptCount >= maxAttempts,
+      lastError: job.lastError,
+    }));
+  }
+  return Object.freeze(failures);
 }
 
 export async function validateAndPublishPendingReport(

--- a/lib/bilans/worker/drain-outbox.ts
+++ b/lib/bilans/worker/drain-outbox.ts
@@ -1,13 +1,13 @@
 import { randomUUID } from 'node:crypto';
 
-import { Prisma, type PrismaClient } from '@prisma/client';
+import { Prisma, UserRole, type PrismaClient } from '@prisma/client';
 
 import { prisma } from '@/lib/prisma';
 
 import { processScoreAttemptJob } from './score-job';
 import { processGenerateReportJob } from './generate-report-job';
 
-type DrainDatabase = Pick<PrismaClient, '$transaction' | '$queryRaw'>;
+type DrainDatabase = Pick<PrismaClient, '$transaction' | '$queryRaw' | 'user' | 'notification'>;
 type DrainLogger = Readonly<{
   info(event: Readonly<Record<string, unknown>>): void;
   error(event: Readonly<Record<string, unknown>>): void;
@@ -110,6 +110,37 @@ async function claimJobs(
   });
 }
 
+const QUARANTINE_NOTIFICATION_TYPE = 'SCORING_JOB_QUARANTINED';
+
+/**
+ * Crée une notification pour l'équipe assistante quand des jobs sont en
+ * quarantaine — dédupliquée : au plus UNE notification non lue par type de
+ * job à la fois, pour ne pas spammer à chaque cycle de drain. Elle reste
+ * jusqu'à lecture ; sa présence dit « des passations ne se scorent pas ».
+ */
+async function ensureQuarantineAlert(
+  database: DrainDatabase,
+  jobType: string,
+  count: number,
+): Promise<void> {
+  const already = await database.notification.findFirst({
+    where: { type: QUARANTINE_NOTIFICATION_TYPE, read: false, message: { contains: jobType } },
+    select: { id: true },
+  });
+  if (already !== null) return;
+  const assistants = await database.user.findMany({ where: { role: UserRole.ASSISTANTE }, select: { id: true } });
+  if (assistants.length === 0) return;
+  const rows: Prisma.NotificationCreateManyInput[] = assistants.map(({ id }) => ({
+    userId: id,
+    userRole: UserRole.ASSISTANTE,
+    type: QUARANTINE_NOTIFICATION_TYPE,
+    title: 'Scoring impossible — élève sans bilan',
+    message: `${count} passation(s) (${jobType}) ne se scorent pas après ${MAX_JOB_ATTEMPTS} tentatives. Ouvrez « Bilans » pour les reprendre.`,
+    data: { jobType, count, maxAttempts: MAX_JOB_ATTEMPTS },
+  }));
+  await database.notification.createMany({ data: rows });
+}
+
 async function drainJobs(
   jobType: 'SCORE_ATTEMPT' | 'GENERATE_REPORT',
   ownerPrefix: string,
@@ -155,6 +186,10 @@ async function drainJobs(
   const quarantinedCount = Number(quarantined[0]?.count ?? BigInt(0));
   if (quarantinedCount > 0) {
     deps.logger.error({ event: `${eventPrefix}_JOBS_QUARANTINED`, jobType, count: quarantinedCount, maxAttempts: MAX_JOB_ATTEMPTS });
+    // Alerte l'équipe — pas seulement le journal : un job en quarantaine
+    // signifie un élève potentiellement sans bilan. Déduplication : une seule
+    // notification non lue par type de job, pour ne pas spammer à chaque cycle.
+    await ensureQuarantineAlert(deps.prisma, jobType, quarantinedCount);
   }
 
   const result = Object.freeze({ claimed: jobIds.length, completed, failed, quarantined: quarantinedCount });

--- a/lib/bilans/worker/score-job.ts
+++ b/lib/bilans/worker/score-job.ts
@@ -199,17 +199,24 @@ export async function processScoreAttemptJob(
     return result;
   } catch (error) {
     const code = error instanceof ScoreJobError ? error.code : failureCode(stage);
+    // Préserver la CAUSE RÉELLE. Une erreur non typée (ex. `A86_ANSWER_MISSING`
+    // levée par buildInputs) était sinon remplacée par le code générique de
+    // stage (`A86_WORKER_FAILED`) : 834 tentatives opaques, cause indéchiffrable
+    // (incident du 13/08/2026). On conserve désormais le message d'origine dans
+    // lastError et dans les logs, sans jamais l'écraser.
+    const cause = error instanceof Error ? error.message : String(error);
+    const lastError = cause && cause !== code ? `${code}: ${cause}` : code;
     await dependencies.prisma.jobOutbox.updateMany({
       where: { id: jobId, status: { not: 'COMPLETED' } },
       data: {
         status: 'FAILED',
         attemptCount: { increment: 1 },
-        lastError: code,
+        lastError,
         leaseOwner: null,
         leaseExpiresAt: null,
       },
     });
-    dependencies.logger.error({ event: 'A86_SCORE_JOB_FAILED', jobId, code, durationMs: Date.now() - started });
+    dependencies.logger.error({ event: 'A86_SCORE_JOB_FAILED', jobId, code, cause, durationMs: Date.now() - started });
     throw new ScoreJobError(code);
   }
 }

--- a/lib/bilans/worker/scoring.ts
+++ b/lib/bilans/worker/scoring.ts
@@ -70,10 +70,38 @@ function buildInputs(input: WorkerScoringInput): Readonly<{
   const scoringAnswers: ScoringAnswer[] = [];
   for (const item of input.pack.questionnaire.items) {
     const stored = answers[item.id];
-    if (stored === undefined || typeof stored.optionId !== 'string') throw new Error('A86_ANSWER_MISSING');
-    const selected = item.options.find(({ id }) => id === stored.optionId);
+    // L'item DOIT figurer dans la passation (jamais d'omission silencieuse).
+    if (stored === undefined) throw new Error('A86_ANSWER_MISSING');
     const correct = item.options.find(({ isCorrect }) => isCorrect);
-    if (selected === undefined || correct === undefined) throw new Error('A86_ANSWER_OPTION_INVALID');
+    if (correct === undefined) throw new Error('A86_ANSWER_OPTION_INVALID');
+
+    // « Sans réponse » DÉCLARÉE (optionId null, sans certitude) : état de saisie
+    // légitime (grille + API l'acceptent, cf. assertAttemptComplete). Le moteur
+    // la profile NON_TRAITE. Avant ce correctif, le worker la rejetait
+    // (A86_ANSWER_MISSING) alors que la saisie l'avait acceptée — une copie
+    // avec « Sans réponse » restait sans bilan (13/08/2026).
+    if (stored.optionId === null) {
+      if (stored.confidence !== null) throw new Error('A86_ANSWER_OPTION_INVALID');
+      items.push({
+        id: item.id,
+        nodeCpsId: item.nodeCpsId,
+        type: 'QCM_SIMPLE',
+        difficulty: item.difficulty,
+        answerKey: { kind: 'QCM_SIMPLE', correct: correct.id },
+        targetTimeSec: item.targetTimeSec,
+      });
+      scoringAnswers.push({
+        itemId: item.id,
+        rawAnswer: null,
+        confidence: null,
+        elapsedMs: elapsedPerItem,
+      });
+      continue;
+    }
+
+    if (typeof stored.optionId !== 'string') throw new Error('A86_ANSWER_MISSING');
+    const selected = item.options.find(({ id }) => id === stored.optionId);
+    if (selected === undefined) throw new Error('A86_ANSWER_OPTION_INVALID');
     const declaredConfidence = confidence(stored.confidence);
     items.push({
       id: item.id,


### PR DESCRIPTION
## Cause racine — une fonctionnalité à moitié posée

L'élève **« 13b Ben Rhouma »** (saisie papier, 13/08 18:02, foyer de test du responsable) est resté **sans bilan** : son job de scoring a échoué **834 fois** avant d'être mis en quarantaine.

`A86_WORKER_FAILED` **masquait** la vraie erreur : `A86_ANSWER_MISSING` (une `Error` simple jetée avant qu'aucune étape ne soit posée, donc mappée sur le code générique). Reproduit sur les données réelles.

**Le vrai défaut** : la fonctionnalité **« Sans réponse »** livrée en #137 était **à moitié posée**. La **saisie** l'acceptait (grille + API + `assertAttemptComplete` : `optionId: null`, sans certitude → NON_TRAITE), mais le **worker de scoring** (`buildInputs`) exigeait toujours un `optionId` chaîne et rejetait `null`. Toute copie avec « Sans réponse » était **acceptée à la saisie puis refusée au scoring**.

## Ampleur — la question qui compte
- **1 seul attempt** concerné aujourd'hui (le seul SUBMITTED sans snapshot, le seul avec `optionId: null`).
- **Mais le risque était réel pour la semaine** : *toute* saisie papier utilisant « Sans réponse » aurait produit le même échec. Une assistante l'aurait déclenché.

## Correction — parité, visibilité, alerte
1. **Parité (root cause)** — `buildInputs` traite `optionId: null` comme le moteur : non-réponse → NON_TRAITE (`rawAnswer: null`), en **refusant** l'incohérence « sans réponse + certitude ». Ce que la saisie accepte, le worker le score. *(Vérifié : la copie 13b score désormais — 3 items NON_TRAITE, couverture 83 %, score 82,5.)*
2. **Visibilité** — `listScoringFailures()` liste les passations SOUMISES dont le scoring échoue ; le dashboard affiche un **bandeau rouge « Scoring impossible — élève sans bilan, à reprendre »** (nom, provenance, date, tentatives, quarantaine). Fini l'échec silencieux.
3. **Alerte** — la quarantaine crée une **notification assistante** (dédupliquée : une seule non lue par type de job), pas seulement un log.

## Tests
Parité « Sans réponse » scorée de bout en bout (NON_TRAITE, couverture correcte) ; incohérence null+certitude refusée ; alerte de quarantaine créée puis dédupliquée. **Suite complète 9070 tests** verte, tsc, cinq contrôles Lint, scans.

## Récupération de l'élève 13b — réservée à votre accord
Après déploiement, **sortir son job de quarantaine** (réinitialiser `attemptCount`/`availableAt`) le fera scorer normalement — la copie est intacte, le moteur la traite maintenant. **Données non touchées ici.** Les 13 régénérés en attente ne sont pas touchés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rend « Sans réponse » scorable de bout en bout et rend les échecs de scoring visibles et actionnables. Ancien comportement: le worker rejetait optionId:null (A86_ANSWER_MISSING) et masquait la cause sous A86_WORKER_FAILED; certaines copies restaient sans bilan. Nouveau: les items « Sans réponse » deviennent NON_TRAITE, l’incohérence « sans réponse + certitude » est refusée, et la cause réelle est préservée dans lastError et les logs.

- Principaux changements
  - Worker de scoring: accepte optionId:null avec confidence:null → NON_TRAITE; refuse null+certitude; maintient les contrôles d’intégrité.
  - Gestion d’erreurs: ne masque plus la cause réelle; lastError devient « <code>: <cause> » et le logger émet un champ cause distinct.
  - Service staff: ajoute listScoringFailures() listant les passations SOUMISES dont le scoring échoue (tentatives, quarantaine, erreur).
  - Dashboard assistante: affiche un bandeau rouge « Scoring impossible — élève sans bilan, à reprendre » avec détails par passation.
  - Drain outbox: crée une notification « quarantaine scoring » pour les assistantes, dédupliquée tant qu’elle n’est pas lue.

- Revue et déploiement
  - Pas de migration de schéma.
  - Action requise après déploiement: sortir de quarantaine les jobs de scoring bloqués (réinitialiser attemptCount/availableAt) pour relancer le scoring des passations concernées.

<sup>Written for commit 508128b67398a0b445777ace0681a6705d3ed791. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

