### PR TITLE
fix(stages): fermer et désindexer les stages expirés

### DIFF
--- a/__tests__/api/admin.stages.route.test.ts
+++ b/__tests__/api/admin.stages.route.test.ts
@@ -3,6 +3,7 @@ jest.mock('@/auth', () => ({
 }));
 
 import { auth } from '@/auth';
+import { Prisma } from '@prisma/client';
 import { NextRequest } from 'next/server';
 
 import { GET as listStages, POST as createStage } from '@/app/api/admin/stages/route';
@@ -11,13 +12,22 @@ import { GET as listSessions, POST as createSession } from '@/app/api/admin/stag
 import { GET as listCoaches, POST as assignCoach, DELETE as unassignCoach } from '@/app/api/admin/stages/[stageId]/coaches/route';
 
 const mockAuth = auth as jest.Mock;
+const NOW = new Date('2026-08-13T12:00:00.000Z');
+const EXPIRED_STAGE_ERROR = 'Un stage terminé ne peut pas être ouvert aux inscriptions';
+const CONCURRENT_STAGE_UPDATE_ERROR = 'Le stage a été modifié entre-temps. Veuillez réessayer.';
 
 let prisma: any;
 
 beforeEach(async () => {
+  jest.useFakeTimers();
+  jest.setSystemTime(NOW);
   const mod = await import('@/lib/prisma');
   prisma = (mod as any).prisma;
   jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
 });
 
 function makeRequest(url: string, init?: ConstructorParameters<typeof NextRequest>[1]) {
@@ -86,8 +96,8 @@ describe('POST /api/admin/stages', () => {
     type: 'INTENSIF',
     subject: ['MATHEMATIQUES'],
     level: ['Terminale'],
-    startDate: '2026-04-20T08:00:00.000Z',
-    endDate: '2026-04-25T17:00:00.000Z',
+    startDate: '2026-10-20T08:00:00.000Z',
+    endDate: '2026-10-25T17:00:00.000Z',
     capacity: 12,
     priceAmount: 650,
     priceCurrency: 'TND',
@@ -136,6 +146,99 @@ describe('POST /api/admin/stages', () => {
     expect(res.status).toBe(201);
     expect(body.stage.slug).toBe('stage-printemps');
   });
+
+  it('refuses an explicitly open expired stage before any database access', async () => {
+    mockAuth.mockResolvedValue(adminSession());
+
+    const res = await createStage(makeRequest('http://localhost:3000/api/admin/stages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...validBody,
+        startDate: '2026-04-20T08:00:00.000Z',
+        endDate: '2026-04-25T17:00:00.000Z',
+        isOpen: true,
+      }),
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body).toEqual({ error: EXPIRED_STAGE_ERROR });
+    expect(prisma.stage.findUnique).not.toHaveBeenCalled();
+    expect(prisma.stage.create).not.toHaveBeenCalled();
+  });
+
+  it('refuses an expired stage whose omitted isOpen defaults to open', async () => {
+    mockAuth.mockResolvedValue(adminSession());
+    const expiredBody: Partial<typeof validBody> = {
+      ...validBody,
+      startDate: '2026-04-20T08:00:00.000Z',
+      endDate: '2026-04-25T17:00:00.000Z',
+    };
+    delete expiredBody.isOpen;
+
+    const res = await createStage(makeRequest('http://localhost:3000/api/admin/stages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(expiredBody),
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body).toEqual({ error: EXPIRED_STAGE_ERROR });
+    expect(prisma.stage.findUnique).not.toHaveBeenCalled();
+    expect(prisma.stage.create).not.toHaveBeenCalled();
+  });
+
+  it('allows creating an expired stage when it is closed', async () => {
+    mockAuth.mockResolvedValue(adminSession());
+    prisma.stage.findUnique.mockResolvedValue(null);
+    prisma.stage.create.mockResolvedValue({
+      id: 'stage-history',
+      ...validBody,
+      startDate: new Date('2026-04-20T08:00:00.000Z'),
+      endDate: new Date('2026-04-25T17:00:00.000Z'),
+      isOpen: false,
+    });
+
+    const res = await createStage(makeRequest('http://localhost:3000/api/admin/stages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...validBody,
+        startDate: '2026-04-20T08:00:00.000Z',
+        endDate: '2026-04-25T17:00:00.000Z',
+        isOpen: false,
+      }),
+    }));
+
+    expect(res.status).toBe(201);
+    expect(prisma.stage.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows an open stage whose endDate equals now', async () => {
+    mockAuth.mockResolvedValue(adminSession());
+    prisma.stage.findUnique.mockResolvedValue(null);
+    prisma.stage.create.mockResolvedValue({
+      id: 'stage-boundary',
+      ...validBody,
+      startDate: new Date('2026-08-13T08:00:00.000Z'),
+      endDate: NOW,
+    });
+
+    const res = await createStage(makeRequest('http://localhost:3000/api/admin/stages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...validBody,
+        startDate: '2026-08-13T08:00:00.000Z',
+        endDate: NOW.toISOString(),
+      }),
+    }));
+
+    expect(res.status).toBe(201);
+    expect(prisma.stage.create).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('GET/PATCH/DELETE /api/admin/stages/[stageId]', () => {
@@ -159,7 +262,12 @@ describe('GET/PATCH/DELETE /api/admin/stages/[stageId]', () => {
 
   it('updates a stage with partial payload', async () => {
     mockAuth.mockResolvedValue(adminSession());
-    prisma.stage.findUnique.mockResolvedValue({ id: 'stage-1', slug: 'old-slug' });
+    prisma.stage.findUnique.mockResolvedValue({
+      id: 'stage-1',
+      slug: 'old-slug',
+      endDate: new Date('2026-10-25T17:00:00.000Z'),
+      isOpen: true,
+    });
     prisma.stage.update.mockResolvedValue({ id: 'stage-1', slug: 'old-slug', title: 'Nouveau titre' });
 
     const res = await patchStage(makeRequest('http://localhost:3000/api/admin/stages/stage-1', {
@@ -169,6 +277,187 @@ describe('GET/PATCH/DELETE /api/admin/stages/[stageId]', () => {
     }), { params });
 
     expect(res.status).toBe(200);
+  });
+
+  it('refuses reopening an expired stage before update', async () => {
+    mockAuth.mockResolvedValue(adminSession());
+    prisma.stage.findUnique.mockResolvedValue({
+      id: 'stage-1',
+      slug: 'stage-history',
+      endDate: new Date('2026-04-25T17:00:00.000Z'),
+      isOpen: false,
+    });
+
+    const res = await patchStage(makeRequest('http://localhost:3000/api/admin/stages/stage-1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isOpen: true }),
+    }), { params });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body).toEqual({ error: EXPIRED_STAGE_ERROR });
+    expect(prisma.stage.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unrelated patch while an expired stage is still open', async () => {
+    mockAuth.mockResolvedValue(adminSession());
+    prisma.stage.findUnique.mockResolvedValue({
+      id: 'stage-1',
+      slug: 'stage-expired-open',
+      endDate: new Date('2026-04-25T17:00:00.000Z'),
+      isOpen: true,
+    });
+
+    const res = await patchStage(makeRequest('http://localhost:3000/api/admin/stages/stage-1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Titre corrigé' }),
+    }), { params });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body).toEqual({ error: EXPIRED_STAGE_ERROR });
+    expect(prisma.stage.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses moving only endDate into the past while the stage remains open', async () => {
+    mockAuth.mockResolvedValue(adminSession());
+    prisma.stage.findUnique.mockResolvedValue({
+      id: 'stage-1',
+      slug: 'stage-future',
+      endDate: new Date('2026-10-25T17:00:00.000Z'),
+      isOpen: true,
+    });
+
+    const res = await patchStage(makeRequest('http://localhost:3000/api/admin/stages/stage-1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ endDate: '2026-04-25T17:00:00.000Z' }),
+    }), { params });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body).toEqual({ error: EXPIRED_STAGE_ERROR });
+    expect(prisma.stage.update).not.toHaveBeenCalled();
+  });
+
+  it('allows closing an expired stage', async () => {
+    mockAuth.mockResolvedValue(adminSession());
+    prisma.stage.findUnique.mockResolvedValue({
+      id: 'stage-1',
+      slug: 'stage-expired-open',
+      endDate: new Date('2026-04-25T17:00:00.000Z'),
+      isOpen: true,
+    });
+    prisma.stage.update.mockResolvedValue({
+      id: 'stage-1',
+      slug: 'stage-expired-open',
+      endDate: new Date('2026-04-25T17:00:00.000Z'),
+      isOpen: false,
+    });
+
+    const res = await patchStage(makeRequest('http://localhost:3000/api/admin/stages/stage-1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isOpen: false }),
+    }), { params });
+
+    expect(res.status).toBe(200);
+    expect(prisma.stage.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows changing visibility on an expired stage that remains closed', async () => {
+    mockAuth.mockResolvedValue(adminSession());
+    prisma.stage.findUnique.mockResolvedValue({
+      id: 'stage-1',
+      slug: 'stage-history',
+      endDate: new Date('2026-04-25T17:00:00.000Z'),
+      isOpen: false,
+    });
+    prisma.stage.update.mockResolvedValue({
+      id: 'stage-1',
+      slug: 'stage-history',
+      endDate: new Date('2026-04-25T17:00:00.000Z'),
+      isOpen: false,
+      isVisible: true,
+    });
+
+    const res = await patchStage(makeRequest('http://localhost:3000/api/admin/stages/stage-1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isVisible: true }),
+    }), { params });
+
+    expect(res.status).toBe(200);
+    expect(prisma.stage.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows extending and reopening an expired closed stage atomically', async () => {
+    mockAuth.mockResolvedValue(adminSession());
+    const previousEndDate = new Date('2026-04-25T17:00:00.000Z');
+    prisma.stage.findUnique.mockResolvedValue({
+      id: 'stage-1',
+      slug: 'stage-history',
+      endDate: previousEndDate,
+      isOpen: false,
+    });
+    prisma.stage.update.mockResolvedValue({
+      id: 'stage-1',
+      slug: 'stage-history',
+      endDate: new Date('2026-10-25T17:00:00.000Z'),
+      isOpen: true,
+    });
+
+    const res = await patchStage(makeRequest('http://localhost:3000/api/admin/stages/stage-1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        endDate: '2026-10-25T17:00:00.000Z',
+        isOpen: true,
+      }),
+    }), { params });
+
+    expect(res.status).toBe(200);
+    expect(prisma.stage.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        id: 'stage-1',
+        endDate: previousEndDate,
+        isOpen: false,
+      },
+    }));
+  });
+
+  it('returns 409 when optimistic stage state changed before update', async () => {
+    mockAuth.mockResolvedValue(adminSession());
+    const previousEndDate = new Date('2026-10-25T17:00:00.000Z');
+    prisma.stage.findUnique.mockResolvedValue({
+      id: 'stage-1',
+      slug: 'stage-future',
+      endDate: previousEndDate,
+      isOpen: false,
+    });
+    prisma.stage.update.mockRejectedValue(new Prisma.PrismaClientKnownRequestError(
+      'Record to update not found.',
+      { code: 'P2025', clientVersion: '6.11.1' }
+    ));
+
+    const res = await patchStage(makeRequest('http://localhost:3000/api/admin/stages/stage-1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isOpen: true }),
+    }), { params });
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(body).toEqual({ error: CONCURRENT_STAGE_UPDATE_ERROR });
+    expect(prisma.stage.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        id: 'stage-1',
+        endDate: previousEndDate,
+        isOpen: false,
+      },
+    }));
   });
 
   it('returns 409 when deleting a stage with confirmed reservations', async () => {

--- a/__tests__/api/stages/inscriptions.test.ts
+++ b/__tests__/api/stages/inscriptions.test.ts
@@ -2,12 +2,21 @@ jest.mock('@/lib/email/outbox', () => ({
   enqueueEmailIntent: jest.fn().mockResolvedValue({ id: 'job-1' }),
 }));
 
+jest.mock('@/lib/email/outbox-scheduler', () => ({
+  kickEmailOutboxDrain: jest.fn(),
+}));
+
 import { NextRequest } from 'next/server';
 
 import { POST } from '@/app/api/stages/[stageSlug]/inscrire/route';
 import { enqueueEmailIntent } from '@/lib/email/outbox';
+import { kickEmailOutboxDrain } from '@/lib/email/outbox-scheduler';
 
 const mockSendMail = enqueueEmailIntent as jest.Mock;
+const mockKickEmailOutboxDrain = kickEmailOutboxDrain as jest.Mock;
+
+const NOW = new Date('2026-08-13T12:00:00.000Z');
+const FUTURE_STAGE_END_DATE = new Date('2026-10-25T17:00:00.000Z');
 
 let prisma: any;
 
@@ -48,8 +57,17 @@ describe('POST /api/stages/[slug]/inscrire', () => {
     expect(res.status).toBe(400);
   });
 
-  it('retourne 404 si stage inexistant ou fermé', async () => {
-    prisma.stage.findUnique.mockResolvedValue(null);
+  it('retourne 404 si un stage futur est fermé', async () => {
+    const closedFutureStage = {
+      id: 'stage-closed',
+      slug: 'printemps-2026',
+      isVisible: true,
+      isOpen: false,
+      endDate: FUTURE_STAGE_END_DATE,
+    };
+    prisma.stage.findUnique.mockImplementation(async ({ where }: { where: any }) => (
+      where.isOpen === closedFutureStage.isOpen ? closedFutureStage : null
+    ));
 
     const res = await POST(makeRequest(validBody), { params });
     const body = await res.json();
@@ -58,12 +76,66 @@ describe('POST /api/stages/[slug]/inscrire', () => {
     expect(body.error).toContain('fermées');
   });
 
+  it("refuse atomiquement un stage visible et ouvert dont la date de fin est dépassée", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+
+    const expiredStage = {
+      id: 'stage-expired',
+      slug: 'printemps-2026',
+      title: 'Printemps 2026',
+      priceAmount: 650,
+      capacity: 12,
+      isVisible: true,
+      isOpen: true,
+      endDate: new Date('2026-04-25T17:00:00.000Z'),
+    };
+    prisma.stage.findUnique.mockImplementation(async ({ where }: { where: any }) => {
+      const lowerBound = where.endDate?.gte;
+      return lowerBound instanceof Date && expiredStage.endDate >= lowerBound
+        ? expiredStage
+        : lowerBound
+          ? null
+          : expiredStage;
+    });
+    prisma.stageReservation.findFirst.mockResolvedValue(null);
+    prisma.stageReservation.count.mockResolvedValue(0);
+    prisma.stageReservation.create.mockResolvedValue({ id: 'must-not-be-created' });
+
+    try {
+      const res = await POST(makeRequest(validBody), { params });
+      const body = await res.json();
+
+      expect(res.status).toBe(404);
+      expect(res.headers.get('location')).toBeNull();
+      expect(body).toEqual({ error: 'Stage introuvable ou inscriptions fermées' });
+      expect(prisma.stage.findUnique).toHaveBeenCalledTimes(1);
+      expect(prisma.stage.findUnique).toHaveBeenCalledWith({
+        where: {
+          slug: 'printemps-2026',
+          isVisible: true,
+          isOpen: true,
+          endDate: { gte: NOW },
+        },
+      });
+      expect(prisma.stageReservation.findFirst).not.toHaveBeenCalled();
+      expect(prisma.stageReservation.count).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(prisma.stageReservation.create).not.toHaveBeenCalled();
+      expect(mockSendMail).not.toHaveBeenCalled();
+      expect(mockKickEmailOutboxDrain).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('retourne 409 si doublon email pour ce stage', async () => {
     prisma.stage.findUnique.mockResolvedValue({
       id: 'stage-1',
       slug: 'printemps-2026',
       isVisible: true,
       isOpen: true,
+      endDate: FUTURE_STAGE_END_DATE,
     });
     prisma.stageReservation.findFirst.mockResolvedValue({ id: 'res-1' });
 
@@ -83,6 +155,7 @@ describe('POST /api/stages/[slug]/inscrire', () => {
       capacity: 12,
       isVisible: true,
       isOpen: true,
+      endDate: FUTURE_STAGE_END_DATE,
     });
     prisma.stageReservation.findFirst.mockResolvedValue(null);
     prisma.stageReservation.count.mockResolvedValue(5);
@@ -107,6 +180,7 @@ describe('POST /api/stages/[slug]/inscrire', () => {
     prisma.stage.findUnique.mockResolvedValue({
       id: 'stage-1', slug: 'printemps-2026', title: 'Printemps 2026',
       priceAmount: 650, capacity: 12, isVisible: true, isOpen: true,
+      endDate: FUTURE_STAGE_END_DATE,
     });
     prisma.stageReservation.findFirst.mockResolvedValue(null);
     prisma.stageReservation.count.mockResolvedValue(0);
@@ -142,6 +216,7 @@ describe('POST /api/stages/[slug]/inscrire', () => {
       capacity: 6,
       isVisible: true,
       isOpen: true,
+      endDate: FUTURE_STAGE_END_DATE,
     });
     prisma.stageReservation.findFirst.mockResolvedValue(null);
     prisma.stageReservation.count.mockResolvedValue(6);
@@ -164,6 +239,7 @@ describe('POST /api/stages/[slug]/inscrire', () => {
       capacity: 12,
       isVisible: true,
       isOpen: true,
+      endDate: FUTURE_STAGE_END_DATE,
     });
     prisma.stageReservation.findFirst.mockResolvedValue(null);
     prisma.stageReservation.count.mockResolvedValue(0);
@@ -189,6 +265,7 @@ describe('POST /api/stages/[slug]/inscrire', () => {
       capacity: 12,
       isVisible: true,
       isOpen: true,
+      endDate: FUTURE_STAGE_END_DATE,
     });
     prisma.stageReservation.findFirst.mockResolvedValue(null);
     prisma.stageReservation.count.mockResolvedValue(0);
@@ -213,6 +290,7 @@ describe('POST /api/stages/[slug]/inscrire', () => {
       capacity: 12,
       isVisible: true,
       isOpen: true,
+      endDate: FUTURE_STAGE_END_DATE,
     });
     prisma.stageReservation.findFirst.mockResolvedValue(null);
     prisma.stageReservation.count.mockResolvedValue(1);

--- a/__tests__/api/stages/stages-list.test.ts
+++ b/__tests__/api/stages/stages-list.test.ts
@@ -2,6 +2,9 @@ import { NextRequest } from 'next/server';
 
 import { GET as getStages } from '@/app/api/stages/route';
 import { GET as getStageDetail } from '@/app/api/stages/[stageSlug]/route';
+import { getPublicStageBySlug, listPublicStages } from '@/lib/stages/public';
+
+const NOW = new Date('2026-08-13T12:00:00.000Z');
 
 let prisma: any;
 
@@ -16,21 +19,21 @@ function listRequest(query = '') {
 }
 
 function detailRequest() {
-  return new NextRequest('http://localhost:3000/api/stages/printemps-2026');
+  return new NextRequest('http://localhost:3000/api/stages/automne-2026');
 }
 
 function stageRecord(overrides: Record<string, unknown> = {}) {
   return {
     id: 'stage-1',
-    slug: 'printemps-2026',
-    title: 'Printemps 2026',
+    slug: 'automne-2026',
+    title: 'Automne 2026',
     subtitle: 'Révisions intensives',
     description: 'Description',
     type: 'INTENSIF',
     subject: ['MATHEMATIQUES'],
     level: ['Terminale'],
-    startDate: new Date('2026-04-21T08:00:00.000Z'),
-    endDate: new Date('2026-04-25T17:00:00.000Z'),
+    startDate: new Date('2026-10-21T08:00:00.000Z'),
+    endDate: new Date('2026-10-25T17:00:00.000Z'),
     capacity: 12,
     priceAmount: 650,
     priceCurrency: 'TND',
@@ -46,8 +49,8 @@ function stageRecord(overrides: Record<string, unknown> = {}) {
         id: 'session-1',
         title: 'Bloc 1',
         subject: 'MATHEMATIQUES',
-        startAt: new Date('2026-04-21T08:00:00.000Z'),
-        endAt: new Date('2026-04-21T10:00:00.000Z'),
+        startAt: new Date('2026-10-21T08:00:00.000Z'),
+        endAt: new Date('2026-10-21T10:00:00.000Z'),
         location: 'Salle A',
         description: 'Fonctions',
         coach: {
@@ -88,7 +91,7 @@ describe('GET /api/stages', () => {
 
     expect(res.status).toBe(200);
     expect(body.stages).toHaveLength(1);
-    expect(body.stages[0].slug).toBe('printemps-2026');
+    expect(body.stages[0].slug).toBe('automne-2026');
   });
 
   it('filtre par open=true', async () => {
@@ -151,8 +154,8 @@ describe('GET /api/stages', () => {
             scoreGlobal: 17,
             isPublished: true,
             pdfUrl: '/private/bilan.pdf',
-            publishedAt: new Date('2026-04-26T10:00:00.000Z'),
-            createdAt: new Date('2026-04-25T10:00:00.000Z'),
+            publishedAt: new Date('2026-10-26T10:00:00.000Z'),
+            createdAt: new Date('2026-10-25T10:00:00.000Z'),
             student: {
               user: {
                 firstName: 'Ahmed',
@@ -200,8 +203,28 @@ describe('GET /api/stages', () => {
   });
 });
 
+describe('lectures publiques des stages actifs', () => {
+  it("propage exactement l'horloge injectée à la liste", async () => {
+    prisma.stage.findMany.mockResolvedValue([stageRecord()]);
+
+    const stages = await listPublicStages(undefined, NOW);
+
+    expect(stages).toHaveLength(1);
+    expect(prisma.stage.findMany.mock.calls[0][0].where.endDate.gte).toBe(NOW);
+  });
+
+  it("propage exactement l'horloge injectée au détail", async () => {
+    prisma.stage.findFirst.mockResolvedValue(stageRecord());
+
+    const stage = await getPublicStageBySlug('automne-2026', NOW);
+
+    expect(stage?.slug).toBe('automne-2026');
+    expect(prisma.stage.findFirst.mock.calls[0][0].where.endDate.gte).toBe(NOW);
+  });
+});
+
 describe('GET /api/stages/[slug]', () => {
-  const params = Promise.resolve({ stageSlug: 'printemps-2026' });
+  const params = Promise.resolve({ stageSlug: 'automne-2026' });
 
   it('retourne 200 avec détail complet du stage', async () => {
     prisma.stage.findFirst.mockResolvedValue(stageRecord());
@@ -210,7 +233,7 @@ describe('GET /api/stages/[slug]', () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.stage.title).toBe('Printemps 2026');
+    expect(body.stage.title).toBe('Automne 2026');
   });
 
   it('retourne 404 si slug inexistant', async () => {
@@ -235,7 +258,7 @@ describe('GET /api/stages/[slug]', () => {
     const res = await getStageDetail(detailRequest(), { params });
     const body = await res.json();
 
-    expect(body.stage.sessions[0].startAt).toBe('2026-04-21T08:00:00.000Z');
+    expect(body.stage.sessions[0].startAt).toBe('2026-10-21T08:00:00.000Z');
     expect(prisma.stage.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
         include: expect.objectContaining({
@@ -264,8 +287,8 @@ describe('GET /api/stages/[slug]', () => {
           scoreGlobal: 15,
           isPublished: true,
           pdfUrl: '/private/bilan.pdf',
-          publishedAt: new Date('2026-04-26T10:00:00.000Z'),
-          createdAt: new Date('2026-04-25T10:00:00.000Z'),
+          publishedAt: new Date('2026-10-26T10:00:00.000Z'),
+          createdAt: new Date('2026-10-25T10:00:00.000Z'),
           student: {
             user: {
               firstName: 'Sara',

--- a/__tests__/lib/stages/lifecycle.test.ts
+++ b/__tests__/lib/stages/lifecycle.test.ts
@@ -1,0 +1,23 @@
+import { getActiveStageEndDateFilter, isStageExpired } from '@/lib/stages/lifecycle';
+
+describe('stage lifecycle', () => {
+  const now = new Date('2026-08-13T12:00:00.000Z');
+
+  describe('isStageExpired', () => {
+    it('considère comme expiré un stage terminé en avril', () => {
+      expect(isStageExpired(new Date('2026-04-25T17:00:00.000Z'), now)).toBe(true);
+    });
+
+    it('conserve un stage dont la fin est future', () => {
+      expect(isStageExpired(new Date('2026-10-25T17:00:00.000Z'), now)).toBe(false);
+    });
+
+    it("conserve un stage dont la fin est exactement à l'heure courante", () => {
+      expect(isStageExpired(now, now)).toBe(false);
+    });
+  });
+
+  it('produit le filtre de fin active inclusif pour Prisma', () => {
+    expect(getActiveStageEndDateFilter(now)).toEqual({ gte: now });
+  });
+});

--- a/__tests__/stages/expired-stage-routing.test.ts
+++ b/__tests__/stages/expired-stage-routing.test.ts
@@ -1,0 +1,31 @@
+import nextConfig from '../../next.config.mjs';
+
+describe('Redirection du stage Printemps 2026', () => {
+  it('redirige uniquement la fiche legacy en 301 vers la liste des stages', async () => {
+    if (typeof nextConfig.redirects !== 'function') {
+      throw new Error('NEXT_REDIRECTS_CONFIGURATION_MISSING');
+    }
+
+    const redirects = await nextConfig.redirects();
+    const legacyRedirects = redirects.filter(
+      (redirect) => redirect.source === '/stages/printemps-2026',
+    );
+
+    expect(legacyRedirects).toEqual([
+      {
+        source: '/stages/printemps-2026',
+        destination: '/stages',
+        statusCode: 301,
+      },
+    ]);
+    expect(redirects).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        source: '/stages/printemps-2026/inscription',
+      }),
+    ]));
+    expect(redirects.some((redirect) => (
+      redirect.source.startsWith('/stages/printemps-2026/')
+      && /[:*]/.test(redirect.source)
+    ))).toBe(false);
+  });
+});

--- a/__tests__/stages/expired-stage-seed-contract.test.ts
+++ b/__tests__/stages/expired-stage-seed-contract.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('Seed du stage Printemps 2026', () => {
+  it('conserve le stage fermé sur une base neuve comme sur une base existante', () => {
+    const seedSource = readFileSync(join(process.cwd(), 'prisma/seed.ts'), 'utf8');
+    const upsertStart = seedSource.indexOf(
+      'const stagePrintemps = await prisma.stage.upsert({',
+    );
+    const sessionsStart = seedSource.indexOf(
+      'await prisma.stageSession.createMany({',
+      upsertStart,
+    );
+
+    expect(upsertStart).toBeGreaterThanOrEqual(0);
+    expect(sessionsStart).toBeGreaterThan(upsertStart);
+
+    const printempsUpsert = seedSource.slice(upsertStart, sessionsStart);
+    const createStart = printempsUpsert.indexOf('create: {');
+
+    expect(printempsUpsert).toMatch(
+      /where:\s*\{\s*slug:\s*'printemps-2026'\s*\}/,
+    );
+    expect(printempsUpsert).toMatch(
+      /update:\s*\{\s*isVisible:\s*false,\s*isOpen:\s*false,?\s*\}/,
+    );
+    expect(createStart).toBeGreaterThanOrEqual(0);
+
+    const createBranch = printempsUpsert.slice(createStart);
+    expect(createBranch).toMatch(/\bisVisible:\s*false\b/);
+    expect(createBranch).toMatch(/\bisOpen:\s*false\b/);
+    expect(createBranch).not.toMatch(/\bis(?:Visible|Open):\s*true\b/);
+  });
+});

--- a/__tests__/stages/expired-stage-sitemap.test.ts
+++ b/__tests__/stages/expired-stage-sitemap.test.ts
@@ -1,0 +1,51 @@
+import { prisma } from '@/lib/prisma';
+import sitemap from '@/app/sitemap';
+
+const NOW = new Date('2026-08-13T12:00:00.000Z');
+const PAST_STAGE = {
+  slug: 'stage-expire-visible',
+  updatedAt: new Date('2026-04-25T17:00:00.000Z'),
+};
+const FUTURE_STAGE = {
+  slug: 'toussaint-2026',
+  updatedAt: new Date('2026-10-20T08:00:00.000Z'),
+};
+
+describe('Sitemap des stages expirés', () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ now: NOW });
+    (prisma.stage.findMany as jest.Mock).mockImplementation(({ where } = {}) => {
+      const activeFrom = where?.endDate?.gte;
+
+      return Promise.resolve(
+        activeFrom instanceof Date && activeFrom.getTime() === NOW.getTime()
+          ? [FUTURE_STAGE]
+          : [PAST_STAGE, FUTURE_STAGE],
+      );
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('requête uniquement les stages non terminés et exclut le passé', async () => {
+    const entries = await sitemap();
+    const paths = entries.map((entry) => new URL(entry.url).pathname);
+
+    expect(prisma.stage.findMany).toHaveBeenCalledWith({
+      where: {
+        isVisible: true,
+        endDate: { gte: NOW },
+      },
+      select: { slug: true, updatedAt: true },
+    });
+    expect(paths).toEqual(expect.arrayContaining([
+      '/stages/toussaint-2026',
+      '/stages/toussaint-2026/inscription',
+    ]));
+    expect(paths).not.toContain('/stages/stage-expire-visible');
+    expect(paths).not.toContain('/stages/stage-expire-visible/inscription');
+  });
+});

--- a/app/api/admin/stages/[stageId]/route.ts
+++ b/app/api/admin/stages/[stageId]/route.ts
@@ -1,11 +1,14 @@
 export const dynamic = 'force-dynamic';
 
 import { NextRequest, NextResponse } from 'next/server';
-import { UserRole } from '@prisma/client';
+import { Prisma, UserRole } from '@prisma/client';
 
 import { isErrorResponse, requireRole } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
 import { updateStageSchema } from '@/lib/stages/admin-schemas';
+import { EXPIRED_STAGE_ERROR, isStageExpired } from '@/lib/stages/lifecycle';
+
+const CONCURRENT_STAGE_UPDATE_ERROR = 'Le stage a été modifié entre-temps. Veuillez réessayer.';
 
 async function getStageById(stageId: string) {
   return prisma.stage.findUnique({
@@ -128,6 +131,15 @@ export async function PATCH(
       return NextResponse.json({ error: 'Stage introuvable' }, { status: 404 });
     }
 
+    const effectiveEndDate = payload.endDate
+      ? new Date(payload.endDate)
+      : existingStage.endDate;
+    const effectiveIsOpen = payload.isOpen ?? existingStage.isOpen;
+
+    if (effectiveIsOpen === true && isStageExpired(effectiveEndDate, new Date())) {
+      return NextResponse.json({ error: EXPIRED_STAGE_ERROR }, { status: 400 });
+    }
+
     if (payload.slug && payload.slug !== existingStage.slug) {
       const duplicateSlug = await prisma.stage.findUnique({ where: { slug: payload.slug } });
       if (duplicateSlug) {
@@ -136,7 +148,11 @@ export async function PATCH(
     }
 
     const stage = await prisma.stage.update({
-      where: { id: stageId },
+      where: {
+        id: stageId,
+        endDate: existingStage.endDate,
+        isOpen: existingStage.isOpen,
+      },
       data: {
         ...payload,
         startDate: payload.startDate ? new Date(payload.startDate) : undefined,
@@ -151,6 +167,10 @@ export async function PATCH(
       },
     });
   } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+      return NextResponse.json({ error: CONCURRENT_STAGE_UPDATE_ERROR }, { status: 409 });
+    }
+
     console.error('[PATCH /api/admin/stages/[stageId]]', error instanceof Error ? error.name : 'unknown');
     return NextResponse.json({ error: 'Erreur interne du serveur' }, { status: 500 });
   }

--- a/app/api/admin/stages/route.ts
+++ b/app/api/admin/stages/route.ts
@@ -6,6 +6,7 @@ import { Prisma, UserRole } from '@prisma/client';
 import { isErrorResponse, requireAnyRole, requireRole } from '@/lib/guards';
 import { prisma } from '@/lib/prisma';
 import { createStageSchema } from '@/lib/stages/admin-schemas';
+import { EXPIRED_STAGE_ERROR, isStageExpired } from '@/lib/stages/lifecycle';
 
 type ReservationLike = {
   richStatus: string | null;
@@ -150,8 +151,15 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
   }
 
-  if (new Date(parsed.data.endDate) <= new Date(parsed.data.startDate)) {
+  const startDate = new Date(parsed.data.startDate);
+  const endDate = new Date(parsed.data.endDate);
+
+  if (endDate <= startDate) {
     return NextResponse.json({ error: 'La date de fin doit être postérieure à la date de début' }, { status: 400 });
+  }
+
+  if (parsed.data.isOpen && isStageExpired(endDate, new Date())) {
+    return NextResponse.json({ error: EXPIRED_STAGE_ERROR }, { status: 400 });
   }
 
   try {
@@ -166,8 +174,8 @@ export async function POST(request: NextRequest) {
     const stage = await prisma.stage.create({
       data: {
         ...parsed.data,
-        startDate: new Date(parsed.data.startDate),
-        endDate: new Date(parsed.data.endDate),
+        startDate,
+        endDate,
       },
     });
 

--- a/app/api/stages/[stageSlug]/inscrire/route.ts
+++ b/app/api/stages/[stageSlug]/inscrire/route.ts
@@ -8,6 +8,7 @@ import { internalNotification } from '@/lib/email/templates';
 import { LEGAL } from '@/lib/legal';
 import { computeReservationStatus } from '@/lib/stages/capacity';
 import { publicStageInscriptionSchema } from '@/lib/stages/inscription-schema';
+import { getActiveStageEndDateFilter } from '@/lib/stages/lifecycle';
 import { guardSensitiveRateLimit } from '@/lib/rate-limit/sensitive';
 import { z } from 'zod';
 import { canAcceptPreRentreeCampaignSubmission } from '@/lib/campaigns/pre-rentree-2026/release-gate';
@@ -83,8 +84,14 @@ export async function POST(
   const normalizedParentEmail = parentEmail ? normalizeUserEmail(parentEmail) : undefined;
 
   try {
+    const now = new Date();
     const stage = await prisma.stage.findUnique({
-      where: { slug: stageSlug, isVisible: true, isOpen: true },
+      where: {
+        slug: stageSlug,
+        isVisible: true,
+        isOpen: true,
+        endDate: getActiveStageEndDateFilter(now),
+      },
     });
     if (!stage) {
       return NextResponse.json(

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,6 +2,7 @@ import { MetadataRoute } from 'next';
 import { prisma } from '@/lib/prisma';
 import { getPreRentreePublicSurfaceDTO } from '@/lib/campaigns/pre-rentree-2026/public-surface';
 import { getPreRentreeReleaseGate } from '@/lib/campaigns/pre-rentree-2026/release-gate';
+import { getActiveStageEndDateFilter } from '@/lib/stages/lifecycle';
 
 export const dynamic = 'force-dynamic';
 
@@ -150,7 +151,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   let stageEntries: MetadataRoute.Sitemap = [];
   try {
     const stages = await prisma.stage.findMany({
-      where: { isVisible: true },
+      where: {
+        isVisible: true,
+        endDate: getActiveStageEndDateFilter(now),
+      },
       select: { slug: true, updatedAt: true },
     });
     stageEntries = stages.flatMap((stage) => {

--- a/app/stages/[stageSlug]/inscription/page.tsx
+++ b/app/stages/[stageSlug]/inscription/page.tsx
@@ -2,6 +2,8 @@ export const dynamic = 'force-dynamic';
 
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import { cache } from 'react';
 
 import { CorporateFooter } from '@/components/layout/CorporateFooter';
 import { CorporateNavbar } from '@/components/layout/CorporateNavbar';
@@ -16,6 +18,37 @@ type PageProps = {
   params: Promise<{ stageSlug: string }>;
 };
 
+const notFoundMetadata: Metadata = {
+  title: 'Stage introuvable | Nexus Réussite',
+  robots: { index: false, follow: false, nocache: true },
+};
+
+const getStageForInscription = cache((stageSlug: string) => getPublicStageBySlug(stageSlug));
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { stageSlug } = await params;
+  if (
+    !canExposePublicStageSlug(stageSlug)
+    || (
+      stageSlug === 'pre-rentree-2026'
+      && !canAcceptPreRentreeCampaignSubmission()
+    )
+  ) {
+    return notFoundMetadata;
+  }
+
+  const stage = await getStageForInscription(stageSlug);
+  if (!stage) return notFoundMetadata;
+
+  return {
+    title: `Inscription — ${stage.title} | Nexus Réussite`,
+    description: `Inscrivez-vous au stage ${stage.title} de Nexus Réussite.`,
+    alternates: {
+      canonical: `/stages/${stage.slug}/inscription`,
+    },
+  };
+}
+
 export default async function StageInscriptionPage({ params }: PageProps) {
   const { stageSlug } = await params;
   if (
@@ -27,7 +60,7 @@ export default async function StageInscriptionPage({ params }: PageProps) {
   ) {
     notFound();
   }
-  const stage = await getPublicStageBySlug(stageSlug);
+  const stage = await getStageForInscription(stageSlug);
 
   if (!stage) {
     notFound();

--- a/docs/audits/2026-08-13-fermeture-stage-printemps-2026.md
+++ b/docs/audits/2026-08-13-fermeture-stage-printemps-2026.md
@@ -1,0 +1,135 @@
+# Fermeture du stage Printemps 2026 et garde d'expiration
+
+## Date
+
+13 août 2026
+
+## Contexte
+
+Le stage `printemps-2026`, terminé le 25 avril 2026, restait visible, ouvert à
+l'inscription, présent dans le sitemap et accessible depuis deux pages publiques.
+La correction doit conserver le stage et ses réservations, ne modifier aucun prix,
+ne toucher ni à la campagne de pré-rentrée 2026 ni au chantier des bilans, et
+empêcher la même situation pour toute campagne future.
+
+## État initial en production
+
+- Source de vérité d'exécution : ligne PostgreSQL du modèle Prisma `Stage`.
+- Le seed ne sert qu'à initialiser les bases fraîches ; son `upsert` avec
+  `update: {}` ne pouvait pas corriger la ligne de production existante.
+- Stage ciblé : `printemps-2026`, du 21 au 25 avril 2026, 350 TND, capacité 12.
+- Drapeaux avant intervention : `isVisible=true`, `isOpen=true`.
+- Les pages `/stages/printemps-2026` et
+  `/stages/printemps-2026/inscription` répondaient 200.
+- Le sitemap dynamique publiait les deux URL.
+- Le formulaire d'inscription était rendu et l'API POST n'appliquait aucun
+  contrôle sur `endDate`.
+- Deux réservations persistées étaient rattachées au stage, toutes deux au statut
+  `COMPLETED`, créées et confirmées le 17 mai 2026. Les vérifications ont été
+  conduites avec des données masquées. Leur rattachement à un compte technique
+  rend leur origine commerciale non démontrée ; elles sont conservées dans tous
+  les cas.
+- Aucun autre stage expiré à la fois visible et ouvert n'a été trouvé dans
+  l'inventaire de production. La campagne distincte de pré-rentrée 2026 n'a pas
+  été modifiée.
+
+## Cause racine
+
+Les drapeaux manuels `isVisible` et `isOpen` constituaient les seules conditions
+de publication et d'inscription. La date de fin n'était contrôlée ni dans les
+lectures publiques, ni dans l'API d'inscription, ni dans le sitemap, ni lors de
+la création ou de la réouverture administrative. Le seed recréait en outre le
+stage historique avec les deux drapeaux à `true` sur une base fraîche.
+
+## Décisions prises
+
+- Un stage est expiré lorsque `endDate < now`. À l'instant exact de sa date de
+  fin, il reste actif ; cette frontière est testée avec une horloge injectée.
+- La fiche historique exacte `/stages/printemps-2026` renvoie un 301 vers
+  `/stages`, afin d'orienter les visiteurs et les moteurs vers l'offre actuelle.
+- L'URL d'inscription historique n'est pas redirigée : elle répond 404 avec des
+  métadonnées `noindex, nofollow, nocache`. Un POST ne peut donc jamais être
+  rejoué sur une autre route.
+- Les listes, fiches et sitemap publics excluent les stages expirés, même si des
+  drapeaux incohérents subsistent.
+- L'API d'inscription exige atomiquement : visible, ouvert et non expiré.
+- L'administration refuse la création ou la réouverture d'un stage expiré, tout
+  en autorisant sa fermeture, sa conservation historique ou son prolongement
+  avant réouverture. La mise à jour utilise une concurrence optimiste et renvoie
+  409 si l'état lu a changé.
+- Le seed conserve le stage et toutes ses données historiques, mais initialise et
+  met désormais à jour ses drapeaux à `false`.
+
+## Fermeture ciblée en production
+
+La ligne `printemps-2026` a été mise à jour transactionnellement par son slug,
+sans `DELETE` et sans mise à jour de `StageReservation`.
+
+- Avant : `isVisible=true`, `isOpen=true`, 2 réservations `COMPLETED`.
+- Après : `isVisible=false`, `isOpen=false`, 2 réservations `COMPLETED`.
+- `updatedAt` observé après transaction : 13 août 2026 à 18:54:57.475 UTC.
+- Après fermeture, l'API publique ne retourne plus ce stage et le sitemap ne
+  contient plus son slug.
+- Tant que le correctif applicatif n'est pas déployé, les deux pages répondent
+  404. Après déploiement, la fiche bénéficiera du 301 prévu ; la page et l'API
+  d'inscription conserveront leur refus explicite.
+
+## Fichiers modifiés
+
+- Règle de cycle de vie : `lib/stages/lifecycle.ts`.
+- Lectures publiques et inscription : `lib/stages/public.ts`,
+  `app/api/stages/[stageSlug]/inscrire/route.ts`.
+- Administration : `app/api/admin/stages/route.ts`,
+  `app/api/admin/stages/[stageId]/route.ts`.
+- SEO et navigation : `app/sitemap.ts`, `next.config.mjs`,
+  `app/stages/[stageSlug]/inscription/page.tsx`.
+- Initialisation : `prisma/seed.ts`.
+- Tests unitaires, contrats et E2E dédiés aux stages expirés.
+- Documents de conception, plan d'implémentation et présent audit.
+
+## Tests exécutés
+
+- Suite unitaire complète avec environnement CI : 819 suites, 9 088 tests,
+  0 échec.
+- Intégration PostgreSQL jetable : 39 suites non-NPC vertes.
+- Harness NPC officiel : 3 suites, 47 tests, 0 échec.
+- Playwright sur pile Docker jetable : 2 scénarios, 0 échec, 0 skip.
+- TypeScript : `tsc --noEmit`, succès.
+- Cinq contrôles du job Lint : secrets/infrastructure, quarantaines/focus,
+  valeurs codées en dur, ESLint et placement des archives, succès.
+- Syntaxe E2E : succès sur 2 438 fichiers suivis.
+- Audit npm des dépendances de production : 0 vulnérabilité.
+- Build E2E dans un checkout temporaire propre hors du dépôt : compilation,
+  validation des types et génération des 91 pages réussies ; traces sans
+  référence externe ; artefact autonome sans fuite de données, avec moteurs
+  Prisma et manifeste de release valides.
+
+## Résultats
+
+- L'offre obsolète n'est plus exposée en production.
+- Les deux réservations et leur historique sont intacts.
+- Un oubli de drapeau ne suffit plus à publier ou vendre un stage expiré.
+- Le cas historique obtient une destination SEO permanente sans risque de rejeu
+  d'un POST.
+- Aucune modification ne concerne les bilans, le canon tarifaire ou la campagne
+  de pré-rentrée 2026.
+
+## Risques restants
+
+- La redirection 301 n'entrera en vigueur qu'après revue, approbation et
+  déploiement de la PR par le responsable ; la fermeture de production reste
+  effective indépendamment.
+- Les scans Semgrep et OSV ainsi que la suite E2E complète sont attestés par les
+  jobs GitHub requis, à contrôler avant toute approbation.
+- Les avertissements ESLint préexistants sont limités au chantier
+  `candidat-libre`, hors périmètre de cette correction.
+
+## Rollback
+
+- Code : revenir sur les commits de la PR, sans toucher aux données historiques.
+- Production : les drapeaux peuvent techniquement être remis à `true` par une
+  transaction ciblée sur le même slug. Ce rollback ne doit pas être utilisé tant
+  que la date de fin reste passée ; la garde applicative continuerait de refuser
+  publication et inscription.
+- Aucune restauration de réservation n'est nécessaire : aucune réservation n'a
+  été supprimée ou modifiée.

--- a/docs/superpowers/plans/2026-08-13-stage-expiration-guard.md
+++ b/docs/superpowers/plans/2026-08-13-stage-expiration-guard.md
@@ -1,0 +1,328 @@
+# Stage Expiration Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fermer proprement `printemps-2026` et empêcher tout stage terminé de rester public, indexable ou inscriptible.
+
+**Architecture:** Une règle temporelle pure et injectable définit l’expiration. Les requêtes publiques, le sitemap, le POST et l’administration l’appliquent à leur frontière ; une redirection statique exacte traite uniquement la fiche legacy déjà indexable.
+
+**Tech Stack:** Next.js 15 App Router, TypeScript, Prisma 6, Jest 29, Playwright 1.58.
+
+---
+
+## Chunk 0: Fermeture opérationnelle réversible
+
+### Task 0: Archiver la seule ligne de production concernée
+
+**Files:**
+- Aucun fichier du dépôt
+
+- [x] **Step 1: lire et verrouiller la ligne exacte sans PII**
+
+La ligne `printemps-2026` était `isVisible=true`, `isOpen=true`, avec deux
+réservations `COMPLETED`.
+
+- [x] **Step 2: mettre les deux drapeaux à false dans une transaction ciblée**
+
+L’opération a exigé exactement une ligne affectée et n’a exécuté aucun
+`DELETE`.
+
+- [x] **Step 3: relire l’état et l’historique avant COMMIT**
+
+Après mutation : `isVisible=false`, `isOpen=false`, toujours deux réservations
+`COMPLETED`.
+
+- [x] **Step 4: vérifier les surfaces publiques**
+
+Avec le code actuellement déployé : fiche et inscription `404`, API publique
+vide, slug absent du sitemap. La PR introduit ensuite le `301` de la fiche.
+
+## Chunk 1: Invariant et frontières serveur
+
+### Task 1: Règle temporelle centrale et lectures publiques
+
+**Files:**
+- Create: `lib/stages/lifecycle.ts`
+- Create: `__tests__/lib/stages/lifecycle.test.ts`
+- Modify: `lib/stages/public.ts:227-266`
+- Modify: `__tests__/api/stages/stages-list.test.ts`
+
+- [ ] **Step 1: écrire les tests rouges de la règle pure**
+
+Tester avec `now = 2026-08-13T12:00:00Z` : fin en avril expirée, fin future valide, fin exactement égale à `now` valide.
+
+- [ ] **Step 2: lancer le test et constater l’échec attendu**
+
+Run: `npx jest --config jest.unit.config.js --runInBand __tests__/lib/stages/lifecycle.test.ts`
+
+Expected: FAIL car `lib/stages/lifecycle.ts` n’existe pas.
+
+- [ ] **Step 3: implémenter le prédicat minimal**
+
+Exporter `isStageExpired(endDate, now)` et `getActiveStageEndDateFilter(now)` sans lecture système cachée.
+
+- [ ] **Step 4: lancer le test et constater le vert**
+
+Run: même commande. Expected: PASS.
+
+- [ ] **Step 5: écrire les tests rouges des getters publics**
+
+Vérifier que `listPublicStages` et `getPublicStageBySlug` transmettent
+`endDate: { gte: now }`, et remplacer les fixtures valides d’avril par une
+date future.
+
+- [ ] **Step 6: lancer les tests et constater l’échec attendu**
+
+Run: `npx jest --config jest.unit.config.js --runInBand __tests__/api/stages/stages-list.test.ts`
+
+Expected: FAIL sur l’absence de filtre `endDate`.
+
+- [ ] **Step 7: appliquer le filtre minimal aux deux getters**
+
+Ajouter un paramètre `now` par défaut à la frontière publique et utiliser le
+même filtre Prisma.
+
+- [ ] **Step 8: relancer les tests ciblés**
+
+Expected: PASS.
+
+- [ ] **Step 9: commit**
+
+```bash
+git add lib/stages/lifecycle.ts lib/stages/public.ts \
+  __tests__/lib/stages/lifecycle.test.ts __tests__/api/stages/stages-list.test.ts
+git commit -m "fix(stages): borner les surfaces publiques par la date"
+```
+
+### Task 2: Refus atomique du POST d’inscription
+
+**Files:**
+- Modify: `app/api/stages/[stageSlug]/inscrire/route.ts:85-94`
+- Modify: `__tests__/api/stages/inscriptions.test.ts`
+- Modify: `__tests__/api/stages.inscrire.security.test.ts` si ses fixtures doivent recevoir `endDate`
+
+- [ ] **Step 1: écrire le test rouge du stage expiré**
+
+Figer l’horloge ; vérifier la clause Prisma `endDate >= now`, le statut `404`
+et l’absence de recherche de doublon, transaction, création et notification.
+
+- [ ] **Step 2: lancer le test et constater l’échec attendu**
+
+Run: `npx jest --config jest.unit.config.js --runInBand __tests__/api/stages/inscriptions.test.ts`
+
+- [ ] **Step 3: ajouter le filtre atomique à la sélection du stage**
+
+Conserver le message et le statut `404` existants.
+
+- [ ] **Step 4: relancer les tests inscription et sécurité**
+
+Expected: PASS, sans changement de réponse publique.
+
+- [ ] **Step 5: commit**
+
+```bash
+git add app/api/stages/[stageSlug]/inscrire/route.ts \
+  __tests__/api/stages/inscriptions.test.ts __tests__/api/stages.inscrire.security.test.ts
+git commit -m "fix(stages): refuser les inscriptions après la fin"
+```
+
+### Task 3: Sitemap, redirection 301 et seed fermé
+
+**Files:**
+- Modify: `app/sitemap.ts:149-174`
+- Modify: `next.config.mjs`
+- Modify: `prisma/seed.ts:603-626`
+- Create: `__tests__/stages/expired-stage-sitemap.test.ts`
+- Create: `__tests__/stages/expired-stage-routing.test.ts`
+- Create: `__tests__/stages/expired-stage-seed-contract.test.ts`
+
+- [ ] **Step 1: écrire les tests rouges sitemap et configuration**
+
+Le nouveau test dédié aux stages doit vérifier que le sitemap requête
+`endDate >= now`, conserve le témoin futur et n’émet pas le passé, sans modifier
+les tests ou le parcours Pré-rentrée. La configuration doit déclarer uniquement
+`/stages/printemps-2026 -> /stages` avec `statusCode: 301`, sans redirection
+de `/inscription`.
+
+- [ ] **Step 2: lancer les tests et constater les échecs attendus**
+
+Run: `npx jest --config jest.unit.config.js --runInBand __tests__/stages/expired-stage-sitemap.test.ts __tests__/stages/expired-stage-routing.test.ts`
+
+- [ ] **Step 3: implémenter le filtre sitemap et le 301 exact**
+
+Ne modifier aucune route de campagne Pré-rentrée.
+
+- [ ] **Step 4: écrire et lancer le test rouge du seed**
+
+Le contrat source doit échouer tant que l’upsert contient `update: {}` ou crée
+le stage avec un des drapeaux à `true`. Il ne doit jamais exécuter le seed.
+
+Run: `npx jest --config jest.unit.config.js --runInBand __tests__/stages/expired-stage-seed-contract.test.ts`
+
+- [ ] **Step 5: fermer les deux branches de l’upsert seed**
+
+Définir `update: { isVisible: false, isOpen: false }` et les mêmes valeurs dans
+`create` pour `printemps-2026`.
+
+- [ ] **Step 6: relancer les tests ciblés**
+
+Expected: PASS.
+
+- [ ] **Step 7: commit**
+
+```bash
+git add app/sitemap.ts next.config.mjs prisma/seed.ts \
+  __tests__/stages/expired-stage-sitemap.test.ts \
+  __tests__/stages/expired-stage-routing.test.ts \
+  __tests__/stages/expired-stage-seed-contract.test.ts
+git commit -m "fix(stages): désindexer le stage printemps 2026"
+```
+
+### Task 4: Empêcher la création et la réouverture administratives
+
+**Files:**
+- Modify: `app/api/admin/stages/route.ts:137-180`
+- Modify: `app/api/admin/stages/[stageId]/route.ts:99-157`
+- Modify: `__tests__/api/admin.stages.route.test.ts`
+
+- [ ] **Step 1: écrire les tests rouges administratifs**
+
+Cas avec horloge figée : création expirée ouverte explicite ou ouverte par
+défaut refusée ; création expirée fermée autorisée ; PATCH rouvrant une ligne
+expirée refusé ; PATCH d’un autre champ sur une ligne expirée encore ouverte
+refusé ; PATCH déplaçant seulement `endDate` dans le passé alors que `isOpen`
+reste vrai refusé ; PATCH fermant la ligne autorisé ; PATCH futur inchangé.
+
+- [ ] **Step 2: lancer le test et constater l’échec attendu**
+
+Run: `npx jest --config jest.unit.config.js --runInBand __tests__/api/admin.stages.route.test.ts`
+
+- [ ] **Step 3: valider l’état effectif avec la règle centrale**
+
+Pour POST, utiliser le payload parsé. Pour PATCH, combiner `payload.endDate ??
+existingStage.endDate` et `payload.isOpen ?? existingStage.isOpen`. Répondre
+`400` avant toute écriture si l’état effectif est expiré et ouvert.
+
+- [ ] **Step 4: relancer le test ciblé**
+
+Expected: PASS.
+
+- [ ] **Step 5: commit**
+
+```bash
+git add app/api/admin/stages/route.ts app/api/admin/stages/[stageId]/route.ts \
+  __tests__/api/admin.stages.route.test.ts
+git commit -m "fix(stages): bloquer la réouverture des stages expirés"
+```
+
+## Chunk 2: Gate E2E et vérification complète
+
+### Task 5: Gate E2E du cycle de vie
+
+**Files:**
+- Create: `e2e/real/pages/08-expired-stage-lifecycle.spec.ts`
+
+- [ ] **Step 1: écrire le scénario E2E rouge**
+
+Avant toute mutation, appeler `assertDisposableE2eDatabase`. Créer deux cas
+distincts dans la base jetable :
+
+- le slug legacy `printemps-2026` vérifie le `301` exact avec redirections
+  désactivées et `Location: /stages` ;
+- un autre slug passé visible/ouvert vérifie la garde générique : absent de la
+  liste, détail API `404`, fiche et inscription `404/noindex`, POST `404` sans
+  réservation, absent du sitemap.
+
+Un témoin futur visible/ouvert reste exposé. Nettoyer uniquement les IDs créés
+dans `finally`, puis déconnecter Prisma.
+
+- [ ] **Step 2: lancer le gate ciblé et constater l’échec attendu**
+
+Exécuter le scénario contre une stack jetable locale si PostgreSQL, Redis et le
+serveur CI-like sont disponibles. La preuve autoritative reste le job GitHub
+`E2E Tests`, dont le workflow démarre ces trois dépendances avant
+`playwright.ci.config.ts`.
+
+- [ ] **Step 3: ajuster uniquement le câblage E2E nécessaire**
+
+Aucune modification bilans, pricing ou campagne Pré-rentrée.
+
+- [ ] **Step 4: relancer le gate ciblé**
+
+Expected: PASS, 0 skip.
+
+- [ ] **Step 5: commit**
+
+```bash
+git add e2e/real/pages/08-expired-stage-lifecycle.spec.ts
+git commit -m "test(stages): verrouiller le cycle de vie expiré en E2E"
+```
+
+### Task 6: Vérifications, documentation d’audit et PR
+
+**Files:**
+- Create: `docs/audits/2026-08-13-fermeture-stage-printemps-2026.md`
+
+- [ ] **Step 1: exécuter tous les tests Jest sans filtre**
+
+Run: `npx npm@10.9.8 test -- --runInBand`
+
+Expected: 0 échec, 0 skip nouveau ou injustifié.
+
+- [ ] **Step 2: exécuter l’intégration complète**
+
+Run: `npx npm@10.9.8 run test:integration`
+
+- [ ] **Step 3: exécuter typecheck et les cinq contrôles du job Lint**
+
+```bash
+npx npm@10.9.8 run typecheck
+npx npm@10.9.8 run security:repo
+npx npm@10.9.8 run check:test-quarantines
+npx npm@10.9.8 run check:no-hardcoded
+npx npm@10.9.8 run lint
+npx npm@10.9.8 run check:docs-archive
+```
+
+- [ ] **Step 4: exécuter syntaxe E2E et build**
+
+```bash
+npx npm@10.9.8 run check:e2e-syntax
+npx npm@10.9.8 run build:e2e
+```
+
+- [ ] **Step 5: exécuter les pré-scans disponibles localement**
+
+Run: `npx npm@10.9.8 audit --omit=dev`. Le résultat local est un pré-contrôle ;
+les politiques attestées restent celles des jobs GitHub.
+
+- [ ] **Step 6: documenter les preuves et le rollback**
+
+Inclure état production avant/après, conservation des deux réservations,
+commandes et résultats exacts.
+
+- [ ] **Step 7: commit documentaire et propreté Git**
+
+```bash
+git add docs/audits/2026-08-13-fermeture-stage-printemps-2026.md \
+  docs/superpowers/plans/2026-08-13-stage-expiration-guard.md
+git commit -m "docs(stages): consigner la fermeture printemps 2026"
+git status --short
+```
+
+Expected: aucun fichier non suivi ou modifié.
+
+- [ ] **Step 8: revue finale indépendante**
+
+Demander une revue de conformité puis une revue de qualité/sécurité sur le diff
+complet contre `origin/main`. Corriger tout point critique ou important et
+relancer les gates concernées.
+
+- [ ] **Step 9: pousser et ouvrir la PR sans merger**
+
+Créer une PR vers `main`, demander l’approbation de `abenrhouma`, puis attendre
+explicitement les jobs `Lint`, `TypeScript Type Check`, suites Jest,
+`Dependency Integrity`, `Security Scan`, `E2E Tests` et l’agrégateur
+`CI Success`. Ces jobs fournissent les gates Semgrep, OSV et Playwright que la
+commande locale seule ne reproduit pas. Ne jamais merger ni déployer depuis
+cette branche.

--- a/docs/superpowers/specs/2026-08-13-stage-expiration-guard-design.md
+++ b/docs/superpowers/specs/2026-08-13-stage-expiration-guard-design.md
@@ -1,0 +1,90 @@
+# Fermeture et garde d’expiration des stages dynamiques
+
+## Date
+
+13 août 2026
+
+## Contexte
+
+Le stage dynamique `printemps-2026`, terminé le 25 avril 2026, est resté
+`isVisible=true` et `isOpen=true` dans PostgreSQL. Le catalogue public, la
+fiche, le formulaire, le sitemap et le POST d’inscription ne tenaient compte
+que de ces drapeaux et jamais de `endDate`.
+
+La fermeture opérationnelle est distincte du correctif applicatif : la ligne
+de production est archivée par ses deux drapeaux, sans supprimer le stage ni
+ses deux réservations `COMPLETED`.
+
+## Décision
+
+Un stage est expiré lorsque `endDate < now`. La frontière `endDate === now`
+reste valide : la date de fin n’est alors pas encore dépassée.
+
+La règle est centralisée dans une fonction pure acceptant explicitement
+l’horloge. Les accès runtime lui transmettent leur instant de référence afin
+que les tests restent déterministes.
+
+La défense en profondeur couvre cinq frontières :
+
+1. listes et détails publics : seuls les stages non expirés sont chargés ;
+2. pages publiques : la fiche legacy exacte redirige en `301` vers `/stages`,
+   tandis que l’inscription expirée répond `404` et ne monte aucun formulaire ;
+3. sitemap : aucun stage expiré ni formulaire associé n’est émis ;
+4. POST d’inscription : la sélection atomique exige `endDate >= now`, sinon
+   elle répond `404` sans écrire ni notifier ;
+5. administration : créer ou rouvrir un stage expiré est refusé avec `400`.
+
+## Redirection et indexation
+
+La seule fiche historique connue, `/stages/printemps-2026`, reçoit une
+redirection exacte `301` vers `/stages`. Le statut est déclaré explicitement
+dans `next.config.mjs` afin d’éviter les redirections Next `307/308` qui
+préservent la méthode.
+
+`/stages/printemps-2026/inscription` n’est pas redirigée : le getter public
+échoue fermé et Next renvoie `404`/`noindex`. Le POST correspondant est
+`/api/stages/printemps-2026/inscrire` et répond lui aussi `404`. Aucun POST ne
+peut donc être rejoué vers `/stages`.
+
+Les futurs stages expirés sont retirés des listes et du sitemap et leurs
+routes génériques échouent fermées. Le `301` reste volontairement spécifique
+à la fiche déjà indexable pour ne pas transformer l’existence de brouillons
+cachés en oracle public.
+
+## Source de vérité et seed
+
+La source runtime reste PostgreSQL. Le seed n’est qu’un bootstrap, mais il doit
+être sûr sur une base fraîche et idempotent sur une base existante. Son upsert
+pour `printemps-2026` place donc `isVisible=false` et `isOpen=false` dans
+`create` comme dans `update`.
+
+Le canon tarifaire et le parcours campagne Pré-rentrée 2026 sont hors périmètre.
+
+## Administration
+
+Un import historique reste possible à condition d’être fermé. À la création,
+un stage passé est accepté uniquement avec `isOpen=false`. Au PATCH, la
+validation se fait sur l’état effectif combinant la ligne existante et le
+payload : modifier un autre champ ne doit pas laisser ou remettre un stage
+expiré ouvert.
+
+## Tests
+
+L’horloge de référence est `2026-08-13T12:00:00.000Z`.
+
+- règle pure : passé, futur et frontière exacte ;
+- liste/détail API : requête Prisma bornée par `endDate >= now` ;
+- inscription : `404` avant toute recherche de doublon ou écriture ;
+- sitemap : stage passé absent, stage futur présent ;
+- administration : création et réouverture passées refusées, import fermé
+  autorisé ;
+- configuration : redirection exacte `301`, sans redirection de l’inscription ;
+- E2E CI : fiche `301`, inscription/API expirées fermées, absence du sitemap,
+  témoin futur encore disponible.
+
+## Rollback
+
+Le correctif code est réversible par revert de la PR. La fermeture de donnée
+est réversible par un PATCH ciblé des deux drapeaux, mais ne doit pas être
+annulée tant que le stage reste expiré. Aucune suppression de ligne ou de
+réservation n’est prévue.

--- a/e2e/real/pages/08-expired-stage-lifecycle.spec.ts
+++ b/e2e/real/pages/08-expired-stage-lifecycle.spec.ts
@@ -1,0 +1,168 @@
+import { PrismaClient, Subject } from '@prisma/client';
+import { expect, test } from '@playwright/test';
+
+import { assertDisposableE2eDatabase } from '../../helpers/disposable-database';
+
+const LEGACY_STAGE_PATH = '/stages/printemps-2026';
+const EXPIRED_STAGE_PREFIX = 'e2e-expired-stage-lifecycle';
+const FUTURE_STAGE_PREFIX = 'e2e-future-stage-lifecycle';
+
+function getDisposableDatabaseUrl(): string {
+  const databaseUrl = process.env.E2E_DATABASE_URL ?? process.env.DATABASE_URL;
+  if (!databaseUrl) throw new Error('E2E_DATABASE_URL_REQUIRED');
+
+  assertDisposableE2eDatabase(databaseUrl);
+  return databaseUrl;
+}
+
+function createStageFixture(params: {
+  id: string;
+  slug: string;
+  title: string;
+  startDate: Date;
+  endDate: Date;
+}) {
+  return {
+    ...params,
+    subject: [Subject.MATHEMATIQUES],
+    level: ['Terminale'],
+    capacity: 5,
+    priceAmount: 350,
+    priceCurrency: 'TND',
+    location: 'Mutuelleville, Tunis',
+    isVisible: true,
+    isOpen: true,
+  };
+}
+
+function extractSitemapPathnames(sitemapXml: string): string[] {
+  return Array.from(sitemapXml.matchAll(/<loc>([^<]+)<\/loc>/g), ([, value]) => (
+    new URL(value).pathname
+  ));
+}
+
+test.describe('REAL — cycle de vie public des stages expirés', () => {
+  test('redirige uniquement la fiche legacy printemps-2026 en 301 vers /stages', async ({ request }) => {
+    const response = await request.get(LEGACY_STAGE_PATH, {
+      maxRedirects: 0,
+    });
+
+    expect(response.status()).toBe(301);
+    expect(response.headers().location).toBe('/stages');
+  });
+
+  test('masque et refuse un stage expiré tout en conservant un témoin futur', async ({ request }) => {
+    const databaseUrl = getDisposableDatabaseUrl();
+    const prisma = new PrismaClient({
+      datasources: { db: { url: databaseUrl } },
+    });
+    const runId = `${Date.now()}-${process.pid}`;
+    const expiredStageId = `${EXPIRED_STAGE_PREFIX}-${runId}`;
+    const expiredStageSlug = `${EXPIRED_STAGE_PREFIX}-${runId}`;
+    const futureStageId = `${FUTURE_STAGE_PREFIX}-${runId}`;
+    const futureStageSlug = `${FUTURE_STAGE_PREFIX}-${runId}`;
+    const createdStageIds: string[] = [];
+
+    try {
+      const expiredStage = await prisma.stage.create({
+        data: createStageFixture({
+          id: expiredStageId,
+          slug: expiredStageSlug,
+          title: 'E2E — stage expiré invisible au public',
+          startDate: new Date('2026-04-21T08:00:00.000Z'),
+          endDate: new Date('2026-04-25T17:00:00.000Z'),
+        }),
+      });
+      createdStageIds.push(expiredStage.id);
+
+      const futureStage = await prisma.stage.create({
+        data: createStageFixture({
+          id: futureStageId,
+          slug: futureStageSlug,
+          title: 'E2E — stage futur témoin',
+          startDate: new Date('2099-10-19T08:00:00.000Z'),
+          endDate: new Date('2099-10-23T17:00:00.000Z'),
+        }),
+      });
+      createdStageIds.push(futureStage.id);
+
+      const listResponse = await request.get('/api/stages');
+      expect(listResponse.status()).toBe(200);
+      const listBody = await listResponse.json() as { stages: Array<{ slug: string }> };
+      const publicSlugs = listBody.stages.map((stage) => stage.slug);
+      expect(publicSlugs).not.toContain(expiredStageSlug);
+      expect(publicSlugs).toContain(futureStageSlug);
+
+      const detailApiResponse = await request.get(`/api/stages/${expiredStageSlug}`);
+      expect(detailApiResponse.status()).toBe(404);
+
+      const detailPageResponse = await request.get(`/stages/${expiredStageSlug}`);
+      expect(detailPageResponse.status()).toBe(404);
+      const detailPageHtml = await detailPageResponse.text();
+      expect(detailPageHtml).toMatch(/<meta\s+name="robots"\s+content="noindex"\s*\/?>/i);
+
+      const registrationPageResponse = await request.get(`/stages/${expiredStageSlug}/inscription`);
+      expect(registrationPageResponse.status()).toBe(404);
+      const registrationPageHtml = await registrationPageResponse.text();
+      expect(registrationPageHtml).toMatch(/<meta\s+name="robots"\s+content="noindex"\s*\/?>/i);
+      expect(registrationPageHtml).not.toMatch(/<form(?:\s|>)/i);
+
+      const registrationResponse = await request.post(`/api/stages/${expiredStageSlug}/inscrire`, {
+        data: {
+          firstName: 'Eleve',
+          lastName: 'Expire',
+          email: `eleve-expire-${runId}@example.test`,
+          phone: '99123456',
+          level: 'Terminale',
+          parentFirstName: 'Parent',
+          parentLastName: 'Expire',
+          parentEmail: `parent-expire-${runId}@example.test`,
+          parentPhone: '99123457',
+          notes: 'Donnée E2E jetable',
+          stageTermsAccepted: true,
+          dataProcessingAccepted: true,
+        },
+      });
+      expect(registrationResponse.status()).toBe(404);
+      await expect(prisma.stageReservation.count({
+        where: { stageId: expiredStageId },
+      })).resolves.toBe(0);
+
+      const sitemapResponse = await request.get('/sitemap.xml');
+      expect(sitemapResponse.status()).toBe(200);
+      const sitemapXml = await sitemapResponse.text();
+      const sitemapPathnames = extractSitemapPathnames(sitemapXml);
+      expect(sitemapPathnames).not.toContain(`/stages/${expiredStageSlug}`);
+      expect(sitemapPathnames).not.toContain(`/stages/${expiredStageSlug}/inscription`);
+      expect(sitemapPathnames).toContain(`/stages/${futureStageSlug}`);
+      expect(sitemapPathnames).toContain(`/stages/${futureStageSlug}/inscription`);
+    } finally {
+      try {
+        if (createdStageIds.length > 0) {
+          const reservations = await prisma.stageReservation.findMany({
+            where: { stageId: { in: createdStageIds } },
+            select: { id: true },
+          });
+          const reservationIds = reservations.map(({ id }) => id);
+          if (reservationIds.length > 0) {
+            await prisma.jobOutbox.deleteMany({
+              where: {
+                aggregateType: 'STAGE_RESERVATION',
+                aggregateId: { in: reservationIds },
+              },
+            });
+          }
+          for (const reservation of reservations) {
+            await prisma.stageReservation.delete({ where: { id: reservation.id } });
+          }
+
+          for (const stageId of [...createdStageIds].reverse()) {
+            await prisma.stage.delete({ where: { id: stageId } });
+          }
+        }
+      } finally {
+        await prisma.$disconnect();
+      }
+    }
+  });
+});

--- a/lib/stages/lifecycle.ts
+++ b/lib/stages/lifecycle.ts
@@ -1,3 +1,5 @@
+export const EXPIRED_STAGE_ERROR = 'Un stage terminé ne peut pas être ouvert aux inscriptions';
+
 export function isStageExpired(endDate: Date, now: Date) {
   return endDate.getTime() < now.getTime();
 }

--- a/lib/stages/lifecycle.ts
+++ b/lib/stages/lifecycle.ts
@@ -1,0 +1,7 @@
+export function isStageExpired(endDate: Date, now: Date) {
+  return endDate.getTime() < now.getTime();
+}
+
+export function getActiveStageEndDateFilter(now: Date) {
+  return { gte: now };
+}

--- a/lib/stages/public.ts
+++ b/lib/stages/public.ts
@@ -1,6 +1,7 @@
 import { Prisma, StageReservationStatus, StageType, Subject } from '@prisma/client';
 
 import { prisma } from '@/lib/prisma';
+import { getActiveStageEndDateFilter } from '@/lib/stages/lifecycle';
 
 type ReservationLike = {
   richStatus: StageReservationStatus | null;
@@ -228,9 +229,10 @@ export async function listPublicStages(filters?: {
   open?: boolean;
   level?: string;
   subject?: string;
-}) {
+}, now: Date = new Date()) {
   const where: Prisma.StageWhereInput = {
     isVisible: true,
+    endDate: getActiveStageEndDateFilter(now),
   };
 
   if (filters?.open === true) {
@@ -254,11 +256,12 @@ export async function listPublicStages(filters?: {
   return stages.map(serializePublicStage);
 }
 
-export async function getPublicStageBySlug(stageSlug: string) {
+export async function getPublicStageBySlug(stageSlug: string, now: Date = new Date()) {
   const stage = await prisma.stage.findFirst({
     where: {
       slug: stageSlug,
       isVisible: true,
+      endDate: getActiveStageEndDateFilter(now),
     },
     include: publicStageInclude,
   });

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -115,6 +115,11 @@ const nextConfig = {
   async redirects() {
     return [
       {
+        source: '/stages/printemps-2026',
+        destination: '/stages',
+        statusCode: 301,
+      },
+      {
         source: '/corrige_dnb_maths_2026',
         destination: '/ressources',
         statusCode: 301,

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -603,7 +603,10 @@ async function main() {
   // ── Stage Printemps 2026 ────────────────────────────────────────────────────
   const stagePrintemps = await prisma.stage.upsert({
     where: { slug: 'printemps-2026' },
-    update: {},
+    update: {
+      isVisible: false,
+      isOpen: false,
+    },
     create: {
       slug: 'printemps-2026',
       title: 'Stage Intensif Printemps 2026',
@@ -620,8 +623,8 @@ async function main() {
       priceAmount: 350,
       priceCurrency: 'TND',
       location: 'Nexus Réussite — Tunis',
-      isVisible: true,
-      isOpen: true,
+      isVisible: false,
+      isOpen: false,
     },
   });
 


### PR DESCRIPTION
## Contexte

Le stage `printemps-2026`, terminé le 25 avril 2026, restait visible, ouvert, indexable et inscriptible. La ligne de production a déjà été fermée de façon transactionnelle (`isVisible=false`, `isOpen=false`) sans supprimer ni modifier ses deux réservations `COMPLETED`.

## Correctif

- borne toutes les lectures publiques et le sitemap par `endDate >= now` ;
- refuse atomiquement tout POST sur un stage expiré ;
- renvoie la fiche legacy exacte en 301 vers `/stages` ;
- maintient la route d inscription en 404 avec `noindex, nofollow, nocache`, sans redirection de POST ;
- bloque en administration la création ou réouverture d un stage expiré, avec garde de concurrence optimiste ;
- ferme le stage dans les branches `create` et `update` du seed ;
- ajoute des tests unitaires, de contrat et Playwright à horloge/données maîtrisées.

## Diagnostic production

- source de vérité : table PostgreSQL `stages` ; seed = bootstrap uniquement ;
- un seul stage expiré visible+ouvert trouvé : `printemps-2026` ;
- deux réservations persistées `COMPLETED`, historique conservé ; origine commerciale non démontrée ;
- après fermeture : API publique vide pour ce stage, slug absent du sitemap, pages non exposées ;
- aucun autre stage, prix, bilan ou parcours Pré-rentrée 2026 modifié.

## Vérifications locales

- suite unitaire complète : 819 suites / 9 088 tests ;
- intégration : 39 suites non-NPC + harness NPC 3 suites / 47 tests ;
- Playwright ciblé : 2/2, 0 skip ;
- typecheck, cinq contrôles Lint, syntaxe E2E et diff-check : verts ;
- audit dépendances de production : 0 vulnérabilité ;
- `build:e2e` et audit artefact autonome : verts ;
- deux revues indépendantes : aucun finding.

## Hors périmètre garanti

Aucun changement dans les bilans, la saisie papier, les régénérations, les liens signés, `data/pricing.canonical.json` ou la campagne Pré-rentrée 2026.

## Exploitation

- aucune suppression de données ;
- aucun merge ni déploiement dans cette PR ;
- approbation demandée à `abenrhouma` ;
- attendre E2E, Semgrep, OSV et tous les checks CI avant arbitrage.

Rapport détaillé : `docs/audits/2026-08-13-fermeture-stage-printemps-2026.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ferme et désindexe les stages expirés et empêche toute réouverture ou inscription après leur fin. Avant, les surfaces publiques et l’inscription ignoraient `endDate`; désormais, listes, détails et sitemap exigent `endDate >= now`, le POST d’inscription refuse les expirés, l’admin bloque création/réouverture d’un expiré, la fiche legacy redirige en 301, et la page d’inscription expirée répond 404 avec `noindex`.

- Centralise la règle dans `lib/stages/lifecycle.ts` (frontière inclusive à `now`; `endDate === now` reste actif).
- Borne les lectures publiques par la date dans `lib/stages/public.ts`, `app/api/stages/*`, et `app/sitemap.ts`.
- Refuse atomiquement l’inscription expirée dans `app/api/stages/[stageSlug]/inscrire/route.ts` (aucune écriture ni envoi d’email si expiré).
- Administration: `POST` et `PATCH` vérifient l’état effectif; refus en 400 si expiré+ouvert; garde de concurrence optimiste avec `@prisma/client` et 409 sur `P2025`.
- Redirection exacte 301 uniquement pour `/stages/printemps-2026` vers `/stages` dans `next.config.mjs`; aucune redirection d’`/inscription`.
- Le seed (`prisma/seed.ts`) conserve le stage historique fermé (`isVisible=false`, `isOpen=false`).
- Ajoute tests unitaires/contrats et Playwright avec horloge injectée pour garantir la frontière temporelle et l’absence d’effets de bord.

<sup>Written for commit 88cdd7fb1c2ffa2e4ee22cbd78ac8941bf7c0840. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

