### PR TITLE
fix(saisie-papier): accepter les numéros internationaux à la création d'un foyer

### DIFF
--- a/__tests__/bilans/saisie-papier-famille.test.ts
+++ b/__tests__/bilans/saisie-papier-famille.test.ts
@@ -489,7 +489,9 @@ describe('Création du foyer — activation en attente', () => {
     const { database, users } = memoryDatabase();
     const response = await handlerWith('ASSISTANTE', database)(familyRequest({
       ...BODY,
-      parentPhone: '+33 6 12 34 56 78',
+      // +33 est désormais un numéro international valide (voir plus bas) ;
+      // ce cas est invalide pour une autre raison : bien trop court.
+      parentPhone: '+33 1',
     }));
 
     expect(response.status).toBe(400);
@@ -706,5 +708,105 @@ describe('Création du foyer — activation en attente', () => {
 
     const response = await handlerWith('ASSISTANTE', database)(familyRequest());
     expect(response.status).toBe(409);
+  });
+});
+
+/**
+ * Numéros internationaux (au-delà de la Tunisie) — lib/contact/parent-phone.ts.
+ *
+ * Le défaut d'origine : `normalizeParentPhone` ne connaissait que la Tunisie,
+ * donc cette route refusait toute famille étrangère. Preuve que ce n'est plus
+ * le cas, et que le rapprochement anti-doublon fonctionne aussi sur les
+ * différentes écritures d'un même numéro international.
+ */
+describe('Création du foyer — téléphone international (Qatar +974)', () => {
+  const QATAR_BODY = {
+    parentEmail: 'Parent.Qatar@example.test',
+    parentPhone: '+97466298752',
+    parentFirstName: 'Nasser',
+    parentLastName: 'Al-Thani',
+    children: [{ firstName: 'Fatima', grade: 'Terminale' }],
+  };
+
+  it('crée un parent avec le numéro qatari, phoneNormalized sans indicatif dupliqué', async () => {
+    const { database, users, students } = memoryDatabase();
+    const response = await handlerWith('ASSISTANTE', database)(familyRequest(QATAR_BODY, 'foyer-qatar-0001'));
+
+    expect(response.status).toBe(201);
+    expect(students).toHaveLength(1);
+    expect(users.find((user) => user.role === 'PARENT')).toMatchObject({
+      phone: '+97466298752',
+      phoneNormalized: '97466298752',
+      password: null,
+      activatedAt: null,
+    });
+  });
+
+  it('conserve le téléphone d’affichage international', async () => {
+    const { database, users } = memoryDatabase();
+    await handlerWith('ASSISTANTE', database)(familyRequest(QATAR_BODY, 'foyer-qatar-0002'));
+
+    expect(users.find((user) => user.role === 'PARENT')?.phone).toBe('+97466298752');
+  });
+
+  it.each([
+    ['00974 66 29 87 52', '00 avec espaces'],
+    ['+974 66 29 87 52', '+ avec espaces'],
+    ['97466298752', 'chiffres nus'],
+  ])('remonte le même candidat anti-doublon depuis %s (%s)', async (parentPhone) => {
+    const { database, duplicateCandidates } = memoryDatabase();
+    duplicateCandidates.push({
+      id: 'parent-qatar-existant',
+      firstName: 'Nasser',
+      lastName: 'Al-Thani',
+      email: null,
+      phone: '+97466298752',
+      phoneNormalized: '97466298752',
+      mergedSources: [],
+      parentProfile: null,
+    } as never);
+
+    const response = await handlerWith('ASSISTANTE', database)(familyRequest({
+      ...QATAR_BODY,
+      parentPhone,
+      // Nom différent : seul le téléphone doit produire le signal fort ici.
+      parentFirstName: 'Autre',
+      parentLastName: 'Personne',
+    }));
+
+    expect(response.status).toBe(409);
+    const payload = await response.json() as { candidates: ReadonlyArray<{ parentUserId: string; matchStrength: string }> };
+    expect(payload.candidates).toContainEqual(expect.objectContaining({
+      parentUserId: 'parent-qatar-existant',
+      matchStrength: 'PHONE',
+    }));
+  });
+
+  it('protège la surface staff-only pour un foyer international comme pour un foyer tunisien', async () => {
+    const { database, users } = memoryDatabase();
+    const response = await handlerWith('ELEVE', database)(familyRequest(QATAR_BODY, 'foyer-qatar-staff'));
+
+    expect(response.status).toBe(404);
+    expect(users).toHaveLength(0);
+  });
+
+  it('reste idempotent sur un renvoi avec la même clé', async () => {
+    const { database, users } = memoryDatabase();
+    const key = 'foyer-qatar-idempotent';
+
+    const first = await handlerWith('ASSISTANTE', database)(familyRequest(QATAR_BODY, key));
+    const second = await handlerWith('ASSISTANTE', database)(familyRequest(QATAR_BODY, key));
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+    expect(users.filter((user) => user.role === 'PARENT')).toHaveLength(1);
+  });
+
+  it('prépare le lien de consentement parent-enfant comme pour un foyer tunisien', async () => {
+    const { database, links } = memoryDatabase();
+    const response = await handlerWith('ASSISTANTE', database)(familyRequest(QATAR_BODY, 'foyer-qatar-consent'));
+
+    expect(response.status).toBe(201);
+    expect(links).toHaveLength(1);
   });
 });

--- a/__tests__/bilans/saisie-papier-workflow.test.tsx
+++ b/__tests__/bilans/saisie-papier-workflow.test.tsx
@@ -80,6 +80,42 @@ describe('Fil guidé de saisie papier', () => {
     );
   });
 
+  it('active le bouton de création et envoie le numéro international saisi (Qatar)', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      children: [{ studentId: 'student-qatar' }],
+    }), { status: 201, headers: { 'content-type': 'application/json' } }));
+    render(<PaperEntryFamilyForm />);
+
+    fireEvent.change(screen.getByLabelText('Prénom du parent'), { target: { value: 'Nasser' } });
+    fireEvent.change(screen.getByLabelText('Nom du parent'), { target: { value: 'Al-Thani' } });
+    fireEvent.change(screen.getByLabelText('Prénom de l’enfant'), { target: { value: 'Fatima' } });
+    expect(screen.getByRole('button', { name: 'Créer le foyer et continuer' })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Téléphone du parent'), { target: { value: '+97466298752' } });
+    expect(screen.getByRole('button', { name: 'Créer le foyer et continuer' })).toBeEnabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Créer le foyer et continuer' }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const request = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(request[1].body));
+    expect(body).toMatchObject({ parentPhone: '+97466298752' });
+    expect(replace).toHaveBeenCalledWith(
+      '/dashboard/assistante/bilans/saisie-papier?studentId=student-qatar',
+    );
+  });
+
+  it('affiche une erreur claire et garde le bouton désactivé pour un numéro invalide', () => {
+    render(<PaperEntryFamilyForm />);
+
+    fireEvent.change(screen.getByLabelText('Prénom du parent'), { target: { value: 'Claire' } });
+    fireEvent.change(screen.getByLabelText('Nom du parent'), { target: { value: 'Bernard' } });
+    fireEvent.change(screen.getByLabelText('Prénom de l’enfant'), { target: { value: 'Inès' } });
+    fireEvent.change(screen.getByLabelText('Téléphone du parent'), { target: { value: '123' } });
+
+    expect(screen.getByRole('button', { name: 'Créer le foyer et continuer' })).toBeDisabled();
+    expect(screen.getByRole('alert')).toHaveTextContent('Numéro de téléphone invalide.');
+  });
+
   it('sur un même téléphone, laisse rattacher le foyer suggéré d’un clic', async () => {
     fetchMock
       .mockResolvedValueOnce(new Response(JSON.stringify({

--- a/__tests__/bilans/whatsapp-transmission.test.ts
+++ b/__tests__/bilans/whatsapp-transmission.test.ts
@@ -17,10 +17,15 @@ describe('buildParentWhatsAppUrl', () => {
     expect(url).toContain(encodeURIComponent('Bonjour, voici : élève').replace(/%20/g, '%20'));
   });
 
-  it('refuse un téléphone hors forme normalisée tunisienne', () => {
+  it('refuse un téléphone hors forme normalisée tunisienne ou internationale', () => {
     for (const invalid of ['', '1234567', '021612345', '+21698123456', '9812345a']) {
       expect(() => buildParentWhatsAppUrl(invalid, 'x')).toThrow('WHATSAPP_PARENT_PHONE_INVALID');
     }
+  });
+
+  it('construit le lien depuis un phoneNormalized international (indicatif déjà inclus, non préfixé par 216)', () => {
+    const url = buildParentWhatsAppUrl('97466298752', 'Bonjour');
+    expect(url).toBe('https://wa.me/97466298752?text=Bonjour');
   });
 });
 

--- a/__tests__/lib/contact/parent-phone.test.ts
+++ b/__tests__/lib/contact/parent-phone.test.ts
@@ -1,6 +1,6 @@
 import { normalizeParentPhone } from '@/lib/contact/parent-phone';
 
-describe('normalizeParentPhone', () => {
+describe('normalizeParentPhone — Tunisie (compatibilité historique impérative)', () => {
   test.each([
     '99 19 28 29',
     '+216 99 19 28 29',
@@ -13,15 +13,69 @@ describe('normalizeParentPhone', () => {
       normalized: '99192829',
     });
   });
+});
 
+describe('normalizeParentPhone — international (E.164 générique)', () => {
+  it.each([
+    ['+97466298752', 'Qatar, +'],
+    ['+974 66 29 87 52', 'Qatar, + avec espaces'],
+    ['00974 66 29 87 52', 'Qatar, 00 avec espaces'],
+    ['97466298752', 'Qatar, chiffres nus'],
+  ])('normalise %s (%s) vers le même numéro qatari canonique', (input) => {
+    expect(normalizeParentPhone(input)).toEqual({
+      display: '+97466298752',
+      normalized: '97466298752',
+    });
+  });
+
+  it('normalise un numéro français', () => {
+    expect(normalizeParentPhone('+33 6 12 34 56 78')).toEqual({
+      display: '+33612345678',
+      normalized: '33612345678',
+    });
+  });
+
+  it('normalise un numéro émirati', () => {
+    expect(normalizeParentPhone('+971 50 123 4567')).toEqual({
+      display: '+971501234567',
+      normalized: '971501234567',
+    });
+  });
+
+  it('normalise un numéro saoudien', () => {
+    expect(normalizeParentPhone('+966 50 123 4567')).toEqual({
+      display: '+966501234567',
+      normalized: '966501234567',
+    });
+  });
+
+  it('accepte la limite maximale E.164 de 15 chiffres', () => {
+    const fifteenDigits = '123456789012345';
+    expect(normalizeParentPhone(`+${fifteenDigits}`)).toEqual({
+      display: `+${fifteenDigits}`,
+      normalized: fifteenDigits,
+    });
+  });
+
+  it('refuse un numéro dépassant 15 chiffres', () => {
+    expect(() => normalizeParentPhone('+1234567890123456')).toThrow('PARENT_PHONE_INVALID');
+  });
+});
+
+describe('normalizeParentPhone — formats invalides', () => {
   test.each([
-    '',
-    '9919282',
-    '991928290',
-    '+33 6 12 34 56 78',
-    '00 216 parent',
-    '00192829',
-  ])('refuse le format invalide %j', (input) => {
+    ['', 'chaîne vide'],
+    ['9919282', 'tunisien trop court (7 chiffres)'],
+    ['991928290', 'nu, ambigu, trop court pour être international (9 chiffres)'],
+    ['00 216 parent', 'lettres'],
+    ['00192829', '00 non tunisien, trop court'],
+    ['+216+99192829', 'deux signes +'],
+    ['216+99192829', 'signe + ailleurs qu’au début'],
+    ['+0123456789', 'indicatif impossible +0'],
+    ['9919282a', 'lettre mêlée aux chiffres'],
+    ['+216 99 19 28 29 ext 12', 'extension textuelle non gérée'],
+    ['+216/99192829', 'caractère non autorisé (/)'],
+  ])('refuse le format invalide %j (%s)', (input) => {
     expect(() => normalizeParentPhone(input)).toThrow('PARENT_PHONE_INVALID');
   });
 });

--- a/app/dashboard/assistante/bilans/saisie-papier/family-form.tsx
+++ b/app/dashboard/assistante/bilans/saisie-papier/family-form.tsx
@@ -145,18 +145,29 @@ export function PaperEntryFamilyForm() {
             className="mt-1 w-full rounded-xl border border-white/15 bg-slate-950 px-3 py-2 text-white"
           />
         </label>
-        <label className="text-sm">
-          <span className="text-slate-300">Téléphone du parent</span>
-          <input
-            type="tel"
-            inputMode="tel"
-            required
-            value={parentPhone}
-            onChange={(event) => setParentPhone(event.target.value)}
-            placeholder={LEGAL.contact.phone}
-            className="mt-1 w-full rounded-xl border border-white/15 bg-slate-950 px-3 py-2 text-white"
-          />
-        </label>
+        <div className="text-sm">
+          <label>
+            <span className="text-slate-300">Téléphone du parent</span>
+            <input
+              type="tel"
+              inputMode="tel"
+              required
+              value={parentPhone}
+              onChange={(event) => setParentPhone(event.target.value)}
+              placeholder={LEGAL.contact.phone}
+              aria-invalid={parentPhone.trim().length > 0 && !phoneIsValid}
+              className="mt-1 w-full rounded-xl border border-white/15 bg-slate-950 px-3 py-2 text-white"
+            />
+          </label>
+          <p className="mt-1 text-xs text-slate-400">
+            Numéros tunisiens et internationaux acceptés, par exemple +216… ou +974…
+          </p>
+          {parentPhone.trim().length > 0 && !phoneIsValid && (
+            <p role="alert" className="mt-1 text-xs text-red-300">
+              Numéro de téléphone invalide.
+            </p>
+          )}
+        </div>
         <label className="text-sm">
           <span className="text-slate-300">E-mail du parent (facultatif)</span>
           <input

--- a/lib/contact/parent-phone.ts
+++ b/lib/contact/parent-phone.ts
@@ -4,22 +4,77 @@ export type NormalizedParentPhone = Readonly<{
 }>;
 
 const TUNISIA_PREFIX = '216';
+const TUNISIA_LOCAL_PATTERN = /^[1-9]\d{7}$/;
 
+// E.164 hard ceiling: country code + subscriber number, no more than 15 digits.
+const E164_MAX_DIGITS = 15;
+// A '+' or '00' prefix is an explicit, unambiguous international marker, so a
+// short-but-plausible significant number is accepted below it. Kept strictly
+// above 8 so a prefixed number can never collide with the 8-digit Tunisian
+// legacy shape that WhatsApp link building (lib/whatsapp.ts) relies on to
+// decide whether to prepend '216'.
+const INTERNATIONAL_PREFIXED_MIN_DIGITS = 9;
+// Without any prefix at all, a short digit string is far more likely to be a
+// malformed local number than a genuine international one written without its
+// '+'. Require two digits more than the Tunisian 8-digit format so a stray
+// extra digit on a local number (e.g. a mistyped 9-digit Tunisian number)
+// still gets rejected rather than silently accepted as "international".
+const INTERNATIONAL_BARE_MIN_DIGITS = 10;
+
+function normalizeTunisianLocal(local: string): NormalizedParentPhone {
+  if (!TUNISIA_LOCAL_PATTERN.test(local)) throw new Error('PARENT_PHONE_INVALID');
+  return Object.freeze({
+    display: local.replace(/(\d{2})(?=\d)/g, '$1 ').trim(),
+    normalized: local,
+  });
+}
+
+function normalizeInternational(digits: string, minDigits: number): NormalizedParentPhone {
+  if (digits.length < minDigits || digits.length > E164_MAX_DIGITS || !/^[1-9]/.test(digits)) {
+    throw new Error('PARENT_PHONE_INVALID');
+  }
+  return Object.freeze({ display: `+${digits}`, normalized: digits });
+}
+
+/**
+ * Normalise un numéro de téléphone parent.
+ *
+ * Tunisie (compatibilité historique impérative — ne pas modifier) : `display`
+ * et `normalized` restent les 8 chiffres locaux sans indicatif, quelle que
+ * soit l'écriture saisie (+216, 00216, ou locale nue). C'est la forme déjà
+ * stockée pour tous les foyers existants ; la changer romprait le
+ * rapprochement anti-doublon et les liens wa.me (lib/whatsapp.ts) sans
+ * migration.
+ *
+ * Tout autre pays : forme canonique E.164 sans « + », `display` = « + » suivi
+ * de ces mêmes chiffres. Aucune validation par indicatif réel (pas de
+ * dépendance type libphonenumber) — seulement une forme générique plausible.
+ */
 export function normalizeParentPhone(value: string): NormalizedParentPhone {
   const input = value.trim();
   if (!input || !/^[\d\s()+.-]+$/.test(input)) throw new Error('PARENT_PHONE_INVALID');
 
-  if (input.startsWith('+') && !input.startsWith('+216')) throw new Error('PARENT_PHONE_INVALID');
-  if (input.startsWith('00') && !input.startsWith('00216')) throw new Error('PARENT_PHONE_INVALID');
+  const plusCount = input.split('+').length - 1;
+  if (plusCount > 1 || (plusCount === 1 && !input.startsWith('+'))) {
+    throw new Error('PARENT_PHONE_INVALID');
+  }
 
-  let digits = input.replace(/\D/g, '');
-  if (digits.startsWith(`00${TUNISIA_PREFIX}`)) digits = digits.slice(5);
-  else if (digits.length === 11 && digits.startsWith(TUNISIA_PREFIX)) digits = digits.slice(3);
+  if (input.startsWith('+')) {
+    const digits = input.slice(1).replace(/\D/g, '');
+    if (digits.startsWith(TUNISIA_PREFIX)) return normalizeTunisianLocal(digits.slice(TUNISIA_PREFIX.length));
+    return normalizeInternational(digits, INTERNATIONAL_PREFIXED_MIN_DIGITS);
+  }
 
-  if (!/^[1-9]\d{7}$/.test(digits)) throw new Error('PARENT_PHONE_INVALID');
+  if (input.startsWith('00')) {
+    const digits = input.slice(2).replace(/\D/g, '');
+    if (digits.startsWith(TUNISIA_PREFIX)) return normalizeTunisianLocal(digits.slice(TUNISIA_PREFIX.length));
+    return normalizeInternational(digits, INTERNATIONAL_PREFIXED_MIN_DIGITS);
+  }
 
-  return Object.freeze({
-    display: digits.replace(/(\d{2})(?=\d)/g, '$1 ').trim(),
-    normalized: digits,
-  });
+  const digits = input.replace(/\D/g, '');
+  if (TUNISIA_LOCAL_PATTERN.test(digits)) return normalizeTunisianLocal(digits);
+  if (digits.length === 11 && digits.startsWith(TUNISIA_PREFIX)) {
+    return normalizeTunisianLocal(digits.slice(TUNISIA_PREFIX.length));
+  }
+  return normalizeInternational(digits, INTERNATIONAL_BARE_MIN_DIGITS);
 }

--- a/lib/whatsapp.ts
+++ b/lib/whatsapp.ts
@@ -36,19 +36,25 @@ export function buildWhatsAppContactUrl(number = WHATSAPP_NUMBER): string {
 /**
  * Lien wa.me vers le téléphone d'un PARENT (envoi assisté d'un bilan).
  *
- * `phoneNormalized` est la forme canonique du dépôt : 8 chiffres tunisiens,
- * sans indicatif (lib/contact/parent-phone.ts). wa.me exige l'international
- * sans « + » : l'indicatif 216 est ajouté ici — et uniquement ici, ce
- * fichier étant la seule source autorisée de littéraux wa.me.
+ * `phoneNormalized` est la forme canonique du dépôt (lib/contact/parent-phone.ts) :
+ * soit 8 chiffres tunisiens sans indicatif (forme historique — l'indicatif 216
+ * est ajouté ici, et uniquement ici, ce fichier étant la seule source
+ * autorisée de littéraux wa.me), soit un numéro international complet
+ * (indicatif déjà inclus, utilisé tel quel). Les deux formes ne peuvent pas
+ * se confondre : parent-phone.ts garantit qu'un numéro international ne
+ * normalise jamais vers exactement 8 chiffres.
  */
 export function buildParentWhatsAppUrl(
   phoneNormalized: string,
   message: string,
 ): string {
-  if (!/^[1-9]\d{7}$/.test(phoneNormalized)) {
-    throw new Error('WHATSAPP_PARENT_PHONE_INVALID');
+  if (/^[1-9]\d{7}$/.test(phoneNormalized)) {
+    return `https://wa.me/216${phoneNormalized}?text=${encodeURIComponent(message)}`;
   }
-  return `https://wa.me/216${phoneNormalized}?text=${encodeURIComponent(message)}`;
+  if (/^[1-9]\d{8,14}$/.test(phoneNormalized)) {
+    return `https://wa.me/${phoneNormalized}?text=${encodeURIComponent(message)}`;
+  }
+  throw new Error('WHATSAPP_PARENT_PHONE_INVALID');
 }
 
 /** Expose the number for tel: links (formatted). */


### PR DESCRIPTION
## Défaut

`normalizeParentPhone` (`lib/contact/parent-phone.ts`) n'acceptait que les numéros tunisiens. Sur `/dashboard/assistante/bilans/saisie-papier`, le bouton **« Créer le foyer et continuer »** restait désactivé pour une famille étrangère — et le serveur (`POST /api/bilans/saisie-papier/famille`) aurait de toute façon refusé la requête.

**Exemple réel devant fonctionner** : `+97466298752` (Qatar).

## Règle de normalisation retenue

- **Tunisie — compatibilité historique impérative, inchangée** : `normalized` reste les 8 chiffres locaux sans indicatif (`"99192829"`), `display` reste `"99 19 28 29"`, quelle que soit l'écriture saisie (`+216…`, `00216…`, locale nue). Aucune donnée existante n'est retransformée en `21699192829` — aucune migration, aucune décision de ce type n'a été prise ici.
- **Tout autre pays — E.164 générique** : `normalized` = indicatif + numéro sans `+` (ex. `"97466298752"`), `display` = `"+"` suivi des mêmes chiffres (ex. `"+97466298752"`). Accepte `+`, `00`, ou une chaîne de chiffres nue.
- Pas de dépendance `libphonenumber` : validation de **forme** seulement (longueur, premier chiffre non nul, plafond E.164 à 15 chiffres) — aucune table d'indicatifs réels.
- Un détail de seuil documenté dans le code : le format "chiffres nus sans préfixe" exige **≥ 10 chiffres** (et non "plus de huit" au sens littéral) pour être accepté comme international, afin qu'un numéro tunisien mal saisi à 9 chiffres (`991928290`, déjà couvert par un test existant) continue d'être rejeté plutôt que silencieusement réinterprété comme un numéro étranger.

## Consommateur corrigé

`lib/whatsapp.ts::buildParentWhatsAppUrl` préfixait toujours `"216"` — cassé pour un `phoneNormalized` international (il aurait levé `WHATSAPP_PARENT_PHONE_INVALID` pour tout numéro non tunisien). Distingue maintenant les deux formes par longueur : exactement 8 chiffres → Tunisie historique (préfixe `216` ajouté) ; 9 à 15 chiffres → international déjà complet (utilisé tel quel). Cette ambiguïté est rendue impossible par construction côté `normalizeParentPhone` (un numéro international ne normalise jamais vers exactement 8 chiffres).

## Anti-doublon

`classifyHouseholdMatch` (`household-matching.ts`) compare déjà `phoneNormalized` par égalité de chaîne pure, sans hypothèse de longueur — aucun changement nécessaire de ce côté. Testé : les 4 écritures d'un même numéro qatari (`+97466298752`, `+974 66 29 87 52`, `00974 66 29 87 52`, `97466298752`) remontent le même candidat anti-doublon (`matchStrength: 'PHONE'`).

## Absence de migration

`phone` et `phoneNormalized` sur `User` sont des `String?` Postgres sans contrainte de longueur, avec un index **non-unique** (`@@index([phoneNormalized])`). `git diff --name-only origin/main...HEAD -- prisma` → vide.

## Formulaire (`family-form.tsx`)

- `type="tel"` / `inputMode="tel"` conservés.
- Texte d'aide ajouté : *« Numéros tunisiens et internationaux acceptés, par exemple +216… ou +974… »*.
- Erreur inline claire (`role="alert"`) si le numéro saisi est invalide.
- Aucun préfixage automatique de `+216` sur un numéro étranger.
- Design existant non retouché au-delà de ces ajouts.

## Tests exécutés

- `npx jest --config jest.config.js __tests__/lib/contact/parent-phone.test.ts` — 25/25 (Tunisie inchangée, Qatar sous 4 écritures, France, Émirats, Arabie saoudite, limite E.164 15 chiffres, formats invalides étendus).
- `npx jest --config jest.config.js __tests__/bilans/saisie-papier-famille.test.ts` — 43/43 (dont un nouveau bloc dédié : création Qatar, `phoneNormalized` sans doublon d'indicatif, affichage international conservé, anti-doublon sur les 3 écritures, staff-only, idempotence, consentement parent-enfant — tous préservés pour le cas international).
- `npx jest --config jest.config.js __tests__/bilans/saisie-papier-workflow.test.tsx` — bouton actif avec `+97466298752`, corps POST correct, erreur inline sur numéro invalide.
- `npx jest --config jest.config.js __tests__/bilans/whatsapp-transmission.test.ts` — lien wa.me correct pour un `phoneNormalized` international, formats invalides toujours rejetés.
- `npm test` (suite complète, `NEXTAUTH_URL` aligné sur la CI) — **828 suites / 9151 tests verts**.
- `npx tsc --noEmit` — aucune erreur.
- `npm run lint` — OK (mêmes warnings pré-existants hors-diff que sur `main`, sous le seuil de 300).
- `npm run check:test-quarantines` — OK, 2450 fichiers, aucune quarantaine.
- `npm run check:no-hardcoded` — OK.
- `npm run build` (installation propre `npm ci`, `npx prisma generate`) — build de production verte, artefact standalone vérifié (`ARTIFACT VALID`, arbres de fichiers statiques identiques, `BUILD_ID` cohérent).
- `git diff --name-only origin/main...HEAD -- prisma` — vide (aucune migration).

## Risques résiduels

- Le seuil de 10 chiffres minimum pour un numéro international saisi **sans** `+`/`00` est un choix documenté dans le code, légèrement plus strict que la formulation littérale du besoin ("plus de huit chiffres") — nécessaire pour ne pas casser le test existant `991928290` (rejeté). Aucun des exemples requis (Qatar 11 chiffres, France/UAE/Arabie saoudite 11-12 chiffres) n'est affecté.
- Aucune validation par indicatif réel (pas de `libphonenumber`) : un numéro syntaxiquement plausible mais avec un indicatif inexistant (ex. `+999...`) sera accepté si sa forme est correcte. Comportement voulu par la consigne ("pas de dépendance lourde").

## SHA et branche

- Branche : `fix/paper-entry-international-phone`
- HEAD : `780361e1a951b103e051d1945d040aed0ad4940b`
- Base : `origin/main` = `dcfed3bd6044c2b4c6d7fa6dfbff24751f7d48b1` (pas de dérive constatée)

## Isolation

Développé dans un worktree séparé (`fix/paper-entry-international-phone`, branché sur `origin/main`), aucun contact avec la branche/PR #153 (planning pré-rentrée).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepte les numéros internationaux lors de la création d’un foyer (saisie papier) et corrige la génération des liens WhatsApp. Avant: seuls les numéros tunisiens passaient; le bouton restait désactivé et l’API rejetait la requête. Maintenant: la Tunisie reste inchangée, les autres pays suivent une forme E.164 générique, et WhatsApp distingue correctement les deux formes.

**Détails pour la revue et le déploiement**
- `lib/contact/parent-phone.ts`: Tunisie inchangée (8 chiffres locaux; `display` «XX XX XX XX»). Autres pays: E.164 générique — `normalized` = indicatif+numéro sans «+», `display` = «+…». Seuils: préfixés `+`/`00` ≥ 9 chiffres; sans préfixe ≥ 10; plafond 15; premier chiffre non nul. Pas de `libphonenumber` (validation de forme uniquement).
- `lib/whatsapp.ts`: 8 chiffres → ajout de `216`; 9–15 chiffres → utilisé tel quel. Rejette les formes hors bornes.
- `app/dashboard/assistante/bilans/saisie-papier/family-form.tsx`: aide utilisateur et erreur inline; pas d’auto-`+216`; `type="tel"` conservé.
- Anti-doublon inchangé (égalité sur `phoneNormalized`). Pas de migration ni de changement Prisma.
- Tests élargis (Qatar et autres écritures, flux UI, WhatsApp).

<sup>Written for commit 780361e1a951b103e051d1945d040aed0ad4940b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

