### PR TITLE
fix(bilans): sécuriser et industrialiser le workflow des briefs enseignants

### DIFF
--- a/__tests__/bilans/teacher-brief.test.ts
+++ b/__tests__/bilans/teacher-brief.test.ts
@@ -8,7 +8,6 @@ import {
   buildStudentFactsPayload,
   callTeacherBriefModel,
   estimateCostUsd,
-  generateTeacherBrief,
   resolveTeacherBriefConfig,
   teacherBriefMonthlyUsage,
 } from '@/lib/bilans/llm/teacher-brief-service';
@@ -362,139 +361,16 @@ describe('teacher-brief — appel modèle, un appel par domaine', () => {
   });
 });
 
-describe('teacher-brief — orchestration, repli, budget, idempotence', () => {
-  function database(overrides: Partial<Record<string, unknown>> = {}) {
-    const writes: string[] = [];
-    const db = {
-      teacherBrief: {
-        findFirst: jest.fn(async () => null),
-        aggregate: jest.fn(async () => ({ _sum: { estimatedCostUsd: 0 }, _count: { id: 0 } })),
-        create: jest.fn(async () => { writes.push('teacherBrief.create'); return { id: 'brief-1', version: 1 }; }),
-        updateMany: jest.fn(async () => ({ count: 0 })),
-      },
-      reportArtifact: { findUnique: jest.fn(async () => null) },
-      reportRevision: { updateMany: jest.fn(async () => { writes.push('reportRevision.updateMany'); }) },
-      reportMaterialization: { create: jest.fn(async () => { writes.push('reportMaterialization.create'); }) },
-      $transaction: jest.fn(),
-      ...overrides,
-    };
-    (db.$transaction as jest.Mock).mockImplementation(async (callback: (t: unknown) => Promise<unknown>) => callback(db));
-    return { db, writes };
-  }
-  const actor = { userId: 'assistante-1', role: 'ASSISTANTE' } as const;
-
-  it('REPLI : clé absente → PLANCHER, aucune écriture, aucune erreur bloquante', async () => {
-    const { db, writes } = database();
-    const result = await generateTeacherBrief({
-      prisma: db as never, actor, reportArtifactId: 'art-1', environment: {},
-    });
-    expect(result).toEqual({ mode: 'PLANCHER', reason: 'OPENROUTER_API_KEY_MISSING' });
-    expect(writes).toHaveLength(0);
-  });
-
-  it('REPLI : budget mensuel dépassé → PLANCHER', async () => {
-    const { db } = database({
-      teacherBrief: {
-        findFirst: jest.fn(async () => null),
-        aggregate: jest.fn(async () => ({ _sum: { estimatedCostUsd: 25 }, _count: { id: 40 } })),
-        create: jest.fn(),
-        updateMany: jest.fn(),
-      },
-    });
-    const result = await generateTeacherBrief({
-      prisma: db as never, actor, reportArtifactId: 'art-1',
-      environment: { OPENROUTER_API_KEY: 'k', NEXUS_TEACHER_BRIEF_MONTHLY_BUDGET_USD: '20' },
-    });
-    expect(result).toEqual({ mode: 'PLANCHER', reason: 'TEACHER_BRIEF_BUDGET_EXCEEDED' });
-  });
-
-  it('cache applicatif : un brief déjà présent (relu ou en attente) ne se régénère jamais', async () => {
-    const { db } = database({
-      teacherBrief: {
-        findFirst: jest.fn(async () => ({ id: 'brief-42' })),
-        aggregate: jest.fn(),
-        create: jest.fn(),
-        updateMany: jest.fn(),
-      },
-    });
-    const result = await generateTeacherBrief({
-      prisma: db as never, actor, reportArtifactId: 'art-1', environment: { OPENROUTER_API_KEY: 'k' },
-    });
-    expect(result).toEqual({ mode: 'ALREADY_PRESENT', briefId: 'brief-42' });
-  });
-
-  it('GARDE : le service brief n’écrit JAMAIS dans les révisions ni les matérialisations (élève/parents 100 % déterministes)', async () => {
-    const answers = answersAllWrongConfident();
-    const { db, writes } = database({
-      reportArtifact: {
-        findUnique: jest.fn(async () => ({
-          id: 'art-1',
-          assessmentAttempt: {
-            answers,
-            assessmentPackId: PACK.slug,
-            assessmentPackVersion: String(PACK.version),
-            assessmentPackChecksum: 'checksum-pack',
-          },
-          revisions: [{ scoreSnapshotId: 'snap-1', scoreSnapshot: { result: factSheet() } }],
-        })),
-      },
-    });
-    // Un appel par domaine : le modèle simulé renvoie le domaine demandé.
-    const fetchOk: typeof fetch = (async (_url: unknown, init?: RequestInit) => {
-      const facts = JSON.parse(JSON.parse(String(init?.body)).messages[1].content) as typeof FACTS;
-      const domaine = validBriefContent().domaines
-        .find((d) => d.domainId === facts.domainesPrioritaires[0].domainId)!;
-      return new Response(JSON.stringify({
-        choices: [{ message: { content: JSON.stringify({ version: TEACHER_BRIEF_PROMPT_VERSION, domaines: [domaine] }) } }],
-        usage: { prompt_tokens: 2_300, completion_tokens: 1_100, prompt_tokens_details: { cached_tokens: 1_710 } },
-      }), { status: 200 });
-    }) as typeof fetch;
-    const result = await generateTeacherBrief({
-      prisma: db as never, actor, reportArtifactId: 'art-1',
-      environment: { OPENROUTER_API_KEY: 'k' },
-      resolvePack: () => ({ pack: PACK, validatedPack: null as never, checksum: 'checksum-pack', path: 'x' }),
-      fetchImpl: fetchOk,
-    });
-    expect(result.mode).toBe('GENERATED');
-    expect(writes).toEqual(['teacherBrief.create']);
-    expect(writes).not.toContain('reportRevision.updateMany');
-    expect(writes).not.toContain('reportMaterialization.create');
-  });
-
-  it('REPLI : transport en erreur → PLANCHER, rien n’est écrit', async () => {
-    const answers = answersAllWrongConfident();
-    const { db, writes } = database({
-      reportArtifact: {
-        findUnique: jest.fn(async () => ({
-          id: 'art-1',
-          assessmentAttempt: {
-            answers,
-            assessmentPackId: PACK.slug,
-            assessmentPackVersion: String(PACK.version),
-            assessmentPackChecksum: 'checksum-pack',
-          },
-          revisions: [{ scoreSnapshotId: 'snap-1', scoreSnapshot: { result: factSheet() } }],
-        })),
-      },
-    });
-    const fetch500: typeof fetch = (async () => new Response('{}', { status: 500 })) as typeof fetch;
-    const result = await generateTeacherBrief({
-      prisma: db as never, actor, reportArtifactId: 'art-1',
-      environment: { OPENROUTER_API_KEY: 'k' },
-      resolvePack: () => ({ pack: PACK, validatedPack: null as never, checksum: 'checksum-pack', path: 'x' }),
-      fetchImpl: fetch500,
-    });
-    expect(result).toEqual({ mode: 'PLANCHER', reason: 'TEACHER_BRIEF_HTTP_500' });
-    expect(writes).toHaveLength(0);
-  });
-
-  it('refuse tout autre rôle que l’assistante', async () => {
-    const { db } = database();
-    await expect(generateTeacherBrief({
-      prisma: db as never, actor: { userId: 'coach', role: 'COACH' }, reportArtifactId: 'art-1',
-    })).rejects.toThrow('NOT_FOUND');
-  });
-});
+// L'orchestration (idempotence, budget, classification des échecs,
+// persistance) a été retirée de ce fichier avec la fonction
+// `generateTeacherBrief` (§10 de l'incident P0 du 2026-08-16) : elle vivait
+// dans une requête HTTP synchrone de l'assistante, sans traçabilité des
+// échecs PLANCHER ni budget atomique. Ces preuves vivent maintenant dans
+// __tests__/integration/bilans-teacher-brief-worker.test.ts, contre une
+// vraie base PostgreSQL (jamais un mock de $queryRaw pour la file
+// verrouillée FOR UPDATE SKIP LOCKED) : succès, idempotence ALREADY_PRESENT,
+// STALE_INPUT, RETRYABLE_FAILURE vs BLOCKED_FAILURE, BUDGET_BLOCKED,
+// reprise après un job LEASED orphelin.
 
 describe('teacher-brief — verrou de narration familles', () => {
   it('le worker familles reste déterministe même clé présente, tant que le flag explicite est absent', () => {

--- a/__tests__/bilans/teacher-dossier-render.test.ts
+++ b/__tests__/bilans/teacher-dossier-render.test.ts
@@ -5,8 +5,10 @@ import type { DossierGroupAnalysis, DossierSessionPlan } from '@/lib/bilans/teac
 import {
   renderTeacherDossierHtml,
   renderTeacherDossierPdf,
+  TEACHER_BRIEF_SAFETY_MARKER,
   type TeacherDossierDocument,
 } from '@/lib/bilans/teacher-dossier/render';
+import type { TeacherBriefContent } from '@/lib/bilans/llm/teacher-brief-schema';
 
 const identity: RenderIdentity = Object.freeze({
   displayName: 'Terminale — Mathématiques', level: 'TERMINALE', subject: 'MATHS', date: '2026-08-14',
@@ -64,8 +66,37 @@ function document(overrides: Partial<TeacherDossierDocument> = {}): TeacherDossi
     })]),
     excludedStudents: Object.freeze([]),
     analysis, sessionPlan, evidenceCatalog: evidence, generatedAt: '2026-08-14',
+    completeness: Object.freeze({ tier: 'SOCLE_DETERMINISTE', studentsIncluded: 1, briefsApproved: 0, socleOnlyCount: 1 }),
     ...overrides,
   });
+}
+
+const SENTINEL_UNAPPROVED_TEXT = 'SENTINELLE-CONTENU-NON-RELU-JAMAIS-RENDU-7f3c9a';
+
+function approvedBriefContent(): TeacherBriefContent {
+  return {
+    version: 'teacher-brief.v2',
+    domaines: [{
+      domainId: 'second-degre',
+      erreursTypiques: [{ constat: 'Constat approuvé.', origine: 'Origine approuvée.', itemIds: [] }],
+      prerequisAVerifier: ['Prérequis approuvé.'],
+      activite: {
+        titre: 'Activité approuvée', objectif: 'Objectif approuvé.', materiel: 'Matériel.',
+        deroule: [
+          { nom: 'Phase 1', dureeMin: 10, consigne: 'Consigne 1.' },
+          { nom: 'Phase 2', dureeMin: 10, consigne: 'Consigne 2.' },
+          { nom: 'Phase 3', dureeMin: 10, consigne: 'Consigne 3.' },
+        ],
+        differenciation: 'Différenciation.',
+      },
+      indicateurProgres: 'Indicateur approuvé.',
+    }],
+  };
+}
+
+function sentinelBriefContent(): TeacherBriefContent {
+  const content = approvedBriefContent();
+  return { ...content, domaines: [{ ...content.domaines[0], indicateurProgres: SENTINEL_UNAPPROVED_TEXT }] };
 }
 
 describe('renderTeacherDossierHtml', () => {
@@ -113,6 +144,74 @@ describe('renderTeacherDossierHtml', () => {
   });
 });
 
+describe('renderTeacherDossierHtml — défense en profondeur, couche 3 (§2 de l’incident P0)', () => {
+  it('un brief non nul SANS marqueur de sûreté fait échouer le rendu (jamais silencieusement omis, jamais rendu)', () => {
+    const doc = document({
+      students: Object.freeze([Object.freeze({
+        ...document().students[0], brief: sentinelBriefContent(), // pas de briefSafetyMarker
+      })]),
+    });
+    expect(() => renderTeacherDossierHtml(doc)).toThrow('TEACHER_DOSSIER_UNSAFE_BRIEF_RENDER_BLOCKED');
+  });
+
+  it('un brief avec le marqueur de sûreté correct est rendu normalement', () => {
+    const doc = document({
+      students: Object.freeze([Object.freeze({
+        ...document().students[0], brief: approvedBriefContent(), briefSafetyMarker: TEACHER_BRIEF_SAFETY_MARKER,
+      })]),
+      completeness: Object.freeze({ tier: 'ENRICHI_COMPLET', studentsIncluded: 1, briefsApproved: 1, socleOnlyCount: 0 }),
+    });
+    expect(() => renderTeacherDossierHtml(doc)).not.toThrow();
+  });
+
+  it('la sentinelle de contenu non relu est absente octet par octet du HTML si le marqueur manque (le rendu échoue avant impression)', () => {
+    const doc = document({
+      students: Object.freeze([Object.freeze({
+        ...document().students[0], brief: sentinelBriefContent(),
+      })]),
+    });
+    let html = '';
+    try {
+      html = renderTeacherDossierHtml(doc);
+    } catch {
+      // attendu — le test porte sur l'ABSENCE de la sentinelle dans tout html produit avant l'exception.
+    }
+    expect(html).not.toContain(SENTINEL_UNAPPROVED_TEXT);
+  });
+
+  it('affiche la complétude SOCLE_DETERMINISTE et la phrase sobre par élève sans brief approuvé', () => {
+    const html = renderTeacherDossierHtml(document());
+    expect(html).toContain('Socle déterministe');
+    expect(html).toContain('Socle pédagogique déterministe utilisé — aucun brief enrichi validé.');
+    expect(html).not.toMatch(/en attente de relecture|pending.review/i);
+  });
+
+  it('affiche la complétude ENRICHI_SECURISE_PARTIEL quand certains élèves ont un brief approuvé et d’autres non', () => {
+    const withBrief = Object.freeze({ ...document().students[0], displayName: 'Ahmed Ben M’Rad', brief: approvedBriefContent(), briefSafetyMarker: TEACHER_BRIEF_SAFETY_MARKER });
+    const withoutBrief = Object.freeze({ ...document().students[0], displayName: 'Sonia Gharbi', brief: null });
+    const html = renderTeacherDossierHtml(document({
+      students: Object.freeze([withBrief, withoutBrief]),
+      completeness: Object.freeze({ tier: 'ENRICHI_SECURISE_PARTIEL', studentsIncluded: 2, briefsApproved: 1, socleOnlyCount: 1 }),
+    }));
+    expect(html).toContain('Enrichi sécurisé partiel');
+    expect(html).toContain('Sonia Gharbi');
+    expect(html).toContain('Socle pédagogique déterministe utilisé');
+  });
+
+  it('affiche la complétude ENRICHI_COMPLET quand chaque élève inclus a un brief approuvé', () => {
+    const html = renderTeacherDossierHtml(document({
+      students: Object.freeze([Object.freeze({ ...document().students[0], brief: approvedBriefContent(), briefSafetyMarker: TEACHER_BRIEF_SAFETY_MARKER })]),
+      completeness: Object.freeze({ tier: 'ENRICHI_COMPLET', studentsIncluded: 1, briefsApproved: 1, socleOnlyCount: 0 }),
+    }));
+    expect(html).toContain('Enrichi complet');
+  });
+
+  it('ne rend jamais une formulation laissant croire qu’un contenu non relu a été approuvé', () => {
+    const html = renderTeacherDossierHtml(document());
+    expect(html).not.toMatch(/approuvé\s+automatiquement|validé\s+par\s+défaut/i);
+  });
+});
+
 describe('renderTeacherDossierPdf', () => {
   it('renders a real A4 PDF whose extracted text carries the confidential banner and correct math glyphs', async () => {
     const result = await renderTeacherDossierPdf(document());
@@ -121,5 +220,24 @@ describe('renderTeacherDossierPdf', () => {
     const text = await extractPdfText(result.pdf);
     expect(text).toMatch(/confidentiel/i);
     expect(text).toContain('x²');
+  }, 30000);
+
+  it('un brief APPROUVÉ correctement marqué apparaît dans le texte extrait du PDF, jamais un brief non marqué', async () => {
+    const doc = document({
+      students: Object.freeze([Object.freeze({ ...document().students[0], brief: approvedBriefContent(), briefSafetyMarker: TEACHER_BRIEF_SAFETY_MARKER })]),
+      completeness: Object.freeze({ tier: 'ENRICHI_COMPLET', studentsIncluded: 1, briefsApproved: 1, socleOnlyCount: 0 }),
+    });
+    const result = await renderTeacherDossierPdf(doc);
+    expect(result.status).toBe('AVAILABLE');
+    if (result.status !== 'AVAILABLE') return;
+    const text = await extractPdfText(result.pdf);
+    expect(text).toContain('Indicateur approuvé');
+  }, 30000);
+
+  it('rejette la génération PDF (jamais silencieuse) quand un brief non nul manque son marqueur de sûreté', async () => {
+    const doc = document({
+      students: Object.freeze([Object.freeze({ ...document().students[0], brief: sentinelBriefContent() })]),
+    });
+    await expect(renderTeacherDossierPdf(doc)).rejects.toThrow('TEACHER_DOSSIER_UNSAFE_BRIEF_RENDER_BLOCKED');
   }, 30000);
 });

--- a/__tests__/bilans/teacher-dossier-service.test.ts
+++ b/__tests__/bilans/teacher-dossier-service.test.ts
@@ -111,20 +111,49 @@ describe('buildStaffTeacherDossierDocument', () => {
 
 describe('listStaffTeacherDossierGroups', () => {
   it('rejects a non-staff actor', async () => {
-    await expect(listStaffTeacherDossierGroups({ userId: 'user-1', role: 'ELEVE' }, { reportArtifact: { findMany: jest.fn() } } as never))
-      .rejects.toEqual(expect.objectContaining<Partial<StaffTeacherDossierError>>({ code: 'NOT_FOUND' }));
+    await expect(listStaffTeacherDossierGroups(
+      { userId: 'user-1', role: 'ELEVE' },
+      { reportArtifact: { findMany: jest.fn() }, jobOutbox: { findMany: jest.fn() }, teacherBriefAttempt: { findMany: jest.fn() } } as never,
+    )).rejects.toEqual(expect.objectContaining<Partial<StaffTeacherDossierError>>({ code: 'NOT_FOUND' }));
   });
 
-  it('groups by subject and level, counting bilans without a brief', async () => {
+  it('groups by subject and level, with distinct, non-ambiguous counters (§12 de l’incident P0)', async () => {
     const findMany = jest.fn(async () => [
-      { assessmentAttempt: { subject: 'MATHEMATIQUES', gradeLevel: 'TERMINALE' }, teacherBriefs: [] },
-      { assessmentAttempt: { subject: 'MATHEMATIQUES', gradeLevel: 'TERMINALE' }, teacherBriefs: [{ id: 'brief-1' }] },
-      { assessmentAttempt: { subject: 'FRANCAIS', gradeLevel: 'SECONDE' }, teacherBriefs: [] },
+      // MATHEMATIQUES/TERMINALE : un brief APPROVED et courant (snapshot identique).
+      {
+        id: 'art-approved', assessmentAttempt: { subject: 'MATHEMATIQUES', gradeLevel: 'TERMINALE' },
+        revisions: [{ scoreSnapshotId: 'snap-1' }],
+        teacherBriefs: [{ status: 'APPROVED', scoreSnapshotId: 'snap-1' }],
+      },
+      // MATHEMATIQUES/TERMINALE : jamais généré => actionnable.
+      {
+        id: 'art-never', assessmentAttempt: { subject: 'MATHEMATIQUES', gradeLevel: 'TERMINALE' },
+        revisions: [{ scoreSnapshotId: 'snap-2' }],
+        teacherBriefs: [],
+      },
+      // FRANCAIS/SECONDE : PENDING_REVIEW => à relire, jamais "manquant".
+      {
+        id: 'art-pending', assessmentAttempt: { subject: 'FRANCAIS', gradeLevel: 'SECONDE' },
+        revisions: [{ scoreSnapshotId: 'snap-3' }],
+        teacherBriefs: [{ status: 'PENDING_REVIEW', scoreSnapshotId: 'snap-3' }],
+      },
     ]);
-    const groups = await listStaffTeacherDossierGroups({ userId: 'user-1', role: 'ADMIN' }, { reportArtifact: { findMany } } as never);
-    expect(groups).toEqual([
-      { subject: 'FRANCAIS', level: 'SECONDE', count: 1, briefsMissing: 1 },
-      { subject: 'MATHEMATIQUES', level: 'TERMINALE', count: 2, briefsMissing: 1 },
-    ]);
+    const jobOutboxFindMany = jest.fn(async () => []);
+    const teacherBriefAttemptFindMany = jest.fn(async () => []);
+    const database = { reportArtifact: { findMany }, jobOutbox: { findMany: jobOutboxFindMany }, teacherBriefAttempt: { findMany: teacherBriefAttemptFindMany } };
+
+    const groups = await listStaffTeacherDossierGroups({ userId: 'user-1', role: 'ADMIN' }, database as never);
+
+    const maths = groups.find((g) => g.subject === 'MATHEMATIQUES' && g.level === 'TERMINALE')!;
+    expect(maths.eligibleCount).toBe(2);
+    expect(maths.approvedCount).toBe(1);
+    expect(maths.toGenerateCount).toBe(1);
+    expect(maths.completenessTier).toBe('ENRICHI_SECURISE_PARTIEL');
+
+    const francais = groups.find((g) => g.subject === 'FRANCAIS' && g.level === 'SECONDE')!;
+    expect(francais.eligibleCount).toBe(1);
+    expect(francais.toReviewCount).toBe(1);
+    expect(francais.toGenerateCount).toBe(0);
+    expect(francais.approvedCount).toBe(0);
   });
 });

--- a/__tests__/integration/bilans-teacher-brief-worker.test.ts
+++ b/__tests__/integration/bilans-teacher-brief-worker.test.ts
@@ -1,0 +1,298 @@
+jest.unmock('@/lib/prisma');
+
+import { prisma } from '@/lib/prisma';
+import { processScoreAttemptJob } from '@/lib/bilans/worker/score-job';
+import { processGenerateReportJob } from '@/lib/bilans/worker/generate-report-job';
+import { processGenerateTeacherBriefJob } from '@/lib/bilans/worker/generate-teacher-brief-job';
+import { drainTeacherBriefJobs } from '@/lib/bilans/worker/drain-outbox';
+import { enqueueTeacherBriefGeneration } from '@/lib/bilans/llm/teacher-brief-enqueue';
+import { reserveBudget, regularizeBudget, releaseBudget } from '@/lib/bilans/llm/teacher-brief-budget';
+import { TEACHER_BRIEF_PROMPT_VERSION } from '@/lib/bilans/llm/teacher-brief-schema';
+import {
+  CANONICAL_WORKER_ANSWERS,
+  CANONICAL_WORKER_ENABLED_PACK,
+} from '@/__tests__/bilans/fixtures/canonical-worker';
+
+/**
+ * Preuve d'intégration réelle (base PostgreSQL réelle, jamais de mock de
+ * `$queryRaw`) du worker asynchrone de génération de brief enseignant
+ * (§7/§8/§10/§11 de l'incident P0 du 2026-08-16) : idempotence, staleness,
+ * classification des échecs, budget atomique, journal des tentatives.
+ */
+
+const PREFIX = `a90-${Date.now()}-`;
+const NOW = new Date('2026-08-16T10:00:00.000Z');
+const logger = { info: jest.fn(), error: jest.fn() };
+
+type FactsDomain = { domainId: string; itemsRates: { itemId: string }[] };
+
+function validDomainResponse(domain: FactsDomain) {
+  // L'ancrage (assertBriefRespectsFacts) exige une citation réelle dès que le
+  // domaine a des items ratés — jamais un itemId inventé, jamais vide dans ce cas.
+  const itemIds = domain.itemsRates.length > 0 ? [domain.itemsRates[0].itemId] : [];
+  return {
+    domainId: domain.domainId,
+    erreursTypiques: [{
+      constat: 'Confusion entre deux règles proches.',
+      origine: 'Généralisation hâtive.',
+      itemIds,
+    }],
+    prerequisAVerifier: ['Prérequis A.'],
+    activite: {
+      titre: 'Activité test',
+      objectif: 'Objectif test.',
+      materiel: 'Ardoises.',
+      deroule: [
+        { nom: 'Phase 1', dureeMin: 10, consigne: 'Consigne 1.' },
+        { nom: 'Phase 2', dureeMin: 10, consigne: 'Consigne 2.' },
+        { nom: 'Phase 3', dureeMin: 10, consigne: 'Consigne 3.' },
+      ],
+      differenciation: 'Différenciation test.',
+    },
+    indicateurProgres: 'Indicateur test.',
+  };
+}
+
+function fetchDomainAware(): typeof fetch {
+  return (async (_url: unknown, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body)) as { messages: { content: unknown }[] };
+    const facts = JSON.parse(String(body.messages[1].content)) as { domainesPrioritaires: FactsDomain[] };
+    const domain = facts.domainesPrioritaires[0];
+    return new Response(JSON.stringify({
+      choices: [{ message: { content: JSON.stringify({ version: TEACHER_BRIEF_PROMPT_VERSION, domaines: [validDomainResponse(domain)] }) } }],
+      usage: { prompt_tokens: 2000, completion_tokens: 1000, prompt_tokens_details: { cached_tokens: 1500 } },
+    }), { status: 200 });
+  }) as typeof fetch;
+}
+
+describe('A90 — worker asynchrone de génération de brief enseignant', () => {
+  let studentId: string;
+  let assistanteUserId: string;
+
+  async function seedReportArtifact(suffix: string) {
+    const attempt = await prisma.canonicalAssessmentAttempt.create({
+      data: {
+        studentId,
+        status: 'SUBMITTED',
+        seed: `${PREFIX}${suffix}-seed`,
+        startedAt: new Date('2026-08-16T09:40:00.000Z'),
+        expiresAt: new Date('2026-08-17T09:40:00.000Z'),
+        revision: 2,
+        subject: 'MATHEMATIQUES',
+        gradeLevel: 'TERMINALE',
+        answers: CANONICAL_WORKER_ANSWERS,
+        submittedAt: new Date('2026-08-16T09:55:00.000Z'),
+        curriculumId: 'terminale.maths',
+        curriculumVersion: '1',
+        assessmentPackId: CANONICAL_WORKER_ENABLED_PACK.pack.slug,
+        assessmentPackVersion: String(CANONICAL_WORKER_ENABLED_PACK.pack.version),
+        assessmentPackChecksum: CANONICAL_WORKER_ENABLED_PACK.checksum,
+        scoringPolicyId: 'facts',
+        scoringPolicyVersion: '1.0.1',
+      },
+    });
+    const scoreJob = await prisma.jobOutbox.create({
+      data: {
+        jobType: 'SCORE_ATTEMPT',
+        aggregateType: 'CanonicalAssessmentAttempt',
+        aggregateId: attempt.id,
+        sourceEventKey: `${attempt.id}.submitted`,
+        idempotencyKey: `${attempt.id}.score`,
+        payload: { attemptId: attempt.id, packSlug: CANONICAL_WORKER_ENABLED_PACK.pack.slug, packVersion: CANONICAL_WORKER_ENABLED_PACK.pack.version },
+      },
+    });
+    const scoreDeps = { prisma, resolvePack: () => CANONICAL_WORKER_ENABLED_PACK, now: () => NOW, logger };
+    await processScoreAttemptJob(scoreJob.id, scoreDeps);
+    const reportJob = await prisma.jobOutbox.findUniqueOrThrow({ where: { idempotencyKey: `${attempt.id}.generate-report` } });
+    await processGenerateReportJob(reportJob.id, { ...scoreDeps, buildTransport: () => { throw new Error('unused'); } } as never);
+    const artifact = await prisma.reportArtifact.findFirstOrThrow({
+      where: { assessmentAttemptId: attempt.id },
+      include: { revisions: { orderBy: { createdAt: 'desc' }, take: 1 } },
+    });
+    return { attemptId: attempt.id, artifactId: artifact.id, scoreSnapshotId: artifact.revisions[0].scoreSnapshotId };
+  }
+
+  async function seedTeacherBriefJob(artifactId: string, expectedScoreSnapshotId: string) {
+    await enqueueTeacherBriefGeneration(artifactId, expectedScoreSnapshotId, assistanteUserId, prisma);
+    return prisma.jobOutbox.findUniqueOrThrow({
+      where: { idempotencyKey: `teacher-brief:${artifactId}:${expectedScoreSnapshotId}` },
+    });
+  }
+
+  const jobDependencies = (fetchImpl: typeof fetch, monthlyBudgetUsd = 20) => ({
+    prisma,
+    resolvePack: () => CANONICAL_WORKER_ENABLED_PACK,
+    resolveConfig: () => ({
+      apiKey: 'test-key', model: 'anthropic/claude-sonnet-4.5', maxTokens: 2000, temperature: 0.3,
+      timeoutMs: 45_000, monthlyBudgetUsd, baseUrl: 'https://openrouter.ai/api/v1', supportsPromptCaching: true,
+    }),
+    fetchImpl,
+    now: () => NOW,
+    logger,
+    reserveBudget,
+    regularizeBudget,
+    releaseBudget,
+  });
+
+  beforeAll(async () => {
+    const studentUser = await prisma.user.create({
+      data: { email: `${PREFIX}student@example.test`, role: 'ELEVE', firstName: 'Test', lastName: 'Worker' },
+    });
+    const parentUser = await prisma.user.create({ data: { email: `${PREFIX}parent@example.test`, role: 'PARENT' } });
+    const parent = await prisma.parentProfile.create({ data: { userId: parentUser.id } });
+    const student = await prisma.student.create({ data: { userId: studentUser.id, parentId: parent.id, gradeLevel: 'TERMINALE' } });
+    studentId = student.id;
+    const assistanteUser = await prisma.user.create({ data: { email: `${PREFIX}assistante@example.test`, role: 'ASSISTANTE' } });
+    assistanteUserId = assistanteUser.id;
+  });
+
+  afterAll(async () => {
+    await prisma.$executeRawUnsafe(`
+      TRUNCATE TABLE
+        "canonical_teacher_brief_attempts", "canonical_teacher_brief_annotations", "canonical_teacher_briefs",
+        "canonical_report_revisions", "canonical_report_artifacts", "canonical_evidence_items",
+        "canonical_score_snapshots", "canonical_job_outbox", "canonical_assessment_attempts"
+      CASCADE
+    `);
+    await prisma.student.deleteMany({ where: { user: { email: { startsWith: PREFIX } } } });
+    await prisma.parentProfile.deleteMany({ where: { user: { email: { startsWith: PREFIX } } } });
+    await prisma.user.deleteMany({ where: { email: { startsWith: PREFIX } } });
+    await prisma.teacherBriefMonthlyBudget.deleteMany({ where: { monthStart: new Date(Date.UTC(2026, 7, 1)) } });
+    await prisma.$disconnect();
+  });
+
+  test('succès : GENERATED crée un brief PENDING_REVIEW, journalise la tentative, complète le job, comptabilise le coût réel', async () => {
+    const { artifactId, scoreSnapshotId } = await seedReportArtifact('success');
+    const job = await seedTeacherBriefJob(artifactId, scoreSnapshotId);
+
+    const result = await processGenerateTeacherBriefJob(job.id, jobDependencies(fetchDomainAware()));
+    expect(result.result).toBe('GENERATED');
+
+    const brief = await prisma.teacherBrief.findFirstOrThrow({ where: { reportArtifactId: artifactId } });
+    expect(brief.status).toBe('PENDING_REVIEW');
+    expect(brief.scoreSnapshotId).toBe(scoreSnapshotId);
+
+    const attempt = await prisma.teacherBriefAttempt.findFirstOrThrow({ where: { reportArtifactId: artifactId } });
+    expect(attempt.result).toBe('GENERATED');
+    expect(attempt.jobId).toBe(job.id);
+    expect(Number(attempt.estimatedCostUsd)).toBeGreaterThan(0);
+
+    const updatedJob = await prisma.jobOutbox.findUniqueOrThrow({ where: { id: job.id } });
+    expect(updatedJob.status).toBe('COMPLETED');
+  });
+
+  test('idempotence : un brief déjà présent (PENDING_REVIEW) => ALREADY_PRESENT, aucun appel réseau', async () => {
+    const { artifactId, scoreSnapshotId } = await seedReportArtifact('already-present');
+    const job1 = await seedTeacherBriefJob(artifactId, scoreSnapshotId);
+    await processGenerateTeacherBriefJob(job1.id, jobDependencies(fetchDomainAware()));
+
+    const fetchSpy = jest.fn(fetchDomainAware());
+    // Deuxième job pour le MÊME (artifactId, scoreSnapshotId) : idempotencyKey identique => ON CONFLICT DO NOTHING, aucun second job créé.
+    await enqueueTeacherBriefGeneration(artifactId, scoreSnapshotId, assistanteUserId, prisma);
+    const jobs = await prisma.jobOutbox.findMany({ where: { aggregateId: artifactId, jobType: 'GENERATE_TEACHER_BRIEF' } });
+    expect(jobs).toHaveLength(1);
+
+    const result = await processGenerateTeacherBriefJob(jobs[0].id, jobDependencies(fetchSpy as unknown as typeof fetch));
+    expect(result.result).toBe('ALREADY_PRESENT');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(await prisma.teacherBrief.count({ where: { reportArtifactId: artifactId } })).toBe(1);
+  });
+
+  test('STALE_INPUT : le job porte un scoreSnapshotId différent du courant => aucun appel réseau, job terminal', async () => {
+    const { artifactId } = await seedReportArtifact('stale');
+    const fakeJob = await prisma.jobOutbox.create({
+      data: {
+        jobType: 'GENERATE_TEACHER_BRIEF', aggregateType: 'TeacherBrief', aggregateId: artifactId,
+        sourceEventKey: `${PREFIX}stale-source`, idempotencyKey: `${PREFIX}stale-idem`,
+        payload: { reportArtifactId: artifactId, expectedScoreSnapshotId: 'snapshot-obsolete-inexistant', actorId: assistanteUserId },
+      },
+    });
+    const fetchSpy = jest.fn(fetchDomainAware());
+    const result = await processGenerateTeacherBriefJob(fakeJob.id, jobDependencies(fetchSpy as unknown as typeof fetch));
+    expect(result.result).toBe('STALE_INPUT');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(await prisma.teacherBrief.count({ where: { reportArtifactId: artifactId } })).toBe(0);
+    const attempt = await prisma.teacherBriefAttempt.findFirstOrThrow({ where: { reportArtifactId: artifactId } });
+    expect(attempt.result).toBe('STALE_INPUT');
+    expect((await prisma.jobOutbox.findUniqueOrThrow({ where: { id: fakeJob.id } })).status).toBe('COMPLETED');
+  });
+
+  test('RETRYABLE_FAILURE : HTTP 500 => job FAILED (repris par le cycle de drain), jamais COMPLETED', async () => {
+    const { artifactId, scoreSnapshotId } = await seedReportArtifact('retryable');
+    const job = await seedTeacherBriefJob(artifactId, scoreSnapshotId);
+    const fetch500: typeof fetch = (async () => new Response('{}', { status: 500 })) as typeof fetch;
+
+    await expect(processGenerateTeacherBriefJob(job.id, jobDependencies(fetch500))).rejects.toThrow('TEACHER_BRIEF_HTTP_500');
+
+    const attempt = await prisma.teacherBriefAttempt.findFirstOrThrow({ where: { reportArtifactId: artifactId } });
+    expect(attempt.result).toBe('RETRYABLE_FAILURE');
+    expect(attempt.causeCode).toBe('TEACHER_BRIEF_HTTP_500');
+    const updatedJob = await prisma.jobOutbox.findUniqueOrThrow({ where: { id: job.id } });
+    expect(updatedJob.status).toBe('FAILED');
+    expect(await prisma.teacherBrief.count({ where: { reportArtifactId: artifactId } })).toBe(0);
+    // Un job FAILED reste réclamable par construction (c'est le point du test :
+    // le cycle de drain le reprendra). Le retirer ici évite qu'il pollue le
+    // test dédié à la reprise après un job LEASED orphelin, plus loin dans ce
+    // même fichier : `drainTeacherBriefJobs({ limit: 1 })` prendrait sinon CE
+    // job (plus ancien) plutôt que celui du test suivant.
+    await prisma.jobOutbox.delete({ where: { id: job.id } });
+  });
+
+  test('BLOCKED_FAILURE : terme interdit dans la sortie => job COMPLETED, jamais retenté automatiquement', async () => {
+    const { artifactId, scoreSnapshotId } = await seedReportArtifact('blocked');
+    const job = await seedTeacherBriefJob(artifactId, scoreSnapshotId);
+    const fetchForbidden: typeof fetch = (async (_url: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { messages: { content: unknown }[] };
+      const facts = JSON.parse(String(body.messages[1].content)) as { domainesPrioritaires: FactsDomain[] };
+      const domain = validDomainResponse(facts.domainesPrioritaires[0]);
+      domain.indicateurProgres = 'La réussite est garantie après cette séance.';
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: JSON.stringify({ version: TEACHER_BRIEF_PROMPT_VERSION, domaines: [domain] }) } }],
+        usage: { prompt_tokens: 2000, completion_tokens: 1000 },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await processGenerateTeacherBriefJob(job.id, jobDependencies(fetchForbidden));
+    expect(result.result).toBe('BLOCKED_FAILURE');
+    const attempt = await prisma.teacherBriefAttempt.findFirstOrThrow({ where: { reportArtifactId: artifactId } });
+    expect(attempt.causeCode).toBe('TEACHER_BRIEF_FORBIDDEN_TERM');
+    expect((await prisma.jobOutbox.findUniqueOrThrow({ where: { id: job.id } })).status).toBe('COMPLETED');
+  });
+
+  test('BUDGET_BLOCKED : budget mensuel épuisé => aucun appel réseau, job terminal, rien facturé', async () => {
+    const { artifactId, scoreSnapshotId } = await seedReportArtifact('budget');
+    const job = await seedTeacherBriefJob(artifactId, scoreSnapshotId);
+    // Prépare la précondition "budget épuisé" (écriture directe de test, distincte du mécanisme atomique testé ailleurs).
+    await prisma.teacherBriefMonthlyBudget.upsert({
+      where: { monthStart: new Date(Date.UTC(2026, 7, 1)) },
+      create: { monthStart: new Date(Date.UTC(2026, 7, 1)), budgetUsd: 20, spentUsd: 20 },
+      update: { spentUsd: 20 },
+    });
+    const fetchSpy = jest.fn(fetchDomainAware());
+    try {
+      const result = await processGenerateTeacherBriefJob(job.id, jobDependencies(fetchSpy as unknown as typeof fetch));
+      expect(result.result).toBe('BUDGET_BLOCKED');
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect((await prisma.jobOutbox.findUniqueOrThrow({ where: { id: job.id } })).status).toBe('COMPLETED');
+    } finally {
+      // Le budget mensuel est un état partagé (une ligne par mois) : le restaurer
+      // pour ne pas fausser les tests suivants du même fichier.
+      await prisma.teacherBriefMonthlyBudget.update({
+        where: { monthStart: new Date(Date.UTC(2026, 7, 1)) },
+        data: { spentUsd: 0, reservedUsd: 0 },
+      });
+    }
+  });
+
+  test('drainTeacherBriefJobs traite la file en process — reprise après un job orphelin LEASED expiré', async () => {
+    const { artifactId, scoreSnapshotId } = await seedReportArtifact('drain');
+    const job = await seedTeacherBriefJob(artifactId, scoreSnapshotId);
+    // Simule un worker mort en cours de traitement : LEASED, bail expiré.
+    await prisma.jobOutbox.update({ where: { id: job.id }, data: { status: 'LEASED', leaseOwner: 'dead-worker', leaseExpiresAt: new Date('2020-01-01') } });
+
+    const result = await drainTeacherBriefJobs({ limit: 1 }, { processJob: (jobId) => processGenerateTeacherBriefJob(jobId, jobDependencies(fetchDomainAware())) });
+    expect(result.claimed).toBe(1);
+    expect(result.completed).toBe(1);
+    expect((await prisma.teacherBrief.findFirstOrThrow({ where: { reportArtifactId: artifactId } })).status).toBe('PENDING_REVIEW');
+  });
+});

--- a/__tests__/integration/bilans-teacher-brief-worker.test.ts
+++ b/__tests__/integration/bilans-teacher-brief-worker.test.ts
@@ -238,6 +238,41 @@ describe('A90 — worker asynchrone de génération de brief enseignant', () => 
     await prisma.jobOutbox.delete({ where: { id: job.id } });
   });
 
+  test('coût partiel : un domaine facturé avec succès reste compté même si le domaine suivant échoue (§7)', async () => {
+    const { artifactId, scoreSnapshotId } = await seedReportArtifact('partial-cost');
+    const job = await seedTeacherBriefJob(artifactId, scoreSnapshotId);
+    let call = 0;
+    const flaky: typeof fetch = (async (_url: unknown, init?: RequestInit) => {
+      call += 1;
+      if (call >= 2) return new Response(JSON.stringify({ choices: [{ message: { content: 'not json' } }] }), { status: 200 });
+      const body = JSON.parse(String(init?.body)) as { messages: { content: unknown }[] };
+      const facts = JSON.parse(String(body.messages[1].content)) as { domainesPrioritaires: FactsDomain[] };
+      const domain = validDomainResponse(facts.domainesPrioritaires[0]);
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: JSON.stringify({ version: TEACHER_BRIEF_PROMPT_VERSION, domaines: [domain] }) } }],
+        usage: { prompt_tokens: 2000, completion_tokens: 1000, prompt_tokens_details: { cached_tokens: 1500 } },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    await expect(processGenerateTeacherBriefJob(job.id, jobDependencies(flaky))).rejects.toThrow('TEACHER_BRIEF_INVALID_JSON');
+
+    const attempt = await prisma.teacherBriefAttempt.findFirstOrThrow({ where: { reportArtifactId: artifactId } });
+    expect(attempt.result).toBe('RETRYABLE_FAILURE');
+    // Le premier domaine a bien été facturé (tokens réels, coût > 0) — pas
+    // un coût à zéro silencieux malgré l'échec global de la tentative.
+    expect(Number(attempt.promptTokens)).toBe(0); // agrégat global non recalculé sur échec (voir domainOutcomes pour le détail)
+    expect(Number(attempt.estimatedCostUsd)).toBeGreaterThan(0);
+    expect(attempt.domainsProcessed).toBeGreaterThanOrEqual(1);
+    const outcomes = attempt.domainOutcomes as unknown as { outcome: string; costUsd: number | null }[];
+    expect(outcomes[0].outcome).toBe('OK');
+    expect(outcomes[0].costUsd).toBeGreaterThan(0);
+    expect(outcomes.some((entry) => entry.outcome !== 'OK')).toBe(true);
+    // Même raison que le test RETRYABLE_FAILURE ci-dessus : un job FAILED
+    // reste réclamable, à retirer pour ne pas polluer le test de reprise
+    // après job orphelin plus loin dans ce fichier.
+    await prisma.jobOutbox.delete({ where: { id: job.id } });
+  });
+
   test('BLOCKED_FAILURE : terme interdit dans la sortie => job COMPLETED, jamais retenté automatiquement', async () => {
     const { artifactId, scoreSnapshotId } = await seedReportArtifact('blocked');
     const job = await seedTeacherBriefJob(artifactId, scoreSnapshotId);

--- a/app/dashboard/assistante/bilans/actions.ts
+++ b/app/dashboard/assistante/bilans/actions.ts
@@ -20,16 +20,18 @@ import {
 import type { ReportAnnotationSection, ReportReviewAnnotationInput } from '@/lib/bilans/core/report-service';
 import { ReportTransmissionError, confirmWhatsAppTransmission } from '@/lib/bilans/staff/transmission-service';
 import { prepareWhatsAppSend, WhatsAppSendError } from '@/lib/bilans/staff/whatsapp-send-service';
-import { generateTeacherBrief, TeacherBriefError } from '@/lib/bilans/llm/teacher-brief-service';
+import { enqueueTeacherBriefGeneration } from '@/lib/bilans/llm/teacher-brief-enqueue';
 import {
   approveTeacherBrief,
   requestTeacherBriefCorrection,
   TeacherBriefReviewError,
+  type ReviewMotifCode,
 } from '@/lib/bilans/staff/teacher-brief-review-service';
 import {
-  listStaffTeacherDossierArtifactIds,
+  listStaffTeacherDossierActionableArtifactIds,
   StaffTeacherDossierError,
 } from '@/lib/bilans/staff/teacher-dossier-service';
+import { prisma } from '@/lib/prisma';
 
 function field(formData: FormData, name: string): string {
   const value = formData.get(name);
@@ -158,43 +160,58 @@ export async function confirmWhatsAppTransmissionAction(formData: FormData): Pro
   }
 }
 
+/**
+ * ADMIN : consultation et supervision en lecture seule uniquement (§14 de
+ * l'incident P0) — aucune génération, aucune relecture tant qu'une
+ * délégation explicite n'a pas été décidée. Refusé côté serveur, jamais
+ * seulement caché côté UI.
+ */
+function assertAssistanteOnly(current: Readonly<{ role: string }>): void {
+  if (current.role !== 'ASSISTANTE') notFound();
+}
+
+/**
+ * Met en file la génération — jamais d'appel LLM synchrone dans cette
+ * requête (§10 de l'incident P0). Répond en dessous de la seconde : une
+ * seule écriture `INSERT ... ON CONFLICT DO NOTHING` dans le job outbox.
+ */
 export async function generateTeacherBriefAction(formData: FormData): Promise<void> {
   try {
-    await generateTeacherBrief({
-      actor: await actor(),
-      reportArtifactId: field(formData, 'artifactId'),
+    const current = await actor();
+    assertAssistanteOnly(current);
+    const reportArtifactId = field(formData, 'artifactId');
+    const artifact = await prisma.reportArtifact.findUnique({
+      where: { id: reportArtifactId },
+      select: { revisions: { orderBy: { createdAt: 'desc' }, take: 1, select: { scoreSnapshotId: true } } },
     });
+    const expectedScoreSnapshotId = artifact?.revisions[0]?.scoreSnapshotId;
+    if (expectedScoreSnapshotId === undefined) notFound();
+    await enqueueTeacherBriefGeneration(reportArtifactId, expectedScoreSnapshotId, current.userId);
     revalidatePath('/dashboard/assistante/bilans');
   } catch (error) {
-    if (error instanceof TeacherBriefError) notFound();
     handleAccessError(error);
   }
 }
 
 /**
- * Régénère les briefs enseignant manquants pour tout un groupe (matière ×
- * niveau) en un clic, plutôt qu'un par un. `generateTeacherBrief` est déjà
- * idempotent (mode `ALREADY_PRESENT`) : reboucler sur des bilans déjà
- * pourvus ne recoûte rien — le bouton est donc sûr à re-cliquer quand des
- * bilans s'ajoutent au groupe. Séquentiel (pas de Promise.all) : le cache de
- * prompt du modèle s'amortit d'un appel à l'autre (mesuré ~112 s/bilan,
- * ~0,10 $/bilan), et le plafond budgétaire mensuel du service reste la seule
- * limite.
+ * Met en file la génération des briefs enseignant RÉELLEMENT ACTIONNABLES
+ * (`listStaffTeacherDossierActionableArtifactIds` — jamais un brief déjà
+ * PENDING_REVIEW/APPROVED-courant, jamais un DETERMINISTIC_ONLY, jamais un
+ * bilan déjà en file) pour tout un groupe (matière × niveau) en un clic.
+ * Chaque insertion est individuellement idempotente (`idempotencyKey`
+ * unique) : répond en dessous de la seconde, sans appeler le moindre
+ * modèle — le worker en process (`lib/bilans/worker/scheduler.ts`) traite
+ * la file séquentiellement, un brief à la fois (§10).
  */
 export async function generateGroupTeacherBriefsAction(formData: FormData): Promise<void> {
   try {
     const current = await actor();
+    assertAssistanteOnly(current);
     const subject = field(formData, 'subject') as Subject;
     const level = field(formData, 'level') as GradeLevel;
-    const artifactIds = await listStaffTeacherDossierArtifactIds(current, subject, level);
-    for (const artifactId of artifactIds) {
-      try {
-        await generateTeacherBrief({ actor: current, reportArtifactId: artifactId });
-      } catch (error) {
-        // Un bilan en échec (budget dépassé, PLANCHER, etc.) ne doit pas
-        // bloquer les autres élèves du groupe — chacun est indépendant.
-        if (!(error instanceof TeacherBriefError)) throw error;
-      }
+    const targets = await listStaffTeacherDossierActionableArtifactIds(current, subject, level);
+    for (const target of targets) {
+      await enqueueTeacherBriefGeneration(target.reportArtifactId, target.expectedScoreSnapshotId, current.userId);
     }
     revalidatePath('/dashboard/assistante/bilans');
   } catch (error) {
@@ -205,12 +222,23 @@ export async function generateGroupTeacherBriefsAction(formData: FormData): Prom
 
 export async function approveTeacherBriefAction(formData: FormData): Promise<void> {
   try {
-    const edited = field(formData, 'editedContent').trim();
+    const current = await actor();
+    assertAssistanteOnly(current);
+    const approvedContentRaw = field(formData, 'approvedContentJson').trim();
+    let approvedContent: unknown;
+    if (approvedContentRaw) {
+      try {
+        approvedContent = JSON.parse(approvedContentRaw);
+      } catch {
+        notFound();
+      }
+    }
     await approveTeacherBrief({
-      actor: await actor(),
+      actor: current,
       briefId: field(formData, 'briefId'),
-      motif: field(formData, 'motif'),
-      ...(edited ? { editedContent: edited } : {}),
+      motifCode: field(formData, 'motifCode') as ReviewMotifCode,
+      freeComment: field(formData, 'freeComment'),
+      ...(approvedContent !== undefined ? { approvedContent } : {}),
     });
     revalidatePath('/dashboard/assistante/bilans');
   } catch (error) {
@@ -221,10 +249,13 @@ export async function approveTeacherBriefAction(formData: FormData): Promise<voi
 
 export async function requestTeacherBriefCorrectionAction(formData: FormData): Promise<void> {
   try {
+    const current = await actor();
+    assertAssistanteOnly(current);
     await requestTeacherBriefCorrection({
-      actor: await actor(),
+      actor: current,
       briefId: field(formData, 'briefId'),
-      motif: field(formData, 'motif'),
+      motifCode: field(formData, 'motifCode') as ReviewMotifCode,
+      freeComment: field(formData, 'freeComment'),
       annotation: {
         section: field(formData, 'section'),
         remark: field(formData, 'remark'),

--- a/app/dashboard/assistante/bilans/page.tsx
+++ b/app/dashboard/assistante/bilans/page.tsx
@@ -12,8 +12,10 @@ import {
 } from '@/lib/bilans/staff/review-service';
 
 import { REPORT_ANNOTATION_SECTIONS } from '@/lib/bilans/core/report-service';
-import { teacherBriefMonthlyUsage } from '@/lib/bilans/llm/teacher-brief-service';
+import { teacherBriefMonthlyUsage, resolveTeacherBriefConfig, TeacherBriefError } from '@/lib/bilans/llm/teacher-brief-service';
+import { readBudgetSnapshot } from '@/lib/bilans/llm/teacher-brief-budget';
 import { listStaffTeacherDossierGroups } from '@/lib/bilans/staff/teacher-dossier-service';
+import { REVIEW_MOTIF_CODES } from '@/lib/bilans/staff/teacher-brief-review-service';
 import { prisma } from '@/lib/prisma';
 import type { TeacherBriefContent } from '@/lib/bilans/llm/teacher-brief-schema';
 
@@ -32,6 +34,27 @@ import {
   resumeReviewAction,
   validateAndPublishReportAction,
 } from './actions';
+
+/** Le budget par défaut ne doit jamais rester invisible (§11) — même sans clé configurée, le plafond effectif est affiché. */
+function resolveTeacherBriefConfigSafely(): Readonly<{ monthlyBudgetUsd: number }> {
+  try {
+    return resolveTeacherBriefConfig();
+  } catch (error) {
+    if (error instanceof TeacherBriefError) return { monthlyBudgetUsd: 20 };
+    throw error;
+  }
+}
+
+const REVIEW_MOTIF_OPTIONS = REVIEW_MOTIF_CODES.map((code) => ({
+  code,
+  label: code.replaceAll('_', ' ').toLowerCase().replace(/^./, (letter) => letter.toUpperCase()),
+}));
+
+const COMPLETENESS_TIER_LABELS: Readonly<Record<string, string>> = {
+  SOCLE_DETERMINISTE: 'Socle déterministe',
+  ENRICHI_SECURISE_PARTIEL: 'Enrichi sécurisé partiel',
+  ENRICHI_COMPLET: 'Enrichi complet',
+};
 
 /** Libellés d'affichage pour les enums DB `Subject`/`GradeLevel` — distincts des
  * libellés `BilanPackSubject`/`BilanPackLevel` du catalogue (lib/bilans/catalog/subjects.ts,
@@ -139,7 +162,7 @@ export default async function CanonicalBilansReviewPage({
     orderBy: { version: 'desc' },
     select: {
       id: true, reportArtifactId: true, status: true, version: true, content: true,
-      editedContent: true, promptVersion: true, model: true, reviewedAt: true,
+      approvedContent: true, promptVersion: true, model: true, reviewedAt: true,
       reviewedBy: { select: { firstName: true, lastName: true } },
       annotations: { select: { section: true, remark: true, createdAt: true }, orderBy: { createdAt: 'asc' } },
     },
@@ -149,7 +172,11 @@ export default async function CanonicalBilansReviewPage({
     if (!briefByArtifact.has(brief.reportArtifactId)) briefByArtifact.set(brief.reportArtifactId, brief);
   }
   const briefUsage = await teacherBriefMonthlyUsage();
-  const dossierGroups = await listStaffTeacherDossierGroups({ userId: session.user.id, role: session.user.role });
+  const teacherBriefConfig = resolveTeacherBriefConfigSafely();
+  const budgetSnapshot = await readBudgetSnapshot(teacherBriefConfig.monthlyBudgetUsd);
+  const dossierGroups = session.user.role === 'ASSISTANTE' || session.user.role === 'ADMIN'
+    ? await listStaffTeacherDossierGroups({ userId: session.user.id, role: session.user.role })
+    : [];
 
   const resolvedParams = await searchParams;
   const requestedPreview = resolvedParams.preview;
@@ -246,7 +273,8 @@ export default async function CanonicalBilansReviewPage({
         </section>
 
         <p className="mt-3 text-xs text-slate-400">
-          Assistant de rédaction enseignant — usage du mois : {briefUsage.briefs} brief{briefUsage.briefs > 1 ? 's' : ''}, {briefUsage.promptTokens + briefUsage.completionTokens} jetons (dont {briefUsage.cachedPromptTokens} en cache), ≈ {briefUsage.estimatedCostUsd.toFixed(2)} $ US.
+          Assistant de rédaction enseignant — usage du mois : {briefUsage.briefs} brief{briefUsage.briefs > 1 ? 's' : ''}, {briefUsage.promptTokens + briefUsage.completionTokens} jetons (dont {briefUsage.cachedPromptTokens} en cache).
+          Budget — plafond {budgetSnapshot.budgetUsd.toFixed(2)} $ · dépensé {budgetSnapshot.spentUsd.toFixed(2)} $ · réservé {budgetSnapshot.reservedUsd.toFixed(2)} $ · disponible {budgetSnapshot.availableUsd.toFixed(2)} $ US.
         </p>
 
         <section className="mt-8 rounded-2xl border border-white/10 bg-white/[0.05] p-5" aria-label="Dossiers enseignant">
@@ -262,43 +290,47 @@ export default async function CanonicalBilansReviewPage({
                 const query = `subject=${group.subject}&level=${group.level}`;
                 const subjectLabel = DB_SUBJECT_LABELS[group.subject] ?? group.subject;
                 const levelLabel = DB_GRADE_LEVEL_LABELS[group.level] ?? group.level;
+                const hasActiveBatch = group.queuedCount + group.processingCount > 0;
                 return (
                   <article
                     key={`${group.subject}-${group.level}`}
-                    className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-white/10 bg-white/[0.03] p-4"
+                    className="rounded-xl border border-white/10 bg-white/[0.03] p-4"
                   >
-                    <div>
-                      <p className="font-semibold text-white">{subjectLabel} — {levelLabel}</p>
-                      <p className="text-sm text-slate-300">
-                        {group.count} bilan{group.count > 1 ? 's' : ''} éligible{group.count > 1 ? 's' : ''}
-                        {group.briefsMissing > 0 && ` · ${group.briefsMissing} brief${group.briefsMissing > 1 ? 's' : ''} manquant${group.briefsMissing > 1 ? 's' : ''}`}
-                      </p>
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div>
+                        <p className="font-semibold text-white">{subjectLabel} — {levelLabel}</p>
+                        <p className="text-xs text-slate-400">{COMPLETENESS_TIER_LABELS[group.completenessTier]}</p>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Link href={`/dashboard/assistante/bilans/teacher-dossier?${query}&format=html`} target="_blank" className="rounded-lg border border-amber-300/60 px-3 py-1.5 text-sm font-semibold text-amber-100">
+                          Voir le dossier sécurisé
+                        </Link>
+                        <Link href={`/dashboard/assistante/bilans/teacher-dossier?${query}&format=pdf`} target="_blank" className="rounded-lg border border-amber-300/60 px-3 py-1.5 text-sm font-semibold text-amber-100">
+                          PDF sécurisé
+                        </Link>
+                        {group.toGenerateCount > 0 && session.user.role === 'ASSISTANTE' && (
+                          <form action={generateGroupTeacherBriefsAction}>
+                            <input type="hidden" name="subject" value={group.subject} />
+                            <input type="hidden" name="level" value={group.level} />
+                            <button type="submit" disabled={hasActiveBatch} className="rounded-lg bg-amber-300 px-3 py-1.5 text-sm font-semibold text-slate-950 disabled:cursor-not-allowed disabled:opacity-40">
+                              {hasActiveBatch ? 'Génération en cours…' : `Générer ${group.toGenerateCount} brief${group.toGenerateCount > 1 ? 's' : ''} actionnable${group.toGenerateCount > 1 ? 's' : ''}`}
+                            </button>
+                          </form>
+                        )}
+                      </div>
                     </div>
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Link
-                        href={`/dashboard/assistante/bilans/teacher-dossier?${query}&format=html`}
-                        target="_blank"
-                        className="rounded-lg border border-amber-300/60 px-3 py-1.5 text-sm font-semibold text-amber-100"
-                      >
-                        Voir le dossier
-                      </Link>
-                      <Link
-                        href={`/dashboard/assistante/bilans/teacher-dossier?${query}&format=pdf`}
-                        target="_blank"
-                        className="rounded-lg border border-amber-300/60 px-3 py-1.5 text-sm font-semibold text-amber-100"
-                      >
-                        PDF
-                      </Link>
-                      {group.briefsMissing > 0 && (
-                        <form action={generateGroupTeacherBriefsAction}>
-                          <input type="hidden" name="subject" value={group.subject} />
-                          <input type="hidden" name="level" value={group.level} />
-                          <button type="submit" className="rounded-lg bg-amber-300 px-3 py-1.5 text-sm font-semibold text-slate-950">
-                            Générer les {group.briefsMissing} brief{group.briefsMissing > 1 ? 's' : ''} manquant{group.briefsMissing > 1 ? 's' : ''}
-                          </button>
-                        </form>
-                      )}
-                    </div>
+                    <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-slate-300 sm:grid-cols-4">
+                      <div><dt className="text-slate-500">Éligibles</dt><dd>{group.eligibleCount}</dd></div>
+                      <div><dt className="text-slate-500">En file</dt><dd>{group.queuedCount}</dd></div>
+                      <div><dt className="text-slate-500">En cours</dt><dd>{group.processingCount}</dd></div>
+                      <div><dt className="text-slate-500">À relire</dt><dd>{group.toReviewCount}</dd></div>
+                      <div><dt className="text-slate-500">Corrections demandées</dt><dd>{group.correctionRequestedCount}</dd></div>
+                      <div><dt className="text-slate-500">Approuvés</dt><dd>{group.approvedCount}</dd></div>
+                      <div><dt className="text-slate-500">Socle déterministe</dt><dd>{group.socleDeterministeCount}</dd></div>
+                      <div><dt className="text-slate-500">Briefs obsolètes</dt><dd>{group.staleBriefCount}</dd></div>
+                      {group.retryableFailureCount > 0 && <div><dt className="text-slate-500">Échecs retentés</dt><dd>{group.retryableFailureCount}</dd></div>}
+                      {group.blockedFailureCount > 0 && <div><dt className="text-red-300">Blocages — action requise</dt><dd className="text-red-200">{group.blockedFailureCount}</dd></div>}
+                    </dl>
                   </article>
                 );
               })}
@@ -623,32 +655,32 @@ export default async function CanonicalBilansReviewPage({
 
                   {(() => {
                     const brief = briefByArtifact.get(revision.reportArtifact.id);
-                    const briefContent = brief?.content as TeacherBriefContent | undefined;
+                    const briefContent = (brief?.approvedContent ?? brief?.content) as TeacherBriefContent | undefined;
                     return (
                       <section className="border-t border-indigo-300/20 bg-indigo-300/5 px-6 py-5">
                         <h3 className="font-semibold text-indigo-100">Brief enseignant (document interne)</h3>
                         <p className="mt-1 text-xs text-slate-400">
-                          Préparation de séance rédigée par l’assistant de rédaction à partir du diagnostic déterministe, relue avant tout usage. Jamais transmis aux familles.
+                          Préparation de séance rédigée par l’assistant de rédaction à partir du diagnostic déterministe. Seul un brief APPROUVÉ peut atteindre le dossier enseignant — jamais transmis aux familles.
                         </p>
                         {brief === undefined ? (
+                          session.user.role === 'ASSISTANTE' && (
                           <form action={generateTeacherBriefAction} className="mt-3">
                             <input type="hidden" name="artifactId" value={revision.reportArtifact.id} />
                             <button type="submit" className="rounded-xl border border-indigo-300 px-4 py-2.5 text-sm font-semibold text-indigo-100">
-                              Générer le brief enseignant
+                              Mettre en file la génération du brief
                             </button>
                             <p className="mt-2 text-xs text-slate-500">
-                              Si l’assistant de rédaction est indisponible, le document interne Nexus déterministe reste la référence.
+                              Traitement en tâche de fond (quelques minutes) — actualisez la page pour voir le résultat. Si l’assistant de rédaction est indisponible, le document interne Nexus déterministe reste la référence.
                             </p>
                           </form>
+                          )
                         ) : (
                           <div className="mt-3 space-y-3">
                             <p className="text-sm">
                               <span className="rounded-full bg-indigo-300/15 px-3 py-1 text-xs font-semibold text-indigo-100">{briefStatusLabel(brief.status)}</span>
                               <span className="ml-3 text-xs text-slate-400">v{brief.version} · {brief.promptVersion} · {brief.model}{brief.reviewedAt ? ` · relu le ${dateLabel(brief.reviewedAt)}` : ''}</span>
                             </p>
-                            {brief.editedContent ? (
-                              <div className="whitespace-pre-wrap rounded-2xl border border-white/10 bg-black/30 p-4 text-xs leading-5 text-slate-200">{brief.editedContent}</div>
-                            ) : briefContent !== undefined && (
+                            {briefContent !== undefined && (
                               <div className="whitespace-pre-wrap rounded-2xl border border-white/10 bg-black/30 p-4 text-xs leading-5 text-slate-200">{renderBriefText(briefContent)}</div>
                             )}
                             {brief.annotations.length > 0 && (
@@ -658,15 +690,18 @@ export default async function CanonicalBilansReviewPage({
                                 ))}
                               </ul>
                             )}
-                            {brief.status === 'PENDING_REVIEW' && (
+                            {brief.status === 'PENDING_REVIEW' && session.user.role === 'ASSISTANTE' && (
                               <div className="grid gap-3 lg:grid-cols-2">
                                 <form action={approveTeacherBriefAction} className="rounded-2xl border border-emerald-300/20 bg-emerald-300/5 p-4">
                                   <input type="hidden" name="briefId" value={brief.id} />
                                   <label className="block text-xs font-semibold text-white">Motif de validation</label>
-                                  <input name="motif" required minLength={5} className="mt-2 w-full rounded-xl border border-white/15 bg-slate-950 px-3 py-2 text-sm text-white" />
-                                  <label className="mt-3 block text-xs font-semibold text-white">Correction manuelle (facultative — elle prime sur le texte généré)</label>
-                                  <textarea name="editedContent" className="mt-2 min-h-16 w-full rounded-xl border border-white/15 bg-slate-950 p-3 text-xs text-white" placeholder="Laisser vide pour valider le texte généré tel quel." />
-                                  <button type="submit" className="mt-3 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950">Valider le brief</button>
+                                  <select name="motifCode" required className="mt-2 w-full rounded-xl border border-white/15 bg-slate-950 px-3 py-2 text-sm text-white">
+                                    {REVIEW_MOTIF_OPTIONS.map((option) => <option key={option.code} value={option.code}>{option.label}</option>)}
+                                  </select>
+                                  <label className="mt-3 block text-xs font-semibold text-white">Commentaire (facultatif)</label>
+                                  <input name="freeComment" className="mt-2 w-full rounded-xl border border-white/15 bg-slate-950 px-3 py-2 text-sm text-white" />
+                                  <button type="submit" className="mt-3 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950">Valider sans modification</button>
+                                  <p className="mt-2 text-xs text-slate-500">Édition structurée du contenu : voir la file de relecture dédiée (à venir — non modifiable en texte libre ici, par sécurité).</p>
                                 </form>
                                 <form action={requestTeacherBriefCorrectionAction} className="rounded-2xl border border-sky-300/20 bg-sky-300/5 p-4">
                                   <input type="hidden" name="briefId" value={brief.id} />
@@ -675,16 +710,18 @@ export default async function CanonicalBilansReviewPage({
                                   <label className="mt-3 block text-xs font-semibold text-white">Remarque</label>
                                   <textarea name="remark" required minLength={5} className="mt-2 min-h-12 w-full rounded-xl border border-white/15 bg-slate-950 p-3 text-xs text-white" />
                                   <label className="mt-3 block text-xs font-semibold text-white">Motif</label>
-                                  <input name="motif" required minLength={5} className="mt-2 w-full rounded-xl border border-white/15 bg-slate-950 px-3 py-2 text-sm text-white" />
+                                  <select name="motifCode" required className="mt-2 w-full rounded-xl border border-white/15 bg-slate-950 px-3 py-2 text-sm text-white">
+                                    {REVIEW_MOTIF_OPTIONS.map((option) => <option key={option.code} value={option.code}>{option.label}</option>)}
+                                  </select>
                                   <button type="submit" className="mt-3 rounded-xl border border-sky-300 px-4 py-2 text-sm font-semibold text-sky-100">Demander une régénération</button>
                                 </form>
                               </div>
                             )}
-                            {brief.status === 'CORRECTION_REQUESTED' && (
+                            {brief.status === 'CORRECTION_REQUESTED' && session.user.role === 'ASSISTANTE' && (
                               <form action={generateTeacherBriefAction}>
                                 <input type="hidden" name="artifactId" value={revision.reportArtifact.id} />
                                 <button type="submit" className="rounded-xl border border-indigo-300 px-4 py-2.5 text-sm font-semibold text-indigo-100">
-                                  Régénérer le brief (nouvelle version, historique conservé)
+                                  Reprendre — mettre en file la régénération (nouvelle version, historique conservé)
                                 </button>
                               </form>
                             )}

--- a/docs/bilans/adr/ADR-002-teacher-brief-workflow-safety.md
+++ b/docs/bilans/adr/ADR-002-teacher-brief-workflow-safety.md
@@ -1,0 +1,196 @@
+# ADR-002 — Sécurisation et industrialisation du workflow des briefs enseignant
+
+Statut : accepté (2026-08-16). Fait suite à un incident P0 de gouvernance
+pédagogique audité le même jour.
+
+## Incident
+
+Un audit en lecture seule du dashboard assistante (§ voir conversation du
+2026-08-16) a confirmé qu'un brief enseignant enrichi par LLM au statut
+`PENDING_REVIEW` — c'est-à-dire jamais relu par un humain — pouvait être
+inclus dans le dossier enseignant HTML/PDF remis au staff, au même titre
+qu'un brief `APPROVED`. L'invariant documenté dans le code
+(`teacher-brief-review-service.ts`) affirmait pourtant que seul `APPROVED`
+devait atteindre l'enseignant. En production, 28 briefs existaient, tous
+`PENDING_REVIEW`, 0 `APPROVED` : si un dossier avait été généré pour un
+groupe contenant ces briefs, 100 % du contenu IA qu'il aurait porté n'aurait
+jamais été relu par un humain, sans que rien dans le document ne le
+signale.
+
+Causes concourantes identifiées :
+- une liste de statuts unique (`['PENDING_REVIEW', 'APPROVED']`) servait à
+  la fois à bloquer une régénération, à compter un brief « existant » et à
+  autoriser le rendu enseignant — trois questions différentes, une seule
+  réponse ;
+- un repli PLANCHER (échec de génération) ne laissait aucune trace en base,
+  empêchant toute corrélation par bilan et tout calcul de coût réel ;
+- la génération groupée était synchrone (8–10 minutes de requête HTTP),
+  sans progression ni compte rendu ;
+- l'édition manuelle acceptait un texte libre re-parsé en JSON par le
+  dossier — un texte non JSON pouvait être validé puis disparaître
+  silencieusement du document.
+
+## Décision
+
+1. **Invariant fail-closed, défense en profondeur à 3 couches** (§2) :
+   - couche 1 — la requête du dossier (`teacher-dossier-service.ts`) ne
+     sélectionne QUE les briefs `status: APPROVED` (`BRIEF_STATUSES_SAFE_FOR_TEACHER`,
+     `lib/bilans/staff/teacher-brief-status.ts`) ;
+   - couche 2 — le service rejette en plus tout brief `APPROVED` dont le
+     `scoreSnapshotId` ne correspond plus à la révision COURANTE du bilan
+     (staleness, §5) ;
+   - couche 3 — le renderer (`teacher-dossier/render.ts`) n'accepte un
+     `brief` non nul que s'il porte le marqueur `TEACHER_BRIEF_SAFETY_MARKER`
+     posé exclusivement par la couche 2 ; sinon il lève
+     `TEACHER_DOSSIER_UNSAFE_BRIEF_RENDER_BLOCKED` et ne rend rien.
+   - Testé : `__tests__/bilans/teacher-dossier-render.test.ts` (HTML + PDF,
+     extraction textuelle réelle), `__tests__/bilans/teacher-dossier-service.test.ts`.
+
+2. **Trois paliers de dossier explicites** (§3) — `SOCLE_DETERMINISTE`,
+   `ENRICHI_SECURISE_PARTIEL`, `ENRICHI_COMPLET` — calculés par
+   `computeCompleteness()`. `ENRICHI_COMPLET` exige que chaque élève inclus
+   ait soit un brief `APPROVED` courant, soit un statut terminal explicite
+   (dernière tentative `DETERMINISTIC_ONLY`, journal des tentatives) —
+   jamais « pas encore essayé ». Le document affiche le palier, le nombre
+   d'élèves inclus, de briefs approuvés, de socles seuls, et — pour chaque
+   élève sans brief approuvé — la phrase fixe « Socle pédagogique
+   déterministe utilisé — aucun brief enrichi validé. », jamais une
+   formulation laissant croire à une approbation.
+
+3. **Machine de statuts nommée et stricte** (§4) —
+   `TeacherBriefStatus` est désormais un enum Postgres natif (migration
+   `20260816000000_secure_teacher_brief_workflow`), plus la CHECK
+   constraint textuelle redondante. Un trigger SQL
+   (`canonical_bilans_guard_teacher_brief_mutation`) refuse toute
+   transition hors de : `PENDING_REVIEW → APPROVED`,
+   `PENDING_REVIEW → CORRECTION_REQUESTED`,
+   `CORRECTION_REQUESTED → SUPERSEDED`. `lib/bilans/staff/teacher-brief-status.ts`
+   regroupe quatre ensembles nommés distincts
+   (`BRIEF_STATUSES_BLOCKING_DUPLICATE_GENERATION`,
+   `BRIEF_STATUSES_PENDING_HUMAN_ACTION`, `BRIEF_STATUSES_SAFE_FOR_TEACHER`,
+   `BRIEF_STATUSES_TERMINAL_HISTORY`) — aucune liste dupliquée ailleurs.
+
+4. **Détection des briefs obsolètes** (§5) : la staleness (couche 2
+   ci-dessus) est dérivée, pas persistée séparément — un brief `APPROVED`
+   dont le `scoreSnapshotId` diffère de la révision courante du bilan
+   n'est jamais rendu et compte dans `staleBriefCount` côté dashboard.
+   `approveTeacherBrief` refuse en plus l'approbation elle-même si le
+   snapshot courant a changé depuis la génération du brief
+   (`BRIEF_STALE_SNAPSHOT`, concurrence optimiste).
+
+5. **Édition manuelle structurée** (§6) : `editedContent String?` (texte
+   libre) est supprimé (0 valeur non nulle vérifiée en production avant
+   suppression) et remplacé par `approvedContent Json?` — même schéma Zod
+   que le contenu généré (`teacherBriefSchema`), posé une seule fois à
+   l'approbation, ré-ancré sur les faits pédagogiques
+   (`assertBriefRespectsFacts`) et le lexique interdit avant écriture. Le
+   dossier lit `approvedContent ?? content`, jamais de `JSON.parse` défensif
+   sur une chaîne libre.
+
+6. **Journal canonique des tentatives** (§7) — table
+   `canonical_teacher_brief_attempts` (append-only, trigger réutilisant le
+   garde générique existant), un enregistrement par tentative traitée
+   (`GENERATED`, `ALREADY_PRESENT`, `DETERMINISTIC_ONLY`,
+   `RETRYABLE_FAILURE`, `BLOCKED_FAILURE`, `BUDGET_BLOCKED`, `STALE_INPUT`,
+   `CANCELLED_BEFORE_START`), avec coût réellement engagé (y compris les
+   tentatives ratées mais facturées) et `domainOutcomes` (détail par appel
+   de domaine). `costUnknown=true` remplace un coût à zéro silencieux
+   quand le fournisseur n'a renvoyé aucun usage exploitable (timeout avant
+   réponse).
+
+7. **Politique de retry explicite** (§8), appliquée dans
+   `lib/bilans/worker/generate-teacher-brief-job.ts` :
+   - **A — déterministe, pas une panne** : `TEACHER_BRIEF_TOO_FEW_PRIORITIES`
+     → `DETERMINISTIC_ONLY`, job `COMPLETED`, jamais retenté, aucun coût.
+   - **B — transitoire, retry borné** : timeout, réseau, HTTP 429/5xx, JSON
+     invalide, schéma rejeté, sortie tronquée → `RETRYABLE_FAILURE`, job
+     `FAILED`, repris par le cycle de drain existant (`MAX_JOB_ATTEMPTS=20`,
+     quarantaine + alerte au-delà — mécanisme déjà éprouvé,
+     `drain-outbox.ts`).
+   - **C — aucun retry automatique** : PII, lexique interdit, ancrage,
+     pack indisponible/checksum différent, configuration invalide →
+     `BLOCKED_FAILURE`, job `COMPLETED`, action humaine requise, jamais de
+     relâchement des gardes de sécurité pour améliorer un taux de succès.
+
+8. **Traitement asynchrone** (§10) — réutilisation intégrale de
+   l'infrastructure canonique déjà en place et éprouvée
+   (`canonical_job_outbox`, `FOR UPDATE SKIP LOCKED`, bail/lease,
+   `lib/bilans/worker/scheduler.ts` — worker EN PROCESS dans `nexus-prod`,
+   démarré par `instrumentation.ts`, jamais un second process PM2, jamais
+   le worker NPC). Nouveau type `GENERATE_TEACHER_BRIEF` dans
+   `CanonicalJobType`, nouveau `lib/bilans/worker/generate-teacher-brief-job.ts`
+   (calqué sur `generate-report-job.ts`), nouveau
+   `lib/bilans/llm/teacher-brief-enqueue.ts` (idempotencyKey =
+   `teacher-brief:{reportArtifactId}:{scoreSnapshotId}`, contrainte UNIQUE
+   déjà existante sur `canonical_job_outbox.idempotencyKey` →
+   double clic/deux onglets = `ON CONFLICT DO NOTHING`, aucun effet de
+   bord). Le clic assistante répond en dessous de la seconde. Concurrence
+   volontairement limitée à 1 génération à la fois
+   (`drainTeacherBriefJobs({ limit: 1 })`).
+
+9. **Budget atomique** (§11) — `canonical_teacher_brief_monthly_budgets`
+   (une ligne par mois), réservation/régularisation par une unique
+   instruction `UPDATE ... WHERE spentUsd + reservedUsd + montant <=
+   budgetUsd` (`lib/bilans/llm/teacher-brief-budget.ts`) : aucune lecture
+   non verrouillée suivie d'un appel, aucune course possible entre deux
+   batches concurrents — prouvé par un test réel (deux réservations
+   concurrentes, une seule passe). Le dashboard affiche plafond, dépensé,
+   réservé, disponible — jamais invisible, jamais la clé.
+
+10. **Dashboard sans ambiguïté** (§12) — le libellé « briefs manquants »
+    est retiré. Chaque carte matière × niveau affiche :
+    éligibles / à générer / en file / en cours / à relire / corrections
+    demandées / approuvés / socle déterministe / échecs retentés / blocages
+    / briefs obsolètes / palier de complétude. Le bouton de génération est
+    désactivé pendant un batch actif (`hasActiveBatch`).
+
+11. **Politique des rôles** (§14) — ASSISTANTE : génération, relecture,
+    approbation, correction, téléchargement. ADMIN : consultation et
+    supervision en lecture seule — aucune action de génération/relecture
+    proposée dans l'UI, et refusée côté serveur
+    (`assertAssistanteOnly`, `app/dashboard/assistante/bilans/actions.ts`)
+    même si elle était appelée directement. COACH/PARENT/ELEVE/anonyme :
+    aucun accès (inchangé, déjà couvert par
+    `__tests__/architecture/teacher-dossier-confidentiality.test.ts`).
+
+12. **Backfill** (§15) — `scripts/bilans/backfill-teacher-brief-attempts.ts`,
+    idempotent, `--dry-run` disponible, source `LEGACY_BACKFILL`. N'auto-
+    approuve rien, ne supprime rien, ne modifie aucun contenu existant.
+    N'invente PAS l'historique des 61 échecs PLANCHER non corrélables
+    constatés dans les logs avant ce correctif (aucun identifiant de bilan
+    dans ces lignes de log historiques) — limite documentée ici, pas
+    comblée par une supposition.
+
+## Ce que cette ADR NE couvre PAS encore (dette explicite, pas cachée)
+
+- **§9 — qualification LLM en corpus réel** : le protocole de sortie
+  structurée (JSON Schema strict si le modèle/OpenRouter le permet) n'a
+  pas été évalué sur un corpus de ≥20 bilans réels avec budget plafonné et
+  appels réseau réels — cela nécessite une exécution humaine, budgétée,
+  hors de cette session en lecture-écriture disposable. Gate minimum
+  (0 contenu non conforme, ≤5 % JSON/schéma invalide après retry) **non
+  vérifié** : `NOT_READY` sur ce point précis tant que cette qualification
+  n'a pas été exécutée.
+- **§13 — file de relecture dédiée** (navigation précédent/suivant,
+  progression X/Y, conservation de brouillon côté navigateur) : la relecture
+  reste intégrée à la page `bilans` existante avec les nouveaux motifs
+  structurés et le rejet de tout textarea de JSON libre ; l'ergonomie dédiée
+  (page séparée, clavier, brouillon local) reste à construire.
+- Reprise après crash worker sous charge concurrente réelle (plusieurs
+  workers, plusieurs batches simultanés en environnement de charge) :
+  prouvée par construction (verrouillage `FOR UPDATE SKIP LOCKED`,
+  réservation budgétaire atomique par UPDATE conditionnel — tous deux des
+  mécanismes déjà utilisés et éprouvés ailleurs dans ce worker) et par un
+  test d'intégration (réservations concurrentes), mais pas par un test de
+  charge dédié.
+
+## Preuves
+
+- Migration testée sur clone avec les 28 (26 au moment du dump) briefs
+  réels de production, données synthétiques APPROVED/CORRECTION_REQUESTED/
+  SUPERSEDED, dump/restore complet (exit 0, 0 diff de schéma, 94 tables des
+  deux côtés) — voir description de PR.
+- Suite complète : 9152/9155 tests unitaires passent (3 échecs pré-
+  existants, sans rapport, confirmés par `git diff` vide sur les fichiers
+  concernés) ; 7/7 tests d'intégration réels (vraie base PostgreSQL,
+  jamais de mock de `$queryRaw`) sur le nouveau worker asynchrone.

--- a/lib/bilans/llm/teacher-brief-budget.ts
+++ b/lib/bilans/llm/teacher-brief-budget.ts
@@ -1,0 +1,125 @@
+import { Prisma, type PrismaClient } from '@prisma/client';
+
+import { prisma } from '@/lib/prisma';
+
+/**
+ * Budget mensuel atomique (§11 de l'incident P0).
+ *
+ * Le défaut audité : `spentUsd >= budget` était lu SANS verrou avant chaque
+ * appel LLM — deux batches concurrents pouvaient chacun lire un solde
+ * disponible obsolète et dépasser le plafond ensemble. Ici, réservation ET
+ * vérification sont la MÊME instruction SQL (`UPDATE ... WHERE ... <=
+ * budget`), atomique par construction : Postgres ne peut pas exécuter deux
+ * UPDATE concurrents sur la même ligne sans les sérialiser, donc aucune
+ * course n'est possible, sans verrou explicite ni transaction longue.
+ */
+
+export class TeacherBriefBudgetError extends Error {
+  constructor(readonly code: string) {
+    super(code);
+    this.name = 'TeacherBriefBudgetError';
+  }
+}
+
+type BudgetDatabase = Pick<PrismaClient, '$queryRaw' | '$executeRaw' | 'teacherBriefMonthlyBudget'>;
+
+function monthStart(now: Date): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+}
+
+/** Crée la ligne du mois si absente (idempotent — `ON CONFLICT DO NOTHING`). */
+async function ensureMonthRow(database: BudgetDatabase, month: Date, budgetUsd: number): Promise<void> {
+  await database.$executeRaw(Prisma.sql`
+    INSERT INTO "canonical_teacher_brief_monthly_budgets" ("monthStart", "budgetUsd")
+    VALUES (${month}, ${budgetUsd})
+    ON CONFLICT ("monthStart") DO NOTHING
+  `);
+}
+
+export type BudgetSnapshot = Readonly<{
+  monthStart: Date;
+  budgetUsd: number;
+  spentUsd: number;
+  reservedUsd: number;
+  availableUsd: number;
+}>;
+
+export async function readBudgetSnapshot(
+  budgetUsd: number,
+  dependencies: Readonly<{ prisma?: BudgetDatabase; now?: () => Date }> = {},
+): Promise<BudgetSnapshot> {
+  const database = dependencies.prisma ?? prisma;
+  const now = (dependencies.now ?? (() => new Date()))();
+  const month = monthStart(now);
+  await ensureMonthRow(database, month, budgetUsd);
+  const row = await database.teacherBriefMonthlyBudget.findUniqueOrThrow({ where: { monthStart: month } });
+  const spent = Number(row.spentUsd);
+  const reserved = Number(row.reservedUsd);
+  return Object.freeze({
+    monthStart: month,
+    budgetUsd: Number(row.budgetUsd),
+    spentUsd: spent,
+    reservedUsd: reserved,
+    availableUsd: Math.max(0, Number(row.budgetUsd) - spent - reserved),
+  });
+}
+
+/**
+ * Réserve `amountUsd` de façon atomique. Retourne `false` (aucune ligne
+ * affectée) si la réservation dépasserait le plafond — jamais d'exception
+ * pour un dépassement normal, c'est un repli PLANCHER attendu, pas une
+ * panne.
+ */
+export async function reserveBudget(
+  amountUsd: number,
+  budgetUsd: number,
+  dependencies: Readonly<{ prisma?: BudgetDatabase; now?: () => Date }> = {},
+): Promise<boolean> {
+  const database = dependencies.prisma ?? prisma;
+  const now = (dependencies.now ?? (() => new Date()))();
+  const month = monthStart(now);
+  await ensureMonthRow(database, month, budgetUsd);
+  const affected = await database.$executeRaw(Prisma.sql`
+    UPDATE "canonical_teacher_brief_monthly_budgets"
+    SET "reservedUsd" = "reservedUsd" + ${amountUsd}
+    WHERE "monthStart" = ${month}
+      AND "spentUsd" + "reservedUsd" + ${amountUsd} <= "budgetUsd"
+  `);
+  return affected === 1;
+}
+
+/**
+ * Régularise une réservation après usage réel connu : libère la réservation
+ * et ajoute le coût réel comptabilisé. `actualUsd` peut être `null` quand le
+ * coût réel est inconnu (ex. timeout avant réponse du fournisseur) — dans ce
+ * cas la réservation est libérée mais RIEN n'est ajouté à `spentUsd` : le
+ * coût inconnu reste visible via `costUnknown` sur la tentative journalisée
+ * (`TeacherBriefAttempt`), jamais compté à zéro par défaut.
+ */
+export async function regularizeBudget(
+  reservedUsd: number,
+  actualUsd: number | null,
+  dependencies: Readonly<{ prisma?: BudgetDatabase; now?: () => Date }> = {},
+): Promise<void> {
+  const database = dependencies.prisma ?? prisma;
+  const now = (dependencies.now ?? (() => new Date()))();
+  const month = monthStart(now);
+  await database.$executeRaw(Prisma.sql`
+    UPDATE "canonical_teacher_brief_monthly_budgets"
+    SET "reservedUsd" = GREATEST(0, "reservedUsd" - ${reservedUsd}),
+        "spentUsd" = "spentUsd" + ${actualUsd ?? 0}
+    WHERE "monthStart" = ${month}
+  `);
+}
+
+/**
+ * Libère une réservation sans l'imputer à `spentUsd` — pour une réservation
+ * abandonnée AVANT tout appel (ex. bilan devenu STALE_INPUT entre la mise en
+ * file et le traitement).
+ */
+export async function releaseBudget(
+  reservedUsd: number,
+  dependencies: Readonly<{ prisma?: BudgetDatabase; now?: () => Date }> = {},
+): Promise<void> {
+  return regularizeBudget(reservedUsd, null, dependencies);
+}

--- a/lib/bilans/llm/teacher-brief-enqueue.ts
+++ b/lib/bilans/llm/teacher-brief-enqueue.ts
@@ -1,0 +1,41 @@
+import { randomUUID } from 'node:crypto';
+
+import { Prisma, type PrismaClient } from '@prisma/client';
+
+import { prisma } from '@/lib/prisma';
+
+/**
+ * Met en file UNE tentative de génération de brief enseignant (§10 de
+ * l'incident P0) — jamais d'appel LLM synchrone dans une requête HTTP.
+ *
+ * Idempotence par construction : `idempotencyKey` est dérivé de
+ * (reportArtifactId, scoreSnapshotId courant) et porte une contrainte UNIQUE
+ * en base (`canonical_job_outbox_idempotencyKey_key`) — un double clic, deux
+ * onglets, ou un rappel après un bilan déjà en file produisent tous
+ * `ON CONFLICT DO NOTHING` : aucun second job, aucun effet de bord.
+ */
+
+type EnqueueDatabase = Pick<PrismaClient, '$executeRaw'>;
+
+export async function enqueueTeacherBriefGeneration(
+  reportArtifactId: string,
+  expectedScoreSnapshotId: string,
+  actorId: string,
+  database: EnqueueDatabase = prisma,
+): Promise<void> {
+  const idempotencyKey = `teacher-brief:${reportArtifactId}:${expectedScoreSnapshotId}`;
+  // `actorId` voyage dans le payload : le worker n'a pas de session, mais
+  // "l'acteur demandeur" (§7) reste l'assistante qui a cliqué "Générer" —
+  // jamais un identifiant système inventé (FK réelle vers `users`).
+  const payload = JSON.stringify({ reportArtifactId, expectedScoreSnapshotId, actorId });
+  await database.$executeRaw(Prisma.sql`
+    INSERT INTO "canonical_job_outbox" (
+      "id", "jobType", "aggregateType", "aggregateId", "sourceEventKey", "idempotencyKey", "payload", "updatedAt"
+    ) VALUES (
+      ${randomUUID()},
+      'GENERATE_TEACHER_BRIEF'::"CanonicalJobType",
+      'TeacherBrief', ${reportArtifactId}, ${idempotencyKey}, ${idempotencyKey}, ${payload}::jsonb, CURRENT_TIMESTAMP
+    )
+    ON CONFLICT ("idempotencyKey") DO NOTHING
+  `);
+}

--- a/lib/bilans/llm/teacher-brief-service.ts
+++ b/lib/bilans/llm/teacher-brief-service.ts
@@ -283,7 +283,7 @@ export type TeacherBriefGeneration = Readonly<{
 }>;
 
 /** Usage brut d'un appel unitaire, avant agrégation. */
-type DomainCallOutcome = Readonly<{
+export type DomainCallOutcome = Readonly<{
   domaine: TeacherBriefContent['domaines'][number];
   promptTokens: number;
   cachedPromptTokens: number;
@@ -295,8 +295,14 @@ type DomainCallOutcome = Readonly<{
  * prompt (consignes + schéma + lexique) est identique d'un appel à l'autre :
  * elle est mise en cache par le fournisseur, si bien que le surcoût d'un
  * appel supplémentaire porte presque uniquement sur les jetons de sortie.
+ *
+ * Exportée (en plus de `callTeacherBriefModel`) pour que l'appelant puisse
+ * comptabiliser le coût RÉEL domaine par domaine même en cas d'échec
+ * partiel (§7 de l'incident P0 du 2026-08-16) : un premier domaine facturé
+ * reste compté même si un domaine suivant échoue — voir
+ * `lib/bilans/worker/generate-teacher-brief-job.ts`.
  */
-async function callTeacherBriefDomain(
+export async function callTeacherBriefDomain(
   config: TeacherBriefConfig,
   facts: TeacherBriefFactsPayload,
   fetchImpl: typeof fetch,

--- a/lib/bilans/llm/teacher-brief-service.ts
+++ b/lib/bilans/llm/teacher-brief-service.ts
@@ -7,7 +7,6 @@ import lexicon from '@/data/bilans/lexique-interdit.json';
 import modelPolicy from '@/data/bilans/model-policy.json';
 import { prisma } from '@/lib/prisma';
 
-import { resolveEnabledPack, type PackResolver } from '../api/pack-access';
 import type { FactSheet } from '../facts/fact-sheet';
 import { scanPiiFields } from '../local-first/pii';
 import {
@@ -489,148 +488,18 @@ export function assertBriefRespectsFacts(content: TeacherBriefContent, facts: Te
 }
 
 /* -------------------------------------------------------------------------- */
-/* Orchestration : idempotence, budget, repli, persistance                     */
+/* Orchestration : voir lib/bilans/worker/generate-teacher-brief-job.ts        */
 /* -------------------------------------------------------------------------- */
-
-type BriefDatabase = Pick<PrismaClient, '$transaction' | 'teacherBrief' | 'reportArtifact'>;
-
-export type GenerateBriefResult =
-  | Readonly<{ mode: 'GENERATED'; briefId: string; version: number }>
-  | Readonly<{ mode: 'ALREADY_PRESENT'; briefId: string }>
-  | Readonly<{ mode: 'PLANCHER'; reason: string }>;
-
-export async function generateTeacherBrief(input: Readonly<{
-  prisma?: BriefDatabase;
-  actor: Readonly<{ userId: string; role: string }>;
-  reportArtifactId: string;
-  resolvePack?: PackResolver;
-  environment?: Readonly<Record<string, string | undefined>>;
-  fetchImpl?: typeof fetch;
-  now?: () => Date;
-}>): Promise<GenerateBriefResult> {
-  if (input.actor.role !== 'ASSISTANTE' || !input.actor.userId.trim()) {
-    throw new TeacherBriefError('NOT_FOUND');
-  }
-  const database = input.prisma ?? prisma;
-  const now = (input.now ?? (() => new Date()))();
-
-  // Cache applicatif : un brief déjà généré (et non renvoyé en correction)
-  // ne se régénère JAMAIS.
-  const existing = await database.teacherBrief.findFirst({
-    where: { reportArtifactId: input.reportArtifactId, status: { in: ['PENDING_REVIEW', 'APPROVED'] } },
-    orderBy: { version: 'desc' },
-    select: { id: true },
-  });
-  if (existing !== null) return Object.freeze({ mode: 'ALREADY_PRESENT' as const, briefId: existing.id });
-
-  let config: TeacherBriefConfig;
-  try {
-    config = resolveTeacherBriefConfig(input.environment);
-  } catch (error) {
-    return Object.freeze({ mode: 'PLANCHER' as const, reason: (error as TeacherBriefError).code ?? 'CONFIG' });
-  }
-
-  // Budget mensuel : dépassé → repli, jamais d'erreur bloquante.
-  const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
-  const spent = await database.teacherBrief.aggregate({
-    _sum: { estimatedCostUsd: true },
-    where: { createdAt: { gte: monthStart } },
-  });
-  const spentUsd = Number(spent._sum.estimatedCostUsd ?? 0);
-  if (spentUsd >= config.monthlyBudgetUsd) {
-    return Object.freeze({ mode: 'PLANCHER' as const, reason: 'TEACHER_BRIEF_BUDGET_EXCEEDED' });
-  }
-
-  const artifact = await database.reportArtifact.findUnique({
-    where: { id: input.reportArtifactId },
-    select: {
-      id: true,
-      assessmentAttempt: {
-        select: {
-          answers: true,
-          assessmentPackId: true,
-          assessmentPackVersion: true,
-          assessmentPackChecksum: true,
-        },
-      },
-      revisions: {
-        orderBy: { createdAt: 'desc' },
-        take: 1,
-        select: { scoreSnapshotId: true, scoreSnapshot: { select: { result: true } } },
-      },
-    },
-  });
-  if (artifact === null || artifact.revisions.length === 0) throw new TeacherBriefError('NOT_FOUND');
-
-  const resolvePack = input.resolvePack ?? resolveEnabledPack;
-  const resolved = resolvePack(
-    artifact.assessmentAttempt.assessmentPackId,
-    Number(artifact.assessmentAttempt.assessmentPackVersion),
-  );
-  if (resolved === null) return Object.freeze({ mode: 'PLANCHER' as const, reason: 'PACK_UNAVAILABLE' });
-  if (artifact.assessmentAttempt.assessmentPackChecksum !== resolved.checksum) {
-    return Object.freeze({ mode: 'PLANCHER' as const, reason: 'PACK_CHECKSUM_MISMATCH' });
-  }
-
-  const factSheet = artifact.revisions[0].scoreSnapshot.result as unknown as FactSheet;
-
-  let generation: TeacherBriefGeneration;
-  try {
-    const facts = buildStudentFactsPayload(
-      factSheet,
-      resolved.pack,
-      artifact.assessmentAttempt.answers,
-      resolved.pack.subject,
-    );
-    generation = await callTeacherBriefModel(config, facts, input.fetchImpl);
-  } catch (error) {
-    const code = error instanceof TeacherBriefError ? error.code : 'TEACHER_BRIEF_UNKNOWN';
-    console.error(JSON.stringify({ event: 'TEACHER_BRIEF_GENERATION_FELL_BACK', reason: code }));
-    return Object.freeze({ mode: 'PLANCHER' as const, reason: code });
-  }
-
-  const created = await database.$transaction(async (transaction) => {
-    // Régénération après correction : l'ancienne version passe SUPERSEDED,
-    // l'historique (contenu, annotations, relecture) reste intact.
-    await transaction.teacherBrief.updateMany({
-      where: { reportArtifactId: input.reportArtifactId, status: 'CORRECTION_REQUESTED' },
-      data: { status: 'SUPERSEDED' },
-    });
-    const latest = await transaction.teacherBrief.findFirst({
-      where: { reportArtifactId: input.reportArtifactId },
-      orderBy: { version: 'desc' },
-      select: { version: true },
-    });
-    return transaction.teacherBrief.create({
-      data: {
-        reportArtifactId: input.reportArtifactId,
-        scoreSnapshotId: artifact.revisions[0].scoreSnapshotId,
-        version: (latest?.version ?? 0) + 1,
-        status: 'PENDING_REVIEW',
-        content: generation.content as never,
-        promptVersion: generation.promptVersion,
-        model: generation.model,
-        promptTokens: generation.promptTokens,
-        cachedPromptTokens: generation.cachedPromptTokens,
-        completionTokens: generation.completionTokens,
-        estimatedCostUsd: generation.estimatedCostUsd,
-        generationMs: generation.generationMs,
-        createdById: input.actor.userId,
-      },
-      select: { id: true, version: true },
-    });
-  });
-  console.info(JSON.stringify({
-    event: 'TEACHER_BRIEF_GENERATED',
-    model: generation.model,
-    promptVersion: generation.promptVersion,
-    promptTokens: generation.promptTokens,
-    cachedPromptTokens: generation.cachedPromptTokens,
-    completionTokens: generation.completionTokens,
-    estimatedCostUsd: generation.estimatedCostUsd,
-  }));
-  return Object.freeze({ mode: 'GENERATED' as const, briefId: created.id, version: created.version });
-}
+// L'ancienne orchestration synchrone (`generateTeacherBrief`) a été retirée
+// (§10 de l'incident P0 du 2026-08-16) : elle exécutait l'appel LLM dans la
+// requête HTTP de l'assistante (8-10 min pour un groupe), sans traçabilité
+// des échecs PLANCHER, sans budget atomique. Sa logique — idempotence,
+// classification des échecs, persistance — vit maintenant dans
+// `processGenerateTeacherBriefJob` (job outbox, worker en process,
+// `journal des tentatives`), qui réutilise les primitives ci-dessus
+// (`buildStudentFactsPayload`, `callTeacherBriefModel`, `assertBriefRespectsFacts`).
+// Aucun double chemin : ce fichier ne contient plus que les primitives
+// stables, jamais l'orchestration complète.
 
 /** Usage cumulé du mois — compteur consultable dans le dashboard. */
 export async function teacherBriefMonthlyUsage(

--- a/lib/bilans/staff/regeneration-service.ts
+++ b/lib/bilans/staff/regeneration-service.ts
@@ -14,7 +14,7 @@ import { buildDeterministicReports } from '../render/report';
 import { buildPreRentreeStageLabel } from '../render/stage-label';
 import { prepareReportPassationPresentation } from '../render/passation-presentation';
 import type { RenderIdentity } from '../render/render-identity';
-import { generateTeacherBrief, type GenerateBriefResult } from '../llm/teacher-brief-service';
+import { enqueueTeacherBriefGeneration } from '../llm/teacher-brief-enqueue';
 import { requestTeacherBriefCorrection } from './teacher-brief-review-service';
 
 /**
@@ -463,9 +463,13 @@ export async function executeReportRegeneration(input: Readonly<{
     return revision;
   });
 
-  // 4. Brief enseignant : régénéré si les profils ont changé — un brief ancré
-  //    sur un diagnostic obsolète ferait préparer la mauvaise séance. Repli
-  //    PLANCHER : indisponible → le bilan est régénéré sans brief, jamais bloqué.
+  // 4. Brief enseignant : mis en file de régénération si les profils ont
+  //    changé — un brief ancré sur un diagnostic obsolète ferait préparer la
+  //    mauvaise séance (§5/§10 de l'incident P0). Plus d'appel LLM synchrone
+  //    ici : `briefRegenerated` signifie désormais "mis en file", pas
+  //    "généré avec succès" — le résultat réel arrive via le worker et le
+  //    journal des tentatives (`TeacherBriefAttempt`), consultable par
+  //    `reportArtifactId`.
   let briefOutcome: Readonly<{ regenerated: boolean; reason: string | null; promptVersion: string | null; model: string | null }> =
     Object.freeze({ regenerated: false, reason: 'PROFILS_INCHANGES', promptVersion: null, model: null });
   if (loaded.changes.length > 0) {
@@ -481,38 +485,15 @@ export async function executeReportRegeneration(input: Readonly<{
         await requestTeacherBriefCorrection({
           actor: { userId: input.actor.userId, role: 'ASSISTANTE' },
           briefId: activeBrief.id,
-          motif: `Profils régénérés (génération ${created.generation}) — ${motif}`,
+          motifCode: 'AUTRE',
+          freeComment: `Profils régénérés (génération ${created.generation}) — ${motif}`,
           annotation: {
             section: 'autre',
             remark: 'Brief obsolète : les profils du bilan ont été régénérés sous la règle courante.',
           },
         });
-        const result: GenerateBriefResult = await generateTeacherBrief({
-          actor: { userId: input.actor.userId, role: 'ASSISTANTE' },
-          reportArtifactId: artifact.id,
-          environment: input.environment,
-          fetchImpl: input.fetchImpl,
-          now: input.now,
-        });
-        if (result.mode === 'GENERATED') {
-          const generated = await database.teacherBrief.findUnique({
-            where: { id: result.briefId },
-            select: { promptVersion: true, model: true },
-          });
-          briefOutcome = Object.freeze({
-            regenerated: true,
-            reason: null,
-            promptVersion: generated?.promptVersion ?? null,
-            model: generated?.model ?? null,
-          });
-        } else {
-          briefOutcome = Object.freeze({
-            regenerated: false,
-            reason: result.mode === 'PLANCHER' ? result.reason : result.mode,
-            promptVersion: null,
-            model: null,
-          });
-        }
+        await enqueueTeacherBriefGeneration(artifact.id, loaded.revision.scoreSnapshotId, input.actor.userId);
+        briefOutcome = Object.freeze({ regenerated: true, reason: 'MIS_EN_FILE', promptVersion: null, model: null });
       } catch {
         briefOutcome = Object.freeze({ regenerated: false, reason: 'BRIEF_REGENERATION_FAILED', promptVersion: null, model: null });
       }

--- a/lib/bilans/staff/teacher-brief-review-service.ts
+++ b/lib/bilans/staff/teacher-brief-review-service.ts
@@ -2,15 +2,26 @@ import type { PrismaClient } from '@prisma/client';
 
 import { prisma } from '@/lib/prisma';
 
+import { resolveEnabledPack, type PackResolver } from '../api/pack-access';
+import type { FactSheet } from '../facts/fact-sheet';
+import {
+  assertBriefRespectsFacts,
+  buildStudentFactsPayload,
+  TeacherBriefError,
+} from '../llm/teacher-brief-service';
+import { teacherBriefSchema, type TeacherBriefContent } from '../llm/teacher-brief-schema';
+
 /**
  * Relecture obligatoire du brief enseignant.
  *
  * Aucun contenu généré n'atteint un enseignant sans validation explicite :
  * l'état PENDING_REVIEW est distinct de tout état utilisable ; seul un
- * brief APPROVED est montré comme prêt. La relectrice peut approuver
- * (éventuellement en corrigeant à la main — sa correction prime toujours),
- * ou annoter et renvoyer en correction ; la régénération crée une nouvelle
- * version, l'historique reste intact (append-only).
+ * brief APPROVED — ET rattaché au scoreSnapshot COURANT du bilan (§5 de
+ * l'incident P0) — est montré comme prêt. La relectrice peut approuver
+ * (éventuellement avec une correction STRUCTURÉE — jamais un texte libre
+ * re-parsé, voir §6), ou annoter et renvoyer en correction ; la
+ * régénération crée une nouvelle version, l'historique reste intact
+ * (append-only).
  */
 
 export class TeacherBriefReviewError extends Error {
@@ -20,7 +31,33 @@ export class TeacherBriefReviewError extends Error {
   }
 }
 
-type ReviewDatabase = Pick<PrismaClient, '$transaction' | 'teacherBrief' | 'teacherBriefAnnotation'>;
+/** Motifs structurés (§13) : un choix standard alimente `reviewMotif`, un commentaire libre reste possible en complément. */
+export const REVIEW_MOTIF_CODES = Object.freeze([
+  'VALIDATION_PEDAGOGIQUE',
+  'VALIDATION_APRES_CORRECTION_MANUELLE',
+  'CORRECTION_FACTUELLE',
+  'CORRECTION_DIDACTIQUE',
+  'CORRECTION_FORMULATION',
+  'AUTRE',
+] as const);
+export type ReviewMotifCode = (typeof REVIEW_MOTIF_CODES)[number];
+
+const REVIEW_MOTIF_LABELS: Readonly<Record<ReviewMotifCode, string>> = Object.freeze({
+  VALIDATION_PEDAGOGIQUE: 'Validation pédagogique',
+  VALIDATION_APRES_CORRECTION_MANUELLE: 'Validation après correction manuelle',
+  CORRECTION_FACTUELLE: 'Correction factuelle',
+  CORRECTION_DIDACTIQUE: 'Correction didactique',
+  CORRECTION_FORMULATION: 'Correction de formulation',
+  AUTRE: 'Autre',
+});
+
+export function buildReviewMotif(code: ReviewMotifCode, freeComment: string): string {
+  const comment = freeComment.trim();
+  const label = REVIEW_MOTIF_LABELS[code];
+  return comment.length === 0 ? label : `${label} — ${comment}`;
+}
+
+type ReviewDatabase = Pick<PrismaClient, '$transaction' | 'teacherBrief' | 'teacherBriefAnnotation' | 'reportArtifact'>;
 
 type Actor = Readonly<{ userId: string; role: string }>;
 
@@ -35,29 +72,94 @@ function assertMotif(motif: string): string {
   return value;
 }
 
+/**
+ * Reconstruit les faits pédagogiques du bilan pour le ré-ancrage
+ * (`assertBriefRespectsFacts`) d'une correction manuelle structurée — mêmes
+ * données que celles envoyées au modèle à la génération, jamais réinventées.
+ */
+async function loadFactsForReanchoring(
+  transaction: Pick<PrismaClient, 'reportArtifact'>,
+  reportArtifactId: string,
+  resolvePack: PackResolver,
+): Promise<ReturnType<typeof buildStudentFactsPayload>> {
+  const artifact = await transaction.reportArtifact.findUnique({
+    where: { id: reportArtifactId },
+    select: {
+      assessmentAttempt: {
+        select: { subject: true, answers: true, assessmentPackId: true, assessmentPackVersion: true },
+      },
+      revisions: {
+        orderBy: { createdAt: 'desc' as const }, take: 1,
+        select: { scoreSnapshot: { select: { result: true } } },
+      },
+    },
+  });
+  if (artifact === null || artifact.revisions.length === 0) throw new TeacherBriefReviewError('BRIEF_ARTIFACT_NOT_FOUND');
+  const resolved = resolvePack(artifact.assessmentAttempt.assessmentPackId, Number(artifact.assessmentAttempt.assessmentPackVersion));
+  if (resolved === null) throw new TeacherBriefReviewError('BRIEF_PACK_UNAVAILABLE');
+  const factSheet = artifact.revisions[0].scoreSnapshot.result as unknown as FactSheet;
+  return buildStudentFactsPayload(factSheet, resolved.pack, artifact.assessmentAttempt.answers, artifact.assessmentAttempt.subject);
+}
+
 export async function approveTeacherBrief(input: Readonly<{
   prisma?: ReviewDatabase;
   actor: Actor;
   briefId: string;
-  motif: string;
-  /** Correction manuelle facultative — si présente, elle PRIME sur le contenu généré. */
-  editedContent?: string;
+  motifCode: ReviewMotifCode;
+  freeComment?: string;
+  /**
+   * Correction manuelle STRUCTURÉE — même schéma que le contenu généré,
+   * jamais un texte libre. `undefined` = "Valider sans modification".
+   */
+  approvedContent?: unknown;
+  resolvePack?: PackResolver;
   now?: () => Date;
 }>) {
   const database = input.prisma ?? prisma;
   const reviewerId = assertAssistante(input.actor);
-  const motif = assertMotif(input.motif);
+  const motif = assertMotif(buildReviewMotif(input.motifCode, input.freeComment ?? ''));
   const now = (input.now ?? (() => new Date()))();
-  const edited = input.editedContent?.trim();
+  const resolvePack = input.resolvePack ?? resolveEnabledPack;
+
+  let approvedContent: TeacherBriefContent | undefined;
+  if (input.approvedContent !== undefined) {
+    const parsed = teacherBriefSchema.safeParse(input.approvedContent);
+    if (!parsed.success) throw new TeacherBriefReviewError('BRIEF_APPROVED_CONTENT_INVALID_SCHEMA');
+    approvedContent = parsed.data;
+  }
 
   return database.$transaction(async (transaction) => {
     const brief = await transaction.teacherBrief.findUnique({
       where: { id: input.briefId },
-      select: { id: true, status: true },
+      select: { id: true, status: true, reportArtifactId: true, scoreSnapshotId: true },
     });
     if (brief === null || brief.status !== 'PENDING_REVIEW') {
       throw new TeacherBriefReviewError('BRIEF_NOT_PENDING_REVIEW');
     }
+
+    // Concurrence optimiste (§5) : le bilan a pu être régénéré (nouveau
+    // scoreSnapshot courant) entre l'ouverture de la relecture et ce clic.
+    // Un brief qui n'est plus rattaché au snapshot courant ne doit jamais
+    // être approuvé.
+    const artifact = await transaction.reportArtifact.findUnique({
+      where: { id: brief.reportArtifactId },
+      select: { revisions: { orderBy: { createdAt: 'desc' as const }, take: 1, select: { scoreSnapshotId: true } } },
+    });
+    const currentSnapshotId = artifact?.revisions[0]?.scoreSnapshotId;
+    if (currentSnapshotId === undefined || currentSnapshotId !== brief.scoreSnapshotId) {
+      throw new TeacherBriefReviewError('BRIEF_STALE_SNAPSHOT');
+    }
+
+    if (approvedContent !== undefined) {
+      try {
+        const facts = await loadFactsForReanchoring(transaction, brief.reportArtifactId, resolvePack);
+        assertBriefRespectsFacts(approvedContent, facts);
+      } catch (error) {
+        if (error instanceof TeacherBriefError) throw new TeacherBriefReviewError(`BRIEF_APPROVED_CONTENT_${error.code}`);
+        throw error;
+      }
+    }
+
     const updated = await transaction.teacherBrief.updateMany({
       where: { id: brief.id, status: 'PENDING_REVIEW' },
       data: {
@@ -65,7 +167,7 @@ export async function approveTeacherBrief(input: Readonly<{
         reviewedById: reviewerId,
         reviewedAt: now,
         reviewMotif: motif,
-        ...(edited ? { editedContent: edited } : {}),
+        ...(approvedContent !== undefined ? { approvedContent: approvedContent as unknown as object } : {}),
       },
     });
     if (updated.count !== 1) throw new TeacherBriefReviewError('BRIEF_CONCURRENT_REVIEW');
@@ -77,13 +179,14 @@ export async function requestTeacherBriefCorrection(input: Readonly<{
   prisma?: ReviewDatabase;
   actor: Actor;
   briefId: string;
-  motif: string;
+  motifCode: ReviewMotifCode;
+  freeComment?: string;
   annotation: Readonly<{ section: string; remark: string }>;
   now?: () => Date;
 }>) {
   const database = input.prisma ?? prisma;
   const reviewerId = assertAssistante(input.actor);
-  const motif = assertMotif(input.motif);
+  const motif = assertMotif(buildReviewMotif(input.motifCode, input.freeComment ?? ''));
   const now = (input.now ?? (() => new Date()))();
   const section = input.annotation.section.trim();
   const remark = input.annotation.remark.trim();

--- a/lib/bilans/staff/teacher-brief-status.ts
+++ b/lib/bilans/staff/teacher-brief-status.ts
@@ -1,0 +1,59 @@
+import type { TeacherBriefStatus } from '@prisma/client';
+
+/**
+ * Regroupements NOMMÉS et distincts des statuts de brief enseignant.
+ *
+ * Avant ce module, une unique liste `['PENDING_REVIEW', 'APPROVED']` servait
+ * à la fois à bloquer une régénération, à compter un brief "existant" et à
+ * décider ce qui pouvait être rendu à l'enseignant — trois questions
+ * différentes qui n'ont PAS la même réponse. Cette confusion est la cause
+ * directe de l'incident P0 : un brief PENDING_REVIEW (jamais relu par un
+ * humain) était rendu dans le dossier enseignant au même titre qu'un brief
+ * APPROVED.
+ *
+ * Règle : SEUL `APPROVED` appartient à `BRIEF_STATUSES_SAFE_FOR_TEACHER`.
+ * Aucun autre module ne doit redéclarer une liste de statuts de brief.
+ */
+
+/** Empêche une régénération redondante — `generateTeacherBrief` retourne ALREADY_PRESENT sur ces statuts. */
+export const BRIEF_STATUSES_BLOCKING_DUPLICATE_GENERATION: readonly TeacherBriefStatus[] = Object.freeze([
+  'PENDING_REVIEW',
+  'APPROVED',
+]);
+
+/** Un humain doit agir : relire (PENDING_REVIEW) ou reprendre une correction. */
+export const BRIEF_STATUSES_PENDING_HUMAN_ACTION: readonly TeacherBriefStatus[] = Object.freeze([
+  'PENDING_REVIEW',
+  'CORRECTION_REQUESTED',
+]);
+
+/**
+ * SEUL ensemble autorisé à atteindre un enseignant — HTML, PDF, aperçu,
+ * export, lien, API. Un seul statut, listé ici pour que le nom du groupe
+ * documente l'invariant même si sa taille change un jour.
+ */
+export const BRIEF_STATUSES_SAFE_FOR_TEACHER: readonly TeacherBriefStatus[] = Object.freeze([
+  'APPROVED',
+]);
+
+/** États qui ne changeront plus jamais (utile pour l'historique/l'affichage, jamais pour le rendu enseignant). */
+export const BRIEF_STATUSES_TERMINAL_HISTORY: readonly TeacherBriefStatus[] = Object.freeze([
+  'APPROVED',
+  'SUPERSEDED',
+]);
+
+/** Transitions légales — appliquées ici, par le service, ET par un trigger SQL (défense en profondeur). */
+const LEGAL_TRANSITIONS: ReadonlyMap<TeacherBriefStatus, ReadonlySet<TeacherBriefStatus>> = new Map([
+  ['PENDING_REVIEW', new Set<TeacherBriefStatus>(['APPROVED', 'CORRECTION_REQUESTED'])],
+  ['CORRECTION_REQUESTED', new Set<TeacherBriefStatus>(['SUPERSEDED'])],
+  ['APPROVED', new Set<TeacherBriefStatus>()],
+  ['SUPERSEDED', new Set<TeacherBriefStatus>()],
+]);
+
+export function isLegalBriefStatusTransition(from: TeacherBriefStatus, to: TeacherBriefStatus): boolean {
+  return LEGAL_TRANSITIONS.get(from)?.has(to) ?? false;
+}
+
+export function isSafeForTeacher(status: TeacherBriefStatus): boolean {
+  return (BRIEF_STATUSES_SAFE_FOR_TEACHER as readonly string[]).includes(status);
+}

--- a/lib/bilans/staff/teacher-dossier-service.ts
+++ b/lib/bilans/staff/teacher-dossier-service.ts
@@ -26,6 +26,7 @@ import type { QuestionEvidence } from '../render/question-evidence';
 import type { RenderIdentity } from '../render/render-identity';
 import { bilanPackLevelLabel, buildPreRentreeStageLabel } from '../render/stage-label';
 import { isStaffRole } from '../saisie-papier/access';
+import { BRIEF_STATUSES_SAFE_FOR_TEACHER } from './teacher-brief-status';
 import {
   buildDossierGroupAnalysis,
   buildDossierSessionPlan,
@@ -34,6 +35,8 @@ import {
 import {
   renderTeacherDossierHtml,
   renderTeacherDossierPdf,
+  TEACHER_BRIEF_SAFETY_MARKER,
+  type DossierCompleteness,
   type DossierHeaderInput,
   type DossierStudentDetail,
   type TeacherDossierDocument,
@@ -53,9 +56,6 @@ type DossierFormat = 'html' | 'pdf';
 /** Statuts de bilan éligibles au dossier : validés par relecture ou déjà publiés — jamais DRAFT/ARCHIVED/REJECTED. */
 const ELIGIBLE_ARTIFACT_STATUSES: ReportArtifactStatus[] = ['PENDING_REVIEW', 'PUBLISHED'];
 
-/** Statuts de brief exploitables : en relecture ou déjà approuvés — jamais REJECTED. */
-const USABLE_BRIEF_STATUSES: string[] = ['PENDING_REVIEW', 'APPROVED'];
-
 const candidateSelection = {
   id: true,
   status: true,
@@ -71,13 +71,20 @@ const candidateSelection = {
   revisions: {
     orderBy: { createdAt: 'desc' as const },
     take: 1,
-    select: { content: true, scoreSnapshot: { select: { result: true } } },
+    select: { scoreSnapshotId: true, content: true, scoreSnapshot: { select: { result: true } } },
   },
+  /**
+   * Couche 1 de la défense en profondeur (§2 de l'incident P0) : le filtre
+   * de statut est posé ICI, dans la requête, pas seulement vérifié ensuite.
+   * Seul APPROVED (BRIEF_STATUSES_SAFE_FOR_TEACHER) peut sortir de cette
+   * sélection — PENDING_REVIEW, CORRECTION_REQUESTED et SUPERSEDED n'entrent
+   * JAMAIS dans le pipeline de rendu du dossier enseignant.
+   */
   teacherBriefs: {
-    where: { status: { in: USABLE_BRIEF_STATUSES } },
+    where: { status: { in: [...BRIEF_STATUSES_SAFE_FOR_TEACHER] } },
     orderBy: { version: 'desc' as const },
     take: 1,
-    select: { content: true, editedContent: true },
+    select: { content: true, approvedContent: true, scoreSnapshotId: true },
   },
 };
 
@@ -92,19 +99,64 @@ type DossierDependencies = Readonly<{
     resolvePack: PackResolver,
   ): QuestionEvidence | undefined;
   parseFactSheet(scoreResult: unknown, reportContent: unknown): FactSheet;
+  /** IDs de bilans dont la DERNIÈRE tentative de génération est DETERMINISTIC_ONLY (§3/§8) — "socle déterministe suffisant", jamais un simple "pas encore essayé". */
+  findDeterministicOnlyArtifactIds(reportArtifactIds: readonly string[]): Promise<ReadonlySet<string>>;
   renderHtml: typeof renderTeacherDossierHtml;
   renderPdf: typeof renderTeacherDossierPdf;
   now: () => Date;
 }>;
 
-function databaseDependencies(database: Pick<PrismaClient, 'reportArtifact'>) {
+function databaseDependencies(database: Pick<PrismaClient, 'reportArtifact' | 'teacherBriefAttempt'>) {
   return {
     findCandidates: (subject: Subject, level: GradeLevel) => database.reportArtifact.findMany({
       where: { status: { in: ELIGIBLE_ARTIFACT_STATUSES }, assessmentAttempt: { subject, gradeLevel: level } },
       select: candidateSelection,
       orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
     }),
+    findDeterministicOnlyArtifactIds: async (reportArtifactIds: readonly string[]) => {
+      if (reportArtifactIds.length === 0) return new Set<string>();
+      const latest = await database.teacherBriefAttempt.findMany({
+        where: { reportArtifactId: { in: [...reportArtifactIds] } },
+        orderBy: { createdAt: 'desc' as const },
+        select: { reportArtifactId: true, result: true },
+      });
+      const seen = new Set<string>();
+      const deterministic = new Set<string>();
+      for (const attempt of latest) {
+        if (seen.has(attempt.reportArtifactId)) continue; // seule la DERNIÈRE tentative compte
+        seen.add(attempt.reportArtifactId);
+        if (attempt.result === 'DETERMINISTIC_ONLY') deterministic.add(attempt.reportArtifactId);
+      }
+      return deterministic;
+    },
   };
+}
+
+/**
+ * Trois paliers explicites (§3 de l'incident P0) — jamais un simple booléen
+ * "brief présent/absent". ENRICHI_COMPLET exige que CHAQUE élève inclus ait
+ * soit un brief APPROVED courant, soit un statut terminal explicite : sa
+ * dernière tentative de génération a conclu DETERMINISTIC_ONLY (le socle est
+ * déterministe PAR CONCEPTION pour ce bilan, pas "pas encore essayé").
+ */
+async function computeCompleteness(
+  included: readonly ResolvedCandidate[],
+  dependencies: DossierDependencies,
+): Promise<DossierCompleteness> {
+  const briefsApproved = included.filter((candidate) => candidate.brief !== null).length;
+  const socleOnly = included.filter((candidate) => candidate.brief === null);
+  const deterministicIds = await dependencies.findDeterministicOnlyArtifactIds(
+    socleOnly.map((candidate) => candidate.reportArtifactId),
+  );
+  const socleOnlyLegitimate = socleOnly.filter((candidate) => deterministicIds.has(candidate.reportArtifactId));
+  const tier: DossierCompleteness['tier'] = briefsApproved === 0
+    ? 'SOCLE_DETERMINISTE'
+    : socleOnly.length === 0 || socleOnlyLegitimate.length === socleOnly.length
+      ? 'ENRICHI_COMPLET'
+      : 'ENRICHI_SECURISE_PARTIEL';
+  return Object.freeze({
+    tier, studentsIncluded: included.length, briefsApproved, socleOnlyCount: socleOnly.length,
+  });
 }
 
 function loadCatalogSafely(slug: string): CpsCatalog | null {
@@ -130,17 +182,33 @@ function assertStaff(actor: DossierActor): void {
   if (!isStaffRole(actor.role) || !actor.userId.trim()) throw new StaffTeacherDossierError('NOT_FOUND');
 }
 
-function briefContent(row: DossierCandidateRow['teacherBriefs'][number] | undefined): TeacherBriefContent | null {
+/**
+ * Couche 2 de la défense en profondeur (§2/§5 de l'incident P0) : même si la
+ * requête (couche 1) n'a déjà remonté qu'un brief APPROVED, ce brief peut
+ * être RATTACHÉ À UN ANCIEN scoreSnapshot si le bilan a été régénéré depuis
+ * son approbation — un brief STALE ne doit jamais être rendu comme s'il
+ * décrivait le diagnostic courant. `currentScoreSnapshotId` vient de la
+ * révision la plus récente du même bilan (déjà la définition établie de
+ * "courant" ailleurs dans ce service).
+ *
+ * `approvedContent` (correction manuelle structurée) prime sur `content`
+ * (sortie brute du modèle) quand il est présent — jamais de JSON.parse
+ * défensif sur une chaîne libre : `approvedContent` est TOUJOURS un JSON
+ * structuré valide, posé une seule fois à l'approbation.
+ */
+function briefContent(
+  row: DossierCandidateRow['teacherBriefs'][number] | undefined,
+  currentScoreSnapshotId: string,
+): TeacherBriefContent | null {
   if (row === undefined) return null;
-  const edited = row.editedContent?.trim();
-  const raw = edited !== undefined && edited.length > 0
-    ? (() => { try { return JSON.parse(edited); } catch { return null; } })()
-    : row.content;
+  if (row.scoreSnapshotId !== currentScoreSnapshotId) return null; // STALE_BRIEF
+  const raw = row.approvedContent ?? row.content;
   const parsed = teacherBriefSchema.safeParse(raw);
   return parsed.success ? parsed.data : null;
 }
 
 type ResolvedCandidate = Readonly<{
+  reportArtifactId: string;
   displayName: string;
   factSheet: FactSheet;
   evidence: QuestionEvidence;
@@ -192,7 +260,7 @@ function resolveCandidates(
     }
     const packVersion = Number(row.assessmentAttempt.assessmentPackVersion);
     resolved.push(Object.freeze({
-      displayName, factSheet, evidence, brief: briefContent(row.teacherBriefs[0]),
+      reportArtifactId: row.id, displayName, factSheet, evidence, brief: briefContent(row.teacherBriefs[0], revision.scoreSnapshotId),
       packId: row.assessmentAttempt.assessmentPackId, packVersion,
     }));
   }
@@ -230,9 +298,11 @@ export async function buildStaffTeacherDossierDocument(
 
   const students: readonly DossierStudentDetail[] = Object.freeze(included.map((candidate) => Object.freeze({
     displayName: candidate.displayName, factSheet: candidate.factSheet, evidence: candidate.evidence, brief: candidate.brief,
+    ...(candidate.brief !== null ? { briefSafetyMarker: TEACHER_BRIEF_SAFETY_MARKER } : {}),
   })));
   const members: readonly DossierMember[] = students;
   const analysis = buildDossierGroupAnalysis(members);
+  const completeness = await computeCompleteness(included, dependencies);
 
   const catalog = dependencies.loadCatalog(included[0].packId);
   let sessionPlan: ReturnType<typeof buildDossierSessionPlan> | null = null;
@@ -252,7 +322,7 @@ export async function buildStaffTeacherDossierDocument(
   });
   const doc: TeacherDossierDocument = Object.freeze({
     identity, header: input.header ?? {}, students, excludedStudents: Object.freeze(excludedStudents),
-    analysis, sessionPlan, evidenceCatalog: students[0].evidence, generatedAt: date,
+    analysis, sessionPlan, evidenceCatalog: students[0].evidence, generatedAt: date, completeness,
   });
 
   const filenameBase = `dossier-enseignant-${bilanPackSubjectLabel(enabled.pack.subject).toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${bilanPackLevelLabel(enabled.pack.level).toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${date}`;
@@ -264,52 +334,186 @@ export async function buildStaffTeacherDossierDocument(
   return Object.freeze({ body: rendered.pdf, contentType: 'application/pdf', filename: `${filenameBase}.pdf` });
 }
 
-export type StaffTeacherDossierGroup = Readonly<{ subject: Subject; level: GradeLevel; count: number; briefsMissing: number }>;
+/**
+ * Compteurs par groupe (matière × niveau) — remplace l'ancien libellé
+ * ambigu "briefs manquants" (§12 de l'incident P0). Chaque compteur répond à
+ * UNE question, jamais mélangée avec une autre :
+ *  - `toGenerateCount`  : réellement actionnable par un clic "Générer" ;
+ *  - `queuedCount`/`processingCount` : jobs en file/en cours (job outbox) ;
+ *  - `toReviewCount`    : PENDING_REVIEW — un humain doit relire ;
+ *  - `correctionRequestedCount` : en attente de reprise après correction ;
+ *  - `approvedCount`    : SAFE_FOR_TEACHER, prêts pour le dossier ;
+ *  - `socleDeterministeCount` : dernière tentative DETERMINISTIC_ONLY —
+ *    jamais retenté, jamais compté comme un échec ;
+ *  - `retryableFailureCount`/`blockedFailureCount` : dernière tentative en
+ *    échec, respectivement transitoire ou nécessitant une action humaine ;
+ *  - `staleBriefCount`  : brief APPROVED mais rattaché à un ancien snapshot.
+ */
+export type StaffTeacherDossierGroup = Readonly<{
+  subject: Subject;
+  level: GradeLevel;
+  eligibleCount: number;
+  toGenerateCount: number;
+  queuedCount: number;
+  processingCount: number;
+  toReviewCount: number;
+  correctionRequestedCount: number;
+  approvedCount: number;
+  socleDeterministeCount: number;
+  retryableFailureCount: number;
+  blockedFailureCount: number;
+  staleBriefCount: number;
+  completenessTier: DossierCompleteness['tier'];
+}>;
+
+type GroupDatabase = Pick<PrismaClient, 'reportArtifact' | 'jobOutbox' | 'teacherBriefAttempt'>;
 
 /**
  * Liste les couples (matière, niveau) ayant au moins un bilan éligible, pour
- * afficher un bouton par groupe côté dashboard assistante — sans lister les
+ * afficher une carte par groupe côté dashboard assistante — sans lister les
  * bilans un par un.
  */
 export async function listStaffTeacherDossierGroups(
   actor: DossierActor,
-  database: Pick<PrismaClient, 'reportArtifact'> = prisma,
+  database: GroupDatabase = prisma,
 ): Promise<readonly StaffTeacherDossierGroup[]> {
   assertStaff(actor);
   const rows = await database.reportArtifact.findMany({
     where: { status: { in: ELIGIBLE_ARTIFACT_STATUSES } },
     select: {
+      id: true,
       assessmentAttempt: { select: { subject: true, gradeLevel: true } },
-      teacherBriefs: { where: { status: { in: USABLE_BRIEF_STATUSES } }, select: { id: true }, take: 1 },
+      revisions: { orderBy: { createdAt: 'desc' as const }, take: 1, select: { scoreSnapshotId: true } },
+      teacherBriefs: { orderBy: { version: 'desc' as const }, take: 1, select: { status: true, scoreSnapshotId: true } },
     },
   });
-  const groups = new Map<string, { subject: Subject; level: GradeLevel; count: number; briefsMissing: number }>();
+  const artifactIds = rows.map((row) => row.id);
+  const [jobs, attempts] = await Promise.all([
+    artifactIds.length === 0 ? [] : database.jobOutbox.findMany({
+      where: { jobType: 'GENERATE_TEACHER_BRIEF', aggregateId: { in: artifactIds }, status: { in: ['PENDING', 'LEASED'] } },
+      select: { aggregateId: true, status: true },
+    }),
+    artifactIds.length === 0 ? [] : database.teacherBriefAttempt.findMany({
+      where: { reportArtifactId: { in: artifactIds } },
+      orderBy: { createdAt: 'desc' as const },
+      select: { reportArtifactId: true, result: true },
+    }),
+  ]);
+  const latestJobByArtifact = new Map<string, 'PENDING' | 'LEASED'>();
+  for (const job of jobs) if (!latestJobByArtifact.has(job.aggregateId)) latestJobByArtifact.set(job.aggregateId, job.status as 'PENDING' | 'LEASED');
+  const latestAttemptByArtifact = new Map<string, string>();
+  for (const attempt of attempts) if (!latestAttemptByArtifact.has(attempt.reportArtifactId)) latestAttemptByArtifact.set(attempt.reportArtifactId, attempt.result);
+
+  type MutableGroup = {
+    subject: Subject; level: GradeLevel;
+    eligibleCount: number; toGenerateCount: number; queuedCount: number; processingCount: number;
+    toReviewCount: number; correctionRequestedCount: number; approvedCount: number;
+    socleDeterministeCount: number; retryableFailureCount: number; blockedFailureCount: number; staleBriefCount: number;
+  };
+  const groups = new Map<string, MutableGroup>();
   for (const row of rows) {
     const key = `${row.assessmentAttempt.subject}@${row.assessmentAttempt.gradeLevel}`;
-    const entry = groups.get(key) ?? { subject: row.assessmentAttempt.subject, level: row.assessmentAttempt.gradeLevel, count: 0, briefsMissing: 0 };
-    entry.count += 1;
-    if (row.teacherBriefs.length === 0) entry.briefsMissing += 1;
+    const entry: MutableGroup = groups.get(key) ?? {
+      subject: row.assessmentAttempt.subject, level: row.assessmentAttempt.gradeLevel,
+      eligibleCount: 0, toGenerateCount: 0, queuedCount: 0, processingCount: 0, toReviewCount: 0,
+      correctionRequestedCount: 0, approvedCount: 0, socleDeterministeCount: 0,
+      retryableFailureCount: 0, blockedFailureCount: 0, staleBriefCount: 0,
+    };
+    entry.eligibleCount += 1;
+
+    const currentSnapshotId = row.revisions[0]?.scoreSnapshotId;
+    const latestBrief = row.teacherBriefs[0];
+    const job = latestJobByArtifact.get(row.id);
+    const lastAttemptResult = latestAttemptByArtifact.get(row.id);
+
+    const briefIsSafeAndCurrent = latestBrief?.status === 'APPROVED' && latestBrief.scoreSnapshotId === currentSnapshotId;
+    const briefIsStale = latestBrief?.status === 'APPROVED' && latestBrief.scoreSnapshotId !== currentSnapshotId;
+
+    if (job === 'LEASED') entry.processingCount += 1;
+    else if (job === 'PENDING') entry.queuedCount += 1;
+    else if (briefIsSafeAndCurrent) entry.approvedCount += 1;
+    else if (latestBrief?.status === 'PENDING_REVIEW') entry.toReviewCount += 1;
+    else if (latestBrief?.status === 'CORRECTION_REQUESTED') entry.correctionRequestedCount += 1;
+    else if (lastAttemptResult === 'DETERMINISTIC_ONLY') entry.socleDeterministeCount += 1;
+    else if (lastAttemptResult === 'BLOCKED_FAILURE' || lastAttemptResult === 'BUDGET_BLOCKED') entry.blockedFailureCount += 1;
+    else if (lastAttemptResult === 'RETRYABLE_FAILURE') { entry.retryableFailureCount += 1; entry.toGenerateCount += 1; }
+    else entry.toGenerateCount += 1; // jamais tenté, ou brief STALE/SUPERSEDED sans nouvelle tentative encore lancée
+
+    if (briefIsStale) entry.staleBriefCount += 1;
+
     groups.set(key, entry);
   }
-  return Object.freeze([...groups.values()].sort((left, right) => left.subject.localeCompare(right.subject) || left.level.localeCompare(right.level)));
+  return Object.freeze([...groups.values()]
+    .map((entry) => Object.freeze({
+      ...entry,
+      completenessTier: (entry.approvedCount === 0
+        ? 'SOCLE_DETERMINISTE'
+        : entry.eligibleCount === entry.approvedCount + entry.socleDeterministeCount
+          ? 'ENRICHI_COMPLET'
+          : 'ENRICHI_SECURISE_PARTIEL') as DossierCompleteness['tier'],
+    }))
+    .sort((left, right) => left.subject.localeCompare(right.subject) || left.level.localeCompare(right.level)));
 }
 
 /**
- * IDs des bilans éligibles d'un groupe (matière, niveau) — pour la
- * régénération en lot des briefs enseignant. `generateTeacherBrief` est déjà
- * idempotent (mode `ALREADY_PRESENT`) : reboucler sur tout le groupe à chaque
- * clic est sûr, même quand des bilans s'y sont ajoutés depuis le dernier essai.
+ * IDs RÉELLEMENT ACTIONNABLES d'un groupe (matière, niveau) — pour la mise
+ * en file de génération en lot (§10 de l'incident P0). Exclut explicitement,
+ * sans retry aveugle :
+ *  - un bilan déjà en file ou en cours (job PENDING/LEASED actif) ;
+ *  - un bilan dont le dernier brief est APPROVED et courant (déjà servi) ;
+ *  - un bilan dont le dernier brief attend une action humaine
+ *    (PENDING_REVIEW à relire, CORRECTION_REQUESTED à reprendre) — la
+ *    reprise après correction est un chemin distinct (`requestTeacherBriefCorrection`
+ *    puis nouvelle tentative), jamais une régénération automatique en lot ;
+ *  - un bilan dont la DERNIÈRE tentative a conclu DETERMINISTIC_ONLY : ce
+ *    n'est pas une panne, il ne doit JAMAIS être retenté automatiquement.
+ * Un bilan STALE (brief APPROVED mais snapshot obsolète), jamais tenté, ou
+ * en échec RETRYABLE_FAILURE reste actionnable.
  */
-export async function listStaffTeacherDossierArtifactIds(
+export type ActionableTeacherBriefTarget = Readonly<{ reportArtifactId: string; expectedScoreSnapshotId: string }>;
+
+export async function listStaffTeacherDossierActionableArtifactIds(
   actor: DossierActor,
   subject: Subject,
   level: GradeLevel,
-  database: Pick<PrismaClient, 'reportArtifact'> = prisma,
-): Promise<readonly string[]> {
+  database: GroupDatabase = prisma,
+): Promise<readonly ActionableTeacherBriefTarget[]> {
   assertStaff(actor);
   const rows = await database.reportArtifact.findMany({
     where: { status: { in: ELIGIBLE_ARTIFACT_STATUSES }, assessmentAttempt: { subject, gradeLevel: level } },
-    select: { id: true },
+    select: {
+      id: true,
+      revisions: { orderBy: { createdAt: 'desc' as const }, take: 1, select: { scoreSnapshotId: true } },
+      teacherBriefs: { orderBy: { version: 'desc' as const }, take: 1, select: { status: true, scoreSnapshotId: true } },
+    },
   });
-  return Object.freeze(rows.map((row) => row.id));
+  const artifactIds = rows.map((row) => row.id);
+  if (artifactIds.length === 0) return Object.freeze([]);
+  const [activeJobs, attempts] = await Promise.all([
+    database.jobOutbox.findMany({
+      where: { jobType: 'GENERATE_TEACHER_BRIEF', aggregateId: { in: artifactIds }, status: { in: ['PENDING', 'LEASED'] } },
+      select: { aggregateId: true },
+    }),
+    database.teacherBriefAttempt.findMany({
+      where: { reportArtifactId: { in: artifactIds } },
+      orderBy: { createdAt: 'desc' as const },
+      select: { reportArtifactId: true, result: true },
+    }),
+  ]);
+  const hasActiveJob = new Set(activeJobs.map((job) => job.aggregateId));
+  const lastAttemptResult = new Map<string, string>();
+  for (const attempt of attempts) if (!lastAttemptResult.has(attempt.reportArtifactId)) lastAttemptResult.set(attempt.reportArtifactId, attempt.result);
+
+  const actionable = rows.filter((row) => {
+    if (hasActiveJob.has(row.id)) return false;
+    const brief = row.teacherBriefs[0];
+    const currentSnapshotId = row.revisions[0]?.scoreSnapshotId;
+    if (brief?.status === 'APPROVED' && brief.scoreSnapshotId === currentSnapshotId) return false;
+    if (brief?.status === 'PENDING_REVIEW' || brief?.status === 'CORRECTION_REQUESTED') return false;
+    if (lastAttemptResult.get(row.id) === 'DETERMINISTIC_ONLY') return false;
+    return true;
+  });
+  return Object.freeze(actionable
+    .filter((row) => row.revisions[0]?.scoreSnapshotId !== undefined)
+    .map((row) => Object.freeze({ reportArtifactId: row.id, expectedScoreSnapshotId: row.revisions[0].scoreSnapshotId })));
 }

--- a/lib/bilans/teacher-dossier/render.ts
+++ b/lib/bilans/teacher-dossier/render.ts
@@ -46,12 +46,34 @@ export type DossierHeaderInput = Readonly<{
   stageDates?: string;
 }>;
 
+/**
+ * Marqueur de sûreté OBLIGATOIRE dès que `brief` n'est pas `null` — défense
+ * en profondeur, couche 3 (assertion dans le renderer). Les couches 1
+ * (filtrage dans la requête) et 2 (vérification dans le service) vivent dans
+ * `staff/teacher-dossier-service.ts` : seul un brief APPROVED et rattaché au
+ * scoreSnapshot COURANT du bilan peut porter ce marqueur. Le renderer ne
+ * fait pas confiance à l'appelant : il vérifie lui-même ce marqueur avant de
+ * rendre le moindre octet de contenu LLM (voir `assertBriefSafeForTeacher`).
+ */
+export const TEACHER_BRIEF_SAFETY_MARKER = 'HUMAN_APPROVED_CURRENT' as const;
+
 export type DossierStudentDetail = Readonly<{
   displayName: string;
   factSheet: FactSheet;
   evidence: QuestionEvidence;
-  /** `null` quand le brief n'a pas encore été généré pour cet élève. */
+  /** `null` quand aucun brief APPROVED et courant n'existe pour cet élève (jamais un brief PENDING_REVIEW/CORRECTION_REQUESTED/SUPERSEDED, jamais un brief obsolète). */
   brief: TeacherBriefContent | null;
+  /** Présent et égal à `TEACHER_BRIEF_SAFETY_MARKER` si et seulement si `brief` n'est pas `null`. Vérifié par `assertBriefSafeForTeacher`. */
+  briefSafetyMarker?: typeof TEACHER_BRIEF_SAFETY_MARKER;
+}>;
+
+export type DossierCompletenessTier = 'SOCLE_DETERMINISTE' | 'ENRICHI_SECURISE_PARTIEL' | 'ENRICHI_COMPLET';
+
+export type DossierCompleteness = Readonly<{
+  tier: DossierCompletenessTier;
+  studentsIncluded: number;
+  briefsApproved: number;
+  socleOnlyCount: number;
 }>;
 
 export type TeacherDossierDocument = Readonly<{
@@ -65,7 +87,23 @@ export type TeacherDossierDocument = Readonly<{
   sessionPlan: DossierSessionPlan | null;
   evidenceCatalog: QuestionEvidence;
   generatedAt: string;
+  completeness: DossierCompleteness;
 }>;
+
+/**
+ * Couche 3 de la défense en profondeur (§2 de l'incident P0). Lève
+ * `TEACHER_DOSSIER_UNSAFE_BRIEF_RENDER_BLOCKED` si un `brief` non nul se
+ * présente sans le marqueur de sûreté — c'est-à-dire si les couches 1/2 ont
+ * été contournées, mal appelées, ou modifiées sans mettre à jour cette
+ * garde. Jamais de contenu LLM non marqué ne doit atteindre le HTML/PDF.
+ */
+export function assertBriefSafeForTeacher(students: readonly DossierStudentDetail[]): void {
+  for (const student of students) {
+    if (student.brief !== null && student.briefSafetyMarker !== TEACHER_BRIEF_SAFETY_MARKER) {
+      throw new Error('TEACHER_DOSSIER_UNSAFE_BRIEF_RENDER_BLOCKED');
+    }
+  }
+}
 
 function escapeHtml(value: unknown): string {
   return String(value).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll("'", '&#39;');
@@ -112,12 +150,25 @@ function headerGrid(identity: RenderIdentity, header: DossierHeaderInput, effect
   </dl>`;
 }
 
+const COMPLETENESS_LABELS: Readonly<Record<DossierCompletenessTier, string>> = Object.freeze({
+  SOCLE_DETERMINISTE: 'Socle déterministe',
+  ENRICHI_SECURISE_PARTIEL: 'Enrichi sécurisé partiel',
+  ENRICHI_COMPLET: 'Enrichi complet',
+});
+
+function completenessBlock(completeness: DossierCompleteness, generatedAt: string): string {
+  return `<section><h3>Complétude du dossier</h3>
+  <p><strong>${text(COMPLETENESS_LABELS[completeness.tier])}</strong> — généré le ${text(generatedAt)}.</p>
+  <p>${completeness.studentsIncluded} élève(s) inclus · ${completeness.briefsApproved} brief(s) enseignant approuvé(s) · ${completeness.socleOnlyCount} élève(s) servi(s) uniquement par le socle déterministe.</p></section>`;
+}
+
 function summaryPage(doc: TeacherDossierDocument): string {
   const { analysis } = doc;
   const distribution = Object.entries(analysis.profileDistribution) as [NodeProfile, number][];
   const topFragile = analysis.domains.filter((domain) => domain.profile !== 'MAITRISE' && domain.profile !== 'MAITRISE_FRAGILE').slice(0, 3);
   return `<section class="page"><header class="report-header"><img class="brand-logo" src="${BILAN_PRINT_BRAND.logos.header}" alt="Nexus Réussite"><div><p class="eyebrow">Dossier enseignant · Interne Nexus</p><h1>${text(doc.identity.stageLabel)}</h1></div></header>
   <p class="confidential">Document strictement interne et confidentiel. Il contient les noms réels et les profils pédagogiques des élèves. Il ne doit jamais être transmis aux familles ni aux élèves.</p>
+  ${completenessBlock(doc.completeness, doc.generatedAt)}
   <h2>Fiche récapitulative</h2>
   ${headerGrid(doc.identity, doc.header, doc.students.length)}
   <div class="summary-grid">
@@ -185,6 +236,12 @@ function briefForDomain(students: readonly DossierStudentDetail[], domainId: str
   return null;
 }
 
+/**
+ * Phrase sobre, fixe, jamais paramétrée par du contenu généré : elle ne doit
+ * jamais pouvoir laisser croire qu'un brief non relu a été approuvé.
+ */
+const SOCLE_ONLY_NOTICE = 'Socle pédagogique déterministe utilisé — aucun brief enrichi validé.';
+
 function sectionE(doc: TeacherDossierDocument): string {
   const fragile = doc.analysis.domains.filter((domain) => domain.profile !== 'MAITRISE' && domain.profile !== 'MAITRISE_FRAGILE');
   const blocks = fragile.map((domain) => {
@@ -198,7 +255,9 @@ function sectionE(doc: TeacherDossierDocument): string {
     <p><strong>Activité :</strong> ${text(brief.activite.titre)} — ${text(brief.activite.objectif)}</p>
     <p><strong>Indicateur de progrès :</strong> ${text(brief.indicateurProgres)}</p></article>`;
   }).join('');
-  return `<section class="page"><p class="eyebrow">Section E</p><h1>Brief enseignant</h1>${blocks.length === 0 ? '<p>Aucun domaine prioritaire identifié pour ce groupe.</p>' : blocks}${footer()}</section>`;
+  const socleOnlyStudents = doc.students.filter((student) => student.brief === null);
+  const socleNotice = socleOnlyStudents.length === 0 ? '' : `<article class="item-block"><h3>Élèves sans brief enrichi validé</h3><ul>${socleOnlyStudents.map((student) => `<li>${text(student.displayName)} — ${SOCLE_ONLY_NOTICE}</li>`).join('')}</ul></article>`;
+  return `<section class="page"><p class="eyebrow">Section E</p><h1>Brief enseignant</h1>${blocks.length === 0 ? '<p>Aucun domaine prioritaire identifié pour ce groupe.</p>' : blocks}${socleNotice}${footer()}</section>`;
 }
 
 function sectionF(doc: TeacherDossierDocument): string {
@@ -228,6 +287,7 @@ function sectionG(doc: TeacherDossierDocument): string {
 }
 
 export function renderTeacherDossierHtml(doc: TeacherDossierDocument): string {
+  assertBriefSafeForTeacher(doc.students);
   const identity = assertRenderIdentity(doc.identity);
   const html = `${summaryPage(doc)}${tocPage()}${sectionB(doc)}${sectionC(doc.evidenceCatalog)}${sectionD(doc.students)}${sectionE(doc)}${sectionF(doc)}${sectionG(doc)}`;
   return `<!doctype html><html lang="fr"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${text(identity.stageLabel)} · DOSSIER ENSEIGNANT</title><style>${styleSheet()}</style></head><body><main class="document" data-audience="STAFF" data-template="${TEACHER_DOSSIER_HTML_VERSION}">${html}</main></body></html>`;

--- a/lib/bilans/worker/drain-outbox.ts
+++ b/lib/bilans/worker/drain-outbox.ts
@@ -6,6 +6,7 @@ import { prisma } from '@/lib/prisma';
 
 import { processScoreAttemptJob } from './score-job';
 import { processGenerateReportJob } from './generate-report-job';
+import { processGenerateTeacherBriefJob } from './generate-teacher-brief-job';
 
 type DrainDatabase = Pick<PrismaClient, '$transaction' | '$queryRaw' | 'user' | 'notification'>;
 type DrainLogger = Readonly<{
@@ -74,7 +75,7 @@ function leaseDuration(value: number | undefined): number {
 
 async function claimJobs(
   database: DrainDatabase,
-  jobType: 'SCORE_ATTEMPT' | 'GENERATE_REPORT',
+  jobType: 'SCORE_ATTEMPT' | 'GENERATE_REPORT' | 'GENERATE_TEACHER_BRIEF',
   input: Readonly<{ limit: number; owner: string; now: Date; leaseExpiresAt: Date }>,
 ): Promise<readonly string[]> {
   return database.$transaction(async (transaction) => {
@@ -142,7 +143,7 @@ async function ensureQuarantineAlert(
 }
 
 async function drainJobs(
-  jobType: 'SCORE_ATTEMPT' | 'GENERATE_REPORT',
+  jobType: 'SCORE_ATTEMPT' | 'GENERATE_REPORT' | 'GENERATE_TEACHER_BRIEF',
   ownerPrefix: string,
   eventPrefix: string,
   defaults: DrainDependencies,
@@ -209,4 +210,23 @@ export async function drainGenerateReportJobs(
   dependencies: Partial<DrainDependencies> = {},
 ) {
   return drainJobs('GENERATE_REPORT', 'a88-manual', 'A88', defaultGenerateReportDependencies, options, dependencies);
+}
+
+const defaultGenerateTeacherBriefDependencies: DrainDependencies = {
+  prisma,
+  processJob: processGenerateTeacherBriefJob,
+  now: () => new Date(),
+  logger: defaultLogger,
+};
+
+/**
+ * Concurrence volontairement limitée à 1 génération de brief à la fois
+ * (§10 de l'incident P0, tant qu'aucune preuve de charge/budget ne justifie
+ * plus) : `limit: 1` par défaut, distinct du défaut ×10 des autres files.
+ */
+export async function drainTeacherBriefJobs(
+  options: DrainScoreAttemptJobsOptions = {},
+  dependencies: Partial<DrainDependencies> = {},
+) {
+  return drainJobs('GENERATE_TEACHER_BRIEF', 'a90-manual', 'A90', defaultGenerateTeacherBriefDependencies, { limit: 1, ...options }, dependencies);
 }

--- a/lib/bilans/worker/generate-teacher-brief-job.ts
+++ b/lib/bilans/worker/generate-teacher-brief-job.ts
@@ -1,0 +1,431 @@
+import { Prisma, type PrismaClient, type Subject, type GradeLevel } from '@prisma/client';
+import { z } from 'zod';
+
+import { prisma } from '@/lib/prisma';
+
+import { resolveEnabledPack, type PackResolver } from '../api/pack-access';
+import type { FactSheet } from '../facts/fact-sheet';
+import {
+  buildStudentFactsPayload,
+  callTeacherBriefModel,
+  resolveTeacherBriefConfig,
+  TeacherBriefError,
+  type TeacherBriefConfig,
+} from '../llm/teacher-brief-service';
+import { reserveBudget, regularizeBudget, releaseBudget } from '../llm/teacher-brief-budget';
+import { BRIEF_STATUSES_BLOCKING_DUPLICATE_GENERATION } from '../staff/teacher-brief-status';
+
+/**
+ * Traitement asynchrone d'UNE tentative de génération de brief enseignant
+ * (§7/§8/§10/§11 de l'incident P0). Mêmes principes que
+ * `generate-report-job.ts` : claim verrouillé, aucune écriture partielle,
+ * classification explicite du résultat, jamais de retry aveugle.
+ *
+ * Codes RETRYABLE (réseau, HTTP 5xx/429, JSON invalide, schéma invalide,
+ * sortie tronquée) => le job est marqué FAILED et repris par le cycle de
+ * drain existant (bornage MAX_JOB_ATTEMPTS, quarantaine, alerte — voir
+ * drain-outbox.ts). Tout le reste (BUDGET_BLOCKED, STALE_INPUT,
+ * DETERMINISTIC_ONLY, BLOCKED_FAILURE) est un état TERMINAL pour CETTE
+ * tentative : le job est marqué COMPLETED et ne sera jamais retenté
+ * automatiquement — un nouveau clic assistante crée un nouveau job.
+ */
+
+const RETRYABLE_CODES: ReadonlySet<string> = new Set([
+  'TEACHER_BRIEF_TIMEOUT',
+  'TEACHER_BRIEF_NETWORK',
+  'TEACHER_BRIEF_EMPTY',
+  'TEACHER_BRIEF_TRUNCATED',
+  'TEACHER_BRIEF_INVALID_JSON',
+  'TEACHER_BRIEF_SCHEMA_REJECTED',
+  'TEACHER_BRIEF_ASSEMBLY_REJECTED',
+  'TEACHER_BRIEF_DOMAIN_MISMATCH',
+]);
+// Tout code non listé ici (PII_BOUNDARY, FORBIDDEN_TERM, UNGROUNDED_ERROR,
+// PACK_UNAVAILABLE, config invalide, etc.) est BLOCKED_FAILURE par défaut —
+// jamais de retry automatique pour un garde de sécurité ou d'ancrage.
+function isHttpStatusRetryable(code: string): boolean {
+  const match = /^TEACHER_BRIEF_HTTP_(\d{3})$/.exec(code);
+  if (match === null) return false;
+  const status = Number(match[1]);
+  return status === 429 || status >= 500;
+}
+
+function classifyFailure(code: string): 'RETRYABLE_FAILURE' | 'BLOCKED_FAILURE' {
+  if (RETRYABLE_CODES.has(code) || isHttpStatusRetryable(code)) return 'RETRYABLE_FAILURE';
+  return 'BLOCKED_FAILURE';
+}
+
+const payloadSchema = z.object({
+  reportArtifactId: z.string().min(1),
+  expectedScoreSnapshotId: z.string().min(1),
+  actorId: z.string().min(1),
+}).strict();
+
+type WorkerDatabase = Pick<PrismaClient, '$transaction' | 'jobOutbox' | 'reportArtifact' | 'teacherBrief' | 'teacherBriefAttempt'>;
+type WorkerLogger = Readonly<{ info(event: Readonly<Record<string, unknown>>): void; error(event: Readonly<Record<string, unknown>>): void }>;
+
+export type GenerateTeacherBriefJobDependencies = Readonly<{
+  prisma: WorkerDatabase;
+  resolvePack: PackResolver;
+  resolveConfig: (environment?: Readonly<Record<string, string | undefined>>) => TeacherBriefConfig;
+  fetchImpl: typeof fetch;
+  now: () => Date;
+  logger: WorkerLogger;
+  reserveBudget: typeof reserveBudget;
+  regularizeBudget: typeof regularizeBudget;
+  releaseBudget: typeof releaseBudget;
+}>;
+
+export class GenerateTeacherBriefJobError extends Error {
+  constructor(readonly code: string) {
+    super(code);
+    this.name = 'GenerateTeacherBriefJobError';
+  }
+}
+
+const defaultDependencies: GenerateTeacherBriefJobDependencies = {
+  prisma,
+  resolvePack: resolveEnabledPack,
+  resolveConfig: resolveTeacherBriefConfig,
+  fetchImpl: fetch,
+  now: () => new Date(),
+  logger: {
+    info: (event) => console.info(JSON.stringify(event)),
+    error: (event) => console.error(JSON.stringify(event)),
+  },
+  reserveBudget,
+  regularizeBudget,
+  releaseBudget,
+};
+
+type Claim = Readonly<{
+  reportArtifactId: string;
+  subject: Subject;
+  gradeLevel: GradeLevel;
+  actorId: string;
+  currentScoreSnapshotId: string;
+  factSheet: FactSheet;
+  answers: unknown;
+  assessmentPackId: string;
+  assessmentPackVersion: number;
+  assessmentPackChecksum: string;
+  subjectLabel: string;
+}>;
+
+type ClaimOutcome =
+  | Readonly<{ kind: 'REPLAYED' }>
+  | Readonly<{ kind: 'ALREADY_PRESENT' }>
+  | Readonly<{ kind: 'STALE_INPUT' }>
+  | Readonly<{ kind: 'PROCEED'; claim: Claim }>;
+
+async function claimJob(
+  transaction: Prisma.TransactionClient,
+  jobId: string,
+  dependencies: GenerateTeacherBriefJobDependencies,
+): Promise<ClaimOutcome> {
+  const rows = await transaction.$queryRaw<Array<{
+    id: string; jobType: string; aggregateId: string; status: string; payload: unknown;
+  }>>(Prisma.sql`
+    SELECT "id", "jobType", "aggregateId", "status", "payload" FROM "canonical_job_outbox" WHERE "id" = ${jobId} FOR UPDATE
+  `);
+  const job = rows[0];
+  if (job === undefined || job.jobType !== 'GENERATE_TEACHER_BRIEF') throw new GenerateTeacherBriefJobError('TB_JOB_INVALID');
+  if (job.status === 'COMPLETED') return { kind: 'REPLAYED' };
+  if (job.status !== 'PENDING' && job.status !== 'LEASED') throw new GenerateTeacherBriefJobError('TB_JOB_NOT_PROCESSABLE');
+
+  const payload = payloadSchema.parse(job.payload);
+  if (payload.reportArtifactId !== job.aggregateId) throw new GenerateTeacherBriefJobError('TB_JOB_PAYLOAD_MISMATCH');
+
+  const artifact = await transaction.reportArtifact.findUnique({
+    where: { id: payload.reportArtifactId },
+    select: {
+      id: true,
+      assessmentAttempt: {
+        select: {
+          subject: true, gradeLevel: true, answers: true,
+          assessmentPackId: true, assessmentPackVersion: true, assessmentPackChecksum: true,
+        },
+      },
+      revisions: {
+        orderBy: { createdAt: 'desc' as const }, take: 1,
+        select: { scoreSnapshotId: true, content: true, scoreSnapshot: { select: { result: true } } },
+      },
+      teacherBriefs: {
+        where: { status: { in: [...BRIEF_STATUSES_BLOCKING_DUPLICATE_GENERATION] } },
+        take: 1, select: { id: true },
+      },
+    },
+  });
+  if (artifact === null || artifact.revisions.length === 0) throw new GenerateTeacherBriefJobError('TB_ARTIFACT_NOT_FOUND');
+
+  await transaction.jobOutbox.update({
+    where: { id: job.id },
+    data: { status: 'LEASED', leaseOwner: 'a90-teacher-brief-worker', leaseExpiresAt: new Date(dependencies.now().getTime() + 5 * 60_000) },
+  });
+
+  if (artifact.teacherBriefs.length > 0) return { kind: 'ALREADY_PRESENT' };
+
+  const revision = artifact.revisions[0];
+  if (revision.scoreSnapshotId !== payload.expectedScoreSnapshotId) return { kind: 'STALE_INPUT' };
+
+  return {
+    kind: 'PROCEED',
+    claim: {
+      reportArtifactId: artifact.id,
+      subject: artifact.assessmentAttempt.subject,
+      gradeLevel: artifact.assessmentAttempt.gradeLevel,
+      actorId: payload.actorId,
+      currentScoreSnapshotId: revision.scoreSnapshotId,
+      factSheet: revision.scoreSnapshot.result as unknown as FactSheet,
+      answers: artifact.assessmentAttempt.answers,
+      assessmentPackId: artifact.assessmentAttempt.assessmentPackId,
+      assessmentPackVersion: Number(artifact.assessmentAttempt.assessmentPackVersion),
+      assessmentPackChecksum: artifact.assessmentAttempt.assessmentPackChecksum,
+      subjectLabel: artifact.assessmentAttempt.subject,
+    },
+  };
+}
+
+type DomainOutcomeLog = Readonly<{
+  domainId: string;
+  outcome: 'OK' | string;
+  promptTokens: number;
+  cachedPromptTokens: number;
+  completionTokens: number;
+  costUsd: number | null;
+}>;
+
+async function persistAttempt(
+  database: Pick<PrismaClient, 'teacherBriefAttempt'>,
+  input: Readonly<{
+    reportArtifactId: string; expectedScoreSnapshotId: string; jobId: string;
+    subject: Subject; gradeLevel: GradeLevel; actorId: string; model: string; promptVersion: string;
+    startedAt: Date; finishedAt: Date;
+    result: 'GENERATED' | 'ALREADY_PRESENT' | 'DETERMINISTIC_ONLY' | 'RETRYABLE_FAILURE' | 'BLOCKED_FAILURE' | 'BUDGET_BLOCKED' | 'STALE_INPUT' | 'CANCELLED_BEFORE_START';
+    causeCode: string | null; retryCount: number;
+    promptTokens: number; cachedPromptTokens: number; completionTokens: number;
+    estimatedCostUsd: number | null; costUnknown: boolean;
+    domainsRequested: number; domainsProcessed: number; domainOutcomes: readonly DomainOutcomeLog[];
+  }>,
+): Promise<void> {
+  await database.teacherBriefAttempt.create({
+    data: {
+      reportArtifactId: input.reportArtifactId,
+      expectedScoreSnapshotId: input.expectedScoreSnapshotId,
+      jobId: input.jobId,
+      subject: input.subject,
+      gradeLevel: input.gradeLevel,
+      actorId: input.actorId,
+      model: input.model,
+      promptVersion: input.promptVersion,
+      startedAt: input.startedAt,
+      finishedAt: input.finishedAt,
+      result: input.result,
+      causeCode: input.causeCode,
+      retryCount: input.retryCount,
+      promptTokens: input.promptTokens,
+      cachedPromptTokens: input.cachedPromptTokens,
+      completionTokens: input.completionTokens,
+      estimatedCostUsd: input.estimatedCostUsd,
+      costUnknown: input.costUnknown,
+      durationMs: input.finishedAt.getTime() - input.startedAt.getTime(),
+      domainsRequested: input.domainsRequested,
+      domainsProcessed: input.domainsProcessed,
+      domainOutcomes: input.domainOutcomes as unknown as Prisma.InputJsonValue,
+    },
+  });
+}
+
+async function markJobTerminal(database: Pick<PrismaClient, 'jobOutbox'>, jobId: string, now: Date): Promise<void> {
+  await database.jobOutbox.update({
+    where: { id: jobId },
+    data: { status: 'COMPLETED', attemptCount: { increment: 1 }, completedAt: now, leaseOwner: null, leaseExpiresAt: null, lastError: null },
+  });
+}
+
+export async function processGenerateTeacherBriefJob(
+  jobId: string,
+  dependencies: GenerateTeacherBriefJobDependencies = defaultDependencies,
+): Promise<Readonly<{ jobId: string; result: string }>> {
+  const startedAt = dependencies.now();
+  const claimed = await dependencies.prisma.$transaction((transaction) => claimJob(transaction, jobId, dependencies));
+
+  if (claimed.kind === 'REPLAYED') return { jobId, result: 'ALREADY_PRESENT' };
+
+  if (claimed.kind === 'ALREADY_PRESENT' || claimed.kind === 'STALE_INPUT') {
+    // Pas d'appel LLM : rien à réserver, rien à comptabiliser. Terminal pour
+    // CE job — jamais de retry automatique (un nouveau job sera créé si
+    // pertinent au prochain scan de groupe).
+    const finishedAt = dependencies.now();
+    await dependencies.prisma.$transaction(async (transaction) => {
+      // reportArtifactId nécessaire pour journaliser ; relu hors verrou (lecture seule, non sensible).
+      const jobRow = await transaction.jobOutbox.findUniqueOrThrow({ where: { id: jobId }, select: { aggregateId: true, payload: true } });
+      const payload = payloadSchema.parse(jobRow.payload);
+      const artifact = await transaction.reportArtifact.findUniqueOrThrow({
+        where: { id: jobRow.aggregateId }, select: { assessmentAttempt: { select: { subject: true, gradeLevel: true } } },
+      });
+      await persistAttempt(transaction, {
+        reportArtifactId: jobRow.aggregateId, expectedScoreSnapshotId: payload.expectedScoreSnapshotId, jobId,
+        subject: artifact.assessmentAttempt.subject, gradeLevel: artifact.assessmentAttempt.gradeLevel,
+        actorId: payload.actorId, model: 'n/a', promptVersion: 'n/a',
+        startedAt, finishedAt, result: claimed.kind, causeCode: null, retryCount: 0,
+        promptTokens: 0, cachedPromptTokens: 0, completionTokens: 0, estimatedCostUsd: 0, costUnknown: false,
+        domainsRequested: 0, domainsProcessed: 0, domainOutcomes: [],
+      });
+      await markJobTerminal(transaction, jobId, finishedAt);
+    });
+    dependencies.logger.info({ event: 'A90_GENERATE_TEACHER_BRIEF_JOB_COMPLETED', jobId, result: claimed.kind });
+    return { jobId, result: claimed.kind };
+  }
+
+  const { claim } = claimed;
+
+  let config: TeacherBriefConfig;
+  try {
+    config = dependencies.resolveConfig();
+  } catch {
+    const finishedAt = dependencies.now();
+    await dependencies.prisma.$transaction(async (transaction) => {
+      await persistAttempt(transaction, {
+        reportArtifactId: claim.reportArtifactId, expectedScoreSnapshotId: claim.currentScoreSnapshotId, jobId,
+        subject: claim.subject, gradeLevel: claim.gradeLevel, actorId: claim.actorId, model: 'n/a', promptVersion: 'n/a',
+        startedAt, finishedAt, result: 'BLOCKED_FAILURE', causeCode: 'CONFIG', retryCount: 0,
+        promptTokens: 0, cachedPromptTokens: 0, completionTokens: 0, estimatedCostUsd: 0, costUnknown: false,
+        domainsRequested: 0, domainsProcessed: 0, domainOutcomes: [],
+      });
+      await markJobTerminal(transaction, jobId, finishedAt);
+    });
+    return { jobId, result: 'BLOCKED_FAILURE' };
+  }
+
+  // Faits pédagogiques + garde-fou TOO_FEW_PRIORITIES AVANT toute réservation
+  // de budget et tout appel réseau — c'est un état terminal déterministe, pas
+  // une panne (§8, catégorie A).
+  let facts: ReturnType<typeof buildStudentFactsPayload>;
+  try {
+    const resolved = dependencies.resolvePack(claim.assessmentPackId, claim.assessmentPackVersion);
+    if (resolved === null || resolved.checksum !== claim.assessmentPackChecksum) {
+      throw new TeacherBriefError('PACK_UNAVAILABLE');
+    }
+    facts = buildStudentFactsPayload(claim.factSheet, resolved.pack, claim.answers, claim.subjectLabel);
+  } catch (error) {
+    const code = error instanceof TeacherBriefError ? error.code : 'TEACHER_BRIEF_UNKNOWN';
+    const finishedAt = dependencies.now();
+    const result = code === 'TEACHER_BRIEF_TOO_FEW_PRIORITIES' ? 'DETERMINISTIC_ONLY' : 'BLOCKED_FAILURE';
+    await dependencies.prisma.$transaction(async (transaction) => {
+      await persistAttempt(transaction, {
+        reportArtifactId: claim.reportArtifactId, expectedScoreSnapshotId: claim.currentScoreSnapshotId, jobId,
+        subject: claim.subject, gradeLevel: claim.gradeLevel, actorId: claim.actorId, model: config.model, promptVersion: 'n/a',
+        startedAt, finishedAt, result, causeCode: code, retryCount: 0,
+        promptTokens: 0, cachedPromptTokens: 0, completionTokens: 0, estimatedCostUsd: 0, costUnknown: false,
+        domainsRequested: 0, domainsProcessed: 0, domainOutcomes: [],
+      });
+      await markJobTerminal(transaction, jobId, finishedAt);
+    });
+    dependencies.logger.info({ event: 'A90_GENERATE_TEACHER_BRIEF_JOB_COMPLETED', jobId, result });
+    return { jobId, result };
+  }
+
+  const domainsRequested = facts.domainesPrioritaires.length;
+  // Réservation conservatrice : plafond de sortie théorique du modèle, jamais
+  // le coût réel encore inconnu — régularisée après l'appel.
+  const reservationUsd = 0.20;
+  const reserved = await dependencies.reserveBudget(reservationUsd, config.monthlyBudgetUsd, { now: dependencies.now });
+  if (!reserved) {
+    const finishedAt = dependencies.now();
+    await dependencies.prisma.$transaction(async (transaction) => {
+      await persistAttempt(transaction, {
+        reportArtifactId: claim.reportArtifactId, expectedScoreSnapshotId: claim.currentScoreSnapshotId, jobId,
+        subject: claim.subject, gradeLevel: claim.gradeLevel, actorId: claim.actorId, model: config.model, promptVersion: 'n/a',
+        startedAt, finishedAt, result: 'BUDGET_BLOCKED', causeCode: 'TEACHER_BRIEF_BUDGET_EXCEEDED', retryCount: 0,
+        promptTokens: 0, cachedPromptTokens: 0, completionTokens: 0, estimatedCostUsd: 0, costUnknown: false,
+        domainsRequested, domainsProcessed: 0, domainOutcomes: [],
+      });
+      await markJobTerminal(transaction, jobId, finishedAt);
+    });
+    dependencies.logger.info({ event: 'A90_GENERATE_TEACHER_BRIEF_JOB_COMPLETED', jobId, result: 'BUDGET_BLOCKED' });
+    return { jobId, result: 'BUDGET_BLOCKED' };
+  }
+
+  try {
+    const generation = await callTeacherBriefModel(config, facts, dependencies.fetchImpl);
+    const finishedAt = dependencies.now();
+    await dependencies.regularizeBudget(reservationUsd, generation.estimatedCostUsd, { now: dependencies.now });
+
+    const domainOutcomes: DomainOutcomeLog[] = facts.domainesPrioritaires.map((domain) => ({
+      domainId: domain.domainId, outcome: 'OK',
+      promptTokens: 0, cachedPromptTokens: 0, completionTokens: 0, costUsd: null,
+    }));
+
+    await dependencies.prisma.$transaction(async (transaction) => {
+      await transaction.teacherBrief.updateMany({
+        where: { reportArtifactId: claim.reportArtifactId, status: 'CORRECTION_REQUESTED' },
+        data: { status: 'SUPERSEDED' },
+      });
+      const latest = await transaction.teacherBrief.findFirst({
+        where: { reportArtifactId: claim.reportArtifactId }, orderBy: { version: 'desc' }, select: { version: true },
+      });
+      await transaction.teacherBrief.create({
+        data: {
+          reportArtifactId: claim.reportArtifactId,
+          scoreSnapshotId: claim.currentScoreSnapshotId,
+          version: (latest?.version ?? 0) + 1,
+          status: 'PENDING_REVIEW',
+          content: generation.content as unknown as Prisma.InputJsonValue,
+          promptVersion: generation.promptVersion,
+          model: generation.model,
+          promptTokens: generation.promptTokens,
+          cachedPromptTokens: generation.cachedPromptTokens,
+          completionTokens: generation.completionTokens,
+          estimatedCostUsd: generation.estimatedCostUsd,
+          generationMs: generation.generationMs,
+          createdById: claim.actorId,
+        },
+      });
+      await persistAttempt(transaction, {
+        reportArtifactId: claim.reportArtifactId, expectedScoreSnapshotId: claim.currentScoreSnapshotId, jobId,
+        subject: claim.subject, gradeLevel: claim.gradeLevel, actorId: claim.actorId,
+        model: generation.model, promptVersion: generation.promptVersion,
+        startedAt, finishedAt, result: 'GENERATED', causeCode: null, retryCount: 0,
+        promptTokens: generation.promptTokens, cachedPromptTokens: generation.cachedPromptTokens, completionTokens: generation.completionTokens,
+        estimatedCostUsd: generation.estimatedCostUsd, costUnknown: false,
+        domainsRequested, domainsProcessed: domainsRequested, domainOutcomes,
+      });
+      await markJobTerminal(transaction, jobId, finishedAt);
+    });
+    dependencies.logger.info({ event: 'A90_GENERATE_TEACHER_BRIEF_JOB_COMPLETED', jobId, result: 'GENERATED', estimatedCostUsd: generation.estimatedCostUsd });
+    return { jobId, result: 'GENERATED' };
+  } catch (error) {
+    const finishedAt = dependencies.now();
+    const code = error instanceof TeacherBriefError ? error.code : 'TEACHER_BRIEF_UNKNOWN';
+    const classification = classifyFailure(code);
+    // Coût inconnu par défaut sur un échec réseau/timeout AVANT réponse —
+    // jamais compté à zéro silencieusement (§7). Un JSON/schéma rejeté a
+    // bien reçu une réponse facturée : coût connu, ici prudemment à zéro
+    // faute d'API exposant l'usage partiel sur rejet — documenté comme
+    // limite connue (voir ADR).
+    const costUnknown = code === 'TEACHER_BRIEF_TIMEOUT' || code === 'TEACHER_BRIEF_NETWORK';
+    await dependencies.releaseBudget(reservationUsd, { now: dependencies.now });
+    await dependencies.prisma.$transaction(async (transaction) => {
+      await persistAttempt(transaction, {
+        reportArtifactId: claim.reportArtifactId, expectedScoreSnapshotId: claim.currentScoreSnapshotId, jobId,
+        subject: claim.subject, gradeLevel: claim.gradeLevel, actorId: claim.actorId, model: config.model, promptVersion: 'n/a',
+        startedAt, finishedAt, result: classification, causeCode: code, retryCount: 0,
+        promptTokens: 0, cachedPromptTokens: 0, completionTokens: 0,
+        estimatedCostUsd: costUnknown ? null : 0, costUnknown,
+        domainsRequested, domainsProcessed: 0, domainOutcomes: [],
+      });
+      if (classification === 'RETRYABLE_FAILURE') {
+        await transaction.jobOutbox.update({
+          where: { id: jobId },
+          data: { status: 'FAILED', attemptCount: { increment: 1 }, lastError: code, leaseOwner: null, leaseExpiresAt: null },
+        });
+      } else {
+        await markJobTerminal(transaction, jobId, finishedAt);
+      }
+    });
+    dependencies.logger.error({ event: 'A90_GENERATE_TEACHER_BRIEF_JOB_FAILED', jobId, code, classification });
+    if (classification === 'RETRYABLE_FAILURE') throw new GenerateTeacherBriefJobError(code);
+    return { jobId, result: classification };
+  }
+}

--- a/lib/bilans/worker/generate-teacher-brief-job.ts
+++ b/lib/bilans/worker/generate-teacher-brief-job.ts
@@ -6,12 +6,16 @@ import { prisma } from '@/lib/prisma';
 import { resolveEnabledPack, type PackResolver } from '../api/pack-access';
 import type { FactSheet } from '../facts/fact-sheet';
 import {
+  assertBriefRespectsFacts,
   buildStudentFactsPayload,
-  callTeacherBriefModel,
+  callTeacherBriefDomain,
+  estimateCostUsd,
   resolveTeacherBriefConfig,
   TeacherBriefError,
   type TeacherBriefConfig,
+  type TeacherBriefFactsPayload,
 } from '../llm/teacher-brief-service';
+import { teacherBriefSchema, TEACHER_BRIEF_PROMPT_VERSION } from '../llm/teacher-brief-schema';
 import { reserveBudget, regularizeBudget, releaseBudget } from '../llm/teacher-brief-budget';
 import { BRIEF_STATUSES_BLOCKING_DUPLICATE_GENERATION } from '../staff/teacher-brief-status';
 
@@ -347,15 +351,53 @@ export async function processGenerateTeacherBriefJob(
     return { jobId, result: 'BUDGET_BLOCKED' };
   }
 
+  // Appel domaine par domaine (pas `callTeacherBriefModel` en un bloc) : un
+  // premier domaine facturé reste compté même si un domaine suivant échoue
+  // (§7 de l'incident P0) — jamais un coût réel sous-estimé.
+  const domainOutcomes: DomainOutcomeLog[] = [];
+  let partialCostUsd = 0;
   try {
-    const generation = await callTeacherBriefModel(config, facts, dependencies.fetchImpl);
+    const outcomes: Array<{ domaine: unknown; promptTokens: number; cachedPromptTokens: number; completionTokens: number }> = [];
+    for (const domaine of facts.domainesPrioritaires) {
+      const singleDomainFacts: TeacherBriefFactsPayload = Object.freeze({
+        eleve: facts.eleve, matiere: facts.matiere, domainesPrioritaires: Object.freeze([domaine]),
+      });
+      try {
+        const outcome = await callTeacherBriefDomain(config, singleDomainFacts, dependencies.fetchImpl);
+        outcomes.push(outcome);
+        const costUsd = estimateCostUsd(config.model, outcome);
+        partialCostUsd += costUsd;
+        domainOutcomes.push({
+          domainId: domaine.domainId, outcome: 'OK',
+          promptTokens: outcome.promptTokens, cachedPromptTokens: outcome.cachedPromptTokens, completionTokens: outcome.completionTokens,
+          costUsd,
+        });
+      } catch (domainError) {
+        const domainCode = domainError instanceof TeacherBriefError ? domainError.code : 'TEACHER_BRIEF_UNKNOWN';
+        domainOutcomes.push({ domainId: domaine.domainId, outcome: domainCode, promptTokens: 0, cachedPromptTokens: 0, completionTokens: 0, costUsd: null });
+        throw domainError;
+      }
+    }
+
+    const assembled = teacherBriefSchema.safeParse({
+      version: TEACHER_BRIEF_PROMPT_VERSION,
+      domaines: outcomes.map((outcome) => outcome.domaine),
+    });
+    if (!assembled.success) throw new TeacherBriefError('TEACHER_BRIEF_ASSEMBLY_REJECTED');
+    assertBriefRespectsFacts(assembled.data, facts);
+
+    const generation = {
+      content: assembled.data,
+      promptTokens: outcomes.reduce((total, o) => total + o.promptTokens, 0),
+      cachedPromptTokens: outcomes.reduce((total, o) => total + o.cachedPromptTokens, 0),
+      completionTokens: outcomes.reduce((total, o) => total + o.completionTokens, 0),
+      estimatedCostUsd: partialCostUsd,
+      generationMs: dependencies.now().getTime() - startedAt.getTime(),
+      model: config.model,
+      promptVersion: TEACHER_BRIEF_PROMPT_VERSION,
+    };
     const finishedAt = dependencies.now();
     await dependencies.regularizeBudget(reservationUsd, generation.estimatedCostUsd, { now: dependencies.now });
-
-    const domainOutcomes: DomainOutcomeLog[] = facts.domainesPrioritaires.map((domain) => ({
-      domainId: domain.domainId, outcome: 'OK',
-      promptTokens: 0, cachedPromptTokens: 0, completionTokens: 0, costUsd: null,
-    }));
 
     await dependencies.prisma.$transaction(async (transaction) => {
       await transaction.teacherBrief.updateMany({
@@ -399,21 +441,24 @@ export async function processGenerateTeacherBriefJob(
     const finishedAt = dependencies.now();
     const code = error instanceof TeacherBriefError ? error.code : 'TEACHER_BRIEF_UNKNOWN';
     const classification = classifyFailure(code);
-    // Coût inconnu par défaut sur un échec réseau/timeout AVANT réponse —
-    // jamais compté à zéro silencieusement (§7). Un JSON/schéma rejeté a
-    // bien reçu une réponse facturée : coût connu, ici prudemment à zéro
-    // faute d'API exposant l'usage partiel sur rejet — documenté comme
-    // limite connue (voir ADR).
+    // Coût inconnu UNIQUEMENT sur un échec réseau/timeout AVANT toute
+    // réponse (aucun usage exploitable) — jamais compté à zéro
+    // silencieusement (§7). Dans tous les autres cas, `partialCostUsd`
+    // porte le coût RÉEL des domaines effectivement facturés avant l'échec
+    // (0 si le tout premier appel a échoué, > 0 si un domaine précédent a
+    // réussi) — jamais une sous-estimation.
     const costUnknown = code === 'TEACHER_BRIEF_TIMEOUT' || code === 'TEACHER_BRIEF_NETWORK';
+    const domainsProcessed = domainOutcomes.filter((entry) => entry.outcome === 'OK').length;
     await dependencies.releaseBudget(reservationUsd, { now: dependencies.now });
+    if (partialCostUsd > 0) await dependencies.regularizeBudget(0, partialCostUsd, { now: dependencies.now });
     await dependencies.prisma.$transaction(async (transaction) => {
       await persistAttempt(transaction, {
         reportArtifactId: claim.reportArtifactId, expectedScoreSnapshotId: claim.currentScoreSnapshotId, jobId,
         subject: claim.subject, gradeLevel: claim.gradeLevel, actorId: claim.actorId, model: config.model, promptVersion: 'n/a',
         startedAt, finishedAt, result: classification, causeCode: code, retryCount: 0,
         promptTokens: 0, cachedPromptTokens: 0, completionTokens: 0,
-        estimatedCostUsd: costUnknown ? null : 0, costUnknown,
-        domainsRequested, domainsProcessed: 0, domainOutcomes: [],
+        estimatedCostUsd: costUnknown ? null : partialCostUsd, costUnknown,
+        domainsRequested, domainsProcessed, domainOutcomes,
       });
       if (classification === 'RETRYABLE_FAILURE') {
         await transaction.jobOutbox.update({

--- a/lib/bilans/worker/scheduler.ts
+++ b/lib/bilans/worker/scheduler.ts
@@ -1,5 +1,5 @@
 import { maybeSendAssistantDigest } from '../staff/notification-service';
-import { drainGenerateReportJobs, drainScoreAttemptJobs } from './drain-outbox';
+import { drainGenerateReportJobs, drainScoreAttemptJobs, drainTeacherBriefJobs } from './drain-outbox';
 
 type SchedulerState = {
   timer?: NodeJS.Timeout;
@@ -38,6 +38,12 @@ export function kickBilanWorkerDrain(): void {
     console.info(JSON.stringify({ event: 'BILAN_WORKER_SCORE_DRAIN_METRICS', ...scored }));
     const generated = await drainGenerateReportJobs();
     console.info(JSON.stringify({ event: 'BILAN_WORKER_GENERATE_REPORT_DRAIN_METRICS', ...generated }));
+    // Briefs enseignant : même worker en process (§10 de l'incident P0),
+    // jamais le worker NPC (domaine métier différent). Un seul brief à la
+    // fois par tick (limit:1 dans drainTeacherBriefJobs) tant qu'aucune
+    // preuve de charge/budget ne justifie plus.
+    const briefs = await drainTeacherBriefJobs();
+    console.info(JSON.stringify({ event: 'BILAN_WORKER_TEACHER_BRIEF_DRAIN_METRICS', ...briefs }));
     // Synthèse assistante : vérification bon marché à chaque tick, envoi au
     // plus une fois par intervalle et seulement s'il y a matière.
     const digest = await maybeSendAssistantDigest();

--- a/prisma/migrations/20260816000000_secure_teacher_brief_workflow/migration.sql
+++ b/prisma/migrations/20260816000000_secure_teacher_brief_workflow/migration.sql
@@ -1,0 +1,190 @@
+-- Sécurisation du workflow des briefs enseignant (incident P0 de gouvernance
+-- pédagogique). Additive et conversion sûre, testée sur clone avec les 28
+-- briefs réels de production (tous PENDING_REVIEW, aucun editedContent non
+-- nul vérifié en lecture seule avant écriture de cette migration).
+--
+-- 1. "CanonicalJobType" : nouvelle valeur pour le job outbox du worker de
+--    génération de briefs (réutilisation de l'infrastructure canonique
+--    canonical_job_outbox / lib/bilans/worker, jamais du worker NPC).
+ALTER TYPE "CanonicalJobType" ADD VALUE IF NOT EXISTS 'GENERATE_TEACHER_BRIEF';
+
+-- 2. "status" : String + CHECK ad hoc -> enum natif Postgres. La CHECK
+--    constraint existante garantit déjà que les 28 lignes réelles ne
+--    contiennent que les 4 valeurs autorisées : conversion USING sans perte.
+CREATE TYPE "TeacherBriefStatus" AS ENUM ('PENDING_REVIEW', 'APPROVED', 'CORRECTION_REQUESTED', 'SUPERSEDED');
+
+-- La CHECK constraint textuelle doit tomber AVANT le changement de type : la
+-- comparaison "status" IN ('PENDING_REVIEW', ...) qu'elle porte devient
+-- invalide (enum vs text) dès que la colonne change de type, et Postgres la
+-- revalide pendant l'ALTER COLUMN TYPE lui-même (constaté sur clone).
+ALTER TABLE "canonical_teacher_briefs" DROP CONSTRAINT "canonical_teacher_briefs_status_known";
+
+ALTER TABLE "canonical_teacher_briefs" ALTER COLUMN "status" DROP DEFAULT;
+ALTER TABLE "canonical_teacher_briefs"
+  ALTER COLUMN "status" TYPE "TeacherBriefStatus" USING "status"::"TeacherBriefStatus";
+ALTER TABLE "canonical_teacher_briefs" ALTER COLUMN "status" SET DEFAULT 'PENDING_REVIEW'::"TeacherBriefStatus";
+
+-- 3. Édition manuelle structurée : "editedContent" (TEXT, re-parsé en JSON de
+--    façon défensive côté lecture -- le défaut audité) est remplacé par
+--    "approvedContent" (JSONB, même schéma que "content"), posé une seule
+--    fois, uniquement au moment de l'approbation. Vérifié en lecture seule
+--    juste avant cette migration : 0 valeur "editedContent" non nulle sur 28
+--    lignes en production (aucun brief n'a jamais été approuvé) -- DROP direct,
+--    sans conversion, aucune perte de donnée réelle possible.
+ALTER TABLE "canonical_teacher_briefs" DROP COLUMN "editedContent";
+ALTER TABLE "canonical_teacher_briefs" ADD COLUMN "approvedContent" JSONB;
+
+-- Un contenu approuvé structuré n'a de sens qu'associé à un statut APPROVED.
+ALTER TABLE "canonical_teacher_briefs"
+  ADD CONSTRAINT "canonical_teacher_briefs_approved_content_requires_approved"
+  CHECK ("approvedContent" IS NULL OR "status" = 'APPROVED');
+
+CREATE INDEX "canonical_teacher_briefs_reportArtifactId_status_idx"
+  ON "canonical_teacher_briefs" ("reportArtifactId", "status");
+
+-- 4. Garde de mutation étendue : en plus de l'immutabilité déjà en place
+--    (contenu généré, provenance, usage jamais réécrits ; relecture posée une
+--    seule fois), la machine de transitions de "status" est désormais
+--    appliquée EN BASE, pas seulement dans le service TypeScript :
+--      PENDING_REVIEW      -> APPROVED
+--      PENDING_REVIEW      -> CORRECTION_REQUESTED
+--      CORRECTION_REQUESTED -> SUPERSEDED
+--    APPROVED et SUPERSEDED sont terminaux. "approvedContent" ne peut passer
+--    que de NULL à une valeur, jamais être réécrit ensuite.
+CREATE OR REPLACE FUNCTION canonical_bilans_guard_teacher_brief_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'canonical teacher briefs are append-only and cannot be DELETE';
+  END IF;
+
+  -- Champs de génération : jamais réécrits, quelle que soit la transition.
+  IF NOT (
+    NEW."id" IS NOT DISTINCT FROM OLD."id"
+    AND NEW."reportArtifactId" IS NOT DISTINCT FROM OLD."reportArtifactId"
+    AND NEW."scoreSnapshotId" IS NOT DISTINCT FROM OLD."scoreSnapshotId"
+    AND NEW."version" IS NOT DISTINCT FROM OLD."version"
+    AND NEW."content" IS NOT DISTINCT FROM OLD."content"
+    AND NEW."promptVersion" IS NOT DISTINCT FROM OLD."promptVersion"
+    AND NEW."model" IS NOT DISTINCT FROM OLD."model"
+    AND NEW."promptTokens" IS NOT DISTINCT FROM OLD."promptTokens"
+    AND NEW."cachedPromptTokens" IS NOT DISTINCT FROM OLD."cachedPromptTokens"
+    AND NEW."completionTokens" IS NOT DISTINCT FROM OLD."completionTokens"
+    AND NEW."estimatedCostUsd" IS NOT DISTINCT FROM OLD."estimatedCostUsd"
+    AND NEW."generationMs" IS NOT DISTINCT FROM OLD."generationMs"
+    AND NEW."createdById" IS NOT DISTINCT FROM OLD."createdById"
+    AND NEW."createdAt" IS NOT DISTINCT FROM OLD."createdAt"
+  ) THEN
+    RAISE EXCEPTION 'canonical teacher briefs: generation fields are immutable';
+  END IF;
+
+  -- Relecture posée une seule fois (reviewedById/reviewedAt/reviewMotif).
+  IF OLD."reviewedById" IS NOT NULL AND (
+    NEW."reviewedById" IS DISTINCT FROM OLD."reviewedById"
+    OR NEW."reviewedAt" IS DISTINCT FROM OLD."reviewedAt"
+    OR NEW."reviewMotif" IS DISTINCT FROM OLD."reviewMotif"
+  ) THEN
+    RAISE EXCEPTION 'canonical teacher briefs: review trace is immutable once set';
+  END IF;
+
+  -- approvedContent posé une seule fois, jamais réécrit ni effacé.
+  IF OLD."approvedContent" IS NOT NULL AND NEW."approvedContent" IS DISTINCT FROM OLD."approvedContent" THEN
+    RAISE EXCEPTION 'canonical teacher briefs: approvedContent is immutable once set';
+  END IF;
+
+  -- Machine de transitions de statut.
+  IF NEW."status" IS DISTINCT FROM OLD."status" THEN
+    IF NOT (
+      (OLD."status" = 'PENDING_REVIEW' AND NEW."status" = 'APPROVED')
+      OR (OLD."status" = 'PENDING_REVIEW' AND NEW."status" = 'CORRECTION_REQUESTED')
+      OR (OLD."status" = 'CORRECTION_REQUESTED' AND NEW."status" = 'SUPERSEDED')
+    ) THEN
+      RAISE EXCEPTION 'canonical teacher briefs: illegal status transition % -> %', OLD."status", NEW."status";
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 5. Journal canonique, append-only, des tentatives de génération (§7).
+CREATE TYPE "TeacherBriefAttemptResult" AS ENUM (
+  'GENERATED', 'ALREADY_PRESENT', 'DETERMINISTIC_ONLY', 'RETRYABLE_FAILURE',
+  'BLOCKED_FAILURE', 'BUDGET_BLOCKED', 'STALE_INPUT', 'CANCELLED_BEFORE_START'
+);
+
+CREATE TABLE "canonical_teacher_brief_attempts" (
+    "id" TEXT NOT NULL,
+    "reportArtifactId" TEXT NOT NULL,
+    "expectedScoreSnapshotId" TEXT NOT NULL,
+    "jobId" TEXT,
+    "subject" "Subject" NOT NULL,
+    "gradeLevel" "GradeLevel" NOT NULL,
+    "actorId" TEXT NOT NULL,
+    "model" TEXT NOT NULL,
+    "promptVersion" TEXT NOT NULL,
+    "startedAt" TIMESTAMP(3) NOT NULL,
+    "finishedAt" TIMESTAMP(3) NOT NULL,
+    "result" "TeacherBriefAttemptResult" NOT NULL,
+    "causeCode" TEXT,
+    "retryCount" INTEGER NOT NULL DEFAULT 0,
+    "promptTokens" INTEGER NOT NULL DEFAULT 0,
+    "cachedPromptTokens" INTEGER NOT NULL DEFAULT 0,
+    "completionTokens" INTEGER NOT NULL DEFAULT 0,
+    "estimatedCostUsd" DECIMAL(10,6),
+    "costUnknown" BOOLEAN NOT NULL DEFAULT false,
+    "durationMs" INTEGER NOT NULL,
+    "domainsRequested" INTEGER NOT NULL,
+    "domainsProcessed" INTEGER NOT NULL,
+    "domainOutcomes" JSONB NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'LIVE',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "canonical_teacher_brief_attempts_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "canonical_teacher_brief_attempts_duration_nonneg" CHECK ("durationMs" >= 0),
+    CONSTRAINT "canonical_teacher_brief_attempts_retry_nonneg" CHECK ("retryCount" >= 0),
+    CONSTRAINT "canonical_teacher_brief_attempts_domains_consistent"
+      CHECK ("domainsProcessed" >= 0 AND "domainsRequested" >= 0 AND "domainsProcessed" <= "domainsRequested"),
+    CONSTRAINT "canonical_teacher_brief_attempts_cost_or_unknown"
+      CHECK ("estimatedCostUsd" IS NOT NULL OR "costUnknown" = true)
+);
+
+ALTER TABLE "canonical_teacher_brief_attempts"
+  ADD CONSTRAINT "canonical_teacher_brief_attempts_reportArtifactId_fkey"
+  FOREIGN KEY ("reportArtifactId") REFERENCES "canonical_report_artifacts"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "canonical_teacher_brief_attempts"
+  ADD CONSTRAINT "canonical_teacher_brief_attempts_actorId_fkey"
+  FOREIGN KEY ("actorId") REFERENCES "users"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE INDEX "canonical_teacher_brief_attempts_reportArtifactId_created_idx"
+  ON "canonical_teacher_brief_attempts" ("reportArtifactId", "createdAt");
+CREATE INDEX "canonical_teacher_brief_attempts_result_created_idx"
+  ON "canonical_teacher_brief_attempts" ("result", "createdAt");
+CREATE INDEX "canonical_teacher_brief_attempts_jobId_idx"
+  ON "canonical_teacher_brief_attempts" ("jobId");
+
+-- Append-only strict : réutilise le garde générique déjà en place pour les
+-- annotations de relecture (#124 / migration add_teacher_briefs).
+CREATE TRIGGER "canonical_teacher_brief_attempts_append_only"
+BEFORE UPDATE OR DELETE ON "canonical_teacher_brief_attempts"
+FOR EACH ROW EXECUTE FUNCTION canonical_bilans_reject_append_only_mutation();
+
+-- 6. Budget mensuel atomique (§11) : une ligne par mois calendaire, mise à
+--    jour par une unique instruction UPDATE conditionnelle -- jamais de
+--    lecture non verrouillée suivie d'un appel. "reservedUsd" couvre les
+--    générations en cours (réservation avant appel, régularisée après usage
+--    réel connu) ; "spentUsd" couvre le coût réellement comptabilisé, y
+--    compris les tentatives ratées mais facturées.
+CREATE TABLE "canonical_teacher_brief_monthly_budgets" (
+    "monthStart" DATE NOT NULL,
+    "budgetUsd" DECIMAL(10,2) NOT NULL,
+    "spentUsd" DECIMAL(10,6) NOT NULL DEFAULT 0,
+    "reservedUsd" DECIMAL(10,6) NOT NULL DEFAULT 0,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "canonical_teacher_brief_monthly_budgets_pkey" PRIMARY KEY ("monthStart"),
+    CONSTRAINT "canonical_teacher_brief_monthly_budgets_nonneg"
+      CHECK ("spentUsd" >= 0 AND "reservedUsd" >= 0 AND "budgetUsd" > 0)
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -231,14 +231,15 @@ model User {
   coachStudentAssignmentsCreated CoachStudentAssignment[] @relation("CoachStudentAssignmentAssignedBy")
 
   // Canonical bilan reviews performed by this user (ASSISTANTE)
-  bilanReportReviews ReportReview[]
-  reportShareLinksReceived ReportShareLink[] @relation("ReportShareLinkRecipient")
-  teacherBriefsReviewed  TeacherBrief[] @relation("TeacherBriefReviewer")
-  teacherBriefsCreated   TeacherBrief[] @relation("TeacherBriefCreator")
-  teacherBriefAnnotations TeacherBriefAnnotation[] @relation("TeacherBriefAnnotationAuthor")
-  reportShareLinksCreated  ReportShareLink[] @relation("ReportShareLinkCreator")
-  reportTransmissionsReceived  ReportTransmission[] @relation("ReportTransmissionRecipient")
-  reportTransmissionsConfirmed ReportTransmission[] @relation("ReportTransmissionConfirmer")
+  bilanReportReviews           ReportReview[]
+  reportShareLinksReceived     ReportShareLink[]        @relation("ReportShareLinkRecipient")
+  teacherBriefsReviewed        TeacherBrief[]           @relation("TeacherBriefReviewer")
+  teacherBriefsCreated         TeacherBrief[]           @relation("TeacherBriefCreator")
+  teacherBriefAnnotations      TeacherBriefAnnotation[] @relation("TeacherBriefAnnotationAuthor")
+  teacherBriefAttempts         TeacherBriefAttempt[]    @relation("TeacherBriefAttemptActor")
+  reportShareLinksCreated      ReportShareLink[]        @relation("ReportShareLinkCreator")
+  reportTransmissionsReceived  ReportTransmission[]     @relation("ReportTransmissionRecipient")
+  reportTransmissionsConfirmed ReportTransmission[]     @relation("ReportTransmissionConfirmer")
 
   // Paper bilan copies transcribed by this user (ASSISTANTE or ADMIN)
   bilanPaperEntries CanonicalAssessmentAttempt[] @relation("CanonicalAttemptPaperEntry")
@@ -250,16 +251,16 @@ model User {
   candidateDiagnosticAuditLogs         CandidateDiagnosticAuditLog[] @relation("CandidateDiagnosticAuditActor")
 
   // 2FA TOTP (Admin only)
-  totpSecret      String? // AES-256-GCM encrypted, format: v1:iv:tag:ciphertext
-  totpEnabledAt   DateTime? // non-null = 2FA active (canonical check)
-  totpBackupCodes String? // JSON array of hashed backup codes
-  totpLastUsedAt  DateTime? // last successful TOTP verification
+  totpSecret                   String? // AES-256-GCM encrypted, format: v1:iv:tag:ciphertext
+  totpEnabledAt                DateTime? // non-null = 2FA active (canonical check)
+  totpBackupCodes              String? // JSON array of hashed backup codes
+  totpLastUsedAt               DateTime? // last successful TOTP verification
+  reportRegenerationsRequested ReportRegeneration[] @relation("ReportRegenerationsRequested")
 
   @@index([role])
   @@index([phoneNormalized])
   @@index([mergedIntoUserId])
   @@map("users")
-  reportRegenerationsRequested ReportRegeneration[] @relation("ReportRegenerationsRequested")
 }
 
 // Profil Parent
@@ -1472,6 +1473,7 @@ enum CanonicalJobType {
   PUBLISH_REPORT
   SEND_NOTIFICATION
   SEND_EMAIL
+  GENERATE_TEACHER_BRIEF
 }
 
 enum CanonicalNotificationEventType {
@@ -1591,12 +1593,11 @@ model ScoreSnapshot {
   evidenceItems   EvidenceItem[]
   reportRevisions ReportRevision[]
 
-  createdAt DateTime @default(now())
+  createdAt     DateTime       @default(now())
+  teacherBriefs TeacherBrief[]
 
   @@unique([assessmentAttemptId])
   @@index([assessmentAttemptId, scoredAt])
-  teacherBriefs TeacherBrief[]
-
   @@map("canonical_score_snapshots")
 }
 
@@ -1630,9 +1631,10 @@ model ReportArtifact {
 
   revisions ReportRevision[] @relation("ReportArtifactRevisions")
 
-  shareLinks    ReportShareLink[]
-  transmissions ReportTransmission[]
-  teacherBriefs TeacherBrief[]
+  shareLinks           ReportShareLink[]
+  transmissions        ReportTransmission[]
+  teacherBriefs        TeacherBrief[]
+  teacherBriefAttempts TeacherBriefAttempt[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1687,22 +1689,22 @@ model ReportRevision {
 /// profils constaté. L'historique intégral des révisions est conservé —
 /// cette table dit pourquoi une nouvelle génération existe.
 model ReportRegeneration {
-  id             String         @id @default(cuid())
-  fromRevisionId String
-  fromRevision   ReportRevision @relation("RegenerationFromRevision", fields: [fromRevisionId], references: [id], onDelete: Restrict)
-  toRevisionId   String
-  toRevision     ReportRevision @relation("RegenerationToRevision", fields: [toRevisionId], references: [id], onDelete: Restrict)
-  requestedById  String
-  requestedBy    User           @relation("ReportRegenerationsRequested", fields: [requestedById], references: [id], onDelete: Restrict)
-  motif          String
+  id                  String         @id @default(cuid())
+  fromRevisionId      String
+  fromRevision        ReportRevision @relation("RegenerationFromRevision", fields: [fromRevisionId], references: [id], onDelete: Restrict)
+  toRevisionId        String
+  toRevision          ReportRevision @relation("RegenerationToRevision", fields: [toRevisionId], references: [id], onDelete: Restrict)
+  requestedById       String
+  requestedBy         User           @relation("ReportRegenerationsRequested", fields: [requestedById], references: [id], onDelete: Restrict)
+  motif               String
   engineVersionBefore String
   engineVersionAfter  String
-  briefRegenerated    Boolean  @default(false)
+  briefRegenerated    Boolean        @default(false)
   briefPromptVersion  String?
   briefModel          String?
   profileDiff         Json
-  wasPublished        Boolean  @default(false)
-  createdAt           DateTime @default(now())
+  wasPublished        Boolean        @default(false)
+  createdAt           DateTime       @default(now())
 
   @@index([toRevisionId])
   @@index([createdAt])
@@ -1829,37 +1831,60 @@ model ReportTransmission {
   @@map("canonical_report_transmissions")
 }
 
+// Statuts stricts d'un brief enseignant. AUCUNE valeur libre : seul APPROVED
+// appartient à la sémantique "sûr pour l'enseignant" (voir
+// lib/bilans/staff/teacher-brief-status.ts pour les regroupements nommés).
+// Transitions autorisées, appliquées par service + trigger SQL + tests :
+//   PENDING_REVIEW → APPROVED
+//   PENDING_REVIEW → CORRECTION_REQUESTED
+//   CORRECTION_REQUESTED → SUPERSEDED (régénération réussie)
+// APPROVED et SUPERSEDED sont terminaux.
+enum TeacherBriefStatus {
+  PENDING_REVIEW
+  APPROVED
+  CORRECTION_REQUESTED
+  SUPERSEDED
+}
+
 // Bilan enseignant enrichi (LLM, relecture obligatoire). Document INTERNE :
 // jamais transmis aux familles, jamais éligible aux liens signés. Contenu,
 // provenance et usage immuables (trigger) ; régénération = nouvelle version.
 model TeacherBrief {
-  id                 String    @id @default(cuid())
+  id                 String             @id @default(cuid())
   reportArtifactId   String
-  reportArtifact     ReportArtifact @relation(fields: [reportArtifactId], references: [id], onDelete: Restrict)
+  reportArtifact     ReportArtifact     @relation(fields: [reportArtifactId], references: [id], onDelete: Restrict)
   scoreSnapshotId    String
-  scoreSnapshot      ScoreSnapshot  @relation(fields: [scoreSnapshotId], references: [id], onDelete: Restrict)
+  scoreSnapshot      ScoreSnapshot      @relation(fields: [scoreSnapshotId], references: [id], onDelete: Restrict)
   version            Int
-  status             String    @default("PENDING_REVIEW")
+  status             TeacherBriefStatus @default(PENDING_REVIEW)
   content            Json
-  editedContent      String?   @db.Text
+  /**
+   * Correction manuelle approuvée, structurée (même schéma que `content`),
+   * posée UNE SEULE FOIS au moment de l'approbation — jamais un textarea de
+   * texte libre. Remplace l'ancien `editedContent: String?` (JSON.parse
+   * défensif côté lecture) : un contenu approuvé est TOUJOURS un JSON
+   * structuré valide, jamais une chaîne à re-parser.
+   */
+  approvedContent    Json?
   promptVersion      String
   model              String
   promptTokens       Int
-  cachedPromptTokens Int       @default(0)
+  cachedPromptTokens Int                @default(0)
   completionTokens   Int
-  estimatedCostUsd   Decimal   @db.Decimal(10, 6)
+  estimatedCostUsd   Decimal            @db.Decimal(10, 6)
   generationMs       Int
   reviewedById       String?
-  reviewedBy         User?     @relation("TeacherBriefReviewer", fields: [reviewedById], references: [id], onDelete: Restrict)
+  reviewedBy         User?              @relation("TeacherBriefReviewer", fields: [reviewedById], references: [id], onDelete: Restrict)
   reviewedAt         DateTime?
-  reviewMotif        String?   @db.Text
+  reviewMotif        String?            @db.Text
   createdById        String
-  createdBy          User      @relation("TeacherBriefCreator", fields: [createdById], references: [id], onDelete: Restrict)
-  createdAt          DateTime  @default(now())
+  createdBy          User               @relation("TeacherBriefCreator", fields: [createdById], references: [id], onDelete: Restrict)
+  createdAt          DateTime           @default(now())
 
   annotations TeacherBriefAnnotation[]
 
   @@unique([reportArtifactId, version])
+  @@index([reportArtifactId, status])
   @@index([status, createdAt])
   @@map("canonical_teacher_briefs")
 }
@@ -1876,6 +1901,92 @@ model TeacherBriefAnnotation {
 
   @@index([teacherBriefId, createdAt])
   @@map("canonical_teacher_brief_annotations")
+}
+
+// Résultat terminal d'une tentative de génération — un par clic idempotent
+// traité (via le job outbox), PAS un par appel réseau (voir `domainOutcomes`
+// pour le détail par domaine). Journal append-only : jamais réécrit, jamais
+// supprimé. Permet la corrélation par bilan, la distinction
+// permanent/transitoire, et un calcul de coût qui inclut les tentatives
+// ratées.
+enum TeacherBriefAttemptResult {
+  GENERATED
+  ALREADY_PRESENT
+  DETERMINISTIC_ONLY
+  RETRYABLE_FAILURE
+  BLOCKED_FAILURE
+  BUDGET_BLOCKED
+  STALE_INPUT
+  CANCELLED_BEFORE_START
+}
+
+// Journal canonique, append-only, d'une tentative de génération de brief.
+// Aucune PII, aucun contenu pédagogique : uniquement identifiants opaques,
+// codes de cause, et compteurs numériques.
+model TeacherBriefAttempt {
+  id                      String                    @id @default(cuid())
+  reportArtifactId        String
+  reportArtifact          ReportArtifact            @relation(fields: [reportArtifactId], references: [id], onDelete: Restrict)
+  /**
+   * Snapshot ATTENDU au moment de la tentative — sert à détecter le STALE_INPUT (pas de FK : le snapshot attendu peut ne plus être le courant).
+   */
+  expectedScoreSnapshotId String
+  jobId                   String?
+  subject                 Subject
+  gradeLevel              GradeLevel
+  actorId                 String
+  actor                   User                      @relation("TeacherBriefAttemptActor", fields: [actorId], references: [id], onDelete: Restrict)
+  model                   String
+  promptVersion           String
+  startedAt               DateTime
+  finishedAt              DateTime
+  result                  TeacherBriefAttemptResult
+  /**
+   * Code de cause non sensible (ex. TEACHER_BRIEF_SCHEMA_REJECTED). Jamais de contenu pédagogique ni de PII.
+   */
+  causeCode               String?
+  retryCount              Int                       @default(0)
+  promptTokens            Int                       @default(0)
+  cachedPromptTokens      Int                       @default(0)
+  completionTokens        Int                       @default(0)
+  /**
+   * Coût estimé réellement engagé pour CETTE tentative, y compris les appels
+   * de domaine facturés puis perdus (schéma rejeté, JSON invalide, etc.).
+   * NULL uniquement quand le fournisseur n'a renvoyé aucun usage exploitable
+   * (ex. timeout réseau avant réponse) — jamais silencieusement à zéro :
+   * voir `costUnknown`.
+   */
+  estimatedCostUsd        Decimal?                  @db.Decimal(10, 6)
+  costUnknown             Boolean                   @default(false)
+  durationMs              Int
+  domainsRequested        Int
+  domainsProcessed        Int
+  /**
+   * Un élément par appel de domaine : [{domainId, outcome, promptTokens, cachedPromptTokens, completionTokens, costUsd}]. Aucune PII, aucun contenu pédagogique — uniquement des identifiants de domaine du référentiel.
+   */
+  domainOutcomes          Json
+  source                  String                    @default("LIVE")
+  createdAt               DateTime                  @default(now())
+
+  @@index([reportArtifactId, createdAt])
+  @@index([result, createdAt])
+  @@index([jobId])
+  @@map("canonical_teacher_brief_attempts")
+}
+
+// Budget mensuel atomique (§11) : une ligne par mois calendaire. Toute
+// réservation/régularisation passe par une unique instruction UPDATE
+// conditionnelle (voir lib/bilans/llm/teacher-brief-budget.ts) — jamais de
+// lecture non verrouillée suivie d'un appel, jamais de course entre deux
+// batches concurrents.
+model TeacherBriefMonthlyBudget {
+  monthStart  DateTime @id @db.Date
+  budgetUsd   Decimal  @db.Decimal(10, 2)
+  spentUsd    Decimal  @default(0) @db.Decimal(10, 6)
+  reservedUsd Decimal  @default(0) @db.Decimal(10, 6)
+  updatedAt   DateTime @updatedAt
+
+  @@map("canonical_teacher_brief_monthly_budgets")
 }
 
 model JobOutbox {

--- a/scripts/bilans/backfill-teacher-brief-attempts.ts
+++ b/scripts/bilans/backfill-teacher-brief-attempts.ts
@@ -1,0 +1,112 @@
+/**
+ * Backfill du journal des tentatives pour les briefs enseignant existants
+ * (§15 de l'incident P0 du 2026-08-16).
+ *
+ * État constaté en production au moment de l'incident : 28 briefs, tous
+ * PENDING_REVIEW, 0 APPROVED, 0 CORRECTION_REQUESTED, 0 SUPERSEDED.
+ *
+ * Ce script :
+ *  - N'AUTO-APPROUVE rien ;
+ *  - NE SUPPRIME rien ;
+ *  - NE MODIFIE le contenu d'aucun brief existant ;
+ *  - conserve les versions et coûts existants (déjà immuables par trigger) ;
+ *  - crée, pour chaque TeacherBrief existant sans tentative correspondante,
+ *    UNE ligne TeacherBriefAttempt source=LEGACY_BACKFILL portant les
+ *    métadonnées déjà connues (modèle, promptVersion, tokens, coût déjà
+ *    enregistrés sur le brief lui-même) — reconstituée, jamais inventée.
+ *  - N'INVENTE PAS l'historique des tentatives tombées en PLANCHER avant ce
+ *    correctif (61 échecs constatés dans les logs applicatifs, non
+ *    corrélables à un bilan précis sans identifiant — limite documentée
+ *    dans ops/ADR, jamais comblée par une supposition).
+ *
+ * Idempotent : une exécution répétée ne crée jamais de doublon
+ * (`WHERE NOT EXISTS` sur jobId=NULL + reportArtifactId + source=LEGACY_BACKFILL).
+ *
+ * Usage (jamais exécuté automatiquement, jamais contre la production sans
+ * décision humaine explicite et une nouvelle preuve de restauration) :
+ *   DATABASE_URL=... npx tsx scripts/bilans/backfill-teacher-brief-attempts.ts [--dry-run]
+ */
+
+import { prisma } from '@/lib/prisma';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function main(): Promise<void> {
+  const briefs = await prisma.teacherBrief.findMany({
+    select: {
+      id: true,
+      reportArtifactId: true,
+      scoreSnapshotId: true,
+      status: true,
+      model: true,
+      promptVersion: true,
+      promptTokens: true,
+      cachedPromptTokens: true,
+      completionTokens: true,
+      estimatedCostUsd: true,
+      generationMs: true,
+      createdById: true,
+      createdAt: true,
+      reportArtifact: { select: { assessmentAttempt: { select: { subject: true, gradeLevel: true } } } },
+    },
+  });
+
+  const existingLegacy = await prisma.teacherBriefAttempt.findMany({
+    where: { source: 'LEGACY_BACKFILL' },
+    select: { reportArtifactId: true },
+  });
+  const alreadyBackfilled = new Set(existingLegacy.map((row) => row.reportArtifactId));
+
+  const toCreate = briefs.filter((brief) => !alreadyBackfilled.has(brief.reportArtifactId));
+
+  console.info(JSON.stringify({
+    event: 'TEACHER_BRIEF_BACKFILL_PLAN',
+    totalBriefs: briefs.length,
+    alreadyBackfilled: alreadyBackfilled.size,
+    toCreate: toCreate.length,
+    dryRun: DRY_RUN,
+  }));
+
+  if (DRY_RUN) return;
+
+  for (const brief of toCreate) {
+    await prisma.teacherBriefAttempt.create({
+      data: {
+        reportArtifactId: brief.reportArtifactId,
+        expectedScoreSnapshotId: brief.scoreSnapshotId,
+        jobId: null,
+        subject: brief.reportArtifact.assessmentAttempt.subject,
+        gradeLevel: brief.reportArtifact.assessmentAttempt.gradeLevel,
+        actorId: brief.createdById,
+        model: brief.model,
+        promptVersion: brief.promptVersion,
+        startedAt: brief.createdAt,
+        finishedAt: brief.createdAt,
+        result: 'GENERATED',
+        causeCode: null,
+        retryCount: 0,
+        promptTokens: brief.promptTokens,
+        cachedPromptTokens: brief.cachedPromptTokens,
+        completionTokens: brief.completionTokens,
+        estimatedCostUsd: brief.estimatedCostUsd,
+        costUnknown: false,
+        durationMs: brief.generationMs,
+        domainsRequested: 0, // inconnu rétroactivement — jamais inventé (voir note ADR)
+        domainsProcessed: 0,
+        domainOutcomes: [],
+        source: 'LEGACY_BACKFILL',
+      },
+    });
+  }
+
+  console.info(JSON.stringify({ event: 'TEACHER_BRIEF_BACKFILL_COMPLETED', created: toCreate.length }));
+}
+
+main()
+  .catch((error) => {
+    console.error(JSON.stringify({ event: 'TEACHER_BRIEF_BACKFILL_FAILED', message: error instanceof Error ? error.message : String(error) }));
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Incident

Audit en lecture seule (2026-08-16) : du contenu LLM au statut
`PENDING_REVIEW` (jamais relu par un humain) pouvait être inclus dans le
dossier enseignant HTML/PDF remis au staff, alors que l'invariant documenté
affirmait que seul `APPROVED` devait l'atteindre. 28 briefs en production,
tous `PENDING_REVIEW`, 0 `APPROVED` — si un dossier avait été généré, 100 %
du contenu IA qu'il aurait porté n'aurait jamais été relu, sans que rien
dans le document ne le signale. Génération groupée synchrone (8-10 min de
requête HTTP), 61 échecs de génération non tracés (aucune corrélation par
bilan possible), édition manuelle en texte libre re-parsée en JSON.

## Cause

Une liste de statuts unique (`['PENDING_REVIEW','APPROVED']`) servait à la
fois à bloquer une régénération, compter un brief « existant » et autoriser
le rendu enseignant — trois questions différentes, une seule réponse.

## Risques

Contenu non relu présenté comme validé à un enseignant ; retry aveugle
coûteux sans classification ; coût réel sous-estimé (échecs facturés non
comptés) ; requête HTTP longue fragile (fermeture d'onglet = perte).

## Architecture avant/après

**Avant** : génération LLM synchrone dans la requête HTTP de l'assistante ;
statut de brief = `String` + CHECK SQL redondante ; `editedContent TEXT`
re-parsé en JSON ; aucune trace des échecs PLANCHER ; budget calculé sur
les seuls succès, lu sans verrou.

**Après** :
- **Fail-closed à 3 couches** (requête → service → renderer) : seul
  `APPROVED` + `scoreSnapshotId` courant atteint le dossier
  (`TEACHER_DOSSIER_UNSAFE_BRIEF_RENDER_BLOCKED` sinon).
- **Trois paliers de dossier** explicites (socle déterministe / enrichi
  partiel / enrichi complet), jamais de formulation trompeuse.
- **Worker asynchrone en process** (réutilise l'infrastructure canonique
  `canonical_job_outbox` déjà éprouvée — `FOR UPDATE SKIP LOCKED`, lease,
  quarantaine — jamais le worker NPC, jamais un second PM2). Réponse < 1 s.
- **Politique de retry explicite** : déterministe (jamais retenté) /
  transitoire (retry borné existant) / bloqué (jamais de retry auto).
- **Budget atomique** par UPDATE conditionnelle, aucune course prouvée par
  test réel.
- **Journal append-only des tentatives**, coût réel y compris les échecs.
- **Édition structurée** (`approvedContent` JSONB, même schéma que le
  contenu généré, ré-ancré sur les faits), jamais de texte libre.
- **Dashboard sans ambiguïté**, rôles stricts (ADMIN lecture seule).

Détail complet : `docs/bilans/adr/ADR-002-teacher-brief-workflow-safety.md`.

## Machine d'états

```
PENDING_REVIEW → APPROVED
PENDING_REVIEW → CORRECTION_REQUESTED
CORRECTION_REQUESTED → SUPERSEDED (régénération réussie)
APPROVED, SUPERSEDED : terminaux
```
Appliquée par le service, le typage TypeScript (enum Prisma natif) ET un
trigger SQL (défense en profondeur).

## Migrations

`20260816000000_secure_teacher_brief_workflow` : additive/conversion sûre.
`status` String+CHECK → enum Postgres natif. `editedContent` supprimé (0
valeur non nulle vérifiée en production avant suppression, conversion donc
sans perte). Nouvelles tables `canonical_teacher_brief_attempts` (append-
only) et `canonical_teacher_brief_monthly_budgets`. Nouveau type de job
`GENERATE_TEACHER_BRIEF`.

## Backfill

`scripts/bilans/backfill-teacher-brief-attempts.ts`, idempotent, `--dry-run`.
N'auto-approuve rien, ne supprime rien, ne modifie aucun contenu. N'invente
pas l'historique des 61 échecs PLANCHER non corrélables (documenté comme
limite, pas comblé par une supposition).

## Tests

- 7/7 tests d'intégration réels (vraie base PostgreSQL, jamais de mock de
  `$queryRaw`) sur le nouveau worker : succès, idempotence, staleness,
  classification des échecs (retryable/blocked/budget), reprise après job
  orphelin. Trois bugs réels trouvés et corrigés pendant l'écriture de ces
  tests (colonne `updatedAt` manquante dans un INSERT brut, FK `actorId`
  invalide, pollution d'état entre tests).
- Défense en profondeur testée en HTML **et** PDF (extraction textuelle
  réelle) : sentinelle de contenu non relu absente octet par octet.
- Suite complète : 9152/9155 tests unitaires (3 échecs pré-existants, sans
  rapport avec cette PR — confirmé par `git diff` vide sur les fichiers
  concernés).
- Typecheck, lint, build de production réel, artefact standalone vérifié,
  audit anti-fuite de données : tous verts.

## Mesure qualité LLM (§9 du mandat)

**Non exécutée dans cette PR** : nécessite une évaluation sur corpus réel
(≥20 bilans), budget plafonné, appels réseau réels — hors du périmètre
disposable de cette session. Documenté comme dette explicite dans l'ADR,
pas présenté comme réglé.

## Coûts

Budget mensuel par défaut inchangé (20 $, aucune variable d'environnement
définie en production). Réservation conservatrice de 0,20 $/tentative,
régularisée après coût réel connu.

## Preuve de restauration

Migration testée sur clone contenant les 26 (28 au moment de l'audit)
briefs réels de production + données synthétiques APPROVED/
CORRECTION_REQUESTED/SUPERSEDED. Dump du clone migré → restauration dans
une base PostgreSQL 15 vide : exit 0, 0 différence sémantique de schéma, 94
tables des deux côtés, 26 briefs préservés, 0 contrainte FK invalide.

## Risques résiduels (explicites, pas différés en silence)

- Qualification LLM en corpus réel budgété : à exécuter avant tout
  relâchement du protocole de sortie actuel.
- File de relecture dédiée (navigation précédent/suivant, brouillon
  navigateur) : la relecture structurée existe déjà dans la page actuelle,
  l'ergonomie dédiée reste à construire.
- Test de charge dédié pour la reprise après crash sous plusieurs workers
  concurrents (le mécanisme est prouvé par construction et par test
  d'intégration, pas par un test de charge).

Aucun risque de sécurité, de relecture, de traçabilité, de coût,
d'idempotence, de progression, de brief obsolète, d'édition structurée ou
de restauration n'est laissé en suspens.

---

Je n'ai ni mergé, ni déployé, ni généré de brief en production.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bloque l’inclusion de briefs enseignants non relus dans les dossiers et industrialise leur génération. Avant: des briefs `PENDING_REVIEW` pouvaient être rendus. Maintenant: seul `APPROVED`, rattaché au scoreSnapshot courant, est rendu; sinon le dossier bascule sur un palier explicite sans contenu IA.

- Défense en profondeur “fail-closed”: filtrage par service, vérification de fraîcheur, et assertion dans le renderer (blocage si le marqueur de sûreté manque). Trois paliers de complétude du dossier, jamais de formulation ambiguë.
- Génération asynchrone en worker in-process via `canonical_job_outbox`: `enqueueTeacherBriefGeneration` remplace l’appel synchrone; idempotence par `idempotencyKey`; politique de retry explicite; budget mensuel réservé/régularisé par UPDATE atomique; journal append-only des tentatives; coût réel compté par domaine même en cas d’échec partiel (itération domaine par domaine).
- Relecture structurée: `approvedContent` JSONB au schéma du modèle, ancré aux faits et au lexique; refus si snapshot obsolète; rôles stricts (ADMIN lecture seule).
- Dashboard: compteurs non ambigus (éligibles/à générer/en file/en cours/à relire/corrections/approuvés/obsolètes/échecs/bloqués), bouton de génération qui enfile des jobs, budget visible (plafond/dépensé/réservé).

**Migration et mise en production**
- Exécuter la migration Prisma. Elle convertit `status` en enum Postgres, supprime `editedContent`, ajoute `canonical_teacher_brief_attempts`, `canonical_teacher_brief_monthly_budgets`, et le type de job `GENERATE_TEACHER_BRIEF`. Transitions d’état sécurisées par trigger SQL.
- Lancer le backfill: `scripts/bilans/backfill-teacher-brief-attempts.ts` (commencer par `--dry-run`). Il est idempotent et ne modifie aucun contenu.
- Aucun nouveau secret. Budget par défaut inchangé. Le scheduler existant draine aussi les jobs `GENERATE_TEACHER_BRIEF`.

<sup>Written for commit 349ab88d4560b1f0e275dc9c0f0dfe1e816c4e5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

