### PR TITLE
fix(bilans): sécuriser les dossiers enseignants et suspendre les briefs

### DIFF
--- a/__tests__/bilans/teacher-brief-suspension.test.ts
+++ b/__tests__/bilans/teacher-brief-suspension.test.ts
@@ -1,0 +1,396 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { NextRequest } from 'next/server';
+
+import {
+  assertTeacherBriefOperationsEnabled,
+  teacherBriefOperationsAreSuspended,
+  TeacherBriefOperationsSuspendedError,
+  TEACHER_BRIEF_SUSPENSION_CODE,
+} from '@/lib/bilans/staff/teacher-brief-operations';
+import { APPROVED_BRIEF_SAFETY_MARKER, assertValidTeacherDossierStudentBrief, TeacherDossierUnsafeBriefRenderError } from '@/lib/bilans/staff/teacher-dossier-safety';
+import { generateTeacherBrief } from '@/lib/bilans/llm/teacher-brief-service';
+import {
+  approveTeacherBrief,
+  requestTeacherBriefCorrection,
+} from '@/lib/bilans/staff/teacher-brief-review-service';
+import {
+  generateTeacherBriefAction,
+  generateGroupTeacherBriefsAction,
+  approveTeacherBriefAction,
+  requestTeacherBriefCorrectionAction,
+} from '@/app/dashboard/assistante/bilans/actions';
+import {
+  prepareReportRegeneration,
+  executeReportRegeneration,
+} from '@/lib/bilans/staff/regeneration-service';
+import {
+  buildStaffTeacherDossierDocument,
+} from '@/lib/bilans/staff/teacher-dossier-service';
+
+jest.mock('@/lib/prisma');
+jest.mock('@/auth');
+jest.mock('@/lib/bilans/staff/teacher-dossier-service', () => ({
+  ...jest.requireActual('@/lib/bilans/staff/teacher-dossier-service'),
+  buildStaffTeacherDossierDocument: jest.fn(),
+}));
+
+import { GET as teacherDossierRouteHandler } from '@/app/dashboard/assistante/bilans/teacher-dossier/route';
+
+process.env.NEXUS_BILAN_PACK_ENTREE_TERMINALE_MATHS_V1_ENABLED = 'true';
+
+describe('Teacher Brief Operations Suspension & Security Anti-Bypass (Hotfix P0)', () => {
+  it('has central suspension flag set to true', () => {
+    expect(teacherBriefOperationsAreSuspended()).toBe(true);
+    expect(() => assertTeacherBriefOperationsEnabled()).toThrow(TeacherBriefOperationsSuspendedError);
+  });
+
+  it('refuses generateTeacherBrief immediately before network, DB, or pack resolution', async () => {
+    const throwingDb = {
+      teacherBrief: {
+        findFirst: jest.fn(() => { throw new Error('DB_SHOULD_NOT_BE_CALLED'); }),
+        aggregate: jest.fn(() => { throw new Error('DB_SHOULD_NOT_BE_CALLED'); }),
+      },
+    };
+    const throwingResolvePack = () => { throw new Error('PACK_SHOULD_NOT_BE_RESOLVED'); };
+    const throwingFetch: typeof fetch = (async () => { throw new Error('FETCH_SHOULD_NOT_BE_CALLED'); }) as typeof fetch;
+
+    await expect(
+      generateTeacherBrief({
+        prisma: throwingDb as never,
+        actor: { userId: 'user-1', role: 'ASSISTANTE' },
+        reportArtifactId: 'art-1',
+        resolvePack: throwingResolvePack as never,
+        fetchImpl: throwingFetch,
+      }),
+    ).rejects.toThrow(TeacherBriefOperationsSuspendedError);
+
+    expect(throwingDb.teacherBrief.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('refuses approveTeacherBrief immediately before DB transaction', async () => {
+    const throwingDb = {
+      $transaction: jest.fn(() => { throw new Error('DB_TRANSACTION_SHOULD_NOT_BE_CALLED'); }),
+    };
+    await expect(
+      approveTeacherBrief({
+        prisma: throwingDb as never,
+        actor: { userId: 'user-1', role: 'ASSISTANTE' },
+        briefId: 'brief-1',
+        motif: 'Validation test',
+      }),
+    ).rejects.toThrow(TeacherBriefOperationsSuspendedError);
+
+    expect(throwingDb.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('refuses requestTeacherBriefCorrection immediately before DB transaction', async () => {
+    const throwingDb = {
+      $transaction: jest.fn(() => { throw new Error('DB_TRANSACTION_SHOULD_NOT_BE_CALLED'); }),
+    };
+    await expect(
+      requestTeacherBriefCorrection({
+        prisma: throwingDb as never,
+        actor: { userId: 'user-1', role: 'ASSISTANTE' },
+        briefId: 'brief-1',
+        motif: 'Correction test',
+        annotation: { section: 'activite', remark: 'A revoir' },
+      }),
+    ).rejects.toThrow(TeacherBriefOperationsSuspendedError);
+
+    expect(throwingDb.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('refuses server actions with controlled TeacherBriefOperationsSuspendedError', async () => {
+    const formData = new FormData();
+    formData.append('artifactId', 'art-1');
+    formData.append('briefId', 'brief-1');
+    formData.append('motif', 'Motif valide');
+    formData.append('subject', 'MATHEMATIQUES');
+    formData.append('level', 'TERMINALE');
+
+    await expect(generateTeacherBriefAction(formData)).rejects.toThrow(TeacherBriefOperationsSuspendedError);
+    await expect(generateGroupTeacherBriefsAction(formData)).rejects.toThrow(TeacherBriefOperationsSuspendedError);
+    await expect(approveTeacherBriefAction(formData)).rejects.toThrow(TeacherBriefOperationsSuspendedError);
+    await expect(requestTeacherBriefCorrectionAction(formData)).rejects.toThrow(TeacherBriefOperationsSuspendedError);
+  });
+
+  it('keeps report regeneration preview deterministic with briefWillRegenerate = false', async () => {
+    process.env.NEXUS_BILAN_PACK_ENTREE_TERMINALE_MATHS_V1_ENABLED = 'true';
+    const { resolveEnabledPack } = require('@/lib/bilans/api/pack-access');
+    const { buildFactSheet } = require('@/lib/bilans/facts/fact-sheet');
+    const enabledPack = resolveEnabledPack('entree-terminale-maths-v1', 1);
+
+    const items = [{
+      itemId: 'ETL-MAT-SDG-01',
+      nodeCpsId: '1re.maths.second-degre.discriminant-racines',
+      weight: 1 as const,
+      rawSuccess: 1,
+      isSuccess: true,
+      isConfident: true,
+      profile: 'MAITRISE' as const,
+      answered: true,
+      elapsedMs: 1000,
+    }];
+    const nodes = [{ nodeCpsId: '1re.maths.second-degre.discriminant-racines', criticality: 1, nodeScore: 100, profile: 'MAITRISE' as const, itemIds: ['ETL-MAT-SDG-01'], priorityRank: 1 }];
+    const computedFactSheet = buildFactSheet(
+      enabledPack.pack,
+      { student: { alias: 'ELEVE_YASMINE', level: 'TERMINALE' }, result: { globalScore: 100, coverage: 100, calibrationIndex: 100, flags: [], groupBand: 'MAITRISE', items, nodes } },
+    );
+
+    const mockDb = {
+      reportRevision: {
+        findUnique: jest.fn(async () => ({
+          id: 'rev-1',
+          generation: 1,
+          scoreSnapshotId: 'snap-1',
+          reportPackId: 'entree-terminale-maths-v1',
+          reportPackVersion: '1',
+          scoreSnapshot: { result: computedFactSheet },
+          reportArtifact: {
+            id: 'art-1',
+            status: 'PUBLISHED',
+            transmissions: [],
+            publishedAt: new Date('2026-08-14'),
+            assessmentAttempt: {
+              answers: {},
+              assessmentPackId: 'entree-terminale-maths-v1',
+              assessmentPackVersion: '1',
+              assessmentPackChecksum: enabledPack.checksum,
+            },
+            revisions: [],
+          },
+        })),
+        aggregate: jest.fn(async () => ({ _max: { generation: 1 } })),
+      },
+      evidenceItem: {
+        findMany: jest.fn(async () => [
+          { payload: { itemId: 'ETL-MAT-SDG-01', nodeCpsId: '1re.maths.second-degre.discriminant-racines', weight: 1, rawSuccess: 1, profile: 'MAITRISE' } },
+        ]),
+      },
+      teacherBrief: {
+        findFirst: jest.fn(async () => ({ id: 'brief-1' })),
+      },
+    };
+
+    const preview = await prepareReportRegeneration({
+      prisma: mockDb as never,
+      actor: { userId: 'user-1', role: 'ASSISTANTE' },
+      revisionId: 'rev-1',
+    });
+
+    expect(preview.briefWillRegenerate).toBe(false);
+  });
+
+  it('executes report regeneration deterministically without mutating TeacherBrief when operations are suspended', async () => {
+    process.env.NEXUS_BILAN_PACK_ENTREE_TERMINALE_MATHS_V1_ENABLED = 'true';
+    const { resolveEnabledPack } = require('@/lib/bilans/api/pack-access');
+    const { buildFactSheet } = require('@/lib/bilans/facts/fact-sheet');
+    const enabledPack = resolveEnabledPack('entree-terminale-maths-v1', 1);
+
+    const items = [{
+      itemId: 'ETL-MAT-SDG-01',
+      nodeCpsId: '1re.maths.second-degre.discriminant-racines',
+      weight: 1 as const,
+      rawSuccess: 1,
+      isSuccess: true,
+      isConfident: true,
+      profile: 'MAITRISE' as const,
+      answered: true,
+      elapsedMs: 1000,
+    }];
+    const nodes = [{ nodeCpsId: '1re.maths.second-degre.discriminant-racines', criticality: 1, nodeScore: 100, profile: 'MAITRISE_FRAGILE' as const, itemIds: ['ETL-MAT-SDG-01'], priorityRank: 1 }];
+    const computedFactSheet = buildFactSheet(
+      enabledPack.pack,
+      { student: { alias: 'ELEVE_YASMINE', level: 'TERMINALE' }, result: { globalScore: 100, coverage: 100, calibrationIndex: 100, flags: [], groupBand: 'MAITRISE', items, nodes } },
+    );
+
+    const writes: string[] = [];
+    const mockDb: any = {
+      reportRevision: {
+        findUnique: jest.fn(async () => ({
+          id: 'rev-1',
+          generation: 1,
+          scoreSnapshotId: 'snap-1',
+          reportPackId: 'entree-terminale-maths-v1',
+          reportPackVersion: '1',
+          scoreSnapshot: { result: computedFactSheet },
+          reportArtifact: {
+            id: 'art-1',
+            status: 'PUBLISHED',
+            transmissions: [],
+            publishedAt: new Date('2026-08-14'),
+            assessmentAttempt: {
+              status: 'REPORT_PENDING_REVIEW',
+              answers: {},
+              assessmentPackId: 'entree-terminale-maths-v1',
+              assessmentPackVersion: '1',
+              assessmentPackChecksum: enabledPack.checksum,
+              submittedAt: new Date('2026-08-14'),
+              provenance: 'PAPER',
+            },
+            revisions: [],
+          },
+        })),
+        aggregate: jest.fn(async () => ({ _max: { generation: 1 } })),
+        create: jest.fn(async () => {
+          writes.push('reportRevision.create');
+          return { id: 'rev-2', generation: 2 };
+        }),
+      },
+      evidenceItem: {
+        findMany: jest.fn(async () => [
+          { payload: { itemId: 'ETL-MAT-SDG-01', nodeCpsId: '1re.maths.second-degre.discriminant-racines', weight: 1, rawSuccess: 1, profile: 'MAITRISE' } },
+        ]),
+      },
+      teacherBrief: {
+        findFirst: jest.fn(async () => {
+          writes.push('teacherBrief.findFirst');
+          return { id: 'brief-1' };
+        }),
+      },
+      reportRegeneration: {
+        create: jest.fn(async () => {
+          writes.push('reportRegeneration.create');
+          return { id: 'regen-1' };
+        }),
+      },
+      $transaction: jest.fn(async (cb: (t: unknown) => Promise<unknown>) => cb(mockDb)),
+    };
+
+    const result = await executeReportRegeneration({
+      prisma: mockDb as never,
+      actor: { userId: 'user-1', role: 'ASSISTANTE' },
+      revisionId: 'rev-1',
+      motif: 'Changement de règle',
+      confirmAlreadyPublished: true,
+      resolvePack: () => ({
+        pack: enabledPack.pack,
+        validatedPack: null as never,
+        checksum: enabledPack.checksum,
+        path: 'p',
+      }),
+      computeFactSheet: () => computedFactSheet as never,
+      materializeArtifact: jest.fn(async () => ({ revisionId: 'rev-2', generation: 2 })) as never,
+    } as any);
+
+    expect(result.brief).toEqual({
+      regenerated: false,
+      reason: TEACHER_BRIEF_SUSPENSION_CODE,
+    });
+    expect(writes).not.toContain('teacherBrief.create');
+    expect(writes).not.toContain('teacherBrief.updateMany');
+  });
+
+  it('decoupled safety marker: marker is independent of suspension and cannot be fabricated via cloning/deserialization', () => {
+    const rawBriefContent = { domaines: [] };
+
+    // 1. Spread / clone does not add safety marker
+    const cloned = { ...rawBriefContent };
+    expect((cloned as any).briefSafetyMarker).toBeUndefined();
+
+    // 2. Student detail without safety marker fails assertion
+    const unsafeStudent = { displayName: 'Élève A', brief: rawBriefContent as any };
+    expect(() => assertValidTeacherDossierStudentBrief(unsafeStudent)).toThrow(TeacherDossierUnsafeBriefRenderError);
+
+    // 3. Student detail with explicit safety marker passes
+    const safeStudent = { displayName: 'Élève A', brief: rawBriefContent as any, briefSafetyMarker: APPROVED_BRIEF_SAFETY_MARKER };
+    expect(() => assertValidTeacherDossierStudentBrief(safeStudent)).not.toThrow();
+
+    // 4. JSON serialization / deserialization never fabricates safety marker
+    const serialized = JSON.stringify(rawBriefContent);
+    const deserialized = JSON.parse(serialized);
+    expect(deserialized.briefSafetyMarker).toBeUndefined();
+
+    // 5. Decoupled module checks
+    const dossierServiceCode = fs.readFileSync(path.join(process.cwd(), 'lib/bilans/staff/teacher-dossier-service.ts'), 'utf-8');
+    expect(dossierServiceCode).toContain("from './teacher-dossier-safety'");
+    expect(dossierServiceCode).not.toContain("APPROVED_BRIEF_SAFETY_MARKER } from './teacher-brief-operations'");
+
+    const renderCode = fs.readFileSync(path.join(process.cwd(), 'lib/bilans/teacher-dossier/render.ts'), 'utf-8');
+    expect(renderCode).toContain("from '../staff/teacher-dossier-safety'");
+  });
+
+  it('architecture anti-bypass: strictly zero forbidden bypass strings or internal entrypoints in production files', () => {
+    const rootDir = process.cwd();
+
+    // 1. Check teacher-dossier-service.ts queries ONLY APPROVED briefs
+    const dossierServiceCode = fs.readFileSync(path.join(rootDir, 'lib/bilans/staff/teacher-dossier-service.ts'), 'utf-8');
+    expect(dossierServiceCode).not.toContain("status: { in: ['PENDING_REVIEW', 'APPROVED'] }");
+    expect(dossierServiceCode).toContain("status: APPROVED_BRIEF_STATUS");
+
+    // 2. Check render.ts calls assertValidTeacherDossierStudentBrief
+    const renderCode = fs.readFileSync(path.join(rootDir, 'lib/bilans/teacher-dossier/render.ts'), 'utf-8');
+    expect(renderCode).toContain("assertValidTeacherDossierStudentBrief(student)");
+
+    // 3. Check actions.ts calls assertTeacherBriefOperationsEnabled
+    const actionsCode = fs.readFileSync(path.join(rootDir, 'app/dashboard/assistante/bilans/actions.ts'), 'utf-8');
+    expect(actionsCode).toContain("assertTeacherBriefOperationsEnabled()");
+
+    // 4. Verify low-level LLM calls and internal entrypoints are NOT imported in app/ or lib/bilans/staff/
+    const checkedPaths = [
+      'lib/bilans/staff/teacher-dossier-service.ts',
+      'lib/bilans/teacher-dossier/render.ts',
+      'app/dashboard/assistante/bilans/actions.ts',
+      'app/dashboard/assistante/bilans/page.tsx',
+    ];
+    for (const relativePath of checkedPaths) {
+      const code = fs.readFileSync(path.join(rootDir, relativePath), 'utf-8');
+      expect(code).not.toContain("callTeacherBriefModel");
+      expect(code).not.toContain("callTeacherBriefDomain");
+      expect(code).not.toContain("executeTeacherBriefGenerationInternal");
+    }
+
+    // 5. Static scan for forbidden bypass strings in production files
+    const forbiddenPatterns = [
+      'bypassSuspension',
+      'bypassSuspensionCheckForUnitTests',
+      'skipTeacherBriefGuard',
+      'ignoreSuspension',
+      'testOnly',
+      'disableSafety',
+    ];
+    for (const relativePath of checkedPaths) {
+      const code = fs.readFileSync(path.join(rootDir, relativePath), 'utf-8');
+      for (const pattern of forbiddenPatterns) {
+        expect(code).not.toContain(pattern);
+      }
+    }
+  });
+
+  it('route & roles: /dashboard/assistante/bilans/teacher-dossier enforces staff roles and private no-store cache control', async () => {
+    const mockAuth = require('@/auth').auth as jest.Mock;
+    (buildStaffTeacherDossierDocument as jest.Mock).mockResolvedValue({
+      body: '<html>dossier</html>',
+      contentType: 'text/html; charset=utf-8',
+      filename: 'dossier-terminale.html',
+    });
+
+    // Anonymous request -> 404
+    mockAuth.mockResolvedValueOnce(null);
+    const reqAnon = new NextRequest('http://localhost:3000/dashboard/assistante/bilans/teacher-dossier?subject=MATHEMATIQUES&level=TERMINALE&format=html');
+    const resAnon = await teacherDossierRouteHandler(reqAnon);
+    expect(resAnon.status).toBe(404);
+
+    // Non-staff role (COACH) -> 404
+    mockAuth.mockResolvedValueOnce({ user: { id: 'u-coach', role: 'COACH' } });
+    const reqCoach = new NextRequest('http://localhost:3000/dashboard/assistante/bilans/teacher-dossier?subject=MATHEMATIQUES&level=TERMINALE&format=html');
+    const resCoach = await teacherDossierRouteHandler(reqCoach);
+    expect(resCoach.status).toBe(404);
+
+    // Staff role (ASSISTANTE) -> 200 with private, no-store headers
+    mockAuth.mockResolvedValueOnce({ user: { id: 'u-assistante', role: 'ASSISTANTE' } });
+    const reqAssistante = new NextRequest('http://localhost:3000/dashboard/assistante/bilans/teacher-dossier?subject=MATHEMATIQUES&level=TERMINALE&format=html');
+    const resAssistante = await teacherDossierRouteHandler(reqAssistante);
+    expect(resAssistante.status).toBe(200);
+    expect(resAssistante.headers.get('cache-control')).toBe('private, no-store');
+    expect(resAssistante.headers.get('content-type')).toContain('text/html');
+
+    // Staff role (ADMIN) -> 200 with private no-store headers
+    mockAuth.mockResolvedValueOnce({ user: { id: 'u-admin', role: 'ADMIN' } });
+    const reqAdmin = new NextRequest('http://localhost:3000/dashboard/assistante/bilans/teacher-dossier?subject=MATHEMATIQUES&level=TERMINALE&format=html');
+    const resAdmin = await teacherDossierRouteHandler(reqAdmin);
+    expect(resAdmin.status).toBe(200);
+    expect(resAdmin.headers.get('cache-control')).toBe('private, no-store');
+  });
+});

--- a/__tests__/bilans/teacher-brief.test.ts
+++ b/__tests__/bilans/teacher-brief.test.ts
@@ -2,12 +2,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { loadBilanPack } from '@/lib/bilans/catalog/load-pack';
+import { TeacherBriefOperationsSuspendedError } from '@/lib/bilans/staff/teacher-brief-operations';
 import {
   assertBriefRespectsFacts,
   buildStableSystemPrompt,
   buildStudentFactsPayload,
   callTeacherBriefModel,
   estimateCostUsd,
+  executeTeacherBriefGenerationInternal,
   generateTeacherBrief,
   resolveTeacherBriefConfig,
   teacherBriefMonthlyUsage,
@@ -385,7 +387,7 @@ describe('teacher-brief — orchestration, repli, budget, idempotence', () => {
 
   it('REPLI : clé absente → PLANCHER, aucune écriture, aucune erreur bloquante', async () => {
     const { db, writes } = database();
-    const result = await generateTeacherBrief({
+    const result = await executeTeacherBriefGenerationInternal({
       prisma: db as never, actor, reportArtifactId: 'art-1', environment: {},
     });
     expect(result).toEqual({ mode: 'PLANCHER', reason: 'OPENROUTER_API_KEY_MISSING' });
@@ -401,7 +403,7 @@ describe('teacher-brief — orchestration, repli, budget, idempotence', () => {
         updateMany: jest.fn(),
       },
     });
-    const result = await generateTeacherBrief({
+    const result = await executeTeacherBriefGenerationInternal({
       prisma: db as never, actor, reportArtifactId: 'art-1',
       environment: { OPENROUTER_API_KEY: 'k', NEXUS_TEACHER_BRIEF_MONTHLY_BUDGET_USD: '20' },
     });
@@ -417,7 +419,7 @@ describe('teacher-brief — orchestration, repli, budget, idempotence', () => {
         updateMany: jest.fn(),
       },
     });
-    const result = await generateTeacherBrief({
+    const result = await executeTeacherBriefGenerationInternal({
       prisma: db as never, actor, reportArtifactId: 'art-1', environment: { OPENROUTER_API_KEY: 'k' },
     });
     expect(result).toEqual({ mode: 'ALREADY_PRESENT', briefId: 'brief-42' });
@@ -449,7 +451,7 @@ describe('teacher-brief — orchestration, repli, budget, idempotence', () => {
         usage: { prompt_tokens: 2_300, completion_tokens: 1_100, prompt_tokens_details: { cached_tokens: 1_710 } },
       }), { status: 200 });
     }) as typeof fetch;
-    const result = await generateTeacherBrief({
+    const result = await executeTeacherBriefGenerationInternal({
       prisma: db as never, actor, reportArtifactId: 'art-1',
       environment: { OPENROUTER_API_KEY: 'k' },
       resolvePack: () => ({ pack: PACK, validatedPack: null as never, checksum: 'checksum-pack', path: 'x' }),
@@ -478,7 +480,7 @@ describe('teacher-brief — orchestration, repli, budget, idempotence', () => {
       },
     });
     const fetch500: typeof fetch = (async () => new Response('{}', { status: 500 })) as typeof fetch;
-    const result = await generateTeacherBrief({
+    const result = await executeTeacherBriefGenerationInternal({
       prisma: db as never, actor, reportArtifactId: 'art-1',
       environment: { OPENROUTER_API_KEY: 'k' },
       resolvePack: () => ({ pack: PACK, validatedPack: null as never, checksum: 'checksum-pack', path: 'x' }),
@@ -490,9 +492,17 @@ describe('teacher-brief — orchestration, repli, budget, idempotence', () => {
 
   it('refuse tout autre rôle que l’assistante', async () => {
     const { db } = database();
-    await expect(generateTeacherBrief({
+    await expect(executeTeacherBriefGenerationInternal({
       prisma: db as never, actor: { userId: 'coach', role: 'COACH' }, reportArtifactId: 'art-1',
     })).rejects.toThrow('NOT_FOUND');
+  });
+
+  it('le point d’entrée public generateTeacherBrief refuse TOUJOURS l’exécution pendant la suspension', async () => {
+    const { db, writes } = database();
+    await expect(generateTeacherBrief({
+      prisma: db as never, actor, reportArtifactId: 'art-1', environment: {},
+    })).rejects.toThrow(TeacherBriefOperationsSuspendedError);
+    expect(writes).toHaveLength(0);
   });
 });
 

--- a/__tests__/bilans/teacher-dossier-render.test.ts
+++ b/__tests__/bilans/teacher-dossier-render.test.ts
@@ -97,9 +97,82 @@ describe('renderTeacherDossierHtml', () => {
     expect(html).toContain('pack différent');
   });
 
-  it('signals a missing brief instead of rendering a silently empty section', () => {
+  it('signals deterministic fallback when no approved brief exists', () => {
     const html = renderTeacherDossierHtml(document());
-    expect(html).toMatch(/brief.*non disponible/i);
+    expect(html).toContain('Socle pédagogique déterministe utilisé — aucun brief enrichi validé.');
+    expect(html).toContain('Version sécurisée — tout enrichissement LLM non validé est exclu.');
+  });
+
+  it('rejects an unverified or unmarked brief with a security exception', () => {
+    const unsafeBrief = {
+      version: 'teacher-brief.v2',
+      domaines: [{ domainId: 'second-degre', erreursTypiques: [], prerequisAVerifier: [], activite: { titre: 't', objectif: 'o', materiel: 'm', deroule: [], differenciation: 'd' }, indicateurProgres: 'i' }],
+    };
+    const docWithUnsafe = document({
+      students: Object.freeze([{
+        ...document().students[0],
+        brief: unsafeBrief as never,
+        // briefSafetyMarker missing
+      }]),
+    });
+    expect(() => renderTeacherDossierHtml(docWithUnsafe)).toThrow('TEACHER_DOSSIER_UNSAFE_BRIEF_RENDER_BLOCKED');
+  });
+
+  it('demonstrates that a spread/clone of brief content without explicit briefSafetyMarker fails render', () => {
+    const safeBrief = {
+      version: 'teacher-brief.v2',
+      domaines: [{
+        domainId: 'second-degre',
+        erreursTypiques: [{ constat: 'Erreur de signe', origine: 'Formule mal apprise', itemIds: [] }],
+        prerequisAVerifier: ['Calcul algébrique'],
+        activite: { titre: 'Activité 1', objectif: 'Maîtriser le discriminant', materiel: 'Tableau', deroule: [{ nom: 'Phase 1', dureeMin: 15, consigne: 'Résoudre' }, { nom: 'P2', dureeMin: 10, consigne: 'C2' }, { nom: 'P3', dureeMin: 10, consigne: 'C3' }], differenciation: 'Calculatrice' },
+        indicateurProgres: '80% de réussite',
+      }],
+    };
+    const clonedBrief = { ...safeBrief };
+    const docWithClonedWithoutMarker = document({
+      students: Object.freeze([{
+        ...document().students[0],
+        brief: clonedBrief as never,
+        // no briefSafetyMarker on student detail!
+      }]),
+    });
+    expect(() => renderTeacherDossierHtml(docWithClonedWithoutMarker)).toThrow('TEACHER_DOSSIER_UNSAFE_BRIEF_RENDER_BLOCKED');
+  });
+
+  it('renders a verified safe brief carrying briefSafetyMarker and ensures unapproved sentinel is absent from HTML and PDF', async () => {
+    const safeBrief = {
+      version: 'teacher-brief.v2',
+      domaines: [{
+        domainId: 'second-degre',
+        erreursTypiques: [{ constat: 'Erreur de signe', origine: 'Formule mal apprise', itemIds: [] }],
+        prerequisAVerifier: ['Calcul algébrique'],
+        activite: { titre: 'Activité 1', objectif: 'Maîtriser le discriminant', materiel: 'Tableau', deroule: [{ nom: 'Phase 1', dureeMin: 15, consigne: 'Résoudre' }, { nom: 'P2', dureeMin: 10, consigne: 'C2' }, { nom: 'P3', dureeMin: 10, consigne: 'C3' }], differenciation: 'Calculatrice' },
+        indicateurProgres: '80% de réussite',
+      }],
+    };
+
+    const docWithSafe = document({
+      students: Object.freeze([{
+        ...document().students[0],
+        brief: safeBrief as never,
+        briefSafetyMarker: 'APPROVED_AND_CURRENT_VERIFIED',
+      }]),
+    });
+
+    const html = renderTeacherDossierHtml(docWithSafe);
+    expect(html).toContain('Maîtriser le discriminant');
+    const sentinel = 'SENTINELLE-BRIEF-NON-RELUE-INTERDITE-20260816';
+    expect(html).not.toContain(sentinel);
+
+    const pdfResult = await renderTeacherDossierPdf(docWithSafe);
+    expect(pdfResult.status).toBe('AVAILABLE');
+    if (pdfResult.status === 'AVAILABLE') {
+      expect(pdfResult.pdf.toString('utf-8')).not.toContain(sentinel);
+      const text = await extractPdfText(pdfResult.pdf);
+      expect(text).not.toContain(sentinel);
+      expect(text).toMatch(/Maîtriser le discriminant|second-degre/i);
+    }
   });
 
   it('flags a majority distractor as a collective error to treat at the board', () => {
@@ -120,6 +193,6 @@ describe('renderTeacherDossierPdf', () => {
     if (result.status !== 'AVAILABLE') return;
     const text = await extractPdfText(result.pdf);
     expect(text).toMatch(/confidentiel/i);
-    expect(text).toContain('x²');
+    expect(text).toContain('Socle pédagogique déterministe utilisé — aucun brief enrichi validé.');
   }, 30000);
 });

--- a/__tests__/bilans/teacher-dossier-service.test.ts
+++ b/__tests__/bilans/teacher-dossier-service.test.ts
@@ -4,6 +4,7 @@ import type { TeacherDossierDocument, TeacherDossierPdfResult } from '@/lib/bila
 import {
   buildStaffTeacherDossierDocument,
   listStaffTeacherDossierGroups,
+  selectApprovedBrief,
   StaffTeacherDossierError,
   type DossierCandidateRow,
 } from '@/lib/bilans/staff/teacher-dossier-service';
@@ -24,7 +25,7 @@ function row(id: string, firstName: string, lastName: string, packId = 'entree-t
     id, status: 'PENDING_REVIEW',
     assessmentAttempt: { answers: {}, assessmentPackId: packId, assessmentPackVersion: '1', assessmentPackChecksum: 'checksum' },
     student: { user: { firstName, lastName } },
-    revisions: [{ content: { NEXUS: { identity: {} } }, scoreSnapshot: { result: {} } }],
+    revisions: [{ content: { NEXUS: { identity: {} } }, scoreSnapshotId: 'snap-curr', scoreSnapshot: { result: {} } }],
     teacherBriefs: [],
   } as unknown as DossierCandidateRow;
 }
@@ -106,6 +107,163 @@ describe('buildStaffTeacherDossierDocument', () => {
     deps.renderPdf.mockResolvedValueOnce({ status: 'UNAVAILABLE' as const, html: '<html></html>', errorCode: 'TEACHER_DOSSIER_PDF_RENDER_FAILED' as const });
     await expect(buildStaffTeacherDossierDocument({ ...baseInput, format: 'pdf' }, deps as never))
       .rejects.toEqual(expect.objectContaining<Partial<StaffTeacherDossierError>>({ code: 'TEACHER_DOSSIER_PDF_RENDER_FAILED' }));
+  });
+
+  it('ignores PENDING_REVIEW, CORRECTION_REQUESTED, and SUPERSEDED briefs', async () => {
+    const candidateRow = row('a', 'Yasmine', 'Ben Ali');
+    candidateRow.revisions = [{ content: { NEXUS: { identity: {} } }, scoreSnapshotId: 'snap-1', scoreSnapshot: { result: {} } }] as never;
+    candidateRow.teacherBriefs = [
+      { status: 'PENDING_REVIEW', scoreSnapshotId: 'snap-1', content: {} },
+      { status: 'CORRECTION_REQUESTED', scoreSnapshotId: 'snap-1', content: {} },
+      { status: 'SUPERSEDED', scoreSnapshotId: 'snap-1', content: {} },
+    ] as never;
+    const deps = dependencies([candidateRow]);
+    await buildStaffTeacherDossierDocument(baseInput, deps as never);
+    const doc = deps.renderHtml.mock.calls[0][0];
+    expect(doc.students[0].brief).toBeNull();
+  });
+
+  it('ignores APPROVED brief linked to an obsolete scoreSnapshot', async () => {
+    const candidateRow = row('a', 'Yasmine', 'Ben Ali');
+    candidateRow.revisions = [{ content: { NEXUS: { identity: {} } }, scoreSnapshotId: 'snap-new', scoreSnapshot: { result: {} } }] as never;
+    candidateRow.teacherBriefs = [
+      {
+        status: 'APPROVED',
+        scoreSnapshotId: 'snap-old',
+        content: {
+          summary: 'Brief old',
+          domaines: [{ domainId: 'second-degre', erreursTypiques: [], prerequisAVerifier: [], activite: { titre: 'a', objectif: 'b', materiel: 'c', deroule: [], differenciation: 'd' }, indicateurProgres: 'e' }],
+        },
+      },
+    ] as never;
+    const deps = dependencies([candidateRow]);
+    await buildStaffTeacherDossierDocument(baseInput, deps as never);
+    const doc = deps.renderHtml.mock.calls[0][0];
+    expect(doc.students[0].brief).toBeNull();
+  });
+
+  it('includes APPROVED current brief and attaches safety marker', async () => {
+    const candidateRow = row('a', 'Yasmine', 'Ben Ali');
+    candidateRow.revisions = [{ content: { NEXUS: { identity: {} } }, scoreSnapshotId: 'snap-curr', scoreSnapshot: { result: {} } }] as never;
+    candidateRow.teacherBriefs = [
+      {
+        status: 'APPROVED',
+        scoreSnapshotId: 'snap-curr',
+        content: {
+          version: 'teacher-brief.v2',
+          domaines: [
+            {
+              domainId: 'second-degre',
+              erreursTypiques: [{ constat: 'Constat valide 1', origine: 'Origine valide 1', itemIds: [] }],
+              prerequisAVerifier: ['Prérequis 1'],
+              activite: {
+                titre: 'Titre 1', objectif: 'Objectif 1', materiel: 'Matériel 1',
+                deroule: [
+                  { nom: 'Phase 1', dureeMin: 10, consigne: 'Consigne 1' },
+                  { nom: 'Phase 2', dureeMin: 10, consigne: 'Consigne 2' },
+                  { nom: 'Phase 3', dureeMin: 10, consigne: 'Consigne 3' },
+                ],
+                differenciation: 'Différenciation 1',
+              },
+              indicateurProgres: 'Indicateur 1',
+            },
+            {
+              domainId: 'trigonometrie',
+              erreursTypiques: [{ constat: 'Constat valide 2', origine: 'Origine valide 2', itemIds: [] }],
+              prerequisAVerifier: ['Prérequis 2'],
+              activite: {
+                titre: 'Titre 2', objectif: 'Objectif 2', materiel: 'Matériel 2',
+                deroule: [
+                  { nom: 'Phase 1', dureeMin: 10, consigne: 'Consigne 1' },
+                  { nom: 'Phase 2', dureeMin: 10, consigne: 'Consigne 2' },
+                  { nom: 'Phase 3', dureeMin: 10, consigne: 'Consigne 3' },
+                ],
+                differenciation: 'Différenciation 2',
+              },
+              indicateurProgres: 'Indicateur 2',
+            },
+          ],
+        },
+      },
+    ] as never;
+    const deps = dependencies([candidateRow]);
+    await buildStaffTeacherDossierDocument(baseInput, deps as never);
+    const doc = deps.renderHtml.mock.calls[0][0];
+    expect(doc.students[0].brief).not.toBeNull();
+    expect(doc.students[0].briefSafetyMarker).toBe('APPROVED_AND_CURRENT_VERIFIED');
+  });
+
+  it('selects highest version APPROVED brief matching current scoreSnapshotId (cases A, B, C, D)', async () => {
+    const validContent = {
+      version: 'teacher-brief.v2',
+      domaines: [
+        { domainId: 'd1', erreursTypiques: [{ constat: 'Constat 1', origine: 'Origine 1', itemIds: [] }], prerequisAVerifier: ['P1'], activite: { titre: 'T1', objectif: 'O1', materiel: 'M1', deroule: [{ nom: 'P1', dureeMin: 10, consigne: 'C1' }, { nom: 'P2', dureeMin: 10, consigne: 'C2' }, { nom: 'P3', dureeMin: 10, consigne: 'C3' }], differenciation: 'D1' }, indicateurProgres: 'I1' },
+        { domainId: 'd2', erreursTypiques: [{ constat: 'Constat 2', origine: 'Origine 2', itemIds: [] }], prerequisAVerifier: ['P2'], activite: { titre: 'T2', objectif: 'O2', materiel: 'M2', deroule: [{ nom: 'P1', dureeMin: 10, consigne: 'C1' }, { nom: 'P2', dureeMin: 10, consigne: 'C2' }, { nom: 'P3', dureeMin: 10, consigne: 'C3' }], differenciation: 'D2' }, indicateurProgres: 'I2' },
+      ],
+    };
+
+    // Case A: v1 APPROVED current, v2 APPROVED obsolete -> v1 chosen
+    const briefsA: Parameters<typeof selectApprovedBrief>[0] = [
+      { id: 'b2', version: 2, status: 'APPROVED', scoreSnapshotId: 'snap-old', content: validContent, editedContent: null },
+      { id: 'b1', version: 1, status: 'APPROVED', scoreSnapshotId: 'snap-curr', content: validContent, editedContent: null },
+    ];
+    expect(selectApprovedBrief(briefsA, 'snap-curr')?.id).toBe('b1');
+
+    // Case B: v1 APPROVED obsolete, v2 APPROVED current -> v2 chosen
+    const briefsB: Parameters<typeof selectApprovedBrief>[0] = [
+      { id: 'b2', version: 2, status: 'APPROVED', scoreSnapshotId: 'snap-curr', content: validContent, editedContent: null },
+      { id: 'b1', version: 1, status: 'APPROVED', scoreSnapshotId: 'snap-old', content: validContent, editedContent: null },
+    ];
+    expect(selectApprovedBrief(briefsB, 'snap-curr')?.id).toBe('b2');
+
+    // Case C: multiple APPROVED current (v1 and v3) -> highest version (v3) chosen
+    const briefsC: Parameters<typeof selectApprovedBrief>[0] = [
+      { id: 'b3', version: 3, status: 'APPROVED', scoreSnapshotId: 'snap-curr', content: validContent, editedContent: null },
+      { id: 'b1', version: 1, status: 'APPROVED', scoreSnapshotId: 'snap-curr', content: validContent, editedContent: null },
+    ];
+    expect(selectApprovedBrief(briefsC, 'snap-curr')?.id).toBe('b3');
+
+    // Case D: no APPROVED current -> undefined
+    const briefsD: Parameters<typeof selectApprovedBrief>[0] = [
+      { id: 'b1', version: 1, status: 'APPROVED', scoreSnapshotId: 'snap-other', content: validContent, editedContent: null },
+    ];
+    expect(selectApprovedBrief(briefsD, 'snap-curr')).toBeUndefined();
+  });
+
+  it('handles editedContent legacy cases (valid JSON, free text, invalid schema)', async () => {
+    const validContent = {
+      version: 'teacher-brief.v2',
+      domaines: [
+        { domainId: 'd1', erreursTypiques: [{ constat: 'Constat 1', origine: 'Origine 1', itemIds: [] }], prerequisAVerifier: ['P1'], activite: { titre: 'T1', objectif: 'O1', materiel: 'M1', deroule: [{ nom: 'P1', dureeMin: 10, consigne: 'C1' }, { nom: 'P2', dureeMin: 10, consigne: 'C2' }, { nom: 'P3', dureeMin: 10, consigne: 'C3' }], differenciation: 'D1' }, indicateurProgres: 'I1' },
+        { domainId: 'd2', erreursTypiques: [{ constat: 'Constat 2', origine: 'Origine 2', itemIds: [] }], prerequisAVerifier: ['P2'], activite: { titre: 'T2', objectif: 'O2', materiel: 'M2', deroule: [{ nom: 'P1', dureeMin: 10, consigne: 'C1' }, { nom: 'P2', dureeMin: 10, consigne: 'C2' }, { nom: 'P3', dureeMin: 10, consigne: 'C3' }], differenciation: 'D2' }, indicateurProgres: 'I2' },
+      ],
+    };
+
+    // 1. editedContent valid JSON -> parses and uses edited content
+    const candidateRowEdited = row('a', 'Yasmine', 'Ben Ali');
+    candidateRowEdited.revisions = [{ content: { NEXUS: { identity: {} } }, scoreSnapshotId: 'snap-curr', scoreSnapshot: { result: {} } }] as never;
+    candidateRowEdited.teacherBriefs = [{
+      status: 'APPROVED',
+      scoreSnapshotId: 'snap-curr',
+      content: validContent,
+      editedContent: JSON.stringify(validContent),
+    }] as never;
+    const deps1 = dependencies([candidateRowEdited]);
+    await buildStaffTeacherDossierDocument(baseInput, deps1 as never);
+    expect(deps1.renderHtml.mock.calls[0][0].students[0].brief).not.toBeNull();
+
+    // 2. editedContent free text -> return null brief (fallback to deterministic)
+    const candidateRowFreeText = row('b', 'Karim', 'Trabelsi');
+    candidateRowFreeText.revisions = [{ content: { NEXUS: { identity: {} } }, scoreSnapshotId: 'snap-curr', scoreSnapshot: { result: {} } }] as never;
+    candidateRowFreeText.teacherBriefs = [{
+      status: 'APPROVED',
+      scoreSnapshotId: 'snap-curr',
+      content: validContent,
+      editedContent: 'Texte libre rédigé manuellement sans JSON SENTINELLE-ERR-1234',
+    }] as never;
+    const deps2 = dependencies([candidateRowFreeText]);
+    await buildStaffTeacherDossierDocument(baseInput, deps2 as never);
+    expect(deps2.renderHtml.mock.calls[0][0].students[0].brief).toBeNull();
   });
 });
 

--- a/app/dashboard/assistante/bilans/actions.ts
+++ b/app/dashboard/assistante/bilans/actions.ts
@@ -30,6 +30,7 @@ import {
   listStaffTeacherDossierArtifactIds,
   StaffTeacherDossierError,
 } from '@/lib/bilans/staff/teacher-dossier-service';
+import { assertTeacherBriefOperationsEnabled } from '@/lib/bilans/staff/teacher-brief-operations';
 
 function field(formData: FormData, name: string): string {
   const value = formData.get(name);
@@ -159,6 +160,7 @@ export async function confirmWhatsAppTransmissionAction(formData: FormData): Pro
 }
 
 export async function generateTeacherBriefAction(formData: FormData): Promise<void> {
+  assertTeacherBriefOperationsEnabled();
   try {
     await generateTeacherBrief({
       actor: await actor(),
@@ -182,6 +184,7 @@ export async function generateTeacherBriefAction(formData: FormData): Promise<vo
  * limite.
  */
 export async function generateGroupTeacherBriefsAction(formData: FormData): Promise<void> {
+  assertTeacherBriefOperationsEnabled();
   try {
     const current = await actor();
     const subject = field(formData, 'subject') as Subject;
@@ -204,6 +207,7 @@ export async function generateGroupTeacherBriefsAction(formData: FormData): Prom
 }
 
 export async function approveTeacherBriefAction(formData: FormData): Promise<void> {
+  assertTeacherBriefOperationsEnabled();
   try {
     const edited = field(formData, 'editedContent').trim();
     await approveTeacherBrief({
@@ -220,6 +224,7 @@ export async function approveTeacherBriefAction(formData: FormData): Promise<voi
 }
 
 export async function requestTeacherBriefCorrectionAction(formData: FormData): Promise<void> {
+  assertTeacherBriefOperationsEnabled();
   try {
     await requestTeacherBriefCorrection({
       actor: await actor(),

--- a/app/dashboard/assistante/bilans/page.tsx
+++ b/app/dashboard/assistante/bilans/page.tsx
@@ -14,6 +14,7 @@ import {
 import { REPORT_ANNOTATION_SECTIONS } from '@/lib/bilans/core/report-service';
 import { teacherBriefMonthlyUsage } from '@/lib/bilans/llm/teacher-brief-service';
 import { listStaffTeacherDossierGroups } from '@/lib/bilans/staff/teacher-dossier-service';
+import { TEACHER_BRIEF_OPERATIONS_SUSPENDED } from '@/lib/bilans/staff/teacher-brief-operations';
 import { prisma } from '@/lib/prisma';
 import type { TeacherBriefContent } from '@/lib/bilans/llm/teacher-brief-schema';
 
@@ -249,10 +250,18 @@ export default async function CanonicalBilansReviewPage({
           Assistant de rédaction enseignant — usage du mois : {briefUsage.briefs} brief{briefUsage.briefs > 1 ? 's' : ''}, {briefUsage.promptTokens + briefUsage.completionTokens} jetons (dont {briefUsage.cachedPromptTokens} en cache), ≈ {briefUsage.estimatedCostUsd.toFixed(2)} $ US.
         </p>
 
+        {TEACHER_BRIEF_OPERATIONS_SUSPENDED && (
+          <section className="mt-8 rounded-2xl border border-amber-400/40 bg-amber-400/10 p-5" data-testid="brief-operations-suspended-banner">
+            <p className="font-semibold text-amber-100">
+              Génération et relecture des briefs temporairement suspendues pour sécurisation. Les dossiers déterministes HTML et PDF restent disponibles.
+            </p>
+          </section>
+        )}
+
         <section className="mt-8 rounded-2xl border border-white/10 bg-white/[0.05] p-5" aria-label="Dossiers enseignant">
           <h2 className="text-lg font-semibold text-white">Dossier enseignant par groupe</h2>
           <p className="mt-1 text-sm text-slate-300">
-            Un document unique par matière et niveau — vue du groupe, énoncés, détail par élève, brief enseignant, plan des 5 séances. Document strictement interne, jamais transmis aux familles.
+            Un document unique par matière et niveau — vue du groupe, énoncés, détail par élève, brief enseignant, plan des 5 séances. Document strictly interne, jamais transmis aux familles.
           </p>
           {dossierGroups.length === 0 ? (
             <p className="mt-4 text-sm text-slate-400">Aucun bilan éligible pour l’instant.</p>
@@ -271,7 +280,11 @@ export default async function CanonicalBilansReviewPage({
                       <p className="font-semibold text-white">{subjectLabel} — {levelLabel}</p>
                       <p className="text-sm text-slate-300">
                         {group.count} bilan{group.count > 1 ? 's' : ''} éligible{group.count > 1 ? 's' : ''}
-                        {group.briefsMissing > 0 && ` · ${group.briefsMissing} brief${group.briefsMissing > 1 ? 's' : ''} manquant${group.briefsMissing > 1 ? 's' : ''}`}
+                        {TEACHER_BRIEF_OPERATIONS_SUSPENDED ? (
+                          ' · Dossier sécurisé disponible — enrichissement suspendu'
+                        ) : (
+                          group.briefsMissing > 0 && ` · ${group.briefsMissing} brief${group.briefsMissing > 1 ? 's' : ''} manquant${group.briefsMissing > 1 ? 's' : ''}`
+                        )}
                       </p>
                     </div>
                     <div className="flex flex-wrap items-center gap-2">
@@ -289,7 +302,7 @@ export default async function CanonicalBilansReviewPage({
                       >
                         PDF
                       </Link>
-                      {group.briefsMissing > 0 && (
+                      {!TEACHER_BRIEF_OPERATIONS_SUSPENDED && group.briefsMissing > 0 && (
                         <form action={generateGroupTeacherBriefsAction}>
                           <input type="hidden" name="subject" value={group.subject} />
                           <input type="hidden" name="level" value={group.level} />
@@ -631,15 +644,21 @@ export default async function CanonicalBilansReviewPage({
                           Préparation de séance rédigée par l’assistant de rédaction à partir du diagnostic déterministe, relue avant tout usage. Jamais transmis aux familles.
                         </p>
                         {brief === undefined ? (
-                          <form action={generateTeacherBriefAction} className="mt-3">
-                            <input type="hidden" name="artifactId" value={revision.reportArtifact.id} />
-                            <button type="submit" className="rounded-xl border border-indigo-300 px-4 py-2.5 text-sm font-semibold text-indigo-100">
-                              Générer le brief enseignant
-                            </button>
-                            <p className="mt-2 text-xs text-slate-500">
-                              Si l’assistant de rédaction est indisponible, le document interne Nexus déterministe reste la référence.
+                          TEACHER_BRIEF_OPERATIONS_SUSPENDED ? (
+                            <p className="mt-3 text-xs text-amber-200" data-testid="brief-generation-suspended-notice">
+                              Génération des briefs temporairement suspendue — le dossier déterministe reste disponible.
                             </p>
-                          </form>
+                          ) : (
+                            <form action={generateTeacherBriefAction} className="mt-3">
+                              <input type="hidden" name="artifactId" value={revision.reportArtifact.id} />
+                              <button type="submit" className="rounded-xl border border-indigo-300 px-4 py-2.5 text-sm font-semibold text-indigo-100">
+                                Générer le brief enseignant
+                              </button>
+                              <p className="mt-2 text-xs text-slate-500">
+                                Si l’assistant de rédaction est indisponible, le document interne Nexus déterministe reste la référence.
+                              </p>
+                            </form>
+                          )
                         ) : (
                           <div className="mt-3 space-y-3">
                             <p className="text-sm">
@@ -659,34 +678,46 @@ export default async function CanonicalBilansReviewPage({
                               </ul>
                             )}
                             {brief.status === 'PENDING_REVIEW' && (
-                              <div className="grid gap-3 lg:grid-cols-2">
-                                <form action={approveTeacherBriefAction} className="rounded-2xl border border-emerald-300/20 bg-emerald-300/5 p-4">
-                                  <input type="hidden" name="briefId" value={brief.id} />
-                                  <label className="block text-xs font-semibold text-white">Motif de validation</label>
-                                  <input name="motif" required minLength={5} className="mt-2 w-full rounded-xl border border-white/15 bg-slate-950 px-3 py-2 text-sm text-white" />
-                                  <label className="mt-3 block text-xs font-semibold text-white">Correction manuelle (facultative — elle prime sur le texte généré)</label>
-                                  <textarea name="editedContent" className="mt-2 min-h-16 w-full rounded-xl border border-white/15 bg-slate-950 p-3 text-xs text-white" placeholder="Laisser vide pour valider le texte généré tel quel." />
-                                  <button type="submit" className="mt-3 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950">Valider le brief</button>
-                                </form>
-                                <form action={requestTeacherBriefCorrectionAction} className="rounded-2xl border border-sky-300/20 bg-sky-300/5 p-4">
-                                  <input type="hidden" name="briefId" value={brief.id} />
-                                  <label className="block text-xs font-semibold text-white">Section concernée</label>
-                                  <input name="section" required className="mt-2 w-full rounded-xl border border-white/15 bg-slate-950 px-3 py-2 text-sm text-white" placeholder="ex. : activité du domaine trigonométrie" />
-                                  <label className="mt-3 block text-xs font-semibold text-white">Remarque</label>
-                                  <textarea name="remark" required minLength={5} className="mt-2 min-h-12 w-full rounded-xl border border-white/15 bg-slate-950 p-3 text-xs text-white" />
-                                  <label className="mt-3 block text-xs font-semibold text-white">Motif</label>
-                                  <input name="motif" required minLength={5} className="mt-2 w-full rounded-xl border border-white/15 bg-slate-950 px-3 py-2 text-sm text-white" />
-                                  <button type="submit" className="mt-3 rounded-xl border border-sky-300 px-4 py-2 text-sm font-semibold text-sky-100">Demander une régénération</button>
-                                </form>
-                              </div>
+                              TEACHER_BRIEF_OPERATIONS_SUSPENDED ? (
+                                <p className="mt-2 text-xs text-amber-200" data-testid="brief-review-suspended-notice">
+                                  Relecture et validation des briefs temporairement suspendues pour sécurisation (statut non relu).
+                                </p>
+                              ) : (
+                                <div className="grid gap-3 lg:grid-cols-2">
+                                  <form action={approveTeacherBriefAction} className="rounded-2xl border border-emerald-300/20 bg-emerald-300/5 p-4">
+                                    <input type="hidden" name="briefId" value={brief.id} />
+                                    <label className="block text-xs font-semibold text-white">Motif de validation</label>
+                                    <input name="motif" required minLength={5} className="mt-2 w-full rounded-xl border border-white/15 bg-slate-950 px-3 py-2 text-sm text-white" />
+                                    <label className="mt-3 block text-xs font-semibold text-white">Correction manuelle (facultative — elle prime sur le texte généré)</label>
+                                    <textarea name="editedContent" className="mt-2 min-h-16 w-full rounded-xl border border-white/15 bg-slate-950 p-3 text-xs text-white" placeholder="Laisser vide pour valider le texte généré tel quel." />
+                                    <button type="submit" className="mt-3 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950">Valider le brief</button>
+                                  </form>
+                                  <form action={requestTeacherBriefCorrectionAction} className="rounded-2xl border border-sky-300/20 bg-sky-300/5 p-4">
+                                    <input type="hidden" name="briefId" value={brief.id} />
+                                    <label className="block text-xs font-semibold text-white">Section concernée</label>
+                                    <input name="section" required className="mt-2 w-full rounded-xl border border-white/15 bg-slate-950 px-3 py-2 text-sm text-white" placeholder="ex. : activité du domaine trigonométrie" />
+                                    <label className="mt-3 block text-xs font-semibold text-white">Remarque</label>
+                                    <textarea name="remark" required minLength={5} className="mt-2 min-h-12 w-full rounded-xl border border-white/15 bg-slate-950 p-3 text-xs text-white" />
+                                    <label className="mt-3 block text-xs font-semibold text-white">Motif</label>
+                                    <input name="motif" required minLength={5} className="mt-2 w-full rounded-xl border border-white/15 bg-slate-950 px-3 py-2 text-sm text-white" />
+                                    <button type="submit" className="mt-3 rounded-xl border border-sky-300 px-4 py-2 text-sm font-semibold text-sky-100">Demander une régénération</button>
+                                  </form>
+                                </div>
+                              )
                             )}
                             {brief.status === 'CORRECTION_REQUESTED' && (
-                              <form action={generateTeacherBriefAction}>
-                                <input type="hidden" name="artifactId" value={revision.reportArtifact.id} />
-                                <button type="submit" className="rounded-xl border border-indigo-300 px-4 py-2.5 text-sm font-semibold text-indigo-100">
-                                  Régénérer le brief (nouvelle version, historique conservé)
-                                </button>
-                              </form>
+                              TEACHER_BRIEF_OPERATIONS_SUSPENDED ? (
+                                <p className="mt-2 text-xs text-amber-200">
+                                  Régénération du brief suspendue.
+                                </p>
+                              ) : (
+                                <form action={generateTeacherBriefAction}>
+                                  <input type="hidden" name="artifactId" value={revision.reportArtifact.id} />
+                                  <button type="submit" className="rounded-xl border border-indigo-300 px-4 py-2.5 text-sm font-semibold text-indigo-100">
+                                    Régénérer le brief (nouvelle version, historique conservé)
+                                  </button>
+                                </form>
+                              )
                             )}
                           </div>
                         )}

--- a/lib/bilans/llm/teacher-brief-service.ts
+++ b/lib/bilans/llm/teacher-brief-service.ts
@@ -499,7 +499,7 @@ export type GenerateBriefResult =
   | Readonly<{ mode: 'ALREADY_PRESENT'; briefId: string }>
   | Readonly<{ mode: 'PLANCHER'; reason: string }>;
 
-export async function generateTeacherBrief(input: Readonly<{
+export async function executeTeacherBriefGenerationInternal(input: Readonly<{
   prisma?: BriefDatabase;
   actor: Readonly<{ userId: string; role: string }>;
   reportArtifactId: string;
@@ -651,4 +651,19 @@ export async function teacherBriefMonthlyUsage(
     completionTokens: aggregate._sum.completionTokens ?? 0,
     estimatedCostUsd: Number(aggregate._sum.estimatedCostUsd ?? 0),
   });
+}
+
+import { assertTeacherBriefOperationsEnabled } from '../staff/teacher-brief-operations';
+
+export async function generateTeacherBrief(input: Readonly<{
+  prisma?: BriefDatabase;
+  actor: Readonly<{ userId: string; role: string }>;
+  reportArtifactId: string;
+  resolvePack?: PackResolver;
+  environment?: Readonly<Record<string, string | undefined>>;
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+}>): Promise<GenerateBriefResult> {
+  assertTeacherBriefOperationsEnabled();
+  return executeTeacherBriefGenerationInternal(input);
 }

--- a/lib/bilans/staff/regeneration-service.ts
+++ b/lib/bilans/staff/regeneration-service.ts
@@ -303,6 +303,11 @@ function assertStaff(actor: Readonly<{ userId: string; role: string }>): void {
   }
 }
 
+import {
+  teacherBriefOperationsAreSuspended,
+  TEACHER_BRIEF_SUSPENSION_CODE,
+} from './teacher-brief-operations';
+
 /** Aperçu lecture seule : ce qui changerait, et ce que la régénération coûte. */
 export async function prepareReportRegeneration(input: Readonly<{
   prisma?: RegenDatabase;
@@ -323,6 +328,7 @@ export async function prepareReportRegeneration(input: Readonly<{
   });
 
   const profilesChanged = loaded.changes.length > 0;
+  const suspended = teacherBriefOperationsAreSuspended();
   return Object.freeze({
     revisionId: loaded.revision.id,
     reportArtifactId: loaded.revision.reportArtifact.id,
@@ -335,7 +341,7 @@ export async function prepareReportRegeneration(input: Readonly<{
     publishedAt: loaded.revision.reportArtifact.publishedAt,
     changes: loaded.changes,
     profilesChanged,
-    briefWillRegenerate: profilesChanged && activeBrief !== null,
+    briefWillRegenerate: !suspended && profilesChanged && activeBrief !== null,
   });
 }
 
@@ -469,7 +475,15 @@ export async function executeReportRegeneration(input: Readonly<{
   let briefOutcome: Readonly<{ regenerated: boolean; reason: string | null; promptVersion: string | null; model: string | null }> =
     Object.freeze({ regenerated: false, reason: 'PROFILS_INCHANGES', promptVersion: null, model: null });
   if (loaded.changes.length > 0) {
-    const activeBrief = await database.teacherBrief.findFirst({
+    if (teacherBriefOperationsAreSuspended()) {
+      briefOutcome = Object.freeze({
+        regenerated: false,
+        reason: TEACHER_BRIEF_SUSPENSION_CODE,
+        promptVersion: null,
+        model: null,
+      });
+    } else {
+      const activeBrief = await database.teacherBrief.findFirst({
       where: { reportArtifactId: artifact.id, status: { in: ['PENDING_REVIEW', 'APPROVED'] } },
       orderBy: { version: 'desc' },
       select: { id: true },
@@ -517,6 +531,7 @@ export async function executeReportRegeneration(input: Readonly<{
         briefOutcome = Object.freeze({ regenerated: false, reason: 'BRIEF_REGENERATION_FAILED', promptVersion: null, model: null });
       }
     }
+  }
   }
 
   // 5. Trace append-only — l'issue réelle du brief y figure.

--- a/lib/bilans/staff/teacher-brief-operations.ts
+++ b/lib/bilans/staff/teacher-brief-operations.ts
@@ -1,0 +1,31 @@
+/**
+ * Suspension temporaire des opérations de génération et de relecture des briefs
+ * enseignant (hotfix P0).
+ *
+ * NOTE DE DÉCOMMISSIONNEMENT :
+ * Cette constante et cette politique de garde doivent être retirées et nettoyées
+ * explicitement lors de la finalisation et du déploiement de la version complète
+ * de la PR #156.
+ */
+export const TEACHER_BRIEF_OPERATIONS_SUSPENDED = true as const;
+export const TEACHER_BRIEF_SUSPENSION_CODE = 'TEACHER_BRIEF_OPERATIONS_SUSPENDED' as const;
+export const TEACHER_BRIEF_SUSPENSION_MESSAGE =
+  'Génération et relecture des briefs temporairement suspendues pour sécurisation.' as const;
+
+export class TeacherBriefOperationsSuspendedError extends Error {
+  readonly code = TEACHER_BRIEF_SUSPENSION_CODE;
+  constructor(message: string = TEACHER_BRIEF_SUSPENSION_MESSAGE) {
+    super(message);
+    this.name = 'TeacherBriefOperationsSuspendedError';
+  }
+}
+
+export function teacherBriefOperationsAreSuspended(): boolean {
+  return TEACHER_BRIEF_OPERATIONS_SUSPENDED;
+}
+
+export function assertTeacherBriefOperationsEnabled(): void {
+  if (TEACHER_BRIEF_OPERATIONS_SUSPENDED) {
+    throw new TeacherBriefOperationsSuspendedError();
+  }
+}

--- a/lib/bilans/staff/teacher-brief-review-service.ts
+++ b/lib/bilans/staff/teacher-brief-review-service.ts
@@ -35,6 +35,8 @@ function assertMotif(motif: string): string {
   return value;
 }
 
+import { assertTeacherBriefOperationsEnabled } from './teacher-brief-operations';
+
 export async function approveTeacherBrief(input: Readonly<{
   prisma?: ReviewDatabase;
   actor: Actor;
@@ -44,6 +46,7 @@ export async function approveTeacherBrief(input: Readonly<{
   editedContent?: string;
   now?: () => Date;
 }>) {
+  assertTeacherBriefOperationsEnabled();
   const database = input.prisma ?? prisma;
   const reviewerId = assertAssistante(input.actor);
   const motif = assertMotif(input.motif);
@@ -81,6 +84,7 @@ export async function requestTeacherBriefCorrection(input: Readonly<{
   annotation: Readonly<{ section: string; remark: string }>;
   now?: () => Date;
 }>) {
+  assertTeacherBriefOperationsEnabled();
   const database = input.prisma ?? prisma;
   const reviewerId = assertAssistante(input.actor);
   const motif = assertMotif(input.motif);

--- a/lib/bilans/staff/teacher-dossier-safety.ts
+++ b/lib/bilans/staff/teacher-dossier-safety.ts
@@ -1,0 +1,36 @@
+/**
+ * Marqueur permanent de sûreté pour les briefs du dossier enseignant (fail-closed).
+ *
+ * RAISON ARCHITECTURALE :
+ * La suspension des opérations de brief LLM (hotfix P0 temporaire) sera
+ * décommissionnée lorsque le workflow complet de relecture sera prêt.
+ * En revanche, le garde de sûreté du dossier enseignant (brief APPROVED +
+ * snapshot de score courant + contenu valide) est un mécanisme PERMANENT de
+ * défense en profondeur.
+ *
+ * Découpler ce marqueur du module de suspension garantit que le retrait ultérieur
+ * de la suspension ne pourra jamais affaiblir ou supprimer le contrôle de sûreté
+ * du rendu du dossier enseignant.
+ */
+export const APPROVED_BRIEF_SAFETY_MARKER = 'APPROVED_AND_CURRENT_VERIFIED' as const;
+export type ApprovedBriefSafetyMarker = typeof APPROVED_BRIEF_SAFETY_MARKER;
+
+export const TEACHER_DOSSIER_UNSAFE_BRIEF_RENDER_BLOCKED =
+  'TEACHER_DOSSIER_UNSAFE_BRIEF_RENDER_BLOCKED' as const;
+
+export class TeacherDossierUnsafeBriefRenderError extends Error {
+  readonly code = TEACHER_DOSSIER_UNSAFE_BRIEF_RENDER_BLOCKED;
+  constructor(message: string = TEACHER_DOSSIER_UNSAFE_BRIEF_RENDER_BLOCKED) {
+    super(message);
+    this.name = 'TeacherDossierUnsafeBriefRenderError';
+  }
+}
+
+export function assertValidTeacherDossierStudentBrief(student: {
+  brief: unknown | null;
+  briefSafetyMarker?: ApprovedBriefSafetyMarker;
+}): void {
+  if (student.brief !== null && student.briefSafetyMarker !== APPROVED_BRIEF_SAFETY_MARKER) {
+    throw new TeacherDossierUnsafeBriefRenderError();
+  }
+}

--- a/lib/bilans/staff/teacher-dossier-service.ts
+++ b/lib/bilans/staff/teacher-dossier-service.ts
@@ -53,8 +53,11 @@ type DossierFormat = 'html' | 'pdf';
 /** Statuts de bilan éligibles au dossier : validés par relecture ou déjà publiés — jamais DRAFT/ARCHIVED/REJECTED. */
 const ELIGIBLE_ARTIFACT_STATUSES: ReportArtifactStatus[] = ['PENDING_REVIEW', 'PUBLISHED'];
 
-/** Statuts de brief exploitables : en relecture ou déjà approuvés — jamais REJECTED. */
-const USABLE_BRIEF_STATUSES: string[] = ['PENDING_REVIEW', 'APPROVED'];
+/** Statuts de brief candidats au dossier enseignant : STRICTEMENT APPROVED (hotfix P0 fail-closed). */
+const APPROVED_BRIEF_STATUS = 'APPROVED' as const;
+
+import { APPROVED_BRIEF_SAFETY_MARKER } from './teacher-dossier-safety';
+export { APPROVED_BRIEF_SAFETY_MARKER };
 
 const candidateSelection = {
   id: true,
@@ -71,13 +74,12 @@ const candidateSelection = {
   revisions: {
     orderBy: { createdAt: 'desc' as const },
     take: 1,
-    select: { content: true, scoreSnapshot: { select: { result: true } } },
+    select: { content: true, scoreSnapshotId: true, scoreSnapshot: { select: { result: true } } },
   },
   teacherBriefs: {
-    where: { status: { in: USABLE_BRIEF_STATUSES } },
+    where: { status: APPROVED_BRIEF_STATUS },
     orderBy: { version: 'desc' as const },
-    take: 1,
-    select: { content: true, editedContent: true },
+    select: { id: true, version: true, status: true, scoreSnapshotId: true, content: true, editedContent: true },
   },
 };
 
@@ -130,14 +132,38 @@ function assertStaff(actor: DossierActor): void {
   if (!isStaffRole(actor.role) || !actor.userId.trim()) throw new StaffTeacherDossierError('NOT_FOUND');
 }
 
-function briefContent(row: DossierCandidateRow['teacherBriefs'][number] | undefined): TeacherBriefContent | null {
+export function selectApprovedBrief(
+  briefs: readonly DossierCandidateRow['teacherBriefs'][number][],
+  currentScoreSnapshotId: string | undefined,
+): DossierCandidateRow['teacherBriefs'][number] | undefined {
+  if (currentScoreSnapshotId === undefined || briefs.length === 0) return undefined;
+  return briefs.find(
+    (b) => b.status === APPROVED_BRIEF_STATUS && b.scoreSnapshotId === currentScoreSnapshotId,
+  );
+}
+
+function briefContent(
+  row: DossierCandidateRow['teacherBriefs'][number] | undefined,
+): TeacherBriefContent | null {
   if (row === undefined) return null;
+  if (row.status !== APPROVED_BRIEF_STATUS) return null;
+
   const edited = row.editedContent?.trim();
-  const raw = edited !== undefined && edited.length > 0
-    ? (() => { try { return JSON.parse(edited); } catch { return null; } })()
-    : row.content;
+  let raw: unknown = null;
+  if (edited !== undefined && edited.length > 0) {
+    try {
+      raw = JSON.parse(edited);
+    } catch {
+      return null;
+    }
+  } else {
+    raw = row.content;
+  }
+
   const parsed = teacherBriefSchema.safeParse(raw);
-  return parsed.success ? parsed.data : null;
+  if (!parsed.success) return null;
+
+  return parsed.data;
 }
 
 type ResolvedCandidate = Readonly<{
@@ -145,6 +171,7 @@ type ResolvedCandidate = Readonly<{
   factSheet: FactSheet;
   evidence: QuestionEvidence;
   brief: TeacherBriefContent | null;
+  briefSafetyMarker?: typeof APPROVED_BRIEF_SAFETY_MARKER;
   packId: string;
   packVersion: number;
 }>;
@@ -191,9 +218,16 @@ function resolveCandidates(
       continue;
     }
     const packVersion = Number(row.assessmentAttempt.assessmentPackVersion);
+    const selectedBrief = selectApprovedBrief(row.teacherBriefs, revision.scoreSnapshotId);
+    const parsedBrief = briefContent(selectedBrief);
     resolved.push(Object.freeze({
-      displayName, factSheet, evidence, brief: briefContent(row.teacherBriefs[0]),
-      packId: row.assessmentAttempt.assessmentPackId, packVersion,
+      displayName,
+      factSheet,
+      evidence,
+      brief: parsedBrief,
+      ...(parsedBrief !== null ? { briefSafetyMarker: APPROVED_BRIEF_SAFETY_MARKER } : {}),
+      packId: row.assessmentAttempt.assessmentPackId,
+      packVersion,
     }));
   }
   return Object.freeze({ resolved: Object.freeze(resolved), excluded: Object.freeze(excluded) });
@@ -229,7 +263,7 @@ export async function buildStaffTeacherDossierDocument(
   if (enabled === null) throw new StaffTeacherDossierError('NOT_FOUND');
 
   const students: readonly DossierStudentDetail[] = Object.freeze(included.map((candidate) => Object.freeze({
-    displayName: candidate.displayName, factSheet: candidate.factSheet, evidence: candidate.evidence, brief: candidate.brief,
+    displayName: candidate.displayName, factSheet: candidate.factSheet, evidence: candidate.evidence, brief: candidate.brief, briefSafetyMarker: candidate.briefSafetyMarker,
   })));
   const members: readonly DossierMember[] = students;
   const analysis = buildDossierGroupAnalysis(members);
@@ -280,7 +314,7 @@ export async function listStaffTeacherDossierGroups(
     where: { status: { in: ELIGIBLE_ARTIFACT_STATUSES } },
     select: {
       assessmentAttempt: { select: { subject: true, gradeLevel: true } },
-      teacherBriefs: { where: { status: { in: USABLE_BRIEF_STATUSES } }, select: { id: true }, take: 1 },
+      teacherBriefs: { where: { status: APPROVED_BRIEF_STATUS }, select: { id: true }, take: 1 },
     },
   });
   const groups = new Map<string, { subject: Subject; level: GradeLevel; count: number; briefsMissing: number }>();

--- a/lib/bilans/teacher-dossier/render.ts
+++ b/lib/bilans/teacher-dossier/render.ts
@@ -23,6 +23,10 @@ import type { FactSheet } from '../facts/fact-sheet';
 import { SEVERITY_RANK } from '../facts/constants';
 import type { NodeProfile } from '../facts/types';
 import type { TeacherBriefContent } from '../llm/teacher-brief-schema';
+import {
+  APPROVED_BRIEF_SAFETY_MARKER,
+  assertValidTeacherDossierStudentBrief,
+} from '../staff/teacher-dossier-safety';
 import { BILAN_PRINT_BRAND, bilanPrintTokenCss } from '../render/brand';
 import { renderHtmlToPdf } from '../render/pdf';
 import {
@@ -50,8 +54,10 @@ export type DossierStudentDetail = Readonly<{
   displayName: string;
   factSheet: FactSheet;
   evidence: QuestionEvidence;
-  /** `null` quand le brief n'a pas encore été généré pour cet élève. */
+  /** `null` quand le brief n'a pas encore été généré ou n'est pas approuvé. */
   brief: TeacherBriefContent | null;
+  /** Marqueur de sécurité explicite posé uniquement par teacher-dossier-service.ts. */
+  briefSafetyMarker?: typeof APPROVED_BRIEF_SAFETY_MARKER;
 }>;
 
 export type TeacherDossierDocument = Readonly<{
@@ -117,7 +123,8 @@ function summaryPage(doc: TeacherDossierDocument): string {
   const distribution = Object.entries(analysis.profileDistribution) as [NodeProfile, number][];
   const topFragile = analysis.domains.filter((domain) => domain.profile !== 'MAITRISE' && domain.profile !== 'MAITRISE_FRAGILE').slice(0, 3);
   return `<section class="page"><header class="report-header"><img class="brand-logo" src="${BILAN_PRINT_BRAND.logos.header}" alt="Nexus Réussite"><div><p class="eyebrow">Dossier enseignant · Interne Nexus</p><h1>${text(doc.identity.stageLabel)}</h1></div></header>
-  <p class="confidential">Document strictement interne et confidentiel. Il contient les noms réels et les profils pédagogiques des élèves. Il ne doit jamais être transmis aux familles ni aux élèves.</p>
+  <p class="confidential">Document strictly interne et confidentiel. Il contient les noms réels et les profils pédagogiques des élèves. Il ne doit jamais être transmis aux familles ni aux élèves.</p>
+  <p class="collective"><strong>Version sécurisée — tout enrichissement LLM non validé est exclu.</strong></p>
   <h2>Fiche récapitulative</h2>
   ${headerGrid(doc.identity, doc.header, doc.students.length)}
   <div class="summary-grid">
@@ -190,7 +197,7 @@ function sectionE(doc: TeacherDossierDocument): string {
   const blocks = fragile.map((domain) => {
     const brief = briefForDomain(doc.students, domain.domainId);
     if (brief === null) {
-      return `<article class="item-block"><h3>${text(domain.domainId)}</h3><p><em>Brief enseignant non disponible pour ce domaine — génère-le via le bouton dédié du dashboard assistante.</em></p></article>`;
+      return `<article class="item-block"><h3>${text(domain.domainId)}</h3><p><em>Socle pédagogique déterministe utilisé — aucun brief enrichi validé.</em></p></article>`;
     }
     return `<article class="item-block"><h3>${text(domain.domainId)}</h3>
     <p><strong>Erreurs typiques attendues :</strong></p><ul>${brief.erreursTypiques.map((erreur) => `<li>${text(erreur.constat)} — <em>${text(erreur.origine)}</em></li>`).join('')}</ul>
@@ -229,6 +236,11 @@ function sectionG(doc: TeacherDossierDocument): string {
 
 export function renderTeacherDossierHtml(doc: TeacherDossierDocument): string {
   const identity = assertRenderIdentity(doc.identity);
+
+  for (const student of doc.students) {
+    assertValidTeacherDossierStudentBrief(student);
+  }
+
   const html = `${summaryPage(doc)}${tocPage()}${sectionB(doc)}${sectionC(doc.evidenceCatalog)}${sectionD(doc.students)}${sectionE(doc)}${sectionF(doc)}${sectionG(doc)}`;
   return `<!doctype html><html lang="fr"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${text(identity.stageLabel)} · DOSSIER ENSEIGNANT</title><style>${styleSheet()}</style></head><body><main class="document" data-audience="STAFF" data-template="${TEACHER_DOSSIER_HTML_VERSION}">${html}</main></body></html>`;
 }

--- a/scripts/bilans/generate-teacher-brief-example.ts
+++ b/scripts/bilans/generate-teacher-brief-example.ts
@@ -18,8 +18,10 @@ import {
 } from '@/lib/bilans/llm/teacher-brief-service';
 import { resolveEnabledPack } from '@/lib/bilans/api/pack-access';
 import type { FactSheet } from '@/lib/bilans/facts/fact-sheet';
+import { assertTeacherBriefOperationsEnabled } from '@/lib/bilans/staff/teacher-brief-operations';
 
 async function main(): Promise<number> {
+  assertTeacherBriefOperationsEnabled();
   const artifactId = process.argv[2];
   if (!artifactId) {
     process.stderr.write('Usage: generate-teacher-brief-example.ts <reportArtifactId>\n');


### PR DESCRIPTION
## Incident

Un `TeacherBrief` au statut `PENDING_REVIEW` pouvait être considéré comme utilisable par le dossier enseignant alors qu'il n'avait jamais été approuvé par un humain.

Le hotfix applique immédiatement un comportement fail-closed afin qu'aucun contenu LLM non validé ne puisse atteindre le dossier enseignant HTML/PDF.

## Correctif P0

- seul un TeacherBrief `APPROVED` peut être utilisé ;
- le brief doit appartenir au `scoreSnapshotId` courant ;
- un brief obsolète ou invalide est exclu ;
- le renderer refuse tout brief sans marqueur de sûreté explicite ;
- en l'absence de brief approuvé, le dossier reste disponible avec son socle pédagogique déterministe ;
- la génération et la relecture des TeacherBrief sont temporairement suspendues côté serveur ;
- l'interface Assistante reflète explicitement cette suspension ;
- la régénération des bilans famille reste disponible ;
- les dossiers enseignants HTML/PDF restent disponibles.

## Défense en profondeur

Le hotfix protège trois niveaux :

1. sélection du brief dans le service de dossier ;
2. suspension serveur des opérations TeacherBrief ;
3. assertion fail-closed dans le renderer.

Erreur de protection du renderer :

`TEACHER_DOSSIER_UNSAFE_BRIEF_RENDER_BLOCKED`

Raison stable de suspension :

`TEACHER_BRIEF_OPERATIONS_SUSPENDED`

## Périmètre

- 14 fichiers ;
- 890 insertions ;
- 68 suppressions ;
- aucune migration ;
- aucun changement Prisma ;
- aucune dépendance ;
- aucun changement de workflow GitHub ;
- aucun nouveau secret ;
- aucun nouveau endpoint LLM.

Commit :

`950d9b9a55fb8238eba77711aa3e6e6246d53d6f`

Base qualifiée :

`5ca9b7301b8a539d7a910763d499b652989bfdeb`

## Qualification locale

Toutes les qualifications ont porté sur le même diff fonctionnel qualifié.

- Unit : 829 suites, 9171/9171 tests PASS
- Integration : PASS
- NPC real DB : 47/47 PASS
- Real DB Integration : 10/10 PASS
- E2E Chromium : 171/171 PASS
- E2E Auth : 49/49 PASS
- Security Scan : PASS
- OSV : 0 vulnérabilité
- Production Build : PASS
- standalone `/api/health` : HTTP 200
- Documents : 8/8 PDF PASS
- Bilan Runtime Real-DB : 9/9 PASS
- Dependency Integrity : PASS
- npm audits : 0 vulnérabilité
- Lint : 0 erreur
- TypeScript : 0 erreur

Une vérification forensique après commit a également confirmé :

- patch-id qualifié = patch-id commité ;
- 14/14 blobs identiques octet par octet ;
- 0 différence de contenu ;
- 0 différence de chemin ;
- 0 différence de mode.

## Invariants de sécurité

- `PENDING_REVIEW` n'est jamais rendu ;
- un `APPROVED` obsolète n'est jamais rendu ;
- un contenu invalide n'est jamais rendu ;
- absence de marqueur de sûreté = refus fail-closed ;
- aucun bypass conditionné par l'environnement de test ;
- aucun chemin public de contournement ;
- aucun appel LLM possible via les opérations suspendues.

## Séparation avec la PR #156

Cette PR est un hotfix P0 minimal et code-only.

Elle est volontairement indépendante de la PR #156 `fix/teacher-brief-workflow-safety-v2`.

Elle n'intègre notamment pas :

- la refonte complète du workflow TeacherBrief ;
- de migration ;
- de worker asynchrone ;
- de nouveau modèle de budget ;
- de journal d'exécution ;
- de backfill ;
- de réactivation du workflow LLM.

Aucun commit de la PR #156 n'a été cherry-pické dans ce hotfix.

La PR #156 doit rester Draft et être réévaluée séparément après sécurisation du P0.

## Déploiement

Aucun déploiement n'est effectué par cette PR.

Après CI, review humaine et merge explicitement autorisé, le déploiement fera l'objet d'une procédure séparée avec sauvegarde préalable et rollback atomique.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks teacher dossiers to approved briefs and temporarily suspends brief generation/review. Previously `PENDING_REVIEW` briefs could render; now only `APPROVED` briefs tied to the current score snapshot render, with a fail‑closed safety check blocking unsafe content.

**Review focus**
- Dossier selection now filters strictly on `APPROVED` and matches `scoreSnapshotId`; `PENDING_REVIEW`, `CORRECTION_REQUESTED`, `SUPERSEDED`, or obsolete briefs are ignored.
- A safety marker is attached to approved briefs; the renderer asserts it and throws `TEACHER_DOSSIER_UNSAFE_BRIEF_RENDER_BLOCKED` when missing. HTML/PDF show deterministic fallback when no approved brief exists.
- Server-side brief operations are suspended: generation and review entrypoints guard with `assertTeacherBriefOperationsEnabled()` and surface `TEACHER_BRIEF_OPERATIONS_SUSPENDED`.
- Regeneration preview sets `briefWillRegenerate = false` under suspension; execution records `TEACHER_BRIEF_OPERATIONS_SUSPENDED` and avoids brief mutations.
- Dashboard reflects suspension (banners, disabled actions); dossier routes enforce staff-only access and `private, no-store` caching.

**Rollout**
- No schema changes or migrations. Existing `APPROVED` briefs remain usable only if bound to the current snapshot.
- Assistants cannot generate/approve briefs during suspension; deterministic dossiers and family reports remain available.

<sup>Written for commit 950d9b9a55fb8238eba77711aa3e6e6246d53d6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyranoaladin/nexus-project_v0/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


